### PR TITLE
V3-14: Add search pause/resume commands

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -56,6 +56,8 @@ func (b *Bot) RegisterHandlers() {
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/watch", tgbot.MatchTypeExact, b.handleWatch)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/list", tgbot.MatchTypeExact, b.handleList)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stop", tgbot.MatchTypePrefix, b.handleStop)
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/pause", tgbot.MatchTypePrefix, b.handlePause)
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/resume", tgbot.MatchTypePrefix, b.handleResume)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/cancel", tgbot.MatchTypeExact, b.handleCancel)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/help", tgbot.MatchTypeExact, b.handleHelp)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stats", tgbot.MatchTypeExact, b.handleStats)
@@ -135,16 +137,21 @@ func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 
 	var buttons [][]tgmodels.InlineKeyboardButton
 	for _, s := range searches {
-		status := "active"
+		prefix := ""
 		if !s.Active {
-			status = "paused"
+			prefix = "\u23f8 "
 		}
 		mfr := yad2.ManufacturerName(s.Manufacturer)
 		mdl := yad2.ModelName(s.Manufacturer, s.Model)
 
+		status := "active"
+		if !s.Active {
+			status = "paused"
+		}
+
 		sb.WriteString(fmt.Sprintf(
-			"#%d %s %s (%d–%d, max %s NIS) [%s]\n",
-			s.ID, mfr, mdl, s.YearMin, s.YearMax, formatNumber(s.PriceMax), status))
+			"%s#%d %s %s (%d\u2013%d, max %s NIS) [%s]\n",
+			prefix, s.ID, mfr, mdl, s.YearMin, s.YearMax, formatNumber(s.PriceMax), status))
 
 		buttons = append(buttons, []tgmodels.InlineKeyboardButton{{
 			Text:         fmt.Sprintf("Delete #%d", s.ID),
@@ -178,6 +185,72 @@ func (b *Bot) handleStop(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	b.send(ctx, chatID, fmt.Sprintf("Search #%d deleted.", id))
 }
 
+func (b *Bot) handlePause(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	chatID := update.Message.Chat.ID
+	parts := strings.Fields(update.Message.Text)
+	if len(parts) < 2 {
+		b.send(ctx, chatID, "Usage: /pause <search_id>\nUse /list to see your search IDs.")
+		return
+	}
+
+	id, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		b.send(ctx, chatID, "Invalid search ID. Use /list to see your searches.")
+		return
+	}
+
+	search, err := b.searches.GetSearch(ctx, id)
+	if err != nil || search == nil || search.ChatID != chatID {
+		b.send(ctx, chatID, "Search not found. Use /list to see your searches.")
+		return
+	}
+
+	if !search.Active {
+		b.send(ctx, chatID, fmt.Sprintf("Search #%d is already paused.", id))
+		return
+	}
+
+	if err := b.searches.SetSearchActive(ctx, id, false); err != nil {
+		b.send(ctx, chatID, "Failed to pause search.")
+		return
+	}
+
+	b.send(ctx, chatID, fmt.Sprintf("Search #%d paused. Use /resume %d to resume it.", id, id))
+}
+
+func (b *Bot) handleResume(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	chatID := update.Message.Chat.ID
+	parts := strings.Fields(update.Message.Text)
+	if len(parts) < 2 {
+		b.send(ctx, chatID, "Usage: /resume <search_id>\nUse /list to see your search IDs.")
+		return
+	}
+
+	id, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		b.send(ctx, chatID, "Invalid search ID. Use /list to see your searches.")
+		return
+	}
+
+	search, err := b.searches.GetSearch(ctx, id)
+	if err != nil || search == nil || search.ChatID != chatID {
+		b.send(ctx, chatID, "Search not found. Use /list to see your searches.")
+		return
+	}
+
+	if search.Active {
+		b.send(ctx, chatID, fmt.Sprintf("Search #%d is already active.", id))
+		return
+	}
+
+	if err := b.searches.SetSearchActive(ctx, id, true); err != nil {
+		b.send(ctx, chatID, "Failed to resume search.")
+		return
+	}
+
+	b.send(ctx, chatID, fmt.Sprintf("Search #%d resumed.", id))
+}
+
 func (b *Bot) handleCancel(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
 	chatID := update.Message.Chat.ID
 	_ = b.users.UpdateUserState(ctx, chatID, StateIdle, "{}")
@@ -189,6 +262,8 @@ func (b *Bot) handleHelp(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 		"*CarWatch Commands:*\n\n"+
 			"/watch — Set up a new car search\n"+
 			"/list — Show your active searches\n"+
+			"/pause <id> — Pause a search\n"+
+			"/resume <id> — Resume a paused search\n"+
 			"/stop <id> — Delete a search\n"+
 			"/cancel — Cancel current wizard\n"+
 			"/help — Show this message")

--- a/internal/bot/pause_resume_test.go
+++ b/internal/bot/pause_resume_test.go
@@ -1,0 +1,229 @@
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func TestPauseSearch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 200, "bob")
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 200, Name: "test-pause", Manufacturer: 1, Model: 1,
+		YearMin: 2020, YearMax: 2024, PriceMax: 100000,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	// Search starts active
+	s, err := store.GetSearch(ctx, id)
+	if err != nil {
+		t.Fatalf("get search: %v", err)
+	}
+	if !s.Active {
+		t.Error("new search should be active")
+	}
+
+	// Pause it
+	if err := store.SetSearchActive(ctx, id, false); err != nil {
+		t.Fatalf("pause search: %v", err)
+	}
+
+	s, err = store.GetSearch(ctx, id)
+	if err != nil {
+		t.Fatalf("get search after pause: %v", err)
+	}
+	if s.Active {
+		t.Error("search should be paused after SetSearchActive(false)")
+	}
+
+	// Paused searches should not appear in active count
+	count, _ := store.CountSearches(ctx, 200)
+	if count != 0 {
+		t.Errorf("active count = %d, want 0 (search is paused)", count)
+	}
+
+	// Paused searches should not appear in ListAllActiveSearches
+	active, _ := store.ListAllActiveSearches(ctx)
+	for _, a := range active {
+		if a.ID == id {
+			t.Error("paused search should not appear in ListAllActiveSearches")
+		}
+	}
+}
+
+func TestResumeSearch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 300, "carol")
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 300, Name: "test-resume", Manufacturer: 2, Model: 1,
+		YearMin: 2019, YearMax: 2023, PriceMax: 200000,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	// Pause then resume
+	if err := store.SetSearchActive(ctx, id, false); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if err := store.SetSearchActive(ctx, id, true); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+
+	s, err := store.GetSearch(ctx, id)
+	if err != nil {
+		t.Fatalf("get search after resume: %v", err)
+	}
+	if !s.Active {
+		t.Error("search should be active after resume")
+	}
+
+	// Resumed search should appear in active count
+	count, _ := store.CountSearches(ctx, 300)
+	if count != 1 {
+		t.Errorf("active count = %d, want 1", count)
+	}
+}
+
+func TestPauseSearchOwnership(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 400, "dave")
+	_ = store.UpsertUser(ctx, 401, "eve")
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 400, Name: "dave-search", Manufacturer: 3, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	// Verify ownership check: GetSearch returns the search but chatID won't match
+	s, err := store.GetSearch(ctx, id)
+	if err != nil {
+		t.Fatalf("get search: %v", err)
+	}
+	if s.ChatID != 400 {
+		t.Errorf("search owner = %d, want 400", s.ChatID)
+	}
+
+	// Eve's chatID (401) doesn't match - the handler would reject this
+	if s.ChatID == 401 {
+		t.Error("search should not belong to eve")
+	}
+}
+
+func TestPauseAlreadyPausedSearch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 500, "frank")
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 500, Name: "test-double-pause", Manufacturer: 4, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	// Pause it
+	if err := store.SetSearchActive(ctx, id, false); err != nil {
+		t.Fatalf("first pause: %v", err)
+	}
+
+	// Pause again - should succeed (idempotent)
+	if err := store.SetSearchActive(ctx, id, false); err != nil {
+		t.Fatalf("second pause: %v", err)
+	}
+
+	s, _ := store.GetSearch(ctx, id)
+	if s.Active {
+		t.Error("search should still be paused")
+	}
+}
+
+func TestResumeAlreadyActiveSearch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 600, "grace")
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 600, Name: "test-double-resume", Manufacturer: 5, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	// Resume an already active search - should succeed (idempotent)
+	if err := store.SetSearchActive(ctx, id, true); err != nil {
+		t.Fatalf("resume active search: %v", err)
+	}
+
+	s, _ := store.GetSearch(ctx, id)
+	if !s.Active {
+		t.Error("search should still be active")
+	}
+}
+
+func TestListSearchesShowsPausedStatus(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 700, "heidi")
+
+	id1, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 700, Name: "active-search", Manufacturer: 1, Model: 1,
+	})
+	id2, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 700, Name: "paused-search", Manufacturer: 2, Model: 1,
+	})
+
+	// Pause the second search
+	_ = store.SetSearchActive(ctx, id2, false)
+
+	searches, err := store.ListSearches(ctx, 700)
+	if err != nil {
+		t.Fatalf("list searches: %v", err)
+	}
+	if len(searches) != 2 {
+		t.Fatalf("expected 2 searches, got %d", len(searches))
+	}
+
+	// Verify both searches are returned with correct active status
+	statusByID := make(map[int64]bool)
+	for _, s := range searches {
+		statusByID[s.ID] = s.Active
+	}
+
+	if !statusByID[id1] {
+		t.Error("search 1 should be active")
+	}
+	if statusByID[id2] {
+		t.Error("search 2 should be paused")
+	}
+}
+
+func TestGetSearchNonExistent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	s, err := store.GetSearch(ctx, 99999)
+	if err != nil {
+		t.Fatalf("get non-existent search: %v", err)
+	}
+	if s != nil {
+		t.Error("expected nil for non-existent search")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `/pause <id>` and `/resume <id>` bot commands that toggle search active state via `SetSearchActive`
- Both commands verify ownership (chat ID match) before modifying the search
- Update `/list` output to show paused searches with a ⏸ prefix and `[paused]` status
- Update `/help` to document the new commands
- Add tests covering pause, resume, ownership checks, idempotency, and list status display

Closes #73