### PR TITLE
V3-19: Add multi-marketplace support with WinWin adapter

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/dashboard"
 	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/fetcher/winwin"
 	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/notifier/telegram"
@@ -80,8 +81,22 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 
 	cachingFetcher := fetcher.NewCachingFetcher(yad2Fetcher, 5*time.Minute)
+
+	var winwinFetcher *winwin.WinWinFetcher
+	if len(cfg.HTTP.Proxies) > 0 {
+		pool := fetcher.NewProxyPool(cfg.HTTP.Proxies)
+		winwinFetcher, err = winwin.NewFetcherWithProxyPool(cfg.HTTP.UserAgents, pool, logger)
+	} else {
+		winwinFetcher, err = winwin.NewFetcher(cfg.HTTP.UserAgents, cfg.HTTP.Proxy, logger)
+	}
+	if err != nil {
+		return fmt.Errorf("create winwin fetcher: %w", err)
+	}
+	cachingWinwin := fetcher.NewCachingFetcher(winwinFetcher, 5*time.Minute)
+
 	fetcherFactory := fetcher.NewFactory()
 	fetcherFactory.Register("yad2", cachingFetcher)
+	fetcherFactory.Register("winwin", cachingWinwin)
 
 	h := health.New()
 	h.SetUserCounter(store)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -109,7 +109,7 @@ func (b *Bot) handleStart(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	}
 
 	b.send(ctx, chatID,
-		"Welcome to *CarWatch*! I monitor Yad2 car listings and send you alerts when new matches appear.\n\n"+
+		"Welcome to *CarWatch*! I monitor car listings on Yad2 and WinWin and send you alerts when new matches appear.\n\n"+
 			"Use /watch to set up a new car search.\n"+
 			"Use /list to see your active searches.\n"+
 			"Use /help for all commands.")
@@ -209,10 +209,10 @@ func (b *Bot) handleWatch(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 		return
 	}
 
-	_ = b.users.UpdateUserState(ctx, chatID, StateAskManufacturer, "{}")
+	_ = b.users.UpdateUserState(ctx, chatID, StateAskSource, "{}")
 	b.sendWithKeyboard(ctx, chatID,
-		"What manufacturer are you looking for?",
-		manufacturerKeyboard())
+		"Which marketplace do you want to search?",
+		sourceKeyboard())
 }
 
 func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
@@ -247,9 +247,10 @@ func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 			status = "paused"
 		}
 
+		src := sourceDisplayName(s.Source)
 		sb.WriteString(fmt.Sprintf(
-			"%s#%d %s %s (%d\u2013%d, max %s NIS) [%s]\n",
-			prefix, s.ID, mfr, mdl, s.YearMin, s.YearMax, formatNumber(s.PriceMax), status))
+			"%s#%d [%s] %s %s (%d\u2013%d, max %s NIS) [%s]\n",
+			prefix, s.ID, src, mfr, mdl, s.YearMin, s.YearMax, formatNumber(s.PriceMax), status))
 
 		buttons = append(buttons, []tgmodels.InlineKeyboardButton{{
 			Text:         fmt.Sprintf("Delete #%d", s.ID),
@@ -418,6 +419,8 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	})
 
 	switch {
+	case strings.HasPrefix(data, cbPrefixSource):
+		b.onSourceSelected(ctx, chatID, data)
 	case strings.HasPrefix(data, cbPrefixMfr):
 		b.onManufacturerSelected(ctx, chatID, data)
 	case strings.HasPrefix(data, cbPrefixModel):
@@ -437,14 +440,23 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	}
 }
 
