### PR TITLE
Add CI, docs, and project tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - 'Dockerfile'
+      - '.github/workflows/ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install C compiler (sqlite3)
+        run: sudo apt-get update && sudo apt-get install -y gcc
+      - name: Run tests
+        run: make test
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: .coverage/
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build binary
+        run: make build
+      - name: Build Docker image
+        run: docker build -t carwatch:ci .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CarWatch Project Rules
+
+## Git Identity (overrides global)
+
+This is a personal project. Always use the private GitHub account:
+
+- **GitHub user:** Danielsio
+- **Email:** kingddd301@gmail.com
+- **Commit sign-off:** `Signed-off-by: Daniel Sionov <kingddd301@gmail.com>`
+
+Before running any `gh` commands, ensure the active account is `Danielsio`:
+```bash
+gh auth switch --user Danielsio
+```
+
+## Commit Format
+
+```
+commit title here
+
+Optional body here.
+
+Assisted-By: Claude opus 4.6 <noreply@anthropic.com>
+Signed-off-by: Daniel Sionov <kingddd301@gmail.com>
+```
+
+## Branch Creation
+
+This is not a fork. Create branches from `main`:
+```bash
+git checkout -b my-branch-name main
+```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: build run test lint clean ci docker-build docker-run
+.PHONY: build run test test-cover test-e2e lint ci clean docker-build docker-run
+
+COVER_DIR := .coverage
+COVER_PROFILE := $(COVER_DIR)/coverage.out
+
+# Only test packages that have test files
+TEST_PKGS := $(shell go list ./... | xargs -I{} sh -c 'go list -f "{{if .TestGoFiles}}{{.ImportPath}}{{end}}" {}' | grep .)
 
 build:
 	go build -o bot ./cmd/bot
@@ -7,7 +13,19 @@ run: build
 	./bot -config config.yaml
 
 test:
-	go test ./...
+	@mkdir -p $(COVER_DIR)
+	go test -count=1 -coverprofile=$(COVER_PROFILE) -covermode=atomic $(TEST_PKGS)
+	@echo ""
+	@echo "=== Coverage Summary ==="
+	@go tool cover -func=$(COVER_PROFILE) | tail -1
+	@echo "HTML report: make test-cover"
+
+test-cover: test
+	go tool cover -html=$(COVER_PROFILE) -o $(COVER_DIR)/coverage.html
+	@echo "Coverage report: $(COVER_DIR)/coverage.html"
+
+test-e2e:
+	go test -count=1 -v -tags=e2e ./e2e/...
 
 lint:
 	golangci-lint run ./...
@@ -16,6 +34,7 @@ ci: lint test
 
 clean:
 	rm -f bot
+	rm -rf $(COVER_DIR)
 
 docker-build:
 	docker build -t carwatch .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,155 @@
