### PR TITLE
Add per-user price drop alerts

### DIFF
--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -65,6 +65,40 @@ func FormatListing(l model.Listing) string {
 	return b.String()
 }
 
+func FormatPriceDrop(l model.Listing, oldPrice int) string {
+	var b strings.Builder
+
+	title := strings.TrimSpace(l.Manufacturer + " " + l.Model)
+	if l.SubModel != "" {
+		title += " " + l.SubModel
+	}
+	if l.Year > 0 {
+		title += fmt.Sprintf(" %d", l.Year)
+	}
+
+	drop := oldPrice - l.Price
+	b.WriteString(fmt.Sprintf("💰 *Price Drop!* %s: ₪%s → ₪%s (-₪%s)\n",
+		title,
+		formatNumber(oldPrice),
+		formatNumber(l.Price),
+		formatNumber(drop),
+	))
+
+	if l.Km > 0 {
+		b.WriteString(fmt.Sprintf("🛣️ %s km", formatNumber(l.Km)))
+		if l.Hand > 0 {
+			b.WriteString(fmt.Sprintf(" · ✋ Hand %d", l.Hand))
+		}
+		b.WriteString("\n")
+	}
+
+	if l.PageLink != "" {
+		b.WriteString(fmt.Sprintf("🔗 %s", l.PageLink))
+	}
+
+	return b.String()
+}
+
 func FormatBatch(listings []model.Listing) string {
 	if len(listings) == 1 {
 		return FormatListing(listings[0])

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -45,6 +45,64 @@ func TestFormatListing(t *testing.T) {
 	}
 }
 
+func TestFormatPriceDrop(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token:        "abc123",
+			Manufacturer: "Mazda",
+			Model:        "3",
+			Year:         2021,
+			Price:        89000,
+			Km:           85000,
+			Hand:         2,
+			PageLink:     "https://www.yad2.co.il/item/abc123",
+		},
+	}
+
+	msg := FormatPriceDrop(l, 95000)
+
+	checks := []string{
+		"Price Drop!",
+		"Mazda 3 2021",
+		"₪95,000",
+		"₪89,000",
+		"-₪6,000",
+		"85,000 km",
+		"Hand 2",
+		"https://www.yad2.co.il/item/abc123",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(msg, check) {
+			t.Errorf("message missing %q:\n%s", check, msg)
+		}
+	}
+}
+
+func TestFormatPriceDrop_MinimalFields(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token:        "xyz",
+			Manufacturer: "Toyota",
+			Model:        "Corolla",
+			SubModel:     "GLi",
+			Price:        70000,
+		},
+	}
+
+	msg := FormatPriceDrop(l, 80000)
+
+	if !strings.Contains(msg, "Toyota Corolla GLi") {
+		t.Errorf("should include submodel in title:\n%s", msg)
+	}
+	if !strings.Contains(msg, "-₪10,000") {
+		t.Errorf("should show correct drop amount:\n%s", msg)
+	}
+	if strings.Contains(msg, "km") {
+		t.Errorf("should not show mileage when zero:\n%s", msg)
+	}
+}
+
 func TestFormatNumber(t *testing.T) {
 	tests := []struct {
 		input int

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/dsionov/carwatch/internal/config"
@@ -145,6 +146,61 @@ func TestRunMultiTenantCycle_SharedScraping(t *testing.T) {
 	defer n.mu.Unlock()
 	if len(n.messages) != 2 {
 		t.Errorf("expected 2 notifications (one per user), got %d", len(n.messages))
+	}
+}
+
+func TestProcessGroup_PriceDropNotification(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Manufacturer: "Mazda", Model: "3", Price: 89000, Year: 2021, EngineVolume: 2000, Km: 50000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	pt := newMockPriceTracker()
+	pt.prices["a"] = 95000
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Prices:      pt,
+	})
+	ctx := context.Background()
+
+	err := s.runMultiTenantCycle(ctx)
+	if err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 Notify calls for price drop, got %d", len(n.messages))
+	}
+
+	if len(n.rawMessages) != 1 {
+		t.Fatalf("expected 1 NotifyRaw call for price drop, got %d", len(n.rawMessages))
+	}
+
+	if n.rawMessages[0].recipient != "100" {
+		t.Errorf("expected recipient '100', got %q", n.rawMessages[0].recipient)
+	}
+
+	msg := n.rawMessages[0].message
+	if !strings.Contains(msg, "Price Drop!") {
+		t.Errorf("price drop message should contain 'Price Drop!', got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "₪95,000") || !strings.Contains(msg, "₪89,000") {
+		t.Errorf("message should contain old and new prices, got:\n%s", msg)
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -263,6 +263,7 @@ func (s *Scheduler) processSearch(ctx context.Context, search config.SearchConfi
 	)
 
 	var newListings []model.Listing
+	var priceDropMessages []string
 	for _, l := range filtered {
 		if s.prices != nil && l.Price > 0 {
 			oldPrice, changed, err := s.prices.RecordPrice(ctx, l.Token, l.Price)
@@ -275,10 +276,8 @@ func (s *Scheduler) processSearch(ctx context.Context, search config.SearchConfi
 					"new_price", l.Price,
 					"search", search.Name,
 				)
-				newListings = append(newListings, model.Listing{
-					RawListing: l,
-					SearchName: search.Name,
-				})
+				listing := model.Listing{RawListing: l, SearchName: search.Name}
+				priceDropMessages = append(priceDropMessages, notifier.FormatPriceDrop(listing, oldPrice))
 				continue
 			}
 		}
@@ -310,6 +309,17 @@ func (s *Scheduler) processSearch(ctx context.Context, search config.SearchConfi
 				PageLink:     l.PageLink,
 				FirstSeenAt:  time.Now(),
 			})
+		}
+	}
+
+	for _, msg := range priceDropMessages {
+		for _, recipient := range search.Recipients {
+			if err := s.notifier.NotifyRaw(ctx, recipient, msg); err != nil {
+				s.logger.Error("price drop notification failed",
+					"recipient", maskPhone(recipient),
+					"error", err,
+				)
+			}
 		}
 	}
 
