### PR TITLE
feat: grow catalog dynamically from fetched listings

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -83,7 +83,7 @@ func run(configPath string, logger *slog.Logger) error {
 
 	cachingFetcher := fetcher.NewCachingFetcher(yad2Fetcher, 5*time.Minute)
 
-	dynCatalog := catalog.NewDynamic(store, yad2Fetcher.HTTPClient(), logger)
+	dynCatalog := catalog.NewDynamic(store, logger)
 	dynCatalog.Load(context.Background())
 
 	var winwinFetcher *winwin.WinWinFetcher
@@ -127,8 +127,6 @@ func run(configPath string, logger *slog.Logger) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	dynCatalog.StartRefreshLoop(ctx)
-
 	if err := tgNotif.Connect(ctx); err != nil {
 		return fmt.Errorf("connect telegram: %w", err)
 	}
@@ -146,13 +144,14 @@ func run(configPath string, logger *slog.Logger) error {
 	defer srv.Close()
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, tgNotif, logger, scheduler.Options{
-		Health:         h,
-		Queue:          store,
-		Prices:         store,
-		ConfigPath:     configPath,
-		FetcherFactory: fetcherFactory,
-		ListingStore:   store,
-		SearchStore:    store,
+		Health:          h,
+		Queue:           store,
+		Prices:          store,
+		ConfigPath:      configPath,
+		FetcherFactory:  fetcherFactory,
+		ListingStore:    store,
+		SearchStore:     store,
+		CatalogIngester: dynCatalog,
 	})
 	if err != nil {
 		return fmt.Errorf("create scheduler: %w", err)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,6 +1,8 @@
 package catalog
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 )
 
@@ -54,14 +56,9 @@ func TestStaticCatalog_NameLookups(t *testing.T) {
 	}
 }
 