+func (b *Bot) onSourceSelected(ctx context.Context, chatID int64, data string) {
+	source := strings.TrimPrefix(data, cbPrefixSource)
+	wd := WizardData{Source: source}
+	b.saveWizardState(ctx, chatID, StateAskManufacturer, wd)
+
+	b.sendWithKeyboard(ctx, chatID,
+		"What manufacturer are you looking for?",
+		manufacturerKeyboard())
+}
+
 func (b *Bot) onManufacturerSelected(ctx context.Context, chatID int64, data string) {
 	idStr := strings.TrimPrefix(data, cbPrefixMfr)
 	id, _ := strconv.Atoi(idStr)
 
-	wd := WizardData{
-		Manufacturer:     id,
-		ManufacturerName: yad2.ManufacturerName(id),
-	}
+	wd := b.loadWizardData(ctx, chatID)
+	wd.Manufacturer = id
+	wd.ManufacturerName = yad2.ManufacturerName(id)
 	b.saveWizardState(ctx, chatID, StateAskModel, wd)
 
 	models := yad2.Models(id)
@@ -485,10 +497,16 @@ func (b *Bot) onEngineSelected(ctx context.Context, chatID int64, data string) {
 func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 	wd := b.loadWizardData(ctx, chatID)
 
+	source := wd.Source
+	if source == "" {
+		source = "yad2"
+	}
+
 	name := fmt.Sprintf("%s-%s", strings.ToLower(wd.ManufacturerName), strings.ToLower(wd.ModelName))
 	id, err := b.searches.CreateSearch(ctx, storage.Search{
 		ChatID:       chatID,
 		Name:         name,
+		Source:       source,
 		Manufacturer: wd.Manufacturer,
 		Model:        wd.Model,
 		YearMin:      wd.YearMin,
@@ -504,15 +522,15 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 
 	_ = b.users.UpdateUserState(ctx, chatID, StateIdle, "{}")
 	b.send(ctx, chatID, fmt.Sprintf(
-		"Search #%d saved! I'll check Yad2 every 15 minutes and send you new listings.\n\nUse /list to see your searches.",
-		id))
+		"Search #%d saved! I'll check %s every 15 minutes and send you new listings.\n\nUse /list to see your searches.",
+		id, sourceDisplayName(source)))
 }
 
 func (b *Bot) onEdit(ctx context.Context, chatID int64) {
-	_ = b.users.UpdateUserState(ctx, chatID, StateAskManufacturer, "{}")
+	_ = b.users.UpdateUserState(ctx, chatID, StateAskSource, "{}")
 	b.sendWithKeyboard(ctx, chatID,
-		"Let's start over. What manufacturer?",
-		manufacturerKeyboard())
+		"Let's start over. Which marketplace?",
+		sourceKeyboard())
 }
 
 func (b *Bot) onCancelCallback(ctx context.Context, chatID int64) {

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	cbPrefixSource    = "src:"
 	cbPrefixMfr       = "mfr:"
 	cbPrefixModel     = "mdl:"
 	cbPrefixEngine    = "eng:"
@@ -19,6 +20,17 @@ const (
 	cbDeleteSearch    = "del:"
 	cbPrefixShareCopy = "share_copy:"
 )
+
+func sourceKeyboard() *tgmodels.InlineKeyboardMarkup {
+	return &tgmodels.InlineKeyboardMarkup{
+		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+			{
+				{Text: "Yad2", CallbackData: cbPrefixSource + "yad2"},
+				{Text: "WinWin", CallbackData: cbPrefixSource + "winwin"},
+			},
+		},
+	}
+}
 
 func manufacturerKeyboard() *tgmodels.InlineKeyboardMarkup {
 	mfrs := yad2.Manufacturers()
@@ -74,18 +86,34 @@ func engineKeyboard() *tgmodels.InlineKeyboardMarkup {
 	}
 }
 