@@ -598,6 +608,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 		filtered := filter.Apply(criteria, raw)
 
 		var newListings []model.Listing
+		var priceDropMessages []string
 		for _, l := range filtered {
 			if l.Price > search.PriceMax && search.PriceMax > 0 {
 				continue
@@ -616,7 +627,8 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 						"old_price", oldPrice,
 						"new_price", l.Price,
 					)
-					newListings = append(newListings, model.Listing{RawListing: l, SearchName: search.Name})
+					listing := model.Listing{RawListing: l, SearchName: search.Name}
+					priceDropMessages = append(priceDropMessages, notifier.FormatPriceDrop(listing, oldPrice))
 					continue
 				}
 			}
@@ -643,6 +655,17 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			}
 		}
 
+		chatIDStr := fmt.Sprintf("%d", search.ChatID)
+
+		for _, msg := range priceDropMessages {
+			if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {
+				s.logger.Error("price drop notification failed",
+					"chat_id", search.ChatID,
+					"error", err,
+				)
+			}
+		}
+
 		if len(newListings) == 0 {
 			continue
 		}
@@ -653,7 +676,6 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			"count", len(newListings),
 		)
 
-		chatIDStr := fmt.Sprintf("%d", search.ChatID)
 		if err := s.notifier.Notify(ctx, chatIDStr, newListings); err != nil {
 			s.logger.Error("notification failed",
 				"chat_id", search.ChatID,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -68,9 +69,10 @@ func (m *mockDedup) Prune(_ context.Context, _ time.Duration) (int64, error) {
 func (m *mockDedup) Close() error { return nil }
 
 type mockNotifier struct {
-	messages []notifyCall
-	err      error
-	mu       sync.Mutex
+	messages    []notifyCall
+	rawMessages []rawNotifyCall
+	err         error
+	mu          sync.Mutex
 }
 
 type notifyCall struct {
@@ -78,9 +80,20 @@ type notifyCall struct {
 	count     int
 }
 
-func (m *mockNotifier) Connect(_ context.Context) error                       { return nil }
-func (m *mockNotifier) Disconnect() error                                     { return nil }
-func (m *mockNotifier) NotifyRaw(_ context.Context, _ string, _ string) error { return nil }
+type rawNotifyCall struct {
+	recipient string
+	message   string
+}
+
+func (m *mockNotifier) Connect(_ context.Context) error { return nil }
+func (m *mockNotifier) Disconnect() error               { return nil }
+
+func (m *mockNotifier) NotifyRaw(_ context.Context, recipient string, message string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rawMessages = append(m.rawMessages, rawNotifyCall{recipient: recipient, message: message})
+	return nil
+}
 
 func (m *mockNotifier) Notify(_ context.Context, recipient string, listings []model.Listing) error {
 	m.mu.Lock()
@@ -90,6 +103,26 @@ func (m *mockNotifier) Notify(_ context.Context, recipient string, listings []mo
 	}
 	m.messages = append(m.messages, notifyCall{recipient: recipient, count: len(listings)})
 	return nil
+}
+
+type mockPriceTracker struct {
+	prices map[string]int
+	mu     sync.Mutex
+}
+
+func newMockPriceTracker() *mockPriceTracker {
+	return &mockPriceTracker{prices: make(map[string]int)}
+}
+
+func (m *mockPriceTracker) RecordPrice(_ context.Context, token string, price int) (int, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	old, exists := m.prices[token]
+	m.prices[token] = price
+	if exists && price < old {
+		return old, true, nil
+	}
+	return 0, false, nil
 }
 
 func testConfig() *config.Config {
@@ -400,6 +433,52 @@ func TestMaskPhone(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("maskPhone(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestProcessSearch_PriceDropNotification(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 89000, Km: 85000},
+		},
+	}
+	d := newMockDedup()
+	// Pre-mark token as seen so the pagination pre-scan stops after page 0,
+	// avoiding duplicate copies of the same listing in allRaw.
+	d.seen[dedupKey{"a", 0}] = true
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	pt := newMockPriceTracker()
+	pt.prices["a"] = 95000
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{Prices: pt})
+	ctx := context.Background()
+
+	if err := s.processSearch(ctx, cfg.Searches[0]); err != nil {
+		t.Fatalf("processSearch: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 Notify calls for price drop (should use NotifyRaw), got %d", len(n.messages))
+	}
+
+	if len(n.rawMessages) != 1 {
+		t.Fatalf("expected 1 NotifyRaw call for price drop, got %d", len(n.rawMessages))
+	}
+
+	msg := n.rawMessages[0].message
+	if !strings.Contains(msg, "Price Drop!") {
+		t.Errorf("price drop message should contain 'Price Drop!', got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "₪95,000") || !strings.Contains(msg, "₪89,000") {
+		t.Errorf("price drop message should contain old and new price, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "-₪6,000") {
+		t.Errorf("price drop message should contain drop amount, got:\n%s", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `FormatPriceDrop` formatter that renders price drops as "Price Drop! Mazda 3 2021: ₪95,000 → ₪89,000 (-₪6,000)" with mileage, hand, and link
- Update both `processSearch` (single-tenant) and `processGroup` (multi-tenant) to send price drops as separate `NotifyRaw` messages instead of mixing them into new listing batches
- Add formatter tests (`TestFormatPriceDrop`, `TestFormatPriceDrop_MinimalFields`) and scheduler tests (`TestProcessSearch_PriceDropNotification`, `TestProcessGroup_PriceDropNotification`)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [x] Price drop formatter produces correct output with full and minimal fields
- [x] Single-tenant scheduler sends price drops via `NotifyRaw` (not `Notify`)
- [x] Multi-tenant scheduler sends price drops via `NotifyRaw` to correct chat ID

Closes #70