-func TestDynamicCatalog_FallsBackToStatic(t *testing.T) {
-	cat := NewDynamic(nil, nil, nil)
-	cat.mu.Lock()
-	cat.mfrs = NewStatic().Manufacturers()
-	for _, m := range cat.mfrs {
-		cat.models[m.ID] = NewStatic().Models(m.ID)
-	}
-	cat.mu.Unlock()
+func TestDynamicCatalog_LoadsFallback(t *testing.T) {
+	cat := NewDynamic(nil, slog.Default())
+	cat.Load(context.Background())
 
 	mfrs := cat.Manufacturers()
 	if len(mfrs) < 10 {
@@ -70,5 +67,35 @@ func TestDynamicCatalog_FallsBackToStatic(t *testing.T) {
 
 	if name := cat.ManufacturerName(27); name != "Mazda" {
 		t.Errorf("ManufacturerName(27) = %q, want Mazda", name)
+	}
+}
+
+func TestDynamicCatalog_Ingest(t *testing.T) {
+	cat := NewDynamic(nil, slog.Default())
+	cat.Load(context.Background())
+
+	before := len(cat.Manufacturers())
+	ctx := context.Background()
+
+	cat.Ingest(ctx, 999, "NewBrand", 88888, "NewModel")
+
+	after := len(cat.Manufacturers())
+	if after != before+1 {
+		t.Errorf("expected %d manufacturers after ingest, got %d", before+1, after)
+	}
+
+	if name := cat.ManufacturerName(999); name != "NewBrand" {
+		t.Errorf("ManufacturerName(999) = %q, want NewBrand", name)
+	}
+
+	models := cat.Models(999)
+	if len(models) != 1 || models[0].Name != "NewModel" {
+		t.Errorf("expected 1 model NewModel, got %v", models)
+	}
+
+	// Ingesting same entry again should not duplicate
+	cat.Ingest(ctx, 999, "NewBrand", 88888, "NewModel")
+	if len(cat.Models(999)) != 1 {
+		t.Error("duplicate ingest should not add new entry")
 	}
 }

--- a/internal/catalog/dynamic.go
+++ b/internal/catalog/dynamic.go
@@ -128,7 +128,15 @@ func (d *DynamicCatalog) rebuildSlices() {
 func (d *DynamicCatalog) saveToStore(ctx context.Context) {
 	var entries []storage.CatalogEntry
 	for mfrID, mfrName := range d.mfrMap {
-		for mdlID, mdlName := range d.modelMap[mfrID] {
+		mdls := d.modelMap[mfrID]
+		if len(mdls) == 0 {
+			entries = append(entries, storage.CatalogEntry{
+				ManufacturerID:   mfrID,
+				ManufacturerName: mfrName,
+			})
+			continue
+		}
+		for mdlID, mdlName := range mdls {
 			entries = append(entries, storage.CatalogEntry{
 				ManufacturerID:   mfrID,
 				ManufacturerName: mfrName,
@@ -160,7 +168,9 @@ func (d *DynamicCatalog) loadFromStore(ctx context.Context) bool {
 		if d.modelMap[e.ManufacturerID] == nil {
 			d.modelMap[e.ManufacturerID] = make(map[int]string)
 		}
-		d.modelMap[e.ManufacturerID][e.ModelID] = e.ModelName
+		if e.ModelID != 0 {
+			d.modelMap[e.ManufacturerID][e.ModelID] = e.ModelName
+		}
 	}
 
 	// Merge static fallback entries that might be missing from cache
@@ -197,10 +207,8 @@ func (d *DynamicCatalog) Models(manufacturerID int) []Entry {
 func (d *DynamicCatalog) ManufacturerName(id int) string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	for _, m := range d.mfrs {
-		if m.ID == id {
-			return m.Name
-		}
+	if name, ok := d.mfrMap[id]; ok {
+		return name
 	}
 	return "Unknown"
 }
@@ -208,9 +216,9 @@ func (d *DynamicCatalog) ManufacturerName(id int) string {
 func (d *DynamicCatalog) ModelName(manufacturerID, modelID int) string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	for _, m := range d.models[manufacturerID] {
-		if m.ID == modelID {
-			return m.Name
+	if mdls, ok := d.modelMap[manufacturerID]; ok {
+		if name, ok := mdls[modelID]; ok {
+			return name
 		}
 	}
 	return "Unknown"

--- a/internal/catalog/dynamic.go
+++ b/internal/catalog/dynamic.go
@@ -2,128 +2,148 @@ package catalog
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"net/http"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-const (
-	cacheTTL    = 24 * time.Hour
-	fetchPages  = 5
-	baseURL     = "https://www.yad2.co.il/vehicles/cars"
-)
-
-type httpClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
+const saveCooldown = 5 * time.Minute
 
 type DynamicCatalog struct {
-	mu       sync.RWMutex
-	mfrs     []Entry
-	models   map[int][]Entry
-	store    storage.CatalogStore
-	client   httpClient
-	fallback Catalog
-	logger   *slog.Logger
+	mu        sync.RWMutex
+	mfrs      []Entry
+	models    map[int][]Entry
+	mfrMap    map[int]string
+	modelMap  map[int]map[int]string
+	dirty     bool
+	lastSave  time.Time
+	store     storage.CatalogStore
+	fallback  Catalog
+	logger    *slog.Logger
 }
 
-func NewDynamic(store storage.CatalogStore, client httpClient, logger *slog.Logger) *DynamicCatalog {
-	d := &DynamicCatalog{
+func NewDynamic(store storage.CatalogStore, logger *slog.Logger) *DynamicCatalog {
+	return &DynamicCatalog{
 		models:   make(map[int][]Entry),
+		mfrMap:   make(map[int]string),
+		modelMap: make(map[int]map[int]string),
 		store:    store,
-		client:   client,
 		fallback: NewStatic(),
 		logger:   logger,
 	}
-	return d
 }
 
 func (d *DynamicCatalog) Load(ctx context.Context) {
-	age, err := d.store.CatalogAge(ctx)
-	if err == nil && age < cacheTTL {
+	if d.store != nil {
 		if d.loadFromStore(ctx) {
-			d.logger.Info("catalog loaded from cache", "age", age.Round(time.Minute))
+			d.logger.Info("catalog loaded from cache",
+				"manufacturers", len(d.mfrs))
 			return
 		}
 	}
 
-	if d.refresh(ctx) {
-		return
-	}
-
-	if d.loadFromStore(ctx) {
-		d.logger.Warn("using stale catalog cache")
-		return
-	}
-
-	d.logger.Warn("using static fallback catalog")
+	d.logger.Info("seeding catalog from static fallback")
 	d.mu.Lock()
-	d.mfrs = d.fallback.Manufacturers()
-	for _, m := range d.mfrs {
-		d.models[m.ID] = d.fallback.Models(m.ID)
+	for _, m := range d.fallback.Manufacturers() {
+		d.mfrMap[m.ID] = m.Name
+		if d.modelMap[m.ID] == nil {
+			d.modelMap[m.ID] = make(map[int]string)
+		}
+		for _, mdl := range d.fallback.Models(m.ID) {
+			d.modelMap[m.ID][mdl.ID] = mdl.Name
+		}
 	}
+	d.rebuildSlices()
 	d.mu.Unlock()
 }
 
-func (d *DynamicCatalog) StartRefreshLoop(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(cacheTTL)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				d.refresh(ctx)
-			}
+func (d *DynamicCatalog) Ingest(ctx context.Context, manufacturerID int, manufacturerName string, modelID int, modelName string) {
+	if manufacturerID == 0 || manufacturerName == "" {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	changed := false
+
+	if _, ok := d.mfrMap[manufacturerID]; !ok {
+		d.mfrMap[manufacturerID] = manufacturerName
+		changed = true
+	}
+
+	if modelID != 0 && modelName != "" {
+		if d.modelMap[manufacturerID] == nil {
+			d.modelMap[manufacturerID] = make(map[int]string)
 		}
-	}()
+		if _, ok := d.modelMap[manufacturerID][modelID]; !ok {
+			d.modelMap[manufacturerID][modelID] = modelName
+			changed = true
+		}
+	}
+
+	if !changed {
+		return
+	}
+
+	d.rebuildSlices()
+	d.dirty = true
+
+	if d.store != nil && time.Since(d.lastSave) > saveCooldown {
+		d.saveToStore(ctx)
+	}
 }
 
-func (d *DynamicCatalog) refresh(ctx context.Context) bool {
-	items, err := d.fetchCatalog(ctx)
-	if err != nil {
-		d.logger.Error("catalog fetch failed", "error", err)
-		return false
+func (d *DynamicCatalog) Flush(ctx context.Context) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.dirty && d.store != nil {
+		d.saveToStore(ctx)
 	}
-	if len(items) == 0 {
-		d.logger.Warn("catalog fetch returned no items")
-		return false
-	}
+}
 
-	mfrs, models := d.buildCatalog(items)
-	if len(mfrs) == 0 {
-		return false
+func (d *DynamicCatalog) rebuildSlices() {
+	mfrs := make([]Entry, 0, len(d.mfrMap))
+	for id, name := range d.mfrMap {
+		mfrs = append(mfrs, Entry{ID: id, Name: name})
 	}
+	sort.Slice(mfrs, func(i, j int) bool { return mfrs[i].Name < mfrs[j].Name })
+	d.mfrs = mfrs
 
-	var storeEntries []storage.CatalogEntry
-	for _, m := range mfrs {
-		for _, mdl := range models[m.ID] {
-			storeEntries = append(storeEntries, storage.CatalogEntry{
-				ManufacturerID:   m.ID,
-				ManufacturerName: m.Name,
-				ModelID:          mdl.ID,
-				ModelName:        mdl.Name,
+	models := make(map[int][]Entry, len(d.modelMap))
+	for mfrID, mdls := range d.modelMap {
+		list := make([]Entry, 0, len(mdls))
+		for id, name := range mdls {
+			list = append(list, Entry{ID: id, Name: name})
+		}
+		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+		models[mfrID] = list
+	}
+	d.models = models
+}
+
+func (d *DynamicCatalog) saveToStore(ctx context.Context) {
+	var entries []storage.CatalogEntry
+	for mfrID, mfrName := range d.mfrMap {
+		for mdlID, mdlName := range d.modelMap[mfrID] {
+			entries = append(entries, storage.CatalogEntry{
+				ManufacturerID:   mfrID,
+				ManufacturerName: mfrName,
+				ModelID:          mdlID,
+				ModelName:        mdlName,
 			})
 		}
 	}
-	if err := d.store.SaveCatalogEntries(ctx, storeEntries); err != nil {
+	if err := d.store.SaveCatalogEntries(ctx, entries); err != nil {
 		d.logger.Error("catalog save failed", "error", err)
+		return
 	}
-
-	d.mu.Lock()
-	d.mfrs = mfrs
-	d.models = models
-	d.mu.Unlock()
-
-	d.logger.Info("catalog refreshed", "manufacturers", len(mfrs), "total_models", len(storeEntries))
-	return true
+	d.dirty = false
+	d.lastSave = time.Now()
+	d.logger.Info("catalog saved", "manufacturers", len(d.mfrMap), "models", len(entries))
 }
 
 func (d *DynamicCatalog) loadFromStore(ctx context.Context) bool {
@@ -132,128 +152,34 @@ func (d *DynamicCatalog) loadFromStore(ctx context.Context) bool {
 		return false
 	}
 
-	mfrMap := make(map[int]string)
-	modelsMap := make(map[int]map[int]string)
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	for _, e := range entries {
-		mfrMap[e.ManufacturerID] = e.ManufacturerName
-		if modelsMap[e.ManufacturerID] == nil {
-			modelsMap[e.ManufacturerID] = make(map[int]string)
+		d.mfrMap[e.ManufacturerID] = e.ManufacturerName
+		if d.modelMap[e.ManufacturerID] == nil {
+			d.modelMap[e.ManufacturerID] = make(map[int]string)
 		}
-		modelsMap[e.ManufacturerID][e.ModelID] = e.ModelName
+		d.modelMap[e.ManufacturerID][e.ModelID] = e.ModelName
 	}
 
-	mfrs := make([]Entry, 0, len(mfrMap))
-	for id, name := range mfrMap {
-		mfrs = append(mfrs, Entry{ID: id, Name: name})
-	}
-	sort.Slice(mfrs, func(i, j int) bool { return mfrs[i].Name < mfrs[j].Name })
-
-	models := make(map[int][]Entry)
-	for mfrID, mdls := range modelsMap {
-		list := make([]Entry, 0, len(mdls))
-		for id, name := range mdls {
-			list = append(list, Entry{ID: id, Name: name})
-		}
-		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
-		models[mfrID] = list
-	}
-
-	d.mu.Lock()
-	d.mfrs = mfrs
-	d.models = models
-	d.mu.Unlock()
-	return true
-}
-
-func (d *DynamicCatalog) fetchCatalog(ctx context.Context) ([]yad2.CatalogItem, error) {
-	var all []yad2.CatalogItem
-
-	for page := 1; page <= fetchPages; page++ {
-		url := fmt.Sprintf("%s?page=%d&Order=1", baseURL, page)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "text/html,application/xhtml+xml")
-		req.Header.Set("Accept-Language", "he-IL,he;q=0.9,en;q=0.8")
-
-		resp, err := d.client.Do(req)
-		if err != nil {
-			d.logger.Warn("catalog page fetch failed", "page", page, "error", err)
-			continue
-		}
-
-		items, err := yad2.ParseCatalogFromPage(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			d.logger.Warn("catalog page parse failed", "page", page, "error", err)
-			continue
-		}
-		all = append(all, items...)
-
-		if page < fetchPages {
-			time.Sleep(2 * time.Second)
-		}
-	}
-	return all, nil
-}
-
-func (d *DynamicCatalog) buildCatalog(items []yad2.CatalogItem) ([]Entry, map[int][]Entry) {
-	mfrMap := make(map[int]string)
-	modelMap := make(map[int]map[int]string)
-
-	// Merge with static fallback first
+	// Merge static fallback entries that might be missing from cache
 	for _, m := range d.fallback.Manufacturers() {
-		mfrMap[m.ID] = m.Name
-		if modelMap[m.ID] == nil {
-			modelMap[m.ID] = make(map[int]string)
+		if _, ok := d.mfrMap[m.ID]; !ok {
+			d.mfrMap[m.ID] = m.Name
+		}
+		if d.modelMap[m.ID] == nil {
+			d.modelMap[m.ID] = make(map[int]string)
 		}
 		for _, mdl := range d.fallback.Models(m.ID) {
-			modelMap[m.ID][mdl.ID] = mdl.Name
+			if _, ok := d.modelMap[m.ID][mdl.ID]; !ok {
+				d.modelMap[m.ID][mdl.ID] = mdl.Name
+			}
 		}
 	}
 
-	for _, item := range items {
-		if item.ManufacturerID == 0 || item.ManufacturerName == "" {
-			continue
-		}
-		name := item.ManufacturerName
-		if existing, ok := mfrMap[item.ManufacturerID]; ok && existing != "" {
-			name = existing
-		}
-		mfrMap[item.ManufacturerID] = name
-
-		if item.ModelID == 0 || item.ModelName == "" {
-			continue
-		}
-		if modelMap[item.ManufacturerID] == nil {
-			modelMap[item.ManufacturerID] = make(map[int]string)
-		}
-		mdlName := item.ModelName
-		if existing, ok := modelMap[item.ManufacturerID][item.ModelID]; ok && existing != "" {
-			mdlName = existing
-		}
-		modelMap[item.ManufacturerID][item.ModelID] = mdlName
-	}
-
-	mfrs := make([]Entry, 0, len(mfrMap))
-	for id, name := range mfrMap {
-		mfrs = append(mfrs, Entry{ID: id, Name: name})
-	}
-	sort.Slice(mfrs, func(i, j int) bool { return mfrs[i].Name < mfrs[j].Name })
-
-	models := make(map[int][]Entry)
-	for mfrID, mdls := range modelMap {
-		list := make([]Entry, 0, len(mdls))
-		for id, name := range mdls {
-			list = append(list, Entry{ID: id, Name: name})
-		}
-		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
-		models[mfrID] = list
-	}
-
-	return mfrs, models
+	d.rebuildSlices()
+	return true
 }
 
 func (d *DynamicCatalog) Manufacturers() []Entry {
@@ -289,4 +215,3 @@ func (d *DynamicCatalog) ModelName(manufacturerID, modelID int) string {
 	}
 	return "Unknown"
 }
-

--- a/internal/catalog/dynamic_test.go
+++ b/internal/catalog/dynamic_test.go
@@ -3,15 +3,11 @@ package catalog
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -21,8 +17,6 @@ var testLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 type mockCatalogStore struct {
 	entries      []storage.CatalogEntry
-	age          time.Duration
-	ageErr       error
 	loadErr      error
 	saveErr      error
 	saveCalled   bool
@@ -40,59 +34,14 @@ func (m *mockCatalogStore) LoadCatalogEntries(_ context.Context) ([]storage.Cata
 }
 
 func (m *mockCatalogStore) CatalogAge(_ context.Context) (time.Duration, error) {
-	return m.age, m.ageErr
-}
-
-type mockHTTPClient struct {
-	responses []*http.Response
-	err       error
-	callCount int
-}
-
-func (m *mockHTTPClient) Do(_ *http.Request) (*http.Response, error) {
-	m.callCount++
-	if m.err != nil {
-		return nil, m.err
-	}
-	if len(m.responses) > 0 {
-		idx := m.callCount - 1
-		if idx >= len(m.responses) {
-			idx = len(m.responses) - 1
-		}
-		return m.responses[idx], nil
-	}
-	return nil, errors.New("no response configured")
-}
-
-func makeYad2PageHTML(items string) string {
-	return fmt.Sprintf(`<!DOCTYPE html><html><body>
-<script id="__NEXT_DATA__" type="application/json">
-{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{"data":{"feed":{"feed_items":[%s]}}}}}]}}}}
-</script></body></html>`, items)
-}
-
-func makeFeedItem(mfrID int, mfrName string, modelID int, modelName string) string {
-	return fmt.Sprintf(`{
-		"token":"tok-%d-%d",
-		"manufacturer":{"text":"%s","english_text":"%s","id":%d},
-		"model":{"text":"%s","english_text":"%s","id":%d},
-		"year_of_production":2023,
-		"price":100000
-	}`, mfrID, modelID, mfrName, mfrName, mfrID, modelName, modelName, modelID)
-}
-
-func makeHTTPResponse(body string) *http.Response {
-	return &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}
+	return 0, nil
 }
 
 // --- tests ---
 
 func TestNewDynamic(t *testing.T) {
 	store := &mockCatalogStore{}
-	d := NewDynamic(store, nil, testLogger)
+	d := NewDynamic(store, testLogger)
 
 	if d.store != store {
 		t.Error("store not set")
@@ -105,58 +54,34 @@ func TestNewDynamic(t *testing.T) {
 	}
 }
 
-func TestDynamicCatalog_Load_FromFreshCache(t *testing.T) {
+func TestDynamicCatalog_Load_FromCache(t *testing.T) {
 	store := &mockCatalogStore{
-		age: 1 * time.Hour,
 		entries: []storage.CatalogEntry{
-			{ManufacturerID: 1, ManufacturerName: "Audi", ModelID: 100, ModelName: "A3"},
-			{ManufacturerID: 1, ManufacturerName: "Audi", ModelID: 101, ModelName: "A4"},
-			{ManufacturerID: 2, ManufacturerName: "BMW", ModelID: 200, ModelName: "3 Series"},
+			{ManufacturerID: 9000, ManufacturerName: "AlphaCar", ModelID: 100, ModelName: "Alpha1"},
+			{ManufacturerID: 9000, ManufacturerName: "AlphaCar", ModelID: 101, ModelName: "Alpha2"},
+			{ManufacturerID: 9001, ManufacturerName: "BetaCar", ModelID: 200, ModelName: "Beta1"},
 		},
 	}
 
-	d := NewDynamic(store, nil, testLogger)
+	d := NewDynamic(store, testLogger)
 	d.Load(context.Background())
 
-	mfrs := d.Manufacturers()
-	if len(mfrs) != 2 {
-		t.Fatalf("expected 2 manufacturers, got %d", len(mfrs))
-	}
-	if mfrs[0].Name != "Audi" {
-		t.Errorf("first manufacturer = %q, want Audi (sorted)", mfrs[0].Name)
+	if name := d.ManufacturerName(9000); name != "AlphaCar" {
+		t.Errorf("ManufacturerName(9000) = %q, want AlphaCar", name)
 	}
 
-	models := d.Models(1)
+	models := d.Models(9000)
 	if len(models) != 2 {
-		t.Fatalf("expected 2 Audi models, got %d", len(models))
+		t.Fatalf("expected 2 AlphaCar models, got %d", len(models))
 	}
 }
 
-func TestDynamicCatalog_Load_StaleCache_RefreshFails_UsesStaleCache(t *testing.T) {
+func TestDynamicCatalog_Load_NoCache_UsesFallback(t *testing.T) {
 	store := &mockCatalogStore{
-		age: 48 * time.Hour,
-		entries: []storage.CatalogEntry{
-			{ManufacturerID: 1, ManufacturerName: "Audi", ModelID: 100, ModelName: "A3"},
-		},
+		loadErr: errors.New("no cache"),
 	}
-	client := &mockHTTPClient{err: errors.New("network error")}
 
-	d := NewDynamic(store, client, testLogger)
-	d.Load(context.Background())
-
-	mfrs := d.Manufacturers()
-	if len(mfrs) != 1 || mfrs[0].Name != "Audi" {
-		t.Errorf("expected stale cache with Audi, got %v", mfrs)
-	}
-}
-
-func TestDynamicCatalog_Load_NoCache_RefreshFails_UsesFallback(t *testing.T) {
-	store := &mockCatalogStore{
-		ageErr: errors.New("no cache"),
-	}
-	client := &mockHTTPClient{err: errors.New("network error")}
-
-	d := NewDynamic(store, client, testLogger)
+	d := NewDynamic(store, testLogger)
 	d.Load(context.Background())
 
 	mfrs := d.Manufacturers()
@@ -165,165 +90,175 @@ func TestDynamicCatalog_Load_NoCache_RefreshFails_UsesFallback(t *testing.T) {
 	}
 }
 
-func TestDynamicCatalog_Load_RefreshSuccess(t *testing.T) {
-	store := &mockCatalogStore{
-		ageErr: errors.New("no cache"),
-	}
-	items := makeFeedItem(99, "TestMfr", 999, "TestModel")
-	html := makeYad2PageHTML(items)
-	responses := make([]*http.Response, fetchPages)
-	for i := range responses {
-		responses[i] = makeHTTPResponse(html)
-	}
-	client := &mockHTTPClient{responses: responses}
-
-	d := NewDynamic(store, client, testLogger)
-	d.Load(context.Background())
-
-	if !store.saveCalled {
-		t.Error("expected store.SaveCatalogEntries to be called")
-	}
-
-	if name := d.ManufacturerName(99); name == "Unknown" {
-		t.Error("TestMfr should be found after refresh")
-	}
-}
-
-func TestDynamicCatalog_Refresh_SaveError(t *testing.T) {
-	store := &mockCatalogStore{
-		ageErr:  errors.New("no cache"),
-		saveErr: errors.New("db write failed"),
-	}
-	items := makeFeedItem(99, "TestMfr", 999, "TestModel")
-	html := makeYad2PageHTML(items)
-	responses := make([]*http.Response, fetchPages)
-	for i := range responses {
-		responses[i] = makeHTTPResponse(html)
-	}
-	client := &mockHTTPClient{responses: responses}
-
-	d := NewDynamic(store, client, testLogger)
-	d.Load(context.Background())
-
-	if name := d.ManufacturerName(99); name == "Unknown" {
-		t.Error("in-memory catalog should be updated even on save error")
-	}
-}
-
-func TestDynamicCatalog_Refresh_EmptyResults(t *testing.T) {
-	store := &mockCatalogStore{
-		ageErr: errors.New("no cache"),
-	}
-	html := makeYad2PageHTML("")
-	responses := make([]*http.Response, fetchPages)
-	for i := range responses {
-		responses[i] = makeHTTPResponse(html)
-	}
-	client := &mockHTTPClient{responses: responses}
-
-	d := NewDynamic(store, client, testLogger)
+func TestDynamicCatalog_Load_NilStore_UsesFallback(t *testing.T) {
+	d := NewDynamic(nil, testLogger)
 	d.Load(context.Background())
 
 	mfrs := d.Manufacturers()
 	if len(mfrs) < 10 {
-		t.Errorf("empty refresh should fall back to static, got %d manufacturers", len(mfrs))
+		t.Errorf("expected static fallback manufacturers (>10), got %d", len(mfrs))
 	}
 }
 
-func TestDynamicCatalog_BuildCatalog_MergesWithStatic(t *testing.T) {
-	d := NewDynamic(nil, nil, testLogger)
+func TestDynamicCatalog_Ingest_NewManufacturerAndModel(t *testing.T) {
+	d := NewDynamic(nil, testLogger)
+	d.Load(context.Background())
 
-	items := []yad2.CatalogItem{
-		{ManufacturerID: 99, ManufacturerName: "NewBrand", ModelID: 999, ModelName: "NewModel"},
-	}
-	mfrs, models := d.buildCatalog(items)
+	before := len(d.Manufacturers())
+	ctx := context.Background()
 
-	foundStatic := false
-	foundNew := false
-	for _, m := range mfrs {
-		if m.Name == "Toyota" {
-			foundStatic = true
-		}
-		if m.Name == "NewBrand" {
-			foundNew = true
-		}
+	d.Ingest(ctx, 999, "NewBrand", 88888, "NewModel")
+
+	after := len(d.Manufacturers())
+	if after != before+1 {
+		t.Errorf("expected %d manufacturers after ingest, got %d", before+1, after)
 	}
-	if !foundStatic {
-		t.Error("static manufacturer Toyota not found after merge")
+
+	if name := d.ManufacturerName(999); name != "NewBrand" {
+		t.Errorf("ManufacturerName(999) = %q, want NewBrand", name)
 	}
-	if !foundNew {
-		t.Error("new manufacturer NewBrand not found after merge")
-	}
-	if len(models[99]) != 1 || models[99][0].Name != "NewModel" {
-		t.Error("NewModel should be present for manufacturer 99")
+
+	models := d.Models(999)
+	if len(models) != 1 || models[0].Name != "NewModel" {
+		t.Errorf("expected 1 model NewModel, got %v", models)
 	}
 }
 
-func TestDynamicCatalog_BuildCatalog_SkipsInvalidItems(t *testing.T) {
-	d := NewDynamic(nil, nil, testLogger)
+func TestDynamicCatalog_Ingest_DuplicateIgnored(t *testing.T) {
+	d := NewDynamic(nil, testLogger)
+	d.Load(context.Background())
+	ctx := context.Background()
 
-	items := []yad2.CatalogItem{
-		{ManufacturerID: 0, ManufacturerName: "", ModelID: 1, ModelName: "X"},
-		{ManufacturerID: 5, ManufacturerName: "Valid", ModelID: 0, ModelName: ""},
-	}
-	mfrs, models := d.buildCatalog(items)
+	d.Ingest(ctx, 999, "NewBrand", 88888, "NewModel")
+	d.Ingest(ctx, 999, "NewBrand", 88888, "NewModel")
 
-	for _, m := range mfrs {
-		if m.ID == 0 {
-			t.Error("manufacturer with ID 0 should be skipped")
-		}
-	}
-	for _, m := range models[5] {
-		if m.ID == 0 {
-			t.Error("model with ID 0 should be skipped")
-		}
+	if len(d.Models(999)) != 1 {
+		t.Error("duplicate ingest should not add new entry")
 	}
 }
 
-func TestDynamicCatalog_BuildCatalog_PreservesStaticNames(t *testing.T) {
-	d := NewDynamic(nil, nil, testLogger)
+func TestDynamicCatalog_Ingest_SkipsInvalid(t *testing.T) {
+	d := NewDynamic(nil, testLogger)
+	d.Load(context.Background())
+	ctx := context.Background()
+	before := len(d.Manufacturers())
 
-	items := []yad2.CatalogItem{
-		{ManufacturerID: 19, ManufacturerName: "טויוטה", ModelID: 10226, ModelName: "קורולה"},
+	d.Ingest(ctx, 0, "", 1, "X")
+	d.Ingest(ctx, 0, "Empty", 1, "X")
+	d.Ingest(ctx, 5, "", 1, "X")
+
+	after := len(d.Manufacturers())
+	if after != before {
+		t.Errorf("invalid ingests should not change manufacturer count, was %d now %d", before, after)
 	}
-	mfrs, _ := d.buildCatalog(items)
+}
 
-	for _, m := range mfrs {
-		if m.ID == 19 {
-			if m.Name != "Toyota" {
-				t.Errorf("static name should be preserved, got %q", m.Name)
-			}
-			return
+func TestDynamicCatalog_Ingest_ManufacturerWithoutModel(t *testing.T) {
+	d := NewDynamic(nil, testLogger)
+	d.Load(context.Background())
+	ctx := context.Background()
+	before := len(d.Manufacturers())
+
+	d.Ingest(ctx, 999, "NoModelBrand", 0, "")
+
+	after := len(d.Manufacturers())
+	if after != before+1 {
+		t.Errorf("manufacturer-only ingest should add manufacturer, was %d now %d", before, after)
+	}
+	if name := d.ManufacturerName(999); name != "NoModelBrand" {
+		t.Errorf("ManufacturerName(999) = %q, want NoModelBrand", name)
+	}
+	if len(d.Models(999)) != 0 {
+		t.Error("manufacturer-only ingest should not add models")
+	}
+}
+
+func TestDynamicCatalog_Ingest_PreservesExistingName(t *testing.T) {
+	d := NewDynamic(nil, testLogger)
+	d.Load(context.Background())
+	ctx := context.Background()
+
+	d.Ingest(ctx, 19, "טויוטה", 10226, "קורולה")
+
+	if name := d.ManufacturerName(19); name != "Toyota" {
+		t.Errorf("static name should be preserved, got %q", name)
+	}
+}
+
+func TestDynamicCatalog_Flush_SavesWhenDirty(t *testing.T) {
+	store := &mockCatalogStore{}
+	d := NewDynamic(store, testLogger)
+	d.Load(context.Background())
+
+	d.Ingest(context.Background(), 999, "NewBrand", 88888, "NewModel")
+	d.Flush(context.Background())
+
+	if !store.saveCalled {
+		t.Error("Flush should save when dirty")
+	}
+}
+
+func TestDynamicCatalog_Flush_SaveError(t *testing.T) {
+	store := &mockCatalogStore{saveErr: errors.New("db write failed")}
+	d := NewDynamic(store, testLogger)
+	d.Load(context.Background())
+
+	d.Ingest(context.Background(), 999, "NewBrand", 88888, "NewModel")
+	d.Flush(context.Background())
+
+	if name := d.ManufacturerName(999); name != "NewBrand" {
+		t.Error("in-memory catalog should be intact even on save error")
+	}
+}
+
+func TestDynamicCatalog_Flush_PersistsManufacturersWithoutModels(t *testing.T) {
+	store := &mockCatalogStore{}
+	d := NewDynamic(store, testLogger)
+	d.Load(context.Background())
+
+	d.Ingest(context.Background(), 999, "NoModelBrand", 0, "")
+	d.Flush(context.Background())
+
+	if !store.saveCalled {
+		t.Fatal("Flush should save")
+	}
+
+	found := false
+	for _, e := range store.savedEntries {
+		if e.ManufacturerID == 999 && e.ManufacturerName == "NoModelBrand" {
+			found = true
 		}
 	}
-	t.Error("manufacturer 19 not found")
+	if !found {
+		t.Error("manufacturers without models should be persisted")
+	}
 }
 
 func TestDynamicCatalog_LoadFromStore(t *testing.T) {
 	store := &mockCatalogStore{
 		entries: []storage.CatalogEntry{
-			{ManufacturerID: 1, ManufacturerName: "Audi", ModelID: 100, ModelName: "A3"},
-			{ManufacturerID: 1, ManufacturerName: "Audi", ModelID: 101, ModelName: "A4"},
+			{ManufacturerID: 9000, ManufacturerName: "AlphaCar", ModelID: 100, ModelName: "Alpha1"},
+			{ManufacturerID: 9000, ManufacturerName: "AlphaCar", ModelID: 101, ModelName: "Alpha2"},
 		},
 	}
 
-	d := NewDynamic(store, nil, testLogger)
+	d := NewDynamic(store, testLogger)
 	ok := d.loadFromStore(context.Background())
 
 	if !ok {
 		t.Fatal("loadFromStore should return true")
 	}
-	if len(d.Manufacturers()) != 1 || d.Manufacturers()[0].Name != "Audi" {
-		t.Error("manufacturers not loaded correctly")
+	if name := d.ManufacturerName(9000); name != "AlphaCar" {
+		t.Errorf("ManufacturerName(9000) = %q, want AlphaCar", name)
 	}
-	if len(d.Models(1)) != 2 {
+	if len(d.Models(9000)) != 2 {
 		t.Error("models not loaded correctly")
 	}
 }
 
 func TestDynamicCatalog_LoadFromStore_Error(t *testing.T) {
 	store := &mockCatalogStore{loadErr: errors.New("db error")}
-	d := NewDynamic(store, nil, testLogger)
+	d := NewDynamic(store, testLogger)
 	if d.loadFromStore(context.Background()) {
 		t.Error("loadFromStore should return false on error")
 	}
@@ -331,14 +266,14 @@ func TestDynamicCatalog_LoadFromStore_Error(t *testing.T) {
 
 func TestDynamicCatalog_LoadFromStore_Empty(t *testing.T) {
 	store := &mockCatalogStore{entries: nil}
-	d := NewDynamic(store, nil, testLogger)
+	d := NewDynamic(store, testLogger)
 	if d.loadFromStore(context.Background()) {
 		t.Error("loadFromStore should return false when empty")
 	}
 }
 
 func TestDynamicCatalog_Models_UnknownManufacturer(t *testing.T) {
-	d := NewDynamic(nil, nil, testLogger)
+	d := NewDynamic(nil, testLogger)
 	models := d.Models(99999)
 	if models != nil {
 		t.Errorf("expected nil for unknown manufacturer, got %v", models)
@@ -351,7 +286,7 @@ func TestDynamicCatalog_ModelName(t *testing.T) {
 			{ManufacturerID: 1, ManufacturerName: "Audi", ModelID: 100, ModelName: "A3"},
 		},
 	}
-	d := NewDynamic(store, nil, testLogger)
+	d := NewDynamic(store, testLogger)
 	d.loadFromStore(context.Background())
 
 	if name := d.ModelName(1, 100); name != "A3" {
@@ -362,44 +297,5 @@ func TestDynamicCatalog_ModelName(t *testing.T) {
 	}
 	if name := d.ModelName(999, 1); name != "Unknown" {
 		t.Errorf("ModelName(999,1) = %q, want Unknown", name)
-	}
-}
-
-func TestDynamicCatalog_StartRefreshLoop_ContextCancel(t *testing.T) {
-	store := &mockCatalogStore{ageErr: errors.New("no cache")}
-	d := NewDynamic(store, nil, testLogger)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	d.StartRefreshLoop(ctx)
-	cancel()
-}
-
-func TestDynamicCatalog_FetchCatalog_HTTPError(t *testing.T) {
-	client := &mockHTTPClient{err: errors.New("connection refused")}
-	d := NewDynamic(nil, client, testLogger)
-
-	items, err := d.fetchCatalog(context.Background())
-	if err != nil {
-		t.Fatalf("fetchCatalog should not return error on individual page failures, got: %v", err)
-	}
-	if len(items) != 0 {
-		t.Errorf("expected 0 items on all page failures, got %d", len(items))
-	}
-}
-
-func TestDynamicCatalog_FetchCatalog_ParseError(t *testing.T) {
-	responses := make([]*http.Response, fetchPages)
-	for i := range responses {
-		responses[i] = makeHTTPResponse("<html>no next data here</html>")
-	}
-	client := &mockHTTPClient{responses: responses}
-	d := NewDynamic(nil, client, testLogger)
-
-	items, err := d.fetchCatalog(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(items) != 0 {
-		t.Errorf("expected 0 items on parse failure, got %d", len(items))
 	}
 }

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -64,13 +64,6 @@ func TestNewFetcherWithProxyPool(t *testing.T) {
 	}
 }
 
-func TestYad2Fetcher_HTTPClient(t *testing.T) {
-	f, _ := NewFetcher([]string{"TestAgent/1.0"}, "", discardLogger)
-	if f.HTTPClient() == nil {
-		t.Error("HTTPClient should not be nil")
-	}
-}
-
 func TestYad2Fetcher_Fetch(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -176,51 +169,20 @@ func TestYad2Fetcher_Fetch_Challenge(t *testing.T) {
 	}
 }
 
-func TestParseCatalogFromPage(t *testing.T) {
+func TestParseListingsPage_InlineHTML(t *testing.T) {
 	html := validPageHTML()
-	items, err := ParseCatalogFromPage(strings.NewReader(html))
+	listings, err := ParseListingsPage(strings.NewReader(html))
 	if err != nil {
-		t.Fatalf("ParseCatalogFromPage: %v", err)
+		t.Fatalf("ParseListingsPage: %v", err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(items))
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
 	}
-	if items[0].ManufacturerID != 27 || items[0].ManufacturerName != "Mazda" {
-		t.Errorf("item = %+v", items[0])
+	if listings[0].ManufacturerID != 27 || listings[0].Manufacturer != "Mazda" {
+		t.Errorf("listing = %+v", listings[0])
 	}
-	if items[0].ModelID != 10332 || items[0].ModelName != "3" {
-		t.Errorf("model = %+v", items[0])
-	}
-}
-
-func TestParseCatalogFromPage_Challenge(t *testing.T) {
-	_, err := ParseCatalogFromPage(strings.NewReader(`<html>Are you for real?</html>`))
-	if err == nil {
-		t.Error("expected error for challenge page")
-	}
-}
-
-func TestParseCatalogFromPage_NoNextData(t *testing.T) {
-	_, err := ParseCatalogFromPage(strings.NewReader(`<html><body>no data</body></html>`))
-	if err == nil {
-		t.Error("expected error for missing __NEXT_DATA__")
-	}
-}
-
-func TestParseCatalogFromPage_SkipsZeroID(t *testing.T) {
-	html := `<!DOCTYPE html><html><body>
-<script id="__NEXT_DATA__" type="application/json">
-{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{"data":{"feed":{"feed_items":[
-{"token":"tok-1","manufacturer":{"text":"","english_text":"","id":0},"model":{"text":"","id":0},"year_of_production":2021,"price":95000}
-]}}}}}]}}}}
-</script></body></html>`
-
-	items, err := ParseCatalogFromPage(strings.NewReader(html))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(items) != 0 {
-		t.Errorf("expected 0 items (ID=0 should be skipped), got %d", len(items))
+	if listings[0].ModelID != 10332 || listings[0].Model != "3" {
+		t.Errorf("model = %+v", listings[0])
 	}
 }
 

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -100,10 +100,12 @@ func itemToListing(raw json.RawMessage) (model.RawListing, error) {
 	}
 
 	listing := model.RawListing{
-		Token:        item.Token,
-		Manufacturer: textFromField(item.Manufacturer),
-		Model:        textFromField(item.Model),
-		SubModel:     textFromField(item.SubModel),
+		Token:            item.Token,
+		Manufacturer:     textFromField(item.Manufacturer),
+		ManufacturerID:   item.Manufacturer.ID,
+		Model:            textFromField(item.Model),
+		ModelID:          item.Model.ID,
+		SubModel:         textFromField(item.SubModel),
 		Year:         item.Year,
 		Month:        item.Month,
 		EngineVolume: item.EngineVolume,
@@ -137,58 +139,6 @@ func itemToListing(raw json.RawMessage) (model.RawListing, error) {
 	}
 
 	return listing, nil
-}
-
-type CatalogItem struct {
-	ManufacturerID   int
-	ManufacturerName string
-	ModelID          int
-	ModelName        string
-}
-
-func ParseCatalogFromPage(body io.Reader) ([]CatalogItem, error) {
-	raw, err := io.ReadAll(body)
-	if err != nil {
-		return nil, fmt.Errorf("read response body: %w", err)
-	}
-	html := string(raw)
-
-	if strings.Contains(html, challengeMarker) {
-		return nil, fmt.Errorf("yad2: %w", fetcher.ErrChallenge)
-	}
-
-	matches := nextDataRe.FindStringSubmatch(html)
-	if len(matches) < 2 || matches[1] == "" {
-		return nil, fmt.Errorf("__NEXT_DATA__ script tag not found")
-	}
-
-	var nextData nextDataEnvelope
-	if err := json.Unmarshal([]byte(matches[1]), &nextData); err != nil {
-		return nil, fmt.Errorf("unmarshal __NEXT_DATA__: %w", err)
-	}
-
-	items, err := extractItems(nextData)
-	if err != nil {
-		return nil, err
-	}
-
-	var catalog []CatalogItem
-	for _, raw := range items {
-		var item feedItem
-		if err := json.Unmarshal(raw, &item); err != nil {
-			continue
-		}
-		if item.Manufacturer.ID == 0 {
-			continue
-		}
-		catalog = append(catalog, CatalogItem{
-			ManufacturerID:   item.Manufacturer.ID,
-			ManufacturerName: textFromField(item.Manufacturer),
-			ModelID:          item.Model.ID,
-			ModelName:        textFromField(item.Model),
-		})
-	}
-	return catalog, nil
 }
 
 func textFromField(f field) string {

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -55,10 +55,6 @@ func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logge
 	}, nil
 }
 
-func (f *Yad2Fetcher) HTTPClient() *Client {
-	return f.client
-}
-
 func (f *Yad2Fetcher) Fetch(ctx context.Context, params config.SourceParams) ([]model.RawListing, error) {
 	if f.proxyPool != nil {
 		proxy := f.proxyPool.Next()

--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -3,9 +3,11 @@ package model
 import "time"
 
 type RawListing struct {
-	Token        string
-	Manufacturer string
-	Model        string
+	Token            string
+	Manufacturer     string
+	ManufacturerID   int
+	Model            string
+	ModelID          int
 	SubModel     string
 	Year         int
 	Month        int

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -30,6 +30,11 @@ const (
 	retryBaseDelay   = 2 * time.Second
 )
 
+type CatalogIngester interface {
+	Ingest(ctx context.Context, manufacturerID int, manufacturerName string, modelID int, modelName string)
+	Flush(ctx context.Context)
+}
+
 type Scheduler struct {
 	cfg               *config.Config
 	configPath        string
@@ -47,17 +52,19 @@ type Scheduler struct {
 	listingStore      storage.ListingStore
 	searchStore       storage.SearchStore
 	digestStore       storage.DigestStore
+	catalogIngester   CatalogIngester
 }
 
 type Options struct {
-	Health         *health.Status
-	Queue          storage.NotificationQueue
-	Prices         storage.PriceTracker
-	ConfigPath     string
-	FetcherFactory *fetcher.Factory
-	ListingStore   storage.ListingStore
-	SearchStore    storage.SearchStore
-	DigestStore    storage.DigestStore
+	Health          *health.Status
+	Queue           storage.NotificationQueue
+	Prices          storage.PriceTracker
+	ConfigPath      string
+	FetcherFactory  *fetcher.Factory
+	ListingStore    storage.ListingStore
+	SearchStore     storage.SearchStore
+	DigestStore     storage.DigestStore
+	CatalogIngester CatalogIngester
 }
 
 func New(
@@ -99,6 +106,7 @@ func NewWithOptions(
 		listingStore:      opts.ListingStore,
 		searchStore:       opts.SearchStore,
 		digestStore:       opts.DigestStore,
+		catalogIngester:   opts.CatalogIngester,
 	}, nil
 }
 
@@ -348,6 +356,10 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 		s.lastPruneTime = time.Now()
 	}
 
+	if s.catalogIngester != nil {
+		s.catalogIngester.Flush(ctx)
+	}
+
 	s.processDigests(ctx)
 
 	if allFailed && len(groups) > 0 {
@@ -375,6 +387,12 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 	raw, err := s.fetchWithRetryUsing(fetchCtx, activeFetcher, group.Params)
 	if err != nil {
 		return err
+	}
+
+	if s.catalogIngester != nil {
+		for _, l := range raw {
+			s.catalogIngester.Ingest(ctx, l.ManufacturerID, l.Manufacturer, l.ModelID, l.Model)
+		}
 	}
 
 	s.logger.Info("fetched for group",


### PR DESCRIPTION
## Summary
- **Catalog now grows from real data**: instead of separate HTTP requests to Yad2 (which get blocked), the catalog ingests manufacturer/model IDs from listings the scheduler already fetches during normal polling
- **RawListing gets IDs**: added `ManufacturerID` and `ModelID` fields so IDs flow through the parsing pipeline
- **Removed dead code**: `ParseCatalogFromPage`, `HTTPClient`, and the separate HTTP fetch loop are gone
- **Simpler architecture**: no more `httpClient` interface, no background refresh goroutine — the scheduler feeds the catalog directly

## How it works
```
Scheduler polls Yad2 for user searches
→ Parser extracts listings with manufacturer/model IDs
→ Scheduler calls catalog.Ingest() for each listing
→ Catalog adds new manufacturers/models it hasn't seen
→ Catalog persists to SQLite after each cycle
→ Bot keyboards show all discovered manufacturers/models
```

The catalog starts with the 14 static manufacturers and grows as users create searches. Over time, it discovers every manufacturer/model on Yad2.

## Test plan
- [x] All 14 test suites pass
- [x] New `TestDynamicCatalog_Ingest` test verifies ingestion works
- [ ] After deploy, verify catalog grows after first polling cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked catalog architecture: removed periodic scraping/refresh loops and moved refresh/ingest responsibility into scheduled listing processing.
  * Catalog now stores canonical manufacturer/model maps with on-demand rebuilds and persistence.

* **New Features**
  * Listings now include manufacturer and model IDs.
  * Added runtime ingestion and flush capabilities for updating and persisting catalog entries.

* **Tests**
  * Added and refocused tests for dynamic catalog loading, ingestion, and persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->