### PR TITLE
ci: remove redundant push-to-main CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ on:
       - 'Dockerfile'
       - '.github/workflows/**'
       - 'docker-compose*.yaml'
-  push:
-    branches: [main]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Removes the `push` trigger from the CI workflow so lint/test/build only run on PRs, not again on merge to main
- The Release workflow already handles the post-merge Docker build and push

## Test plan
- [ ] Merge and verify CI does **not** run on the push to main
- [ ] Verify Release workflow still triggers normally