### PR TITLE
fix: SetBot must initialize messenger, fix Watchtower API version

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -12,12 +12,13 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower
+    image: containrrr/watchtower:latest
     container_name: watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HOME}/.docker/config.json:/config.json:ro
     environment:
+      - DOCKER_API_VERSION=1.45
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_POLL_INTERVAL=300
       - WATCHTOWER_LABEL_ENABLE=true

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -68,6 +68,9 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 
 func (b *Bot) SetBot(tg *tgbot.Bot) {
 	b.bot = tg
+	if tg != nil {
+		b.msg = &telegramMessenger{bot: tg}
+	}
 }
 
 func (b *Bot) DefaultHandler() tgbot.HandlerFunc {


### PR DESCRIPTION
## Summary
- **Panic fix**: `SetBot` only set `b.bot` but left `b.msg` nil — first real Telegram message caused a nil pointer panic
- **Watchtower fix**: Add `DOCKER_API_VERSION=1.45` to fix compatibility with Docker 29 (Watchtower ships with API v1.25, Docker 29 requires minimum v1.40)

## Test plan
- [x] All bot tests pass
- [ ] Deploy and verify bot responds to `/watch` without panic
- [ ] Verify Watchtower starts and polls successfully