### PR TITLE
V3-12: Add notification digest mode

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -20,6 +20,7 @@ type Bot struct {
 	bot         *tgbot.Bot
 	users       storage.UserStore
 	searches    storage.SearchStore
+	digests     storage.DigestStore
 	adminChatID int64
 	maxSearches int
 	botUsername  string
@@ -32,6 +33,7 @@ type Config struct {
 	MaxSearches int
 	BotUsername  string
 	Health      *health.Status
+	Digests     storage.DigestStore
 }
 
 func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cfg Config, logger *slog.Logger) *Bot {
@@ -42,6 +44,7 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 		bot:         b,
 		users:       users,
 		searches:    searches,
+		digests:     cfg.Digests,
 		adminChatID: cfg.AdminChatID,
 		maxSearches: cfg.MaxSearches,
 		botUsername:  cfg.BotUsername,
@@ -68,6 +71,7 @@ func (b *Bot) RegisterHandlers() {
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/share", tgbot.MatchTypePrefix, b.handleShare)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/cancel", tgbot.MatchTypeExact, b.handleCancel)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/help", tgbot.MatchTypeExact, b.handleHelp)
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/digest", tgbot.MatchTypeExact, b.handleDigest)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/settings", tgbot.MatchTypeExact, b.handleSettings)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stats", tgbot.MatchTypeExact, b.handleStats)
 	b.bot.RegisterHandler(tgbot.HandlerTypeCallbackQueryData, "", tgbot.MatchTypePrefix, b.handleCallback)
@@ -364,6 +368,7 @@ func (b *Bot) handleHelp(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 			"/resume <id> — Resume a paused search\n"+
 			"/stop <id> — Delete a search\n"+
 			"/share <id> — Share a search via link\n"+
+			"/digest — Toggle notification mode (instant/digest)\n"+
 			"/settings — View your current limits\n"+
 			"/cancel — Cancel current wizard\n"+
 			"/help — Show this message")
@@ -403,6 +408,45 @@ func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	b.send(ctx, chatID, sb.String())
 }
 
+func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	chatID := update.Message.Chat.ID
+	b.ensureUser(ctx, chatID, update.Message.From.Username)
+
+	if b.digests == nil {
+		b.send(ctx, chatID, "Digest mode is not available.")
+		return
+	}
+
+	mode, interval, err := b.digests.GetDigestMode(ctx, chatID)
+	if err != nil {
+		b.send(ctx, chatID, "Failed to load digest settings.")
+		return
+	}
+
+	var kb *tgmodels.InlineKeyboardMarkup
+	if mode == "digest" {
+		kb = &tgmodels.InlineKeyboardMarkup{
+			InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+				{
+					{Text: "Switch to instant", CallbackData: cbDigestOff},
+				},
+			},
+		}
+		b.sendWithKeyboard(ctx, chatID,
+			fmt.Sprintf("*Notification mode:* digest (every %s)\n\nNew listings are batched and sent periodically.", interval), kb)
+	} else {
+		kb = &tgmodels.InlineKeyboardMarkup{
+			InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+				{
+					{Text: "Switch to digest (every 6h)", CallbackData: cbDigestOn},
+				},
+			},
+		}
+		b.sendWithKeyboard(ctx, chatID,
+			"*Notification mode:* instant\n\nNew listings are sent immediately as they are found.", kb)
+	}
+}
+
 // --- Callback Handler ---
 
 func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
@@ -434,6 +478,10 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 		b.onDeleteSearch(ctx, chatID, data)
 	case strings.HasPrefix(data, cbPrefixShareCopy):
 		b.onShareCopy(ctx, chatID, data)
+	case data == cbDigestOn:
+		b.onDigestOn(ctx, chatID)
+	case data == cbDigestOff:
+		b.onDigestOff(ctx, chatID)
 	}
 }
 
