### PR TITLE
feat: add automatic versioning pipeline with Watchtower auto-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
       - 'go.sum'
       - 'Makefile'
       - 'Dockerfile'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
+      - 'docker-compose*.yaml'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,25 @@ jobs:
 
       - name: Determine version bump from merge commit
         id: bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          MERGE_MSG=$(git log -1 --pretty=%s)
-          echo "Merge message: $MERGE_MSG"
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          COMMIT_BODY=$(git log -1 --pretty=%b)
+          echo "Commit message: $COMMIT_MSG"
 
-          if echo "$MERGE_MSG" | grep -qiE '(BREAKING CHANGE|^[a-z]+(\(.+\))?!:)'; then
+          # For "Merge pull request #N" commits, extract the PR title
+          if echo "$COMMIT_MSG" | grep -qE '^Merge pull request #'; then
+            PR_NUM=$(echo "$COMMIT_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+            MSG=$(gh pr view "$PR_NUM" --json title -q .title 2>/dev/null || echo "$COMMIT_MSG")
+          else
+            MSG="$COMMIT_MSG"
+          fi
+          echo "Parsed message: $MSG"
+
+          if echo "$MSG" | grep -qiE '(^[a-z]+(\(.+\))?!:)' || echo "$COMMIT_BODY" | grep -qiE 'BREAKING CHANGE'; then
             BUMP=major
-          elif echo "$MERGE_MSG" | grep -qiE '^feat(\(.+\))?:'; then
+          elif echo "$MSG" | grep -qiE '^feat(\(.+\))?:'; then
             BUMP=minor
           else
             BUMP=patch

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -16,7 +16,7 @@ services:
     container_name: watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /root/.docker/config.json:/config.json:ro
+      - ${HOME}/.docker/config.json:/config.json:ro
     environment:
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_POLL_INTERVAL=300


### PR DESCRIPTION
## Summary
- **Release workflow**: on merge to main, detects conventional commit type from PR title, bumps VERSION, builds & pushes Docker image to GHCR with versioned + `latest` tags, creates GitHub Release
- **Production compose**: `docker-compose.prod.yaml` with Watchtower sidecar that polls GHCR every 5 min, auto-pulls new images, restarts carwatch, and sends Telegram notifications
- **Version bump script**: `scripts/bump-version.sh` for semver patch/minor/major increments

## How it works
```
PR merged to main → release.yml detects feat:/fix:/etc. from PR title
→ bumps VERSION → builds Docker image → pushes to GHCR
→ Watchtower on VM detects new :latest → pulls & restarts container
```

## VM setup (done)
- Oracle Cloud VM (Always Free) with Docker installed
- GHCR authentication configured
- Config and compose files deployed to `~/carwatch/`
- Waiting for first image push to start the stack

## Test plan
- [ ] Merge this PR and verify release workflow runs successfully
- [ ] Check GHCR for `ghcr.io/danielsio/carwatch:1.1.0` and `:latest` tags
- [ ] Verify GitHub Release `v1.1.0` is created
- [ ] Start stack on VM: `docker compose up -d`
- [ ] Verify Watchtower is polling and carwatch container is running