+# CarWatch
+
+A self-hosted bot that monitors Israeli car listing sites (starting with Yad2) and sends notifications when new listings match your search criteria.
+
+## What it does
+
+1. Polls Yad2 on a schedule (every 10-20 minutes)
+2. Filters results by engine size, mileage, ownership count, keywords
+3. Deduplicates using SQLite so you only get notified once per listing
+4. Sends formatted notifications with specs, price, and a direct link
+
+## Quick start
+
+```bash
+cp config.example.yaml config.yaml
+# Edit config.yaml with your search criteria and recipients
+
+make build
+./bot -config config.yaml
+```
+
+### Docker
+
+```bash
+docker compose up -d
+```
+
+Mount your config and a data volume for persistence:
+
+```yaml
+services:
+  bot:
+    build: .
+    volumes:
+      - ./data:/data
+      - ./config.yaml:/config.yaml:ro
+    environment:
+      - TZ=Asia/Jerusalem
+    restart: unless-stopped
+```
+
+## Configuration
+
+See [`config.example.yaml`](config.example.yaml) for all options. Key sections:
+
+**Polling** -- how often and when to check:
+
+```yaml
+polling:
+  interval: 15m
+  jitter: 5m
+  active_hours:
+    start: "08:00"
+    end: "22:00"
+  timezone: "Asia/Jerusalem"
+```
+
+**Searches** -- what to look for:
+
+```yaml
+searches:
+  - name: "mazda3-2.0"
+    source: yad2
+    params:
+      manufacturer: 27
+      model: 10332
+      year_min: 2018
+      year_max: 2026
+      price_min: 40000
+      price_max: 200000
+    filters:
+      engine_min_cc: 1800    # Always in cc, not liters
+      engine_max_cc: 2100
+      max_km: 150000
+      max_hand: 3
+      keywords: []
+      exclude_keys: []
+    recipients:
+      - "+972XXXXXXXXX"
+```
+
+**Secrets** -- use environment variables for sensitive values:
+
+```yaml
+http:
+  proxy: "${PROXY_URL}"
+```
+
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for the full breakdown.
+
+```
+Scheduler (interval + jitter + adaptive backoff)
+    |
+    v
+Fetcher -----> Parser (HTML -> JSON -> RawListing)
+    |
+    v
+Filter (engine, km, hand, keywords)
+    |
+    v
+Dedup Store (SQLite: atomic claim)
+    |
+    v
+Notifier (WhatsApp stub / future: Telegram)
+    |
+    v
+User
+```
+
+All components communicate through interfaces, making each layer independently testable and swappable.
+
+## Project structure
+
+```
+carwatch/
+├── cmd/bot/main.go              # Entry point, wiring
+├── internal/
+│   ├── config/                  # YAML loading, validation, defaults
+│   ├── fetcher/                 # Fetcher interface + error sentinels
+│   │   └── yad2/                # Yad2 adapter (client, parser, fetcher)
+│   ├── filter/                  # Stateless listing filter
+│   ├── model/                   # RawListing, Listing
+│   ├── notifier/                # Notifier interface + formatter
+│   │   └── whatsapp/            # WhatsApp adapter (stub)
+│   ├── scheduler/               # Polling loop, retry, backoff
+│   └── storage/                 # DedupStore interface
+│       └── sqlite/              # SQLite adapter
+├── testdata/                    # HTML/JSON fixtures
+├── docs/                        # Architecture docs
+├── config.example.yaml
+├── Dockerfile
+├── docker-compose.yaml
+└── Makefile
+```
+
+## Development
+
+```bash
+make test          # Run tests with coverage
+make lint          # Run golangci-lint
+make ci            # Lint + test (what CI runs)
+make test-cover    # Generate HTML coverage report
+```
+
+Requires Go 1.24+ and a C compiler (for SQLite via cgo).
+
+## Current status
+
+All core pipeline components are implemented and tested. The WhatsApp notifier is currently a stub that logs to stdout. See the [project board](https://github.com/users/Danielsio/projects/1) for remaining work.
+
+## License
+
+Private project.

--- a/bugs.md
+++ b/bugs.md
@@ -1,0 +1,210 @@
+# CarWatch -- Bugs
+
+> **15 issues** | 2 Critical | 4 High | 5 Medium | 4 Low
+
+---
+
+## Critical
+
+### B-01 -- Mark-before-notify data loss
+
+- **Where:** `scheduler.go:136` vs `scheduler.go:154`
+- **Impact:** Users silently miss car listings. The system's core purpose is defeated.
+
+`processSearch` marks tokens as seen *before* attempting notification.
+If `Notify` fails for all recipients, listings are permanently lost --
+never received, never retried.
+
+**Fix:** Move `MarkSeen` to *after* successful notification. Or batch:
+collect new listings, attempt notify, only mark the ones delivered
+to at least one recipient.
+
+---
+
+### B-02 -- Engine volume unit mismatch
+
+- **Where:** `config.example.yaml`, `DESIGN.md`, `FilterCriteria`
+- **Impact:** Filters either pass everything or reject everything.
+
+`config.example.yaml` uses cc (`1800`, `2100`). DESIGN.md uses liters
+(`1.8`, `2.0`). `FilterCriteria` is `float64` with no documented unit.
+Yad2 returns cc in JSON. Following DESIGN.md examples breaks filtering.
+
+**Fix:** Standardize on cc. Rename fields to `EngineMinCC float64`.
+Add validation: if `EngineMin < 100`, warn it looks like liters.
+
+---
+
+## High
+
+### B-03 -- No `data/` directory creation
+
+- **Where:** `sqlite.New("./data/dedup.db")`
+- **Impact:** Crashes on first run in a clean environment.
+
+No `os.MkdirAll` anywhere in the codebase. Fresh Docker containers
+or cloned repos will fail immediately.
+
+**Fix:** Add `os.MkdirAll(filepath.Dir(dbPath), 0750)` in `sqlite.New()`
+before opening the database.
+
+---
+
+### B-04 -- Brotli response crashes parsing
+
+- **Where:** `client.go:42`, `yad2.go:52-58`
+- **Impact:** Silent data corruption or crash on every poll cycle.
+
+Client sends `Accept-Encoding: gzip, deflate, br` but only handles gzip
+decompression. Brotli-encoded responses are fed raw to goquery.
+
+**Fix:** Remove `br` from Accept-Encoding, or add Brotli decompression
+via `github.com/andybalholm/brotli`. Simplest: only advertise `gzip`.
+
+---
+
+### B-05 -- No retry or backoff implemented
+
+- **Where:** `yad2.go:47-49`
+- **Impact:** Transient errors cause missed poll cycles.
+
+DESIGN.md describes exponential backoff on 429/403/5xx. The actual code
+has zero retry logic -- a single network blip fails the entire search.
+
+**Fix:** Add retry with exponential backoff (3 attempts, starting at 2s)
+in `Fetch()`. Differentiate retriable (429, 5xx, timeout) from fatal (4xx).
+
+---
+
+### B-06 -- Anti-bot challenge has no backoff
+
+- **Where:** `scheduler.go:113-115`
+- **Impact:** Bot hammers Yad2 during a challenge, likely escalating to IP ban.
+
+When `ErrChallenge` is detected, scheduler logs a warning and continues
+at normal interval. DESIGN.md says to double the interval and cap at 1h.
+
+**Fix:** Track consecutive challenge count. Multiply next delay by
+2^n (capped at 1h). Reset counter on successful fetch.
+
+---
+
+## Medium
+
+### B-07 -- `runCycle` swallows all errors
+
+- **Where:** `scheduler.go:85-108`
+- **Impact:** No way to detect persistent failures.
+
+Logs search failures but always returns `nil`. The error check in `Run`
+at line 76-79 is dead code for cycle errors.
+
+**Fix:** Return an error when ALL searches in a cycle fail, or track
+consecutive failure count and log/alert at thresholds.
+
+---
+
+### B-08 -- HasSeen/MarkSeen race condition
+
+- **Where:** `scheduler.go:129-136`
+- **Impact:** Duplicate notifications (currently unlikely, planned for Phase 2).
+
+Two separate DB operations with no transaction. Concurrent searches with
+overlapping params could both pass `HasSeen` and both send notifications.
+
+**Fix:** Use `INSERT OR IGNORE` + `changes()` in a single operation.
+If the row was inserted (changes > 0), it's new. Eliminates the
+read-then-write race entirely.
+
+---
+
+### B-09 -- Active hours parse failure silently disables the feature
+
+- **Where:** `scheduler.go:189-194`
+- **Impact:** User thinks active hours are configured but bot polls 24/7.
+
+`isActiveHours()` returns `true` if `parseTimeOfDay` fails.
+Invalid config like `start: "8am"` silently polls around the clock.
+
+**Fix:** Validate active hours format at config load time in `validate()`.
+Fail startup on invalid format.
+
+---
+
+### B-10 -- No response body size limit
+
+- **Where:** `parser.go:21`
+- **Impact:** OOM crash on malformed or malicious response.
+
+`goquery.NewDocumentFromReader(body)` reads the entire response into memory.
+A malformed response could be gigabytes.
+
+**Fix:** Wrap the reader: `io.LimitReader(body, 10*1024*1024)` (10 MB cap).
+Yad2 pages are typically ~500KB.
+
+---
+
+### B-11 -- No per-fetch context timeout
+
+- **Where:** `scheduler.go:111`
+- **Impact:** A hung TCP connection blocks the entire scheduler.
+
+The root context (signal cancellation only) is passed to `Fetch`.
+No timeout means indefinite blocking.
+
+**Fix:** Create a child context with 60-second timeout:
+`ctx, cancel := context.WithTimeout(ctx, 60*time.Second)`.
+
+---
+
+## Low
+
+### B-12 -- Prune runs every cycle
+
+- **Where:** `scheduler.go:98-105`
+- **Impact:** Unnecessary I/O and SQLite write lock contention.
+
+`Prune` executes a `DELETE FROM` scan every 10-20 minutes
+for a 30-day retention window.
+
+**Fix:** Track last prune time; only prune once every 24 hours
+(or on startup + daily).
+
+---
+
+### B-13 -- `make clean` destroys production data
+
+- **Where:** `Makefile:11`
+- **Impact:** Accidental `make clean` loses all state.
+
+`rm -rf data/` deletes the dedup database and WhatsApp session.
+Duplicate notifications flood, WhatsApp re-auth required.
+
+**Fix:** Remove `rm -rf data/` from clean target, or rename to
+`make purge` with a confirmation prompt. `clean` should only
+remove build artifacts.
+
+---
+
+### B-14 -- `.PHONY` incomplete
+
+- **Where:** `Makefile`
+- **Impact:** Targets silently stop working if a file shares the name.
+
+Only `build run test clean` are declared `.PHONY`.
+`lint`, `docker-build`, `docker-run` are missing.
+
+**Fix:** Add all targets to `.PHONY`.
+
+---
+
+### B-15 -- Scheduler imports concrete `yad2` package
+
+- **Where:** `scheduler.go:10`
+- **Impact:** Adding a new fetcher adapter requires modifying the scheduler.
+
+`scheduler.go` imports `yad2` to match `ErrChallenge`.
+This breaks the ports & adapters boundary.
+
+**Fix:** Define `fetcher.ErrChallenge` sentinel in the `fetcher` package.
+Each adapter wraps it. Scheduler checks against the abstract error.

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -61,7 +61,7 @@ func run(configPath string, bootstrapLogger *slog.Logger) error {
 	if err := notif.Connect(ctx); err != nil {
 		return fmt.Errorf("connect notifier: %w", err)
 	}
-	defer notif.Disconnect()
+	defer func() { _ = notif.Disconnect() }()
 
 	sched, err := scheduler.New(cfg, fetcher, store, notif, logger)
 	if err != nil {

--- a/code-quality.md
+++ b/code-quality.md
@@ -1,0 +1,252 @@
+# CarWatch -- Code Quality Audit
+
+> **20 issues** across architecture, testing, security, and maintainability
+
+---
+
+## Architecture & Design
+
+### CQ-01 -- Leaky abstraction: scheduler imports concrete `yad2`
+
+- **Where:** `scheduler.go:10`
+
+Imports `yad2` to match `ErrChallenge`. The scheduler should depend only
+on the `fetcher.Fetcher` interface.
+
+**Fix:** Define `var ErrChallenge = errors.New(...)` in `fetcher` package.
+Yad2 adapter wraps it. Scheduler uses `errors.Is(err, fetcher.ErrChallenge)`.
+
+---
+
+### CQ-02 -- `validate()` mutates config
+
+- **Where:** `config.go:119`
+
+A function named `validate` sets `cfg.HTTP.UserAgents` as a side effect.
+Violates the principle of least surprise.
+
+**Fix:** Split into `validate()` (pure) and `applyDefaults()` (mutates).
+Call `applyDefaults` before `validate` in `Load()`.
+
+---
+
+### CQ-03 -- `FilterCriteria` field names don't encode units
+
+- **Where:** `filter.go`, `config.go`
+
+`EngineMin float64` -- is that cc or liters? Causes bug B-02.
+
+**Fix:** Rename to `EngineMinCC` / `EngineMaxCC`.
+Validate at config load that values > 100.
+
+---
+
+### CQ-20 -- `source` field in config is never used
+
+- **Where:** `go.mod`, `main.go`
+
+`SearchConfig.Source` is validated but never read to select a fetcher.
+`main.go` hardcodes `yad2.NewFetcher`.
+
+**Fix:** Either remove the field (YAGNI) or implement a fetcher factory:
+`fetcherFor(source string) (fetcher.Fetcher, error)`.
+
+---
+
+## Parsing & HTTP
+
+### CQ-04 -- URL construction uses string concatenation
+
+- **Where:** `yad2.go:71-102`
+
+`buildURL` manually concatenates query params with `+` and `&`.
+No escaping, no `net/url` usage. Works for integers but is fragile.
+
+**Fix:** Use `url.Values{}` and `u.RawQuery = values.Encode()`.
+
+---
+
+### CQ-05 -- Hardcoded `baseURL` constant
+
+- **Where:** `yad2.go`
+
+Cannot be overridden for testing or if Yad2 changes URL structure.
+
+**Fix:** Accept base URL as a parameter to `NewFetcher` or make it
+a field on `Yad2Fetcher`. Default to production URL.
+
+---
+
+### CQ-06 -- Silent item skip on parse error
+
+- **Where:** `parser.go:54`
+
+`parseNextData` skips items that fail `itemToListing` with `continue`,
+no logging. If JSON schema drifts, listings silently disappear.
+
+**Fix:** Log a warning with the item token on parse failure.
+Track skip count and surface it in cycle metrics.
+
+---
+
+### CQ-07 -- Full DOM parse for one script tag
+
+- **Where:** `parser.go`
+
+`goquery.NewDocumentFromReader` builds a complete DOM tree
+just to find `<script id="__NEXT_DATA__">`. A 500KB page becomes
+multi-MB DOM in memory.
+
+**Fix:** Use `io.ReadAll` (with size limit), then regex to extract
+the JSON from the script tag. Faster, lower memory, fewer deps.
+
+---
+
+### CQ-19 -- No connection pooling configuration
+
+- **Where:** `client.go`
+
+Uses cloned default transport but doesn't configure `MaxIdleConns`,
+`MaxIdleConnsPerHost`, or `IdleConnTimeout`.
+
+**Fix:** Set explicit transport values or add a comment that
+defaults are intentional.
+
+---
+
+## Testing
+
+### CQ-09 -- No test coverage: scheduler
+
+- **Where:** `scheduler.go`
+
+The scheduler is the orchestration core. It has zero tests.
+All its bugs (B-01, B-06, B-07, B-11) are untested.
+
+**Fix:** Add unit tests using interface mocks. Test: successful cycle,
+all-seen listings, fetch errors, challenge detection, active hours,
+notification failure after mark-seen.
+
+---
+
+### CQ-10 -- No test coverage: parser
+
+- **Where:** `parser.go`
+
+The most fragile component (depends on Yad2's internal JSON schema).
+Zero tests. Schema changes won't be caught until production.
+
+**Fix:** Save a real `__NEXT_DATA__` JSON blob as `testdata/yad2_feed.json`.
+Write tests asserting field mapping. Add a "schema changed" detection test.
+
+---
+
+### CQ-11 -- No test coverage: wiring
+
+- **Where:** `main.go`
+
+The `run()` function wires all components. A type mismatch would
+only be caught at runtime.
+
+**Fix:** Add `TestRun_InvalidConfig`. Ideally, add an integration test
+with mock fetcher + in-memory SQLite + mock notifier.
+
+---
+
+### CQ-18 -- No table-driven test pattern
+
+- **Where:** `filter_test.go`
+
+Each filter has a separate test function with inline setup.
+Adding a new filter requires copy-paste.
+
+**Fix:** Consolidate into `TestApply` with
+`[]struct{name, criteria, listings, expected}` table.
+
+---
+
+## Security & Privacy
+
+### CQ-15 -- Dockerfile: no non-root user
+
+- **Where:** `Dockerfile`
+
+Container runs as root. A vulnerability gives full container access.
+
+**Fix:** Add `RUN adduser -D -u 1000 bot` and `USER bot`.
+Ensure `/data` is writable by this user.
+
+---
+
+### CQ-16 -- No env var interpolation for secrets
+
+- **Where:** `config.go`
+
+DESIGN.md says to support env var interpolation.
+Not implemented. Proxy credentials and phone numbers sit in plaintext YAML.
+
+**Fix:** Add `os.ExpandEnv()` on raw YAML bytes before unmarshalling.
+Config can then use `proxy: "${PROXY_URL}"`.
+
+---
+
+### CQ-17 -- Phone numbers logged on notification failure
+
+- **Where:** `scheduler.go:157`
+
+Logs `recipient` (a phone number). If logs are shipped to a
+centralized system, this is a PII leak.
+
+**Fix:** Log a masked version: `+972***XXX`.
+Or log only a recipient index/alias from config.
+
+---
+
+## Maintainability
+
+### CQ-08 -- WhatsApp notifier is a stub
+
+- **Where:** `whatsapp.go`
+
+The system's primary output channel is a no-op that prints to stdout.
+The commented-out implementation has issues (text QR, no reconnection,
+no message queuing).
+
+**Fix:** Either implement whatsmeow properly, or implement Telegram first
+(simpler, no ban risk, no QR flow). A shipping product needs at least
+one real notifier.
+
+---
+
+### CQ-12 -- `Listing` embeds `RawListing` -- tight coupling
+
+- **Where:** `model/listing.go`
+
+Every consumer gets all `RawListing` fields promoted.
+Makes refactoring `RawListing` ripple everywhere.
+
+**Fix:** Acceptable for MVP. If `RawListing` grows, consider composition:
+`Listing{Raw RawListing; SearchName string}`.
+
+---
+
+### CQ-13 -- `isActiveHours` called after sleep, not before
+
+- **Where:** `scheduler.go`
+
+The loop sleeps 10-20 min, *then* checks active hours. Could compute
+a delay at 21:50 and reject the cycle at 22:05.
+
+**Fix:** Check active hours *before* computing delay. If outside hours,
+sleep until start of next active window.
+
+---
+
+### CQ-14 -- `test` target doesn't fail on lint
+
+- **Where:** `Makefile`
+
+`test` and `lint` are separate targets with no dependency.
+CI could pass tests but ship lint failures.
+
+**Fix:** Add `lint` as a prerequisite to a `ci` target: `ci: lint test`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,188 @@
+# Architecture
+
+CarWatch follows a ports-and-adapters pattern. The scheduler orchestrates the pipeline, and each stage communicates through interfaces so implementations can be swapped independently.
+
+## Component diagram
+
+```
+┌──────────────────────────────────────────────────────┐
+│                     Scheduler                        │
+│                                                      │
+│  ┌─────────┐    ┌────────┐    ┌───────┐    ┌──────┐ │
+│  │ Fetcher │───>│ Filter │───>│ Dedup │───>│Notify│ │
+│  └────┬────┘    └────────┘    └───┬───┘    └──────┘ │
+│       │                          │                   │
+│  ┌────┴────┐               ┌─────┴─────┐            │
+│  │  Yad2   │               │  SQLite   │            │
+│  │ Adapter │               │  Store    │            │
+│  └─────────┘               └───────────┘            │
+└──────────────────────────────────────────────────────┘
+```
+
+## Interfaces
+
+### Fetcher
+
+```go
+type Fetcher interface {
+    Fetch(ctx context.Context, params config.SourceParams) ([]model.RawListing, error)
+}
+```
+
+Retrieves raw listings from a marketplace. The only implementation is `yad2.Yad2Fetcher`. Error sentinels `ErrChallenge` and `ErrRateLimited` live in the `fetcher` package so the scheduler can react without importing concrete adapters.
+
+### DedupStore
+
+```go
+type DedupStore interface {
+    ClaimNew(ctx context.Context, token string, searchName string) (bool, error)
+    ReleaseClaim(ctx context.Context, token string) error
+    Prune(ctx context.Context, olderThan time.Duration) (int64, error)
+    Close() error
+}
+```
+
+`ClaimNew` uses `INSERT OR IGNORE` + `RowsAffected` for atomic deduplication -- no read-then-write race. If notification fails for all recipients, `ReleaseClaim` removes the token so it retries next cycle.
+
+### Notifier
+
+```go
+type Notifier interface {
+    Connect(ctx context.Context) error
+    Notify(ctx context.Context, recipient string, listings []model.Listing) error
+    Disconnect() error
+}
+```
+
+Currently a WhatsApp stub (logs to stdout). Planned: Telegram.
+
+## Data flow
+
+A single poll cycle works like this:
+
+```
+1. Scheduler wakes up
+   - Check active hours (skip if outside window)
+   - Apply adaptive backoff multiplier to delay
+
+2. For each search config:
+   a. Fetch
+      - HTTP GET to Yad2 with browser-like headers
+      - Rotate User-Agent, support SOCKS5 proxy
+      - Retry up to 3 times (2s/4s/8s exponential backoff)
+      - Detect anti-bot challenges (doubles backoff multiplier)
+      - Parse HTML, extract __NEXT_DATA__ JSON
+      - Return []RawListing (~40 per page)
+
+   b. Filter
+      - Engine volume range (cc)
+      - Max mileage, max ownership count
+      - Required/excluded keywords (case-insensitive)
+      - Zero values disable that filter
+      - Pure function, no I/O
+
+   c. Dedup
+      - For each filtered listing: ClaimNew(token)
+      - Atomic: INSERT OR IGNORE + check RowsAffected
+      - If new -> add to notification batch
+      - If seen -> skip
+
+   d. Notify
+      - Format listings with specs, emoji, link
+      - Send to each recipient
+      - If all recipients fail -> ReleaseClaim (retry next cycle)
+      - If at least one succeeds -> keep claims
+
+3. Housekeeping
+   - Prune listings older than 30 days (once per 24h)
+   - Adjust backoff: challenge -> 2x, success -> 0.5x
+```
+
+## Scheduler timing
+
+```
+Base delay:   interval * backoffMultiplier
+Jitter:       +/- (jitter / 2), randomly distributed
+Minimum:      1 minute floor
+Active hours: if outside, sleep until window opens
+
+Backoff multiplier:
+  Challenge detected -> multiply by 2 (cap at 4x)
+  Successful fetch   -> divide by 2 (floor at 1x)
+
+Example with defaults (15m interval, 5m jitter, 1x backoff):
+  Delay range: 12.5m to 17.5m
+  After challenge: 25m to 35m (2x)
+  After two challenges: 50m to 70m (4x, capped)
+  After recovery: back to 12.5m-17.5m
+```
+
+## Yad2 adapter internals
+
+### HTTP client (`client.go`)
+
+- Clones `http.DefaultTransport`
+- 30-second overall timeout
+- Optional SOCKS5 proxy
+- Realistic browser headers on every request:
+  - User-Agent rotation from configured pool
+  - `Accept-Language: he-IL,he;q=0.9,en-US;q=0.8`
+  - `Sec-Fetch-*` metadata headers
+  - `Accept-Encoding: gzip, deflate` (no brotli)
+
+### Parser (`parser.go`)
+
+Yad2 is a Next.js app. Listing data lives in a `<script id="__NEXT_DATA__">` tag as JSON.
+
+```
+HTML page
+  -> goquery finds <script id="__NEXT_DATA__">
+  -> extract JSON text
+  -> unmarshal to nested structure
+  -> navigate: props.pageProps.dehydratedState.queries[].state.data.data.feed.feed_items[]
+  -> map each item to RawListing
+  -> skip items with empty token
+  -> prefer english_text over hebrew text for field values
+```
+
+### URL builder (`yad2.go`)
+
+Uses `net/url.Values` for query parameter construction. Maps `SourceParams` fields to Yad2's query format (ranges use `min-max` syntax).
+
+## Config loading pipeline
+
+```
+1. Read YAML file
+2. os.ExpandEnv() on raw bytes (enables ${VAR} interpolation)
+3. yaml.Unmarshal into Config struct
+4. applyDefaults() -- interval, jitter, timezone, paths, log level
+5. validate() -- required fields, format checks, unit sanity
+```
+
+Validation is strict and fails at startup:
+- At least one search required
+- Each search needs name, source, recipients
+- Engine values < 100 are rejected (likely liters, not cc)
+- Active hours must be `HH:MM` format
+- Log level must be debug/info/warn/error
+
+## SQLite schema
+
+```sql
+CREATE TABLE IF NOT EXISTS seen_listings (
+    token         TEXT PRIMARY KEY,
+    search_name   TEXT NOT NULL,
+    first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+Opened with WAL mode and 5-second busy timeout. Parent directories are created automatically.
+
+## Security considerations
+
+- Non-root Docker user (UID 1000)
+- Phone numbers masked in logs (`+972***XXX`)
+- Secrets via env var interpolation (never hardcoded in config)
+- Response body capped at 10 MB (prevents OOM)
+- Per-search 60-second timeout (prevents hung connections)
+- No brotli advertised (only decompressors we ship)

--- a/enhancements.md
+++ b/enhancements.md
@@ -1,0 +1,192 @@
+# CarWatch -- Enhancements
+
+> **18 proposals** | 2 P0 | 4 P1 | 5 P2 | 3 P3 | 4 P4
+
+---
+
+## P0 -- Must Have
+
+### E-01 -- Atomic dedup-then-notify pattern
+
+- **Complexity:** Low
+- **Fixes:** B-01 (data loss), B-08 (race condition)
+
+Replace separate `HasSeen`/`MarkSeen` with a single
+`ClaimNew(token) bool` using `INSERT OR IGNORE` + `changes()`.
+Only notify on successful claim. Move to mark-after-notify
+with a `ReleaseUnclaimed` fallback on notification failure.
+
+---
+
+### E-02 -- Fetch retry with categorized backoff
+
+- **Complexity:** Medium
+
+Wrap `Fetch` with a retry loop: 3 attempts with 2s/4s/8s delays
+for retriable errors (429, 5xx, timeout, DNS). Immediately fail on
+4xx (except 429), parse errors. Respect `Retry-After` header on 429.
+
+---
+
+## P1 -- Should Have
+
+### E-03 -- Adaptive backoff on anti-bot challenges
+
+- **Complexity:** Low
+
+Add a `backoffMultiplier` field to `Scheduler`. On challenge, double it
+(cap at 4x). On success, halve it back to 1x. Apply multiplier to
+`nextDelay()`. Prevents IP bans. Automatically recovers.
+
+---
+
+### E-04 -- Per-search fetch timeout
+
+- **Complexity:** Low
+
+Create a 60-second child context for each `processSearch` call.
+Prevents a single hung connection from blocking all searches.
+
+---
+
+### E-05 -- Notification queue with at-least-once delivery
+
+- **Complexity:** Medium
+
+Store unsent notifications in SQLite (`pending_notifications` table).
+On notify success, delete. On startup, retry pending. No listing is
+ever lost, even across crashes and restarts.
+
+---
+
+### E-06 -- Health check endpoint
+
+- **Complexity:** Low
+
+Add a minimal HTTP server (`:8080/healthz`) returning last successful
+poll time, cycle count, error count. Enables Docker healthcheck,
+Kubernetes probes, or any uptime checker.
+
+---
+
+### E-07 -- Structured error types for fetcher
+
+- **Complexity:** Medium
+
+Define `ErrChallenge`, `ErrRateLimited`, `ErrServerError` in the
+`fetcher` package. Each adapter maps its errors to these. Scheduler
+switches on error type for retry/backoff strategy. New adapters
+don't require scheduler changes.
+
+---
+
+## P2 -- Nice to Have
+
+### E-08 -- Configurable log level
+
+- **Complexity:** Low
+
+Add `log_level: debug|info|warn|error` to config.
+Enables debugging in production without code changes.
+
+---
+
+### E-09 -- Pagination support
+
+- **Complexity:** Medium
+
+Fetch page 0, then page 1 if all tokens on page 0 are new
+(indicating the listing window scrolled). Stop early when
+encountering seen tokens. Catches listings during high-volume periods.
+
+---
+
+### E-10 -- Version/build info embedded
+
+- **Complexity:** Low
+
+Use `ldflags` to embed version, git SHA, build time. Add `--version` flag.
+Enables support debugging. Required for any release process.
+
+---
+
+### E-11 -- Telegram notifier
+
+- **Complexity:** Medium
+
+Implement `TelegramNotifier` using `go-telegram-bot-api`.
+Zero ban risk, free, first-class bot support. Provides an immediately
+usable notification channel without WhatsApp's issues.
+
+---
+
+### E-12 -- Config hot reload via SIGHUP
+
+- **Complexity:** Medium
+
+Watch for SIGHUP, re-read config, swap search configs in scheduler.
+Add/remove searches and recipients without restarting the bot.
+
+---
+
+## P3 -- Future
+
+### E-13 -- Metrics via Prometheus
+
+- **Complexity:** Medium
+
+Expose counters: `fetch_total`, `fetch_errors_total`, `listings_new_total`,
+`notifications_sent_total`, `challenge_detected_total`.
+Expose gauges: `last_successful_fetch_timestamp`.
+Enables alerting on failure patterns.
+
+---
+
+### E-14 -- Response caching
+
+- **Complexity:** Low
+
+Cache parsed listings in memory with 5-minute TTL. If a retry hits
+within TTL, use cached result. Reduces Yad2 request rate during retries.
+
+---
+
+### E-15 -- Price change detection
+
+- **Complexity:** Medium
+
+Track `(token, price)` history. Notify when a previously seen listing
+drops in price by more than a configurable threshold. High-value feature
+for car buyers -- price drops are exactly what they want to know.
+
+---
+
+## P4 -- Backlog
+
+### E-16 -- Listing history/dashboard
+
+- **Complexity:** High
+
+Add a simple HTTP server with SQLite-backed listing history. Serve a
+minimal HTML page showing all seen listings with filter/sort. Gives users
+a way to review listings without scrolling WhatsApp.
+
+---
+
+### E-17 -- Multi-marketplace support
+
+- **Complexity:** High
+
+Add fetcher adapters for AutoTrader, Facebook Marketplace, or other
+Israeli car sites. Each implements `Fetcher` interface. `source` field
+in config selects the adapter. Completes the pluggable design.
+
+---
+
+### E-18 -- Proxy rotation
+
+- **Complexity:** Medium
+
+Support a pool of proxies with round-robin or random selection.
+Mark failed proxies as unhealthy and skip temporarily.
+Distributes scraping load across IPs.

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -74,7 +74,7 @@ func FormatBatch(listings []model.Listing) string {
 	b.WriteString(fmt.Sprintf("🚗 *%d New Listings Found*\n", len(listings)))
 
 	for i, l := range listings {
-		b.WriteString(fmt.Sprintf("\n━━━━━━━━━━━━━━━━━━━━\n"))
+		b.WriteString("\n━━━━━━━━━━━━━━━━━━━━\n")
 		b.WriteString(fmt.Sprintf("*[%d/%d]*\n", i+1, len(listings)))
 		b.WriteString(FormatListing(l))
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -280,7 +280,7 @@ func TestRunCycle_ChallengeIncreasesBackoff(t *testing.T) {
 	ctx := context.Background()
 
 	initialBackoff := s.backoffMultiplier
-	s.runCycle(ctx)
+	_ = s.runCycle(ctx)
 
 	if s.backoffMultiplier <= initialBackoff {
 		t.Errorf("backoff should increase on challenge: was %f, now %f", initialBackoff, s.backoffMultiplier)
@@ -297,7 +297,7 @@ func TestRunCycle_SuccessDecreasesBackoff(t *testing.T) {
 	s.backoffMultiplier = 4.0
 	ctx := context.Background()
 
-	s.runCycle(ctx)
+	_ = s.runCycle(ctx)
 
 	if s.backoffMultiplier >= 4.0 {
 		t.Errorf("backoff should decrease on success: %f", s.backoffMultiplier)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -41,7 +41,7 @@ func TestReleaseClaim(t *testing.T) {
 
 	ctx := context.Background()
 
-	store.ClaimNew(ctx, "token1", "search1")
+	_, _ = store.ClaimNew(ctx, "token1", "search1")
 
 	if err := store.ReleaseClaim(ctx, "token1"); err != nil {
 		t.Fatalf("ReleaseClaim: %v", err)
@@ -65,7 +65,7 @@ func TestPrune(t *testing.T) {
 
 	ctx := context.Background()
 
-	store.ClaimNew(ctx, "old-token", "search1")
+	_, _ = store.ClaimNew(ctx, "old-token", "search1")
 
 	pruned, err := store.Prune(ctx, 0)
 	if err != nil {
@@ -90,7 +90,7 @@ func TestPruneKeepsRecent(t *testing.T) {
 
 	ctx := context.Background()
 
-	store.ClaimNew(ctx, "recent-token", "search1")
+	_, _ = store.ClaimNew(ctx, "recent-token", "search1")
 
 	pruned, err := store.Prune(ctx, 24*time.Hour)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **CI workflow** (`.github/workflows/ci.yml`): runs lint, test, and build on PRs touching code. Skips on docs-only changes. Branch protection requires all 3 checks to pass.
- **README.md**: quick start (local + Docker), config reference, architecture overview, project structure, dev commands.
- **docs/architecture.md**: component diagram, all interfaces, full data flow walkthrough, scheduler timing math, Yad2 parser internals, security considerations.
- **Tracking files**: bugs.md, code-quality.md, enhancements.md reformatted from wide tables to responsive card layouts grouped by severity/priority.
- **Makefile**: added coverage targets (`test-cover`, `test-e2e`), coverage cleanup in `clean`.
- **CLAUDE.md**: project-level config for private GitHub identity.

## Test plan

- [ ] CI triggers on this PR and all 3 jobs pass
- [ ] Docs render correctly on GitHub
- [ ] Branch protection blocks merge until checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)