@@ -579,6 +627,28 @@ func (b *Bot) onShareCopy(ctx context.Context, chatID int64, data string) {
 	b.send(ctx, chatID, fmt.Sprintf(
 		"Search #%d saved! I'll check Yad2 every 15 minutes and send you new listings.\n\nUse /list to see your searches.",
 		newID))
+}
+
+func (b *Bot) onDigestOn(ctx context.Context, chatID int64) {
+	if b.digests == nil {
+		return
+	}
+	if err := b.digests.SetDigestMode(ctx, chatID, "digest", "6h"); err != nil {
+		b.send(ctx, chatID, "Failed to update digest mode.")
+		return
+	}
+	b.send(ctx, chatID, "Switched to *digest* mode. Listings will be batched and sent every 6 hours.")
+}
+
+func (b *Bot) onDigestOff(ctx context.Context, chatID int64) {
+	if b.digests == nil {
+		return
+	}
+	if err := b.digests.SetDigestMode(ctx, chatID, "instant", "6h"); err != nil {
+		b.send(ctx, chatID, "Failed to update digest mode.")
+		return
+	}
+	b.send(ctx, chatID, "Switched to *instant* mode. Listings will be sent immediately.")
 }
 
 // --- Default Handler (free text during wizard) ---

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -18,6 +18,8 @@ const (
 	cbCancel          = "confirm:cancel"
 	cbDeleteSearch    = "del:"
 	cbPrefixShareCopy = "share_copy:"
+	cbDigestOn        = "digest:on"
+	cbDigestOff       = "digest:off"
 )
 
 func manufacturerKeyboard() *tgmodels.InlineKeyboardMarkup {

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -3,7 +3,9 @@ package scheduler
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/model"
@@ -201,6 +203,270 @@ func TestProcessGroup_PriceDropNotification(t *testing.T) {
 	}
 	if !strings.Contains(msg, "₪95,000") || !strings.Contains(msg, "₪89,000") {
 		t.Errorf("message should contain old and new prices, got:\n%s", msg)
+	}
+}
+
+type mockDigestStore struct {
+	mu       sync.Mutex
+	modes    map[int64]struct{ mode, interval string }
+	items    map[int64][]string
+	flushed  map[int64]time.Time
+}
+
+func newMockDigestStore() *mockDigestStore {
+	return &mockDigestStore{
+		modes:   make(map[int64]struct{ mode, interval string }),
+		items:   make(map[int64][]string),
+		flushed: make(map[int64]time.Time),
+	}
+}
+
+func (m *mockDigestStore) SetDigestMode(_ context.Context, chatID int64, mode string, interval string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.modes[chatID] = struct{ mode, interval string }{mode, interval}
+	return nil
+}
+
+func (m *mockDigestStore) GetDigestMode(_ context.Context, chatID int64) (string, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.modes[chatID]; ok {
+		return v.mode, v.interval, nil
+	}
+	return "instant", "6h", nil
+}
+
+func (m *mockDigestStore) AddDigestItem(_ context.Context, chatID int64, payload string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items[chatID] = append(m.items[chatID], payload)
+	return nil
+}
+
+func (m *mockDigestStore) FlushDigest(_ context.Context, chatID int64) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	items := m.items[chatID]
+	delete(m.items, chatID)
+	m.flushed[chatID] = time.Now()
+	return items, nil
+}
+
+func (m *mockDigestStore) PendingDigestUsers(_ context.Context) ([]int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var users []int64
+	for chatID := range m.items {
+		if len(m.items[chatID]) > 0 {
+			users = append(users, chatID)
+		}
+	}
+	return users, nil
+}
+
+func (m *mockDigestStore) DigestLastFlushed(_ context.Context, chatID int64) (time.Time, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.flushed[chatID], nil
+}
+
+func TestProcessGroup_DigestMode_StoresInsteadOfSending(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Manufacturer: "Mazda", Model: "3", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ds := newMockDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "6h")
+	// Set last flushed to now so processDigests won't flush immediately.
+	ds.flushed[100] = time.Now()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+	ctx := context.Background()
+
+	err := s.runMultiTenantCycle(ctx)
+	if err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	// Should NOT have sent any direct Notify calls.
+	n.mu.Lock()
+	notifyCount := len(n.messages)
+	rawCount := len(n.rawMessages)
+	n.mu.Unlock()
+	if notifyCount != 0 {
+		t.Errorf("expected 0 direct Notify calls, got %d", notifyCount)
+	}
+	if rawCount != 0 {
+		t.Errorf("expected 0 NotifyRaw calls (digest interval not elapsed), got %d", rawCount)
+	}
+
+	// Should have stored the item in the digest store.
+	ds.mu.Lock()
+	items := ds.items[100]
+	ds.mu.Unlock()
+	if len(items) != 1 {
+		t.Errorf("expected 1 digest item, got %d", len(items))
+	}
+}
+
+func TestProcessGroup_InstantMode_SendsDirectly(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Manufacturer: "Mazda", Model: "3", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ds := newMockDigestStore()
+	// Default is instant, no need to set.
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+	ctx := context.Background()
+
+	err := s.runMultiTenantCycle(ctx)
+	if err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	// Should have sent directly.
+	n.mu.Lock()
+	notifyCount := len(n.messages)
+	n.mu.Unlock()
+	if notifyCount != 1 {
+		t.Errorf("expected 1 direct notification, got %d", notifyCount)
+	}
+
+	// Digest store should be empty.
+	ds.mu.Lock()
+	items := ds.items[100]
+	ds.mu.Unlock()
+	if len(items) != 0 {
+		t.Errorf("expected 0 digest items, got %d", len(items))
+	}
+}
+
+func TestProcessDigests_FlushesWhenIntervalElapsed(t *testing.T) {
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ds := newMockDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "1ms")
+	ds.items[100] = []string{"listing A", "listing B"}
+	// Set last flushed to epoch so interval has elapsed.
+	ds.flushed[100] = time.Time{}
+
+	f := &mockFetcher{listings: []model.RawListing{}}
+	d := newMockDedup()
+
+	ss := &mockSearchStore{}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+	ctx := context.Background()
+
+	s.processDigests(ctx)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 1 {
+		t.Fatalf("expected 1 digest notification, got %d", len(n.rawMessages))
+	}
+
+	msg := n.rawMessages[0].message
+	if !strings.Contains(msg, "listing A") || !strings.Contains(msg, "listing B") {
+		t.Errorf("digest message should contain items, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Digest Summary") {
+		t.Errorf("digest message should contain header, got: %s", msg)
+	}
+}
+
+func TestProcessDigests_SkipsWhenIntervalNotElapsed(t *testing.T) {
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ds := newMockDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "24h")
+	ds.items[100] = []string{"listing A"}
+	ds.flushed[100] = time.Now() // Just flushed.
+
+	f := &mockFetcher{listings: []model.RawListing{}}
+	d := newMockDedup()
+	ss := &mockSearchStore{}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+	ctx := context.Background()
+
+	s.processDigests(ctx)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 0 {
+		t.Errorf("expected 0 digest notifications (interval not elapsed), got %d", len(n.rawMessages))
+	}
+}
+
+func TestProcessDigests_FlushesImmediatelyWhenSwitchedToInstant(t *testing.T) {
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ds := newMockDigestStore()
+	// User has pending items but switched back to instant.
+	_ = ds.SetDigestMode(context.Background(), 100, "instant", "6h")
+	ds.items[100] = []string{"leftover listing"}
+
+	f := &mockFetcher{listings: []model.RawListing{}}
+	d := newMockDedup()
+	ss := &mockSearchStore{}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+	ctx := context.Background()
+
+	s.processDigests(ctx)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 1 {
+		t.Fatalf("expected 1 digest notification (flush on mode switch), got %d", len(n.rawMessages))
+	}
+	if !strings.Contains(n.rawMessages[0].message, "leftover listing") {
+		t.Errorf("flushed digest should contain pending items")
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -46,6 +47,7 @@ type Scheduler struct {
 	fetcherFactory    *fetcher.Factory
 	listingStore      storage.ListingStore
 	searchStore       storage.SearchStore
+	digestStore       storage.DigestStore
 }
 
 type Options struct {
@@ -56,6 +58,7 @@ type Options struct {
 	FetcherFactory *fetcher.Factory
 	ListingStore   storage.ListingStore
 	SearchStore    storage.SearchStore
+	DigestStore    storage.DigestStore
 }
 
 func New(
@@ -96,6 +99,7 @@ func NewWithOptions(
 		fetcherFactory:    opts.FetcherFactory,
 		listingStore:      opts.ListingStore,
 		searchStore:       opts.SearchStore,
+		digestStore:       opts.DigestStore,
 	}, nil
 }
 
@@ -575,6 +579,8 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 		s.lastPruneTime = time.Now()
 	}
 
+	s.processDigests(ctx)
+
 	if allFailed && len(groups) > 0 {
 		if s.health != nil {
 			s.health.RecordError()
@@ -664,12 +670,29 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 
 		chatIDStr := fmt.Sprintf("%d", search.ChatID)
 
+		// Check if user is in digest mode.
+		digestMode := false
+		if s.digestStore != nil {
+			mode, _, err := s.digestStore.GetDigestMode(ctx, search.ChatID)
+			if err != nil {
+				s.logger.Error("get digest mode failed", "chat_id", search.ChatID, "error", err)
+			} else if mode == "digest" {
+				digestMode = true
+			}
+		}
+
 		for _, msg := range priceDropMessages {
-			if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {
-				s.logger.Error("price drop notification failed",
-					"chat_id", search.ChatID,
-					"error", err,
-				)
+			if digestMode {
+				if err := s.digestStore.AddDigestItem(ctx, search.ChatID, msg); err != nil {
+					s.logger.Error("add digest item failed", "chat_id", search.ChatID, "error", err)
+				}
+			} else {
+				if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {
+					s.logger.Error("price drop notification failed",
+						"chat_id", search.ChatID,
+						"error", err,
+					)
+				}
 			}
 		}
 
@@ -687,20 +710,110 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			"count", len(newListings),
 		)
 
-		if err := s.notifier.Notify(ctx, chatIDStr, newListings); err != nil {
-			s.logger.Error("notification failed",
-				"chat_id", search.ChatID,
-				"error", err,
-			)
-			for _, l := range newListings {
-				_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
+		if digestMode {
+			msg := notifier.FormatBatch(newListings)
+			if err := s.digestStore.AddDigestItem(ctx, search.ChatID, msg); err != nil {
+				s.logger.Error("add digest item failed",
+					"chat_id", search.ChatID,
+					"error", err,
+				)
+				for _, l := range newListings {
+					_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
+				}
 			}
-		} else if s.health != nil {
-			s.health.RecordNotificationSent()
+		} else {
+			if err := s.notifier.Notify(ctx, chatIDStr, newListings); err != nil {
+				s.logger.Error("notification failed",
+					"chat_id", search.ChatID,
+					"error", err,
+				)
+				for _, l := range newListings {
+					_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
+				}
+			} else if s.health != nil {
+				s.health.RecordNotificationSent()
+			}
 		}
 	}
 
 	return nil
+}
+
+func (s *Scheduler) processDigests(ctx context.Context) {
+	if s.digestStore == nil {
+		return
+	}
+
+	users, err := s.digestStore.PendingDigestUsers(ctx)
+	if err != nil {
+		s.logger.Error("list pending digest users failed", "error", err)
+		return
+	}
+
+	for _, chatID := range users {
+		mode, intervalStr, err := s.digestStore.GetDigestMode(ctx, chatID)
+		if err != nil {
+			s.logger.Error("get digest mode failed", "chat_id", chatID, "error", err)
+			continue
+		}
+		if mode != "digest" {
+			// User switched back to instant; flush and send immediately.
+			s.flushAndSendDigest(ctx, chatID)
+			continue
+		}
+
+		interval, err := time.ParseDuration(intervalStr)
+		if err != nil {
+			s.logger.Error("parse digest interval failed",
+				"chat_id", chatID,
+				"interval", intervalStr,
+				"error", err,
+			)
+			interval = 6 * time.Hour
+		}
+
+		lastFlushed, err := s.digestStore.DigestLastFlushed(ctx, chatID)
+		if err != nil {
+			s.logger.Error("get last flushed failed", "chat_id", chatID, "error", err)
+			continue
+		}
+
+		if time.Since(lastFlushed) >= interval {
+			s.flushAndSendDigest(ctx, chatID)
+		}
+	}
+}
+
+func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
+	payloads, err := s.digestStore.FlushDigest(ctx, chatID)
+	if err != nil {
+		s.logger.Error("flush digest failed", "chat_id", chatID, "error", err)
+		return
+	}
+	if len(payloads) == 0 {
+		return
+	}
+
+	chatIDStr := fmt.Sprintf("%d", chatID)
+	header := fmt.Sprintf("*Digest Summary (%d items):*\n", len(payloads))
+	combined := header + strings.Join(payloads, "\n\n━━━━━━━━━━━━━━━━━━━━\n\n")
+
+	if err := s.notifier.NotifyRaw(ctx, chatIDStr, combined); err != nil {
+		s.logger.Error("send digest failed",
+			"chat_id", chatID,
+			"items", len(payloads),
+			"error", err,
+		)
+		return
+	}
+
+	s.logger.Info("digest sent",
+		"chat_id", chatID,
+		"items", len(payloads),
+	)
+	if s.health != nil {
+		s.health.RecordNotificationSent()
+	}
 }
 
 func maskPhone(phone string) string {

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -74,6 +74,15 @@ type PriceTracker interface {
 	RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error)
 }
 
+type DigestStore interface {
+	SetDigestMode(ctx context.Context, chatID int64, mode string, interval string) error
+	GetDigestMode(ctx context.Context, chatID int64) (mode string, interval string, err error)
+	AddDigestItem(ctx context.Context, chatID int64, payload string) error
+	FlushDigest(ctx context.Context, chatID int64) ([]string, error)
+	PendingDigestUsers(ctx context.Context) ([]int64, error)
+	DigestLastFlushed(ctx context.Context, chatID int64) (time.Time, error)
+}
+
 type ListingRecord struct {
 	Token        string
 	SearchName   string

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -100,7 +100,44 @@ func migrate(db *sql.DB) error {
 			page_link TEXT,
 			first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
+
+		CREATE TABLE IF NOT EXISTS pending_digest (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			chat_id INTEGER NOT NULL,
+			listing_payload TEXT NOT NULL,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
 	`)
+	if err != nil {
+		return err
+	}
+
+	// Add digest columns to users table if they don't exist yet.
+	// ALTER TABLE ADD COLUMN is idempotent-safe with the "IF NOT EXISTS" check below.
+	for _, col := range []struct {
+		name string
+		def  string
+	}{
+		{"digest_mode", "TEXT NOT NULL DEFAULT 'instant'"},
+		{"digest_interval", "TEXT NOT NULL DEFAULT '6h'"},
+		{"digest_last_flushed", "TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00'"},
+	} {
+		// SQLite doesn't support IF NOT EXISTS on ALTER TABLE ADD COLUMN,
+		// so we check table_info first.
+		var count int
+		err := db.QueryRow(
+			"SELECT COUNT(*) FROM pragma_table_info('users') WHERE name = ?", col.name,
+		).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("check column %s: %w", col.name, err)
+		}
+		if count == 0 {
+			_, err = db.Exec(fmt.Sprintf("ALTER TABLE users ADD COLUMN %s %s", col.name, col.def))
+			if err != nil {
+				return fmt.Errorf("add column %s: %w", col.name, err)
+			}
+		}
+	}
 	return err
 }
 
@@ -392,6 +429,104 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 		listings = append(listings, l)
 	}
 	return listings, rows.Err()
+}
+
+// --- DigestStore ---
+
+func (s *Store) SetDigestMode(ctx context.Context, chatID int64, mode string, interval string) error {
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE users SET digest_mode = ?, digest_interval = ? WHERE chat_id = ?",
+		mode, interval, chatID)
+	return err
+}
+
+func (s *Store) GetDigestMode(ctx context.Context, chatID int64) (string, string, error) {
+	var mode, interval string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT digest_mode, digest_interval FROM users WHERE chat_id = ?",
+		chatID).Scan(&mode, &interval)
+	if err == sql.ErrNoRows {
+		return "instant", "6h", nil
+	}
+	return mode, interval, err
+}
+
+func (s *Store) AddDigestItem(ctx context.Context, chatID int64, payload string) error {
+	_, err := s.db.ExecContext(ctx,
+		"INSERT INTO pending_digest (chat_id, listing_payload) VALUES (?, ?)",
+		chatID, payload)
+	return err
+}
+
+func (s *Store) FlushDigest(ctx context.Context, chatID int64) ([]string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx,
+		"SELECT listing_payload FROM pending_digest WHERE chat_id = ? ORDER BY created_at", chatID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var payloads []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		payloads = append(payloads, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(payloads) > 0 {
+		if _, err := tx.ExecContext(ctx, "DELETE FROM pending_digest WHERE chat_id = ?", chatID); err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx,
+			"UPDATE users SET digest_last_flushed = CURRENT_TIMESTAMP WHERE chat_id = ?", chatID); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return payloads, nil
+}
+
+func (s *Store) PendingDigestUsers(ctx context.Context) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT DISTINCT chat_id FROM pending_digest")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var chatIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		chatIDs = append(chatIDs, id)
+	}
+	return chatIDs, rows.Err()
+}
+
+func (s *Store) DigestLastFlushed(ctx context.Context, chatID int64) (time.Time, error) {
+	var t time.Time
+	err := s.db.QueryRowContext(ctx,
+		"SELECT digest_last_flushed FROM users WHERE chat_id = ?", chatID).Scan(&t)
+	if err == sql.ErrNoRows {
+		return time.Time{}, nil
+	}
+	return t, err
 }
 
 // --- Close ---

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -468,7 +468,7 @@ func (s *Store) FlushDigest(ctx context.Context, chatID int64) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.QueryContext(ctx,
 		"SELECT listing_payload FROM pending_digest WHERE chat_id = ? ORDER BY created_at", chatID)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -403,6 +403,188 @@ func TestRecordPrice(t *testing.T) {
 
 // --- ListingStore ---
 
+// --- DigestStore ---
+
+func TestSetAndGetDigestMode(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	// Default should be instant.
+	mode, interval, err := store.GetDigestMode(ctx, 100)
+	if err != nil {
+		t.Fatalf("get digest mode: %v", err)
+	}
+	if mode != "instant" || interval != "6h" {
+		t.Errorf("default mode=%q interval=%q, want instant/6h", mode, interval)
+	}
+
+	// Switch to digest mode.
+	if err := store.SetDigestMode(ctx, 100, "digest", "12h"); err != nil {
+		t.Fatalf("set digest mode: %v", err)
+	}
+
+	mode, interval, err = store.GetDigestMode(ctx, 100)
+	if err != nil {
+		t.Fatalf("get digest mode: %v", err)
+	}
+	if mode != "digest" || interval != "12h" {
+		t.Errorf("mode=%q interval=%q, want digest/12h", mode, interval)
+	}
+
+	// Switch back to instant.
+	if err := store.SetDigestMode(ctx, 100, "instant", "6h"); err != nil {
+		t.Fatalf("set instant: %v", err)
+	}
+	mode, _, _ = store.GetDigestMode(ctx, 100)
+	if mode != "instant" {
+		t.Errorf("mode=%q, want instant", mode)
+	}
+}
+
+func TestGetDigestMode_NonexistentUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	mode, interval, err := store.GetDigestMode(ctx, 999)
+	if err != nil {
+		t.Fatalf("get digest mode: %v", err)
+	}
+	if mode != "instant" || interval != "6h" {
+		t.Errorf("nonexistent user: mode=%q interval=%q, want instant/6h", mode, interval)
+	}
+}
+
+func TestAddAndFlushDigest(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	// Add items.
+	if err := store.AddDigestItem(ctx, 100, "listing 1"); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+	if err := store.AddDigestItem(ctx, 100, "listing 2"); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+
+	// Flush.
+	payloads, err := store.FlushDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("expected 2 payloads, got %d", len(payloads))
+	}
+	if payloads[0] != "listing 1" || payloads[1] != "listing 2" {
+		t.Errorf("payloads = %v", payloads)
+	}
+
+	// Flush again should return empty.
+	payloads, err = store.FlushDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if len(payloads) != 0 {
+		t.Errorf("expected 0 payloads after flush, got %d", len(payloads))
+	}
+}
+
+func TestFlushDigest_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	payloads, err := store.FlushDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(payloads) != 0 {
+		t.Errorf("expected 0 payloads, got %d", len(payloads))
+	}
+}
+
+func TestPendingDigestUsers(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	// No pending items.
+	users, err := store.PendingDigestUsers(ctx)
+	if err != nil {
+		t.Fatalf("pending users: %v", err)
+	}
+	if len(users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(users))
+	}
+
+	// Add items for two users.
+	_ = store.AddDigestItem(ctx, 100, "item1")
+	_ = store.AddDigestItem(ctx, 100, "item2")
+	_ = store.AddDigestItem(ctx, 200, "item3")
+
+	users, err = store.PendingDigestUsers(ctx)
+	if err != nil {
+		t.Fatalf("pending users: %v", err)
+	}
+	if len(users) != 2 {
+		t.Errorf("expected 2 users, got %d", len(users))
+	}
+}
+
+func TestDigestLastFlushed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	// Initial value should be epoch.
+	ts, err := store.DigestLastFlushed(ctx, 100)
+	if err != nil {
+		t.Fatalf("last flushed: %v", err)
+	}
+	if ts.Year() != 1970 {
+		t.Errorf("expected epoch, got %v", ts)
+	}
+
+	// Add and flush to update timestamp.
+	_ = store.AddDigestItem(ctx, 100, "item")
+	_, _ = store.FlushDigest(ctx, 100)
+
+	ts, err = store.DigestLastFlushed(ctx, 100)
+	if err != nil {
+		t.Fatalf("last flushed after flush: %v", err)
+	}
+
+	if time.Since(ts) > 10*time.Second {
+		t.Errorf("last flushed should be recent, got %v", ts)
+	}
+}
+
+func TestDigestIsolation_BetweenUsers(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	_ = store.AddDigestItem(ctx, 100, "user100-item")
+	_ = store.AddDigestItem(ctx, 200, "user200-item")
+
+	// Flush user 100 only.
+	payloads, _ := store.FlushDigest(ctx, 100)
+	if len(payloads) != 1 || payloads[0] != "user100-item" {
+		t.Errorf("user 100 payloads = %v", payloads)
+	}
+
+	// User 200 should still have their item.
+	payloads, _ = store.FlushDigest(ctx, 200)
+	if len(payloads) != 1 || payloads[0] != "user200-item" {
+		t.Errorf("user 200 payloads = %v", payloads)
+	}
+}
+
+// --- ListingStore ---
+
 func TestSaveAndListListings(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Add digest notification mode allowing users to receive batched listing updates instead of instant notifications
- Implement `/digest` Telegram command to toggle between instant and digest (every 6h) delivery modes
- Add `DigestStore` interface with `pending_digest` table and digest columns on users table
- Integrate digest routing in the scheduler's `processGroup` and add `processDigests` for periodic flushing

## Storage changes

- New columns on `users`: `digest_mode` (TEXT, default "instant"), `digest_interval` (TEXT, default "6h"), `digest_last_flushed` (TIMESTAMP)
- New table `pending_digest` for buffering listing payloads per user
- Migration is backward-compatible using conditional ALTER TABLE ADD COLUMN

## Behavior

- **Instant mode (default):** Notifications sent immediately as before
- **Digest mode:** Listings are stored in `pending_digest` and flushed when the user's interval elapses
- If a user switches back to instant mode, any pending digest items are flushed immediately on the next cycle
- Price drop alerts in digest mode are also batched

## Test plan

- [x] SQLite storage tests: SetDigestMode, GetDigestMode, AddDigestItem, FlushDigest, PendingDigestUsers, DigestLastFlushed, cross-user isolation
- [x] Scheduler tests: digest mode stores instead of sending, instant mode sends directly, digest flush on interval elapsed, skip when interval not elapsed, immediate flush when user switches to instant
- [x] All existing tests pass (`go test ./...`)

Closes #71