+func sourceDisplayName(source string) string {
+	switch source {
+	case "winwin":
+		return "WinWin"
+	default:
+		return "Yad2"
+	}
+}
+
 func confirmKeyboard(data WizardData) (*tgmodels.InlineKeyboardMarkup, string) {
 	engineStr := "Any"
 	if data.EngineMinCC > 0 {
 		engineStr = fmt.Sprintf("%.1fL+", float64(data.EngineMinCC)/1000)
 	}
 
+	source := data.Source
+	if source == "" {
+		source = "yad2"
+	}
+
 	summary := fmt.Sprintf(
 		"*Your search:*\n"+
+			"Source: %s\n"+
 			"Car: %s %s\n"+
 			"Year: %d–%d\n"+
 			"Max price: %s NIS\n"+
 			"Engine: %s",
+		sourceDisplayName(source),
 		data.ManufacturerName, data.ModelName,
 		data.YearMin, data.YearMax,
 		formatNumber(data.PriceMax),

--- a/internal/bot/state.go
+++ b/internal/bot/state.go
@@ -2,6 +2,7 @@ package bot
 
 const (
 	StateIdle            = "idle"
+	StateAskSource       = "ask_source"
 	StateAskManufacturer = "ask_manufacturer"
 	StateAskModel        = "ask_model"
 	StateAskYearMin      = "ask_year_min"
@@ -12,6 +13,7 @@ const (
 )
 
 type WizardData struct {
+	Source          string `json:"source,omitempty"`
 	Manufacturer    int    `json:"manufacturer,omitempty"`
 	ManufacturerName string `json:"manufacturer_name,omitempty"`
 	Model           int    `json:"model,omitempty"`

--- a/internal/bot/wizard_test.go
+++ b/internal/bot/wizard_test.go
@@ -115,6 +115,91 @@ func TestLoadWizardData_Populated(t *testing.T) {
 	}
 }
 
+func TestWizardData_Source(t *testing.T) {
+	data := `{"source":"winwin","manufacturer":27,"manufacturer_name":"Mazda"}`
+	var wd WizardData
+	if err := json.Unmarshal([]byte(data), &wd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wd.Source != "winwin" {
+		t.Errorf("Source = %q, want %q", wd.Source, "winwin")
+	}
+	if wd.Manufacturer != 27 {
+		t.Errorf("Manufacturer = %d, want 27", wd.Manufacturer)
+	}
+}
+
+func TestWizardCompleteFlow_WithSource(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 100, "alice")
+
+	wd := WizardData{
+		Source:           "winwin",
+		Manufacturer:     27,
+		ManufacturerName: "Mazda",
+		Model:            10332,
+		ModelName:        "3",
+		YearMin:          2018,
+		YearMax:          2024,
+		PriceMax:         150000,
+		EngineMinCC:      2000,
+	}
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID:       100,
+		Name:         "mazda-3",
+		Source:       wd.Source,
+		Manufacturer: wd.Manufacturer,
+		Model:        wd.Model,
+		YearMin:      wd.YearMin,
+		YearMax:      wd.YearMax,
+		PriceMax:     wd.PriceMax,
+		EngineMinCC:  wd.EngineMinCC,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+	if id == 0 {
+		t.Error("expected non-zero search ID")
+	}
+
+	searches, _ := store.ListSearches(ctx, 100)
+	if len(searches) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(searches))
+	}
+	if searches[0].Source != "winwin" {
+		t.Errorf("Source = %q, want %q", searches[0].Source, "winwin")
+	}
+}
+
+func TestSourceDefaultsToYad2(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.UpsertUser(ctx, 100, "alice")
+
+	// Create search with empty source - should default to yad2.
+	_, err := store.CreateSearch(ctx, storage.Search{
+		ChatID:       100,
+		Name:         "mazda-3",
+		Manufacturer: 27,
+		Model:        10332,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	searches, _ := store.ListSearches(ctx, 100)
+	if len(searches) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(searches))
+	}
+	if searches[0].Source != "yad2" {
+		t.Errorf("Source = %q, want %q (default)", searches[0].Source, "yad2")
+	}
+}
+
 func TestSearchRateLimit(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/fetcher/winwin/client.go
+++ b/internal/fetcher/winwin/client.go
@@ -1,0 +1,53 @@
+package winwin
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client wraps an HTTP client configured for WinWin requests.
+type Client struct {
+	httpClient *http.Client
+	userAgents []string
+}
+
+// NewClient creates an HTTP client with optional proxy support.
+func NewClient(userAgents []string, proxy string) (*Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 10
+	transport.MaxIdleConnsPerHost = 5
+	transport.IdleConnTimeout = 90 * time.Second
+
+	if proxy != "" {
+		proxyURL, err := url.Parse(proxy)
+		if err != nil {
+			return nil, fmt.Errorf("parse proxy URL: %w", err)
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Transport: transport,
+			Timeout:   30 * time.Second,
+		},
+		userAgents: userAgents,
+	}, nil
+}
+
+// Do executes an HTTP request with browser-like headers for winwin.co.il.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	ua := c.userAgents[rand.IntN(len(c.userAgents))]
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7")
+	req.Header.Set("Accept-Encoding", "gzip, deflate")
+	req.Header.Set("DNT", "1")
+	req.Header.Set("Upgrade-Insecure-Requests", "1")
+	req.Header.Set("Cache-Control", "max-age=0")
+
+	return c.httpClient.Do(req)
+}

--- a/internal/fetcher/winwin/parser.go
+++ b/internal/fetcher/winwin/parser.go
@@ -1,0 +1,15 @@
+package winwin
+
+import (
+	"io"
+
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+// ParseListingsPage parses WinWin HTML into raw listings.
+// TODO: Implement actual HTML parsing once the WinWin page structure is
+// reverse-engineered. The parser should extract listing tokens, prices,
+// years, mileage, etc. from the HTML response body.
+func ParseListingsPage(_ io.Reader) ([]model.RawListing, error) {
+	return nil, nil
+}

--- a/internal/fetcher/winwin/url.go
+++ b/internal/fetcher/winwin/url.go
@@ -1,0 +1,43 @@
+package winwin
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/dsionov/carwatch/internal/config"
+)
+
+const defaultBaseURL = "https://www.winwin.co.il/vehicles/cars"
+
+// buildURL constructs a WinWin search URL from the given parameters.
+// TODO: Reverse-engineer the actual WinWin URL structure and query parameters.
+// The parameters below are placeholders based on common patterns.
+func buildURL(base string, params config.SourceParams) string {
+	u, _ := url.Parse(base)
+	v := url.Values{}
+
+	if params.Manufacturer > 0 {
+		v.Set("manufacturer", strconv.Itoa(params.Manufacturer))
+	}
+	if params.Model > 0 {
+		v.Set("model", strconv.Itoa(params.Model))
+	}
+	if params.YearMin > 0 {
+		v.Set("yearFrom", strconv.Itoa(params.YearMin))
+	}
+	if params.YearMax > 0 {
+		v.Set("yearTo", strconv.Itoa(params.YearMax))
+	}
+	if params.PriceMin > 0 {
+		v.Set("priceFrom", strconv.Itoa(params.PriceMin))
+	}
+	if params.PriceMax > 0 {
+		v.Set("priceTo", strconv.Itoa(params.PriceMax))
+	}
+	if params.Page > 0 {
+		v.Set("page", strconv.Itoa(params.Page))
+	}
+
+	u.RawQuery = v.Encode()
+	return u.String()
+}

--- a/internal/fetcher/winwin/winwin.go
+++ b/internal/fetcher/winwin/winwin.go
@@ -1,0 +1,63 @@
+package winwin
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+// WinWinFetcher implements the fetcher.Fetcher interface for winwin.co.il.
+type WinWinFetcher struct {
+	client    *Client
+	baseURL   string
+	logger    *slog.Logger
+	proxyPool *fetcher.ProxyPool
+}
+
+// NewFetcher creates a WinWin fetcher with optional proxy support.
+func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*WinWinFetcher, error) {
+	client, err := NewClient(userAgents, proxy)
+	if err != nil {
+		return nil, err
+	}
+	return &WinWinFetcher{
+		client:  client,
+		baseURL: defaultBaseURL,
+		logger:  logger,
+	}, nil
+}
+
+// NewFetcherWithProxyPool creates a WinWin fetcher with rotating proxy support.
+func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logger *slog.Logger) (*WinWinFetcher, error) {
+	proxy := ""
+	if pool != nil {
+		proxy = pool.Next()
+	}
+	client, err := NewClient(userAgents, proxy)
+	if err != nil {
+		return nil, err
+	}
+	return &WinWinFetcher{
+		client:    client,
+		baseURL:   defaultBaseURL,
+		logger:    logger,
+		proxyPool: pool,
+	}, nil
+}
+
+// Fetch retrieves car listings from WinWin.
+// TODO: Implement actual scraping logic once the WinWin API/page structure
+// is reverse-engineered. For now this returns empty results so the fetcher
+// can be registered and tested end-to-end without hitting a real server.
+func (f *WinWinFetcher) Fetch(ctx context.Context, params config.SourceParams) ([]model.RawListing, error) {
+	reqURL := buildURL(f.baseURL, params)
+	f.logger.Info("winwin fetch stub", "url", reqURL)
+
+	// TODO: Make HTTP request, parse response, return listings.
+	// The full implementation requires reverse-engineering the WinWin
+	// HTML structure or discovering a JSON API endpoint.
+	return nil, nil
+}

--- a/internal/fetcher/winwin/winwin_test.go
+++ b/internal/fetcher/winwin/winwin_test.go
@@ -1,0 +1,83 @@
+package winwin
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/config"
+)
+
+func TestWinWinFetcher_StubReturnsEmpty(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	f, err := NewFetcher([]string{"TestAgent/1.0"}, "", logger)
+	if err != nil {
+		t.Fatalf("NewFetcher: %v", err)
+	}
+
+	listings, err := f.Fetch(context.Background(), config.SourceParams{
+		Manufacturer: 27,
+		Model:        10332,
+		YearMin:      2020,
+		YearMax:      2024,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings from stub, got %d", len(listings))
+	}
+}
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		params config.SourceParams
+		want   string
+	}{
+		{
+			name:   "empty params",
+			params: config.SourceParams{},
+			want:   "https://www.winwin.co.il/vehicles/cars",
+		},
+		{
+			name: "full params",
+			params: config.SourceParams{
+				Manufacturer: 27,
+				Model:        10332,
+				YearMin:      2020,
+				YearMax:      2024,
+				PriceMax:     150000,
+			},
+			want: "https://www.winwin.co.il/vehicles/cars?manufacturer=27&model=10332&priceTo=150000&yearFrom=2020&yearTo=2024",
+		},
+		{
+			name: "with page",
+			params: config.SourceParams{
+				Manufacturer: 35,
+				Page:         2,
+			},
+			want: "https://www.winwin.co.il/vehicles/cars?manufacturer=35&page=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildURL(defaultBaseURL, tt.params)
+			if got != tt.want {
+				t.Errorf("buildURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseListingsPage_Stub(t *testing.T) {
+	listings, err := ParseListingsPage(nil)
+	if err != nil {
+		t.Fatalf("ParseListingsPage: %v", err)
+	}
+	if listings != nil {
+		t.Errorf("expected nil from stub parser, got %v", listings)
+	}
+}

--- a/internal/scheduler/grouper.go
+++ b/internal/scheduler/grouper.go
@@ -6,6 +6,7 @@ import (
 )
 
 type CanonicalGroup struct {
+	Source       string
 	Manufacturer int
 	Model        int
 	Params       config.SourceParams
@@ -14,6 +15,7 @@ type CanonicalGroup struct {
 
 func GroupSearches(searches []storage.Search) []CanonicalGroup {
 	type groupKey struct {
+		Source       string
 		Manufacturer int
 		Model        int
 	}
@@ -21,10 +23,15 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 	grouped := make(map[groupKey]*CanonicalGroup)
 
 	for _, s := range searches {
-		key := groupKey{s.Manufacturer, s.Model}
+		source := s.Source
+		if source == "" {
+			source = "yad2"
+		}
+		key := groupKey{source, s.Manufacturer, s.Model}
 		g, ok := grouped[key]
 		if !ok {
 			g = &CanonicalGroup{
+				Source:       source,
 				Manufacturer: s.Manufacturer,
 				Model:        s.Model,
 				Params: config.SourceParams{

--- a/internal/scheduler/grouper_test.go
+++ b/internal/scheduler/grouper_test.go
@@ -51,3 +51,67 @@ func TestGroupSearches_Empty(t *testing.T) {
 		t.Errorf("expected 0 groups, got %d", len(groups))
 	}
 }
+
+func TestGroupSearches_GroupBySource(t *testing.T) {
+	searches := []storage.Search{
+		{ID: 1, ChatID: 100, Source: "yad2", Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024, PriceMax: 150000},
+		{ID: 2, ChatID: 200, Source: "winwin", Manufacturer: 27, Model: 10332, YearMin: 2020, YearMax: 2026, PriceMax: 200000},
+		{ID: 3, ChatID: 300, Source: "yad2", Manufacturer: 27, Model: 10332, YearMin: 2019, YearMax: 2025, PriceMax: 180000},
+	}
+
+	groups := GroupSearches(searches)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups (same car, different sources), got %d", len(groups))
+	}
+
+	// Find each group by source.
+	var yad2Group, winwinGroup *CanonicalGroup
+	for i := range groups {
+		switch groups[i].Source {
+		case "yad2":
+			yad2Group = &groups[i]
+		case "winwin":
+			winwinGroup = &groups[i]
+		}
+	}
+
+	if yad2Group == nil || winwinGroup == nil {
+		t.Fatal("expected one yad2 group and one winwin group")
+	}
+
+	if len(yad2Group.Searches) != 2 {
+		t.Errorf("yad2 group has %d searches, want 2", len(yad2Group.Searches))
+	}
+	if len(winwinGroup.Searches) != 1 {
+		t.Errorf("winwin group has %d searches, want 1", len(winwinGroup.Searches))
+	}
+
+	// Verify yad2 group merged params correctly.
+	if yad2Group.Params.YearMin != 2018 {
+		t.Errorf("yad2 YearMin = %d, want 2018", yad2Group.Params.YearMin)
+	}
+	if yad2Group.Params.YearMax != 2025 {
+		t.Errorf("yad2 YearMax = %d, want 2025", yad2Group.Params.YearMax)
+	}
+	if yad2Group.Params.PriceMax != 180000 {
+		t.Errorf("yad2 PriceMax = %d, want 180000", yad2Group.Params.PriceMax)
+	}
+}
+
+func TestGroupSearches_EmptySourceDefaultsToYad2(t *testing.T) {
+	searches := []storage.Search{
+		{ID: 1, ChatID: 100, Source: "", Manufacturer: 27, Model: 10332},
+		{ID: 2, ChatID: 200, Source: "yad2", Manufacturer: 27, Model: 10332},
+	}
+
+	groups := GroupSearches(searches)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group (empty source defaults to yad2), got %d", len(groups))
+	}
+	if groups[0].Source != "yad2" {
+		t.Errorf("Source = %q, want %q", groups[0].Source, "yad2")
+	}
+	if len(groups[0].Searches) != 2 {
+		t.Errorf("expected 2 searches in group, got %d", len(groups[0].Searches))
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -592,7 +592,11 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 	fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
-	activeFetcher := s.fetcherForSource("yad2")
+	source := group.Source
+	if source == "" {
+		source = "yad2"
+	}
+	activeFetcher := s.fetcherForSource(source)
 	raw, err := s.fetchWithRetryUsing(fetchCtx, activeFetcher, group.Params)
 	if err != nil {
 		return err

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -18,6 +18,7 @@ type Search struct {
 	ID           int64
 	ChatID       int64
 	Name         string
+	Source       string
 	Manufacturer int
 	Model        int
 	YearMin      int

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -52,6 +52,7 @@ func migrate(db *sql.DB) error {
 			id            INTEGER PRIMARY KEY AUTOINCREMENT,
 			chat_id       INTEGER NOT NULL REFERENCES users(chat_id),
 			name          TEXT NOT NULL,
+			source        TEXT NOT NULL DEFAULT 'yad2',
 			manufacturer  INTEGER NOT NULL,
 			model         INTEGER NOT NULL,
 			year_min      INTEGER NOT NULL DEFAULT 2000,
@@ -175,10 +176,14 @@ func scanUsers(rows *sql.Rows) ([]storage.User, error) {
 // --- SearchStore ---
 
 func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64, error) {
+	source := search.Source
+	if source == "" {
+		source = "yad2"
+	}
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO searches (chat_id, name, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		search.ChatID, search.Name, search.Manufacturer, search.Model,
+		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax,
 		search.EngineMinCC, search.MaxKm, search.MaxHand)
 	if err != nil {
@@ -189,7 +194,7 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, name, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
+		SELECT id, chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
 		FROM searches WHERE chat_id = ? ORDER BY created_at DESC`, chatID)
 	if err != nil {
 		return nil, err
@@ -200,11 +205,11 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 
 func (s *Store) GetSearch(ctx context.Context, id int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, name, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
+		SELECT id, chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
 		FROM searches WHERE id = ?`, id)
 
 	var search storage.Search
-	err := row.Scan(&search.ID, &search.ChatID, &search.Name, &search.Manufacturer, &search.Model,
+	err := row.Scan(&search.ID, &search.ChatID, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Active, &search.CreatedAt)
@@ -231,11 +236,11 @@ func (s *Store) SetSearchActive(ctx context.Context, id int64, active bool) erro
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.chat_id, s.name, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.active, s.created_at
+		SELECT s.id, s.chat_id, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.active, s.created_at
 		FROM searches s
 		JOIN users u ON s.chat_id = u.chat_id
 		WHERE s.active = true AND u.active = true
-		ORDER BY s.manufacturer, s.model`)
+		ORDER BY s.source, s.manufacturer, s.model`)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +267,7 @@ func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 	var searches []storage.Search
 	for rows.Next() {
 		var s storage.Search
-		if err := rows.Scan(&s.ID, &s.ChatID, &s.Name, &s.Manufacturer, &s.Model,
+		if err := rows.Scan(&s.ID, &s.ChatID, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
 			&s.YearMin, &s.YearMax, &s.PriceMax,
 			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
 			&s.Active, &s.CreatedAt); err != nil {


### PR DESCRIPTION
## Summary

- Add `Source` field to `storage.Search` and SQLite schema (defaults to `"yad2"` for backward compatibility)
- Introduce `StateAskSource` wizard step with inline keyboard letting users choose between Yad2 and WinWin
- Update `GroupSearches` to group by `{source, manufacturer, model}` so each marketplace is fetched independently
- Create `internal/fetcher/winwin/` package with full structure (client, URL builder, parser, fetcher) -- currently a stub returning empty results pending reverse-engineering of winwin.co.il
- Register WinWin fetcher in `cmd/bot/main.go` alongside Yad2
- Update `processGroup` to dynamically select the fetcher based on the group's source
- Add tests for source-based grouping, empty-source default, WinWin stub, and wizard source selection

Closes #78

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 16 packages)
- [ ] Manual: `/watch` command now shows marketplace selection before manufacturer
- [ ] Manual: `/list` shows `[Yad2]` or `[WinWin]` prefix per search
- [ ] Manual: confirm summary includes source line
- [ ] Verify existing yad2-only searches continue working (source defaults to "yad2")

🤖 Generated with [Claude Code](https://claude.com/claude-code)