### PR TITLE
test: improve test coverage across 4 packages

### DIFF
--- a/cmd/bot/main_test.go
+++ b/cmd/bot/main_test.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
 func TestRun_InvalidConfigPath(t *testing.T) {
-	err := run("/nonexistent/config.yaml", nil)
+	err := run("/nonexistent/config.yaml", testLogger())
 	if err == nil {
 		t.Fatal("expected error for missing config file")
 	}
@@ -18,19 +24,181 @@ func TestRun_InvalidConfig(t *testing.T) {
 	path := filepath.Join(dir, "bad.yaml")
 	_ = os.WriteFile(path, []byte("invalid: {[broken yaml"), 0644)
 
-	err := run(path, nil)
+	err := run(path, testLogger())
 	if err == nil {
 		t.Fatal("expected error for invalid YAML")
 	}
 }
 
-func TestRun_NoSearches(t *testing.T) {
+func TestRun_MissingTelegramToken(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "empty.yaml")
-	_ = os.WriteFile(path, []byte("log_level: info\n"), 0644)
+	path := filepath.Join(dir, "no-token.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+storage:
+  db_path: ":memory:"
+`
+	_ = os.WriteFile(path, []byte(cfg), 0644)
 
-	err := run(path, nil)
+	err := run(path, testLogger())
 	if err == nil {
-		t.Fatal("expected error for config with no searches")
+		t.Fatal("expected error for missing telegram token")
+	}
+	if !strings.Contains(err.Error(), "telegram.token") {
+		t.Errorf("expected telegram.token validation error, got: %v", err)
+	}
+}
+
+func TestRun_InvalidDBPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+telegram:
+  token: "test-token"
+storage:
+  db_path: "/nonexistent/deep/path/db.sqlite"
+`
+	_ = os.WriteFile(path, []byte(cfg), 0644)
+
+	err := run(path, testLogger())
+	if err == nil {
+		t.Fatal("expected error for invalid DB path")
+	}
+	if !strings.Contains(err.Error(), "store") {
+		t.Errorf("expected store creation error, got: %v", err)
+	}
+}
+
+func TestRun_InvalidLogLevel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: "invalid_level"
+telegram:
+  token: "test-token"
+`
+	_ = os.WriteFile(path, []byte(cfg), 0644)
+
+	err := run(path, testLogger())
+	if err == nil {
+		t.Fatal("expected error for invalid log level")
+	}
+	if !strings.Contains(err.Error(), "log_level") {
+		t.Errorf("expected log_level validation error, got: %v", err)
+	}
+}
+
+func TestRun_InvalidActiveHours(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+  active_hours:
+    start: "not-a-time"
+    end: "23:00"
+telegram:
+  token: "test-token"
+`
+	_ = os.WriteFile(path, []byte(cfg), 0644)
+
+	err := run(path, testLogger())
+	if err == nil {
+		t.Fatal("expected error for invalid active hours")
+	}
+	if !strings.Contains(err.Error(), "active_hours") {
+		t.Errorf("expected active_hours validation error, got: %v", err)
+	}
+}
+
+func TestRun_EmptyProxies_UsesDefault(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+telegram:
+  token: "invalid-token-but-valid-format"
+storage:
+  db_path: "` + dbPath + `"
+http:
+  proxies: []
+`
+	_ = os.WriteFile(path, []byte(cfg), 0644)
+
+	err := run(path, testLogger())
+	// Will fail at telegram connection, but should get past SQLite and fetcher creation.
+	if err == nil {
+		t.Fatal("expected error (telegram connection)")
+	}
+	if strings.Contains(err.Error(), "create store") || strings.Contains(err.Error(), "create fetcher") {
+		t.Errorf("should not fail at store/fetcher creation, got: %v", err)
+	}
+}
+
+func TestRun_WithProxies(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+telegram:
+  token: "invalid-token-but-valid-format"
+storage:
+  db_path: "` + dbPath + `"
+http:
+  proxies:
+    - "http://proxy1:8080"
+    - "http://proxy2:8080"
+`
+	_ = os.WriteFile(path, []byte(cfg), 0644)
+
+	err := run(path, testLogger())
+	if err == nil {
+		t.Fatal("expected error (telegram connection)")
+	}
+	if strings.Contains(err.Error(), "create store") || strings.Contains(err.Error(), "create fetcher") {
+		t.Errorf("should not fail at store/fetcher creation with proxies, got: %v", err)
+	}
+}
+
+func TestRun_CustomLogLevels(t *testing.T) {
+	for _, level := range []string{"debug", "warn", "error"} {
+		t.Run(level, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			cfg := `
+log_level: ` + level + `
+telegram:
+  token: "test-token"
+storage:
+  db_path: "/nonexistent/db.sqlite"
+`
+			_ = os.WriteFile(path, []byte(cfg), 0644)
+
+			err := run(path, testLogger())
+			if err == nil {
+				t.Fatal("expected error (bad db path)")
+			}
+			// Should fail at store creation, not config/log level.
+			if strings.Contains(err.Error(), "log_level") {
+				t.Errorf("log_level %q should be valid, got: %v", level, err)
+			}
+		})
 	}
 }

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -1,0 +1,834 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	tgmodels "github.com/go-telegram/bot/models"
+
+	"github.com/dsionov/carwatch/internal/catalog"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// errMessenger returns configurable errors from SendMessage and AnswerCallback.
+type errMessenger struct {
+	mockMessenger
+	sendErr     error
+	callbackErr error
+}
+
+func (m *errMessenger) SendMessage(ctx context.Context, chatID int64, text string, parseMode string, kb *tgmodels.InlineKeyboardMarkup) error {
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	return m.mockMessenger.SendMessage(ctx, chatID, text, parseMode, kb)
+}
+
+func (m *errMessenger) AnswerCallback(_ context.Context, _ string) error {
+	return m.callbackErr
+}
+
+// errUserStore implements UserStore and returns errors.
+type errUserStore struct {
+	upsertErr      error
+	getUserErr     error
+	updateStateErr error
+	user           *storage.User
+}
+
+func (m *errUserStore) UpsertUser(_ context.Context, _ int64, _ string) error {
+	return m.upsertErr
+}
+
+func (m *errUserStore) GetUser(_ context.Context, _ int64) (*storage.User, error) {
+	if m.getUserErr != nil {
+		return nil, m.getUserErr
+	}
+	return m.user, nil
+}
+
+func (m *errUserStore) UpdateUserState(_ context.Context, _ int64, _ string, _ string) error {
+	return m.updateStateErr
+}
+
+func (m *errUserStore) ListActiveUsers(_ context.Context) ([]storage.User, error) { return nil, nil }
+func (m *errUserStore) SetUserActive(_ context.Context, _ int64, _ bool) error    { return nil }
+func (m *errUserStore) CountUsers(_ context.Context) (int64, error)               { return 0, nil }
+
+// errSearchStore implements SearchStore and returns errors.
+type errSearchStore struct {
+	listErr       error
+	createErr     error
+	deleteErr     error
+	getErr        error
+	countErr      error
+	searches      []storage.Search
+	setActiveErr  error
+}
+
+func (m *errSearchStore) CreateSearch(_ context.Context, _ storage.Search) (int64, error) {
+	if m.createErr != nil {
+		return 0, m.createErr
+	}
+	return 1, nil
+}
+
+func (m *errSearchStore) ListSearches(_ context.Context, _ int64) ([]storage.Search, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.searches, nil
+}
+
+func (m *errSearchStore) GetSearch(_ context.Context, _ int64) (*storage.Search, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if len(m.searches) > 0 {
+		return &m.searches[0], nil
+	}
+	return nil, nil
+}
+
+func (m *errSearchStore) DeleteSearch(_ context.Context, _ int64, _ int64) error {
+	return m.deleteErr
+}
+
+func (m *errSearchStore) SetSearchActive(_ context.Context, _ int64, _ bool) error {
+	return m.setActiveErr
+}
+
+func (m *errSearchStore) ListAllActiveSearches(_ context.Context) ([]storage.Search, error) {
+	return m.searches, nil
+}
+
+func (m *errSearchStore) CountSearches(_ context.Context, _ int64) (int64, error) {
+	if m.countErr != nil {
+		return 0, m.countErr
+	}
+	return int64(len(m.searches)), nil
+}
+
+func (m *errSearchStore) CountAllSearches(_ context.Context) (int64, error) { return 0, nil }
+
+// errDigestStore implements DigestStore and returns errors.
+type errDigestStore struct {
+	getModeErr error
+	setModeErr error
+	mode       string
+	interval   string
+}
+
+func (m *errDigestStore) SetDigestMode(_ context.Context, _ int64, _ string, _ string) error {
+	return m.setModeErr
+}
+
+func (m *errDigestStore) GetDigestMode(_ context.Context, _ int64) (string, string, error) {
+	if m.getModeErr != nil {
+		return "", "", m.getModeErr
+	}
+	return m.mode, m.interval, nil
+}
+
+func (m *errDigestStore) AddDigestItem(_ context.Context, _ int64, _ string) error { return nil }
+func (m *errDigestStore) FlushDigest(_ context.Context, _ int64) ([]string, error) { return nil, nil }
+func (m *errDigestStore) PendingDigestUsers(_ context.Context) ([]int64, error)    { return nil, nil }
+
+func (m *errDigestStore) DigestLastFlushed(_ context.Context, _ int64) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func newErrBot(t *testing.T, msg messenger, users storage.UserStore, searches storage.SearchStore) *Bot {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &Bot{
+		msg:         msg,
+		users:       users,
+		searches:    searches,
+		catalog:     catalog.NewStatic(),
+		adminChatID: 999,
+		maxSearches: 3,
+		botUsername:  "test_bot",
+		logger:      logger,
+	}
+}
+
+// --- Send error tests ---
+
+func TestSend_Error_LogsAndContinues(t *testing.T) {
+	msg := &errMessenger{sendErr: errors.New("telegram down")}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	b.send(context.Background(), 100, "hello")
+	// Should not panic — error is logged.
+}
+
+func TestSendMarkdown_Error_LogsAndContinues(t *testing.T) {
+	msg := &errMessenger{sendErr: errors.New("telegram down")}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	b.sendMarkdown(context.Background(), 100, "*bold*")
+	// Should not panic.
+}
+
+func TestSendWithKeyboard_Error_LogsAndContinues(t *testing.T) {
+	msg := &errMessenger{sendErr: errors.New("telegram down")}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	kb := &tgmodels.InlineKeyboardMarkup{
+		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+			{{Text: "OK", CallbackData: "ok"}},
+		},
+	}
+	b.sendWithKeyboard(context.Background(), 100, "choose", kb)
+	// Should not panic.
+}
+
+// --- ensureUser error test ---
+
+func TestEnsureUser_Error_LogsAndContinues(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{upsertErr: errors.New("db full")}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	b.ensureUser(context.Background(), 100, "alice")
+	// Should not panic.
+}
+
+// --- loadWizardData error tests ---
+
+func TestLoadWizardData_GetUserError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{getUserErr: errors.New("db error")}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	wd := b.loadWizardData(context.Background(), 100)
+	if wd != (WizardData{}) {
+		t.Errorf("expected empty WizardData on error, got %+v", wd)
+	}
+}
+
+func TestLoadWizardData_NilUser(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: nil}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	wd := b.loadWizardData(context.Background(), 100)
+	if wd != (WizardData{}) {
+		t.Errorf("expected empty WizardData for nil user, got %+v", wd)
+	}
+}
+
+func TestLoadWizardData_CorruptJSON(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{
+		user: &storage.User{ChatID: 100, State: StateAskYearMin, StateData: "{{not json"},
+	}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	wd := b.loadWizardData(context.Background(), 100)
+	if wd != (WizardData{}) {
+		t.Errorf("expected empty WizardData for corrupt JSON, got %+v", wd)
+	}
+}
+
+// --- saveWizardState error tests ---
+
+func TestSaveWizardState_UpdateError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{updateStateErr: errors.New("write failed")}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	b.saveWizardState(context.Background(), 100, StateAskYearMin, WizardData{Manufacturer: 27})
+	// Should not panic — error is logged.
+}
+
+// --- handleList error test ---
+
+func TestHandleList_StoreError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{listErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/list")
+	b.handleList(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to load") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- handleWatch CountSearches error test ---
+
+func TestHandleWatch_CountSearchesError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{countErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/watch")
+	b.handleWatch(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "marketplace") {
+		t.Errorf("should proceed despite count error, got %q", last.Text)
+	}
+}
+
+// --- onConfirm error test ---
+
+func TestOnConfirm_CreateSearchError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{
+		user: &storage.User{
+			ChatID:    100,
+			State:     StateConfirm,
+			StateData: `{"manufacturer":27,"manufacturerName":"Mazda","model":10332,"modelName":"3","yearMin":2020,"yearMax":2024,"priceMax":150000,"engineMinCC":2000,"source":"yad2"}`,
+		},
+	}
+	searches := &errSearchStore{createErr: errors.New("db full")}
+	b := newErrBot(t, msg, users, searches)
+
+	b.onConfirm(context.Background(), 100)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to save") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- onDeleteSearch error tests ---
+
+func TestOnDeleteSearch_NotFoundError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{deleteErr: storage.ErrNotFound}
+	b := newErrBot(t, msg, users, searches)
+
+	b.onDeleteSearch(context.Background(), 100, cbDeleteSearch+"1")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "not found") {
+		t.Errorf("expected 'not found' message, got %q", last.Text)
+	}
+}
+
+func TestOnDeleteSearch_GenericError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{deleteErr: errors.New("db locked")}
+	b := newErrBot(t, msg, users, searches)
+
+	b.onDeleteSearch(context.Background(), 100, cbDeleteSearch+"1")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to delete") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+func TestOnDeleteSearch_InvalidID(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	b.onDeleteSearch(context.Background(), 100, cbDeleteSearch+"notanumber")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Invalid") {
+		t.Errorf("expected invalid ID message, got %q", last.Text)
+	}
+}
+
+// --- handleDigest error tests ---
+
+func TestHandleDigest_GetModeError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	ds := &errDigestStore{getModeErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+	b.digests = ds
+
+	update := fakeMessage(100, "/digest")
+	b.handleDigest(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to load") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+func TestOnDigestOn_SetModeError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	ds := &errDigestStore{setModeErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+	b.digests = ds
+
+	b.onDigestOn(context.Background(), 100)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to update") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+func TestOnDigestOff_SetModeError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	ds := &errDigestStore{setModeErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+	b.digests = ds
+
+	b.onDigestOff(context.Background(), 100)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to update") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- handleCallback edge cases ---
+
+func TestHandleCallback_InaccessibleMessage(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+
+	update := &tgmodels.Update{
+		CallbackQuery: &tgmodels.CallbackQuery{
+			ID:   "cb-1",
+			Data: cbConfirm,
+			From: tgmodels.User{Username: "alice"},
+			Message: tgmodels.MaybeInaccessibleMessage{
+				Message: nil,
+			},
+		},
+	}
+
+	tb.bot.handleCallback(ctx, nil, update)
+	// Should return early without panicking.
+}
+
+func TestHandleCallback_AnswerCallbackError(t *testing.T) {
+	msg := &errMessenger{callbackErr: errors.New("callback ack failed")}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeCallback(100, cbConfirm)
+	b.handleCallback(context.Background(), nil, update)
+	// Should continue despite callback ack failure.
+}
+
+// --- handleDefault with GetUser error ---
+
+func TestHandleDefault_GetUserError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{getUserErr: errors.New("db error")}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "some text")
+	b.handleDefault(context.Background(), nil, update)
+	// Should not panic, no messages sent.
+	if len(msg.messages) != 0 {
+		t.Errorf("expected no messages on GetUser error, got %d", len(msg.messages))
+	}
+}
+
+// --- handleStop delete error ---
+
+func TestHandleStop_DeleteError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{deleteErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/stop 1")
+	b.handleStop(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to delete") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- handlePause SetSearchActive error ---
+
+func TestHandlePause_SetActiveError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{
+		searches:     []storage.Search{{ID: 1, ChatID: 100, Active: true}},
+		setActiveErr: errors.New("db error"),
+	}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/pause 1")
+	b.handlePause(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to pause") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- handleResume SetSearchActive error ---
+
+func TestHandleResume_SetActiveError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{
+		searches:     []storage.Search{{ID: 1, ChatID: 100, Active: false}},
+		setActiveErr: errors.New("db error"),
+	}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/resume 1")
+	b.handleResume(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to resume") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- onShareCopy CreateSearch error ---
+
+func TestOnShareCopy_CreateSearchError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 200, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{
+		searches:  []storage.Search{{ID: 1, ChatID: 100, Manufacturer: 27, Model: 10332, Source: "yad2"}},
+		createErr: errors.New("db full"),
+	}
+	b := newErrBot(t, msg, users, searches)
+
+	b.onShareCopy(context.Background(), 200, cbPrefixShareCopy+"1")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to copy") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
+// --- SetBot and DefaultHandler coverage ---
+
+func TestSetBot_Nil(t *testing.T) {
+	tb := newTestBot(t)
+	tb.bot.SetBot(nil)
+	if tb.bot.bot != nil {
+		t.Error("SetBot(nil) should set bot to nil")
+	}
+}
+
+func TestDefaultHandler_ReturnsFunction(t *testing.T) {
+	tb := newTestBot(t)
+	handler := tb.bot.DefaultHandler()
+	if handler == nil {
+		t.Error("DefaultHandler should return non-nil")
+	}
+
+	update := fakeMessage(100, "test")
+	_ = tb.store.UpsertUser(context.Background(), 100, "alice")
+	handler(context.Background(), nil, update)
+	// Should handle without panic.
+}
+
+// --- ShareLink function test ---
+
+func TestShareLink_Format(t *testing.T) {
+	link := ShareLink("mybot", 42)
+	expected := "https://t.me/mybot?start=share_42"
+	if link != expected {
+		t.Errorf("ShareLink = %q, want %q", link, expected)
+	}
+}
+
+// --- handleShareStart invalid ID ---
+
+func TestHandleShareStart_InvalidID(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	b := newErrBot(t, msg, users, searches)
+
+	b.handleShareStart(context.Background(), 100, "share_notanumber")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Invalid") {
+		t.Errorf("expected invalid message, got %q", last.Text)
+	}
+}
+
+func TestHandleShareStart_NotFoundSearch(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{getErr: errors.New("not found")}
+	b := newErrBot(t, msg, users, searches)
+
+	b.handleShareStart(context.Background(), 100, "share_999")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "not found") {
+		t.Errorf("expected 'not found' message, got %q", last.Text)
+	}
+}
+
+func TestHandleShareStart_WithEngine(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{
+		searches: []storage.Search{{
+			ID: 1, ChatID: 200, Manufacturer: 27, Model: 10332,
+			YearMin: 2020, YearMax: 2024, PriceMax: 100000, EngineMinCC: 2000,
+		}},
+	}
+	b := newErrBot(t, msg, users, searches)
+
+	b.handleShareStart(context.Background(), 100, "share_1")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "2.0L+") {
+		t.Errorf("expected engine size in summary, got %q", last.Text)
+	}
+	if !last.HasKB {
+		t.Error("expected copy button")
+	}
+}
+
+func TestHandleShareStart_WithoutEngine(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{
+		searches: []storage.Search{{
+			ID: 1, ChatID: 200, Manufacturer: 27, Model: 10332,
+			YearMin: 2020, YearMax: 2024, PriceMax: 100000, EngineMinCC: 0,
+		}},
+	}
+	b := newErrBot(t, msg, users, searches)
+
+	b.handleShareStart(context.Background(), 100, "share_1")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Any") {
+		t.Errorf("expected 'Any' for zero engine, got %q", last.Text)
+	}
+}
+
+// --- handleShare GetSearch error ---
+
+func TestHandleShare_GetSearchError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{getErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/share 1")
+	b.handleShare(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "not found") {
+		t.Errorf("expected 'not found' message on GetSearch error, got %q", last.Text)
+	}
+}
+
+// --- handlePause/Resume GetSearch error ---
+
+func TestHandlePause_GetSearchError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{getErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/pause 1")
+	b.handlePause(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "not found") {
+		t.Errorf("expected 'not found' message, got %q", last.Text)
+	}
+}
+
+func TestHandleResume_GetSearchError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{getErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(100, "/resume 1")
+	b.handleResume(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "not found") {
+		t.Errorf("expected 'not found' message, got %q", last.Text)
+	}
+}
+
+// --- New constructor coverage ---
+
+func TestNew_DefaultCatalog(t *testing.T) {
+	b := New(nil, nil, nil, Config{}, slog.Default())
+	if b.catalog == nil {
+		t.Error("catalog should default to static when nil")
+	}
+	if b.maxSearches != 3 {
+		t.Errorf("maxSearches = %d, want 3", b.maxSearches)
+	}
+}
+
+func TestNew_WithCatalog(t *testing.T) {
+	cat := catalog.NewStatic()
+	b := New(nil, nil, nil, Config{Catalog: cat}, slog.Default())
+	if b.catalog != cat {
+		t.Error("catalog should use provided instance")
+	}
+}
+
+// --- handleStats with CountUsers/CountSearches errors ---
+
+func TestHandleStats_Admin_CountErrors(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 999, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{countErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+
+	update := fakeMessage(999, "/stats")
+	b.handleStats(context.Background(), nil, update)
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Stats") {
+		t.Errorf("should still display stats despite count errors, got %q", last.Text)
+	}
+}
+
+// --- handleOnSourceSelected coverage (quick smoke) ---
+
+func TestOnSourceSelected_WinWin(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 100
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+	tb.simulateCommand(ctx, chatID, "/watch")
+	tb.msg.reset()
+
+	tb.simulateCallback(ctx, chatID, cbPrefixSource+"winwin")
+
+	user, _ := tb.store.GetUser(ctx, chatID)
+	if user.State != StateAskManufacturer {
+		t.Errorf("state = %q, want %q", user.State, StateAskManufacturer)
+	}
+
+	last := tb.msg.last()
+	if !last.HasKB {
+		t.Error("expected manufacturer keyboard")
+	}
+}
+
+// --- Wizard with WinWin source creates correct search ---
+
+func TestWizardFlow_WinWin(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 100
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+	tb.simulateCommand(ctx, chatID, "/watch")
+	tb.simulateCallback(ctx, chatID, cbPrefixSource+"winwin")
+	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
+	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
+	tb.simulateText(ctx, chatID, "2018")
+	tb.simulateText(ctx, chatID, "2024")
+	tb.simulateText(ctx, chatID, "150000")
+	tb.simulateCallback(ctx, chatID, cbPrefixEngine+"2000")
+	tb.simulateCallback(ctx, chatID, cbConfirm)
+
+	searches, _ := tb.store.ListSearches(ctx, chatID)
+	if len(searches) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(searches))
+	}
+	if searches[0].Source != "winwin" {
+		t.Errorf("source = %q, want winwin", searches[0].Source)
+	}
+
+	last := tb.msg.last()
+	if !strings.Contains(last.Text, "WinWin") {
+		t.Errorf("confirm message should mention WinWin, got %q", last.Text)
+	}
+}
+
+// --- Confirm with empty source defaults to yad2 ---
+
+func TestOnConfirm_EmptySourceDefaultsToYad2(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 100
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+
+	wd := WizardData{
+		Manufacturer: 27, ManufacturerName: "Mazda",
+		Model: 10332, ModelName: "3",
+		YearMin: 2020, YearMax: 2024, PriceMax: 100000,
+	}
+	tb.bot.saveWizardState(ctx, chatID, StateConfirm, wd)
+	tb.msg.reset()
+
+	tb.simulateCallback(ctx, chatID, cbConfirm)
+
+	searches, _ := tb.store.ListSearches(ctx, chatID)
+	if len(searches) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(searches))
+	}
+	if searches[0].Source != "yad2" {
+		t.Errorf("empty source should default to yad2, got %q", searches[0].Source)
+	}
+}
+
+// --- Multiple delete callbacks ---
+
+func TestDeleteSearch_TwiceYields404(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 100
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+	id, _ := tb.store.CreateSearch(ctx, newFakeSearch(chatID, 27))
+	tb.msg.reset()
+
+	tb.simulateCallback(ctx, chatID, cbDeleteSearch+fmt.Sprintf("%d", id))
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "deleted") {
+		t.Fatalf("first delete should succeed, got %q", msg.Text)
+	}
+
+	tb.msg.reset()
+	tb.simulateCallback(ctx, chatID, cbDeleteSearch+fmt.Sprintf("%d", id))
+	msg = tb.msg.last()
+	if !strings.Contains(msg.Text, "not found") {
+		t.Errorf("second delete should say 'not found', got %q", msg.Text)
+	}
+}

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -41,7 +41,7 @@ var sendMessageOK = tgResponse(map[string]any{
 func routingHandler(sendMessageHandler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "getMe") {
-			w.Write(getMeResponse)
+			_, _ = w.Write(getMeResponse)
 			return
 		}
 		sendMessageHandler(w, r)
@@ -180,7 +180,7 @@ func TestLastRuneNewlineBefore_Empty(t *testing.T) {
 
 func TestSendMessage_InvalidChatID(t *testing.T) {
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	err := n.NotifyRaw(context.Background(), "not-a-number", "hello")
@@ -196,7 +196,7 @@ func TestSendMessage_Success(t *testing.T) {
 	var sendCalls atomic.Int32
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
 		sendCalls.Add(1)
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	err := n.NotifyRaw(context.Background(), "123", "hello world")
@@ -215,7 +215,7 @@ func TestSendMessage_APIError(t *testing.T) {
 			"ok":          false,
 			"description": "Forbidden: bot was blocked by the user",
 		})
-		w.Write(resp)
+		_, _ = w.Write(resp)
 	}))
 
 	err := n.NotifyRaw(context.Background(), "123", "hello")
@@ -231,7 +231,7 @@ func TestSendMessage_LargeMessage_MultipleChunks(t *testing.T) {
 	var sendCalls atomic.Int32
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
 		sendCalls.Add(1)
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	text := strings.Repeat("a\n", maxMessageLen)
@@ -254,10 +254,10 @@ func TestSendMessage_PartialFailure(t *testing.T) {
 				"ok":          false,
 				"description": "Too Many Requests",
 			})
-			w.Write(resp)
+			_, _ = w.Write(resp)
 			return
 		}
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	text := strings.Repeat("x", maxMessageLen+100)
@@ -278,7 +278,7 @@ func TestNotify_FormatsAndSends(t *testing.T) {
 		mu.Lock()
 		bodies = append(bodies, string(body))
 		mu.Unlock()
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	listings := []model.Listing{
@@ -311,7 +311,7 @@ func TestNotify_FormatsAndSends(t *testing.T) {
 
 func TestConnect_Success(t *testing.T) {
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	err := n.Connect(context.Background())
@@ -326,7 +326,7 @@ func TestConnect_Failure(t *testing.T) {
 		if strings.Contains(r.URL.Path, "getMe") {
 			c := getMeCalls.Add(1)
 			if c == 1 {
-				w.Write(getMeResponse)
+				_, _ = w.Write(getMeResponse)
 				return
 			}
 			w.WriteHeader(http.StatusUnauthorized)
@@ -334,10 +334,10 @@ func TestConnect_Failure(t *testing.T) {
 				"ok":          false,
 				"description": "Unauthorized",
 			})
-			w.Write(resp)
+			_, _ = w.Write(resp)
 			return
 		}
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -359,7 +359,7 @@ func TestConnect_Failure(t *testing.T) {
 
 func TestDisconnect_ReturnsNil(t *testing.T) {
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	if err := n.Disconnect(); err != nil {
@@ -371,7 +371,7 @@ func TestDisconnect_ReturnsNil(t *testing.T) {
 
 func TestBot_ReturnsInstance(t *testing.T) {
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(sendMessageOK)
+		_, _ = w.Write(sendMessageOK)
 	}))
 
 	if n.Bot() == nil {

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -1,0 +1,389 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	tgbot "github.com/go-telegram/bot"
+
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+type discardWriter struct{}
+
+func (d *discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func tgResponse(result any) []byte {
+	b, _ := json.Marshal(map[string]any{"ok": true, "result": result})
+	return b
+}
+
+var getMeResponse = tgResponse(map[string]any{
+	"id": 12345, "is_bot": true, "first_name": "TestBot", "username": "test_bot",
+})
+
+var sendMessageOK = tgResponse(map[string]any{
+	"message_id": 1, "chat": map[string]any{"id": 123}, "date": 0,
+})
+
+func routingHandler(sendMessageHandler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "getMe") {
+			w.Write(getMeResponse)
+			return
+		}
+		sendMessageHandler(w, r)
+	}
+}
+
+func newTestNotifier(t *testing.T, handler http.Handler) *Notifier {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	n, err := New("test-token", testLogger(),
+		tgbot.WithServerURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("create notifier: %v", err)
+	}
+	return n
+}
+
+// --- splitMessage tests ---
+
+func TestSplitMessage_ShortMessage(t *testing.T) {
+	chunks := splitMessage("hello", 100)
+	if len(chunks) != 1 || chunks[0] != "hello" {
+		t.Errorf("expected single chunk 'hello', got %v", chunks)
+	}
+}
+
+func TestSplitMessage_ExactLimit(t *testing.T) {
+	text := strings.Repeat("a", 100)
+	chunks := splitMessage(text, 100)
+	if len(chunks) != 1 {
+		t.Errorf("expected 1 chunk for text at exact limit, got %d", len(chunks))
+	}
+}
+
+func TestSplitMessage_SplitsAtNewline(t *testing.T) {
+	line := strings.Repeat("a", 40)
+	text := line + "\n" + line + "\n" + line
+	chunks := splitMessage(text, 50)
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if len([]rune(chunk)) > 50 {
+			t.Errorf("chunk %d exceeds limit: %d runes", i, len([]rune(chunk)))
+		}
+	}
+}
+
+func TestSplitMessage_NoNewline_SplitsAtLimit(t *testing.T) {
+	text := strings.Repeat("x", 200)
+	chunks := splitMessage(text, 100)
+
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if len([]rune(chunks[0])) != 100 {
+		t.Errorf("first chunk should be 100 runes, got %d", len([]rune(chunks[0])))
+	}
+	if len([]rune(chunks[1])) != 100 {
+		t.Errorf("second chunk should be 100 runes, got %d", len([]rune(chunks[1])))
+	}
+}
+
+func TestSplitMessage_Unicode(t *testing.T) {
+	text := strings.Repeat("שלום", 30) // 4 runes each = 120 runes
+	chunks := splitMessage(text, 50)
+
+	total := 0
+	for i, chunk := range chunks {
+		runeLen := len([]rune(chunk))
+		if runeLen > 50 {
+			t.Errorf("chunk %d has %d runes, exceeds limit 50", i, runeLen)
+		}
+		total += runeLen
+	}
+	if total != 120 {
+		t.Errorf("total runes = %d, want 120", total)
+	}
+}
+
+func TestSplitMessage_EmptyString(t *testing.T) {
+	chunks := splitMessage("", 100)
+	if len(chunks) != 1 || chunks[0] != "" {
+		t.Errorf("expected single empty chunk, got %v", chunks)
+	}
+}
+
+func TestSplitMessage_PreservesContent(t *testing.T) {
+	text := "line1\nline2\nline3\nline4\nline5"
+	chunks := splitMessage(text, 15)
+
+	combined := strings.Join(chunks, "")
+	if combined != text {
+		t.Errorf("reassembled text differs:\ngot:  %q\nwant: %q", combined, text)
+	}
+}
+
+// --- lastRuneNewlineBefore tests ---
+
+func TestLastRuneNewlineBefore_Found(t *testing.T) {
+	r := []rune("hello\nworld\nfoo")
+	idx := lastRuneNewlineBefore(r, 12)
+	if idx != 11 {
+		t.Errorf("expected 11, got %d", idx)
+	}
+}
+
+func TestLastRuneNewlineBefore_NotFound(t *testing.T) {
+	r := []rune("helloworld")
+	idx := lastRuneNewlineBefore(r, 10)
+	if idx != -1 {
+		t.Errorf("expected -1 when no newline, got %d", idx)
+	}
+}
+
+func TestLastRuneNewlineBefore_PosExceedsLen(t *testing.T) {
+	r := []rune("a\nb")
+	idx := lastRuneNewlineBefore(r, 100)
+	if idx != 1 {
+		t.Errorf("expected 1, got %d", idx)
+	}
+}
+
+func TestLastRuneNewlineBefore_Empty(t *testing.T) {
+	idx := lastRuneNewlineBefore(nil, 5)
+	if idx != -1 {
+		t.Errorf("expected -1 for nil slice, got %d", idx)
+	}
+}
+
+// --- sendMessage tests ---
+
+func TestSendMessage_InvalidChatID(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(sendMessageOK)
+	}))
+
+	err := n.NotifyRaw(context.Background(), "not-a-number", "hello")
+	if err == nil {
+		t.Fatal("expected error for invalid chat ID")
+	}
+	if !strings.Contains(err.Error(), "invalid chat ID") {
+		t.Errorf("expected 'invalid chat ID' error, got: %v", err)
+	}
+}
+
+func TestSendMessage_Success(t *testing.T) {
+	var sendCalls atomic.Int32
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		sendCalls.Add(1)
+		w.Write(sendMessageOK)
+	}))
+
+	err := n.NotifyRaw(context.Background(), "123", "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sendCalls.Load() != 1 {
+		t.Errorf("expected 1 sendMessage call, got %d", sendCalls.Load())
+	}
+}
+
+func TestSendMessage_APIError(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		resp, _ := json.Marshal(map[string]any{
+			"ok":          false,
+			"description": "Forbidden: bot was blocked by the user",
+		})
+		w.Write(resp)
+	}))
+
+	err := n.NotifyRaw(context.Background(), "123", "hello")
+	if err == nil {
+		t.Fatal("expected error for API failure")
+	}
+	if !strings.Contains(err.Error(), "telegram sendMessage") {
+		t.Errorf("expected 'telegram sendMessage' error, got: %v", err)
+	}
+}
+
+func TestSendMessage_LargeMessage_MultipleChunks(t *testing.T) {
+	var sendCalls atomic.Int32
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		sendCalls.Add(1)
+		w.Write(sendMessageOK)
+	}))
+
+	text := strings.Repeat("a\n", maxMessageLen)
+	err := n.NotifyRaw(context.Background(), "123", text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sendCalls.Load() < 2 {
+		t.Errorf("expected multiple sendMessage calls for large message, got %d", sendCalls.Load())
+	}
+}
+
+func TestSendMessage_PartialFailure(t *testing.T) {
+	var sendCalls atomic.Int32
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		c := sendCalls.Add(1)
+		if c == 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			resp, _ := json.Marshal(map[string]any{
+				"ok":          false,
+				"description": "Too Many Requests",
+			})
+			w.Write(resp)
+			return
+		}
+		w.Write(sendMessageOK)
+	}))
+
+	text := strings.Repeat("x", maxMessageLen+100)
+	err := n.NotifyRaw(context.Background(), "123", text)
+	if err == nil {
+		t.Fatal("expected error on second chunk failure")
+	}
+}
+
+// --- Notify tests ---
+
+func TestNotify_FormatsAndSends(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		w.Write(sendMessageOK)
+	}))
+
+	listings := []model.Listing{
+		{
+			RawListing: model.RawListing{
+				Token: "abc", Manufacturer: "Toyota", Model: "Corolla",
+				Year: 2021, Price: 120000, Km: 30000,
+			},
+			SearchName: "test",
+		},
+	}
+
+	err := n.Notify(context.Background(), "123", listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) == 0 {
+		t.Fatal("expected at least one sendMessage call")
+	}
+	allBodies := strings.Join(bodies, " ")
+	if !strings.Contains(allBodies, "Toyota") {
+		t.Errorf("message should contain manufacturer name, got: %s", allBodies)
+	}
+}
+
+// --- Connect tests ---
+
+func TestConnect_Success(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(sendMessageOK)
+	}))
+
+	err := n.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConnect_Failure(t *testing.T) {
+	var getMeCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "getMe") {
+			c := getMeCalls.Add(1)
+			if c == 1 {
+				w.Write(getMeResponse)
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			resp, _ := json.Marshal(map[string]any{
+				"ok":          false,
+				"description": "Unauthorized",
+			})
+			w.Write(resp)
+			return
+		}
+		w.Write(sendMessageOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	n, err := New("test-token", testLogger(), tgbot.WithServerURL(srv.URL))
+	if err != nil {
+		t.Fatalf("create notifier: %v", err)
+	}
+
+	err = n.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unauthorized getMe")
+	}
+	if !strings.Contains(err.Error(), "telegram getMe") {
+		t.Errorf("expected 'telegram getMe' error, got: %v", err)
+	}
+}
+
+// --- Disconnect test ---
+
+func TestDisconnect_ReturnsNil(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(sendMessageOK)
+	}))
+
+	if err := n.Disconnect(); err != nil {
+		t.Errorf("Disconnect should return nil, got: %v", err)
+	}
+}
+
+// --- Bot accessor test ---
+
+func TestBot_ReturnsInstance(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(sendMessageOK)
+	}))
+
+	if n.Bot() == nil {
+		t.Error("Bot() should return non-nil")
+	}
+}
+
+// --- New error test ---
+
+func TestNew_EmptyToken(t *testing.T) {
+	_, err := New("", testLogger())
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -81,7 +81,6 @@ type errDigestStore struct {
 	flushErr        error
 	pendingErr      error
 	lastFlushedErr  error
-	parseDurErr     bool // set to true to use unparseable interval
 }
 
 func newErrDigestStore() *errDigestStore {
@@ -157,7 +156,6 @@ type errNotificationQueue struct {
 	pendingErr  error
 	enqueueErr  error
 	ackErr      error
-	notifyErr   error
 }
 
 func (m *errNotificationQueue) PendingNotifications(_ context.Context) ([]storage.PendingNotification, error) {

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -1,0 +1,793 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// --- Error-returning mock variants ---
+
+type errDedup struct {
+	mockDedup
+	claimErr   error
+	releaseErr error
+	pruneErr   error
+}
+
+func newErrDedup() *errDedup {
+	return &errDedup{mockDedup: mockDedup{seen: make(map[dedupKey]bool)}}
+}
+
+func (m *errDedup) ClaimNew(ctx context.Context, token string, chatID int64, searchID int64) (bool, error) {
+	if m.claimErr != nil {
+		return false, m.claimErr
+	}
+	return m.mockDedup.ClaimNew(ctx, token, chatID, searchID)
+}
+
+func (m *errDedup) ReleaseClaim(ctx context.Context, token string, chatID int64) error {
+	if m.releaseErr != nil {
+		return m.releaseErr
+	}
+	return m.mockDedup.ReleaseClaim(ctx, token, chatID)
+}
+
+func (m *errDedup) Prune(_ context.Context, _ time.Duration) (int64, error) {
+	if m.pruneErr != nil {
+		return 0, m.pruneErr
+	}
+	return 0, nil
+}
+
+type errPriceTracker struct {
+	mockPriceTracker
+	err error
+}
+
+func newErrPriceTracker() *errPriceTracker {
+	return &errPriceTracker{mockPriceTracker: mockPriceTracker{prices: make(map[string]int)}}
+}
+
+func (m *errPriceTracker) RecordPrice(ctx context.Context, token string, price int) (int, bool, error) {
+	if m.err != nil {
+		return 0, false, m.err
+	}
+	return m.mockPriceTracker.RecordPrice(ctx, token, price)
+}
+
+type errSearchStore struct {
+	mockSearchStore
+	listErr error
+}
+
+func (m *errSearchStore) ListAllActiveSearches(_ context.Context) ([]storage.Search, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.mockSearchStore.ListAllActiveSearches(context.Background())
+}
+
+type errDigestStore struct {
+	mockDigestStore
+	getModeErr      error
+	addItemErr      error
+	flushErr        error
+	pendingErr      error
+	lastFlushedErr  error
+	parseDurErr     bool // set to true to use unparseable interval
+}
+
+func newErrDigestStore() *errDigestStore {
+	return &errDigestStore{
+		mockDigestStore: mockDigestStore{
+			modes:   make(map[int64]struct{ mode, interval string }),
+			items:   make(map[int64][]string),
+			flushed: make(map[int64]time.Time),
+		},
+	}
+}
+
+func (m *errDigestStore) GetDigestMode(ctx context.Context, chatID int64) (string, string, error) {
+	if m.getModeErr != nil {
+		return "", "", m.getModeErr
+	}
+	return m.mockDigestStore.GetDigestMode(ctx, chatID)
+}
+
+func (m *errDigestStore) AddDigestItem(ctx context.Context, chatID int64, payload string) error {
+	if m.addItemErr != nil {
+		return m.addItemErr
+	}
+	return m.mockDigestStore.AddDigestItem(ctx, chatID, payload)
+}
+
+func (m *errDigestStore) FlushDigest(ctx context.Context, chatID int64) ([]string, error) {
+	if m.flushErr != nil {
+		return nil, m.flushErr
+	}
+	return m.mockDigestStore.FlushDigest(ctx, chatID)
+}
+
+func (m *errDigestStore) PendingDigestUsers(_ context.Context) ([]int64, error) {
+	if m.pendingErr != nil {
+		return nil, m.pendingErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var users []int64
+	for chatID := range m.items {
+		if len(m.items[chatID]) > 0 {
+			users = append(users, chatID)
+		}
+	}
+	return users, nil
+}
+
+func (m *errDigestStore) DigestLastFlushed(ctx context.Context, chatID int64) (time.Time, error) {
+	if m.lastFlushedErr != nil {
+		return time.Time{}, m.lastFlushedErr
+	}
+	return m.mockDigestStore.DigestLastFlushed(ctx, chatID)
+}
+
+type errNotifier struct {
+	mockNotifier
+	rawErr error
+}
+
+func (m *errNotifier) NotifyRaw(_ context.Context, recipient string, message string) error {
+	if m.rawErr != nil {
+		return m.rawErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rawMessages = append(m.rawMessages, rawNotifyCall{recipient: recipient, message: message})
+	return nil
+}
+
+type errNotificationQueue struct {
+	mockNotificationQueue
+	pendingErr  error
+	enqueueErr  error
+	ackErr      error
+	notifyErr   error
+}
+
+func (m *errNotificationQueue) PendingNotifications(_ context.Context) ([]storage.PendingNotification, error) {
+	if m.pendingErr != nil {
+		return nil, m.pendingErr
+	}
+	return m.pending, nil
+}
+
+func (m *errNotificationQueue) EnqueueNotification(_ context.Context, _, _, _ string) error {
+	if m.enqueueErr != nil {
+		return m.enqueueErr
+	}
+	return nil
+}
+
+func (m *errNotificationQueue) AckNotification(_ context.Context, id int64) error {
+	if m.ackErr != nil {
+		return m.ackErr
+	}
+	if m.acked == nil {
+		m.acked = make(map[int64]bool)
+	}
+	m.acked[id] = true
+	return nil
+}
+
+type mockCatalogIngester struct {
+	mu       sync.Mutex
+	ingested int
+	flushed  int
+}
+
+func (m *mockCatalogIngester) Ingest(_ context.Context, _ int, _ string, _ int, _ string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ingested++
+}
+
+func (m *mockCatalogIngester) Flush(_ context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.flushed++
+}
+
+// --- Tests ---
+
+func TestProcessGroup_ClaimNewError(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newErrDedup()
+	d.claimErr = errors.New("db locked")
+	n := &mockNotifier{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+
+	err := s.runMultiTenantCycle(context.Background())
+	if err != nil {
+		t.Fatalf("cycle should succeed even with claim errors: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 notifications when claim fails, got %d", len(n.messages))
+	}
+}
+
+func TestProcessGroup_RecordPriceError(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	pt := newErrPriceTracker()
+	pt.err = errors.New("price db error")
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Prices:      pt,
+	})
+
+	err := s.runMultiTenantCycle(context.Background())
+	if err != nil {
+		t.Fatalf("cycle should succeed despite price tracking error: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("listing should still be notified despite price error, got %d notifications", len(n.messages))
+	}
+}
+
+func TestProcessGroup_DigestModeError(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+
+	ds := newErrDigestStore()
+	ds.getModeErr = errors.New("digest db error")
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+
+	err := s.runMultiTenantCycle(context.Background())
+	if err != nil {
+		t.Fatalf("cycle should succeed despite digest mode error: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("should fall back to instant mode, got %d notifications", len(n.messages))
+	}
+}
+
+func TestProcessGroup_DigestAddItemError_ReleasesClaims(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+
+	ds := newErrDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "6h")
+	ds.flushed[100] = time.Now()
+	ds.addItemErr = errors.New("write failed")
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		DigestStore: ds,
+	})
+
+	_ = s.runMultiTenantCycle(context.Background())
+
+	d.mu.Lock()
+	_, claimed := d.seen[dedupKey{"a", 100}]
+	d.mu.Unlock()
+	if claimed {
+		t.Error("claim should be released when digest add fails")
+	}
+}
+
+func TestProcessGroup_PriceDropInDigestMode(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Manufacturer: "Mazda", Model: "3", Price: 89000, Year: 2021, EngineVolume: 2000, Km: 50000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+
+	pt := newMockPriceTracker()
+	pt.prices["a"] = 95000
+
+	ds := newMockDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "6h")
+	ds.flushed[100] = time.Now()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Prices:      pt,
+		DigestStore: ds,
+	})
+
+	_ = s.runMultiTenantCycle(context.Background())
+
+	n.mu.Lock()
+	rawCount := len(n.rawMessages)
+	n.mu.Unlock()
+	if rawCount != 0 {
+		t.Errorf("price drop should go to digest, not instant. got %d raw messages", rawCount)
+	}
+
+	ds.mu.Lock()
+	items := ds.items[100]
+	ds.mu.Unlock()
+	if len(items) != 1 {
+		t.Errorf("expected 1 digest item for price drop, got %d", len(items))
+	}
+}
+
+func TestProcessGroup_NotifyFails_EnqueuesAndKeepsClaim(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{err: errors.New("telegram down")}
+	q := &errNotificationQueue{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Queue:       q,
+	})
+
+	_ = s.runMultiTenantCycle(context.Background())
+
+	d.mu.Lock()
+	_, claimed := d.seen[dedupKey{"a", 100}]
+	d.mu.Unlock()
+	if !claimed {
+		t.Error("claim should be kept when enqueue succeeds")
+	}
+}
+
+func TestProcessGroup_NotifyFails_EnqueueFails_ReleasesClaim(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{err: errors.New("telegram down")}
+	q := &errNotificationQueue{enqueueErr: errors.New("queue full")}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Queue:       q,
+	})
+
+	_ = s.runMultiTenantCycle(context.Background())
+
+	d.mu.Lock()
+	_, claimed := d.seen[dedupKey{"a", 100}]
+	d.mu.Unlock()
+	if claimed {
+		t.Error("claim should be released when both notify and enqueue fail")
+	}
+}
+
+func TestRunMultiTenantCycle_SearchStoreError(t *testing.T) {
+	ss := &errSearchStore{listErr: errors.New("db connection lost")}
+	s, _ := NewWithOptions(testConfig(), nil, nil, nil, testLogger(), Options{SearchStore: ss})
+
+	err := s.runMultiTenantCycle(context.Background())
+	if err == nil {
+		t.Fatal("expected error when search store fails")
+	}
+	if !errors.Is(err, ss.listErr) {
+		t.Errorf("expected wrapped db error, got: %v", err)
+	}
+}
+
+func TestRunMultiTenantCycle_PruneError(t *testing.T) {
+	f := &mockFetcher{listings: []model.RawListing{}}
+	d := newErrDedup()
+	d.pruneErr = errors.New("prune failed")
+	n := &mockNotifier{}
+	h := health.New()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332, Active: true},
+		},
+	}
+	cfg := testConfig()
+	cfg.Storage.PruneAfter = 1 * time.Hour
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Health:      h,
+	})
+	s.lastPruneTime = time.Time{} // force prune
+
+	err := s.runMultiTenantCycle(context.Background())
+	if err != nil {
+		t.Fatalf("cycle should succeed despite prune error: %v", err)
+	}
+}
+
+func TestRetryPending_PendingNotificationsError(t *testing.T) {
+	q := &errNotificationQueue{
+		pendingErr: errors.New("db error"),
+	}
+	s, _ := NewWithOptions(testConfig(), nil, nil, &mockNotifier{}, testLogger(), Options{Queue: q})
+	s.retryPending(context.Background())
+}
+
+func TestRetryPending_NotifyRawFails(t *testing.T) {
+	n := &errNotifier{rawErr: errors.New("send failed")}
+	q := &errNotificationQueue{
+		mockNotificationQueue: mockNotificationQueue{
+			pending: []storage.PendingNotification{
+				{ID: 1, Recipient: "123", Payload: "test"},
+			},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{Queue: q})
+	s.retryPending(context.Background())
+
+	if q.acked != nil && q.acked[1] {
+		t.Error("should not ack notification when retry fails")
+	}
+}
+
+func TestRetryPending_AckFails(t *testing.T) {
+	n := &mockNotifier{}
+	q := &errNotificationQueue{
+		mockNotificationQueue: mockNotificationQueue{
+			pending: []storage.PendingNotification{
+				{ID: 1, Recipient: "123", Payload: "test"},
+			},
+		},
+		ackErr: errors.New("ack failed"),
+	}
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{Queue: q})
+	s.retryPending(context.Background())
+
+	if len(n.rawMessages) != 1 {
+		t.Errorf("message should still be sent, got %d", len(n.rawMessages))
+	}
+}
+
+func TestProcessDigests_PendingUsersError(t *testing.T) {
+	ds := newErrDigestStore()
+	ds.pendingErr = errors.New("db error")
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, &mockNotifier{}, testLogger(), Options{DigestStore: ds})
+	s.processDigests(context.Background())
+}
+
+func TestProcessDigests_GetDigestModeError(t *testing.T) {
+	ds := newErrDigestStore()
+	ds.items[100] = []string{"item1"}
+	ds.getModeErr = errors.New("mode error")
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, &mockNotifier{}, testLogger(), Options{DigestStore: ds})
+	s.processDigests(context.Background())
+}
+
+func TestProcessDigests_LastFlushedError(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newErrDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "6h")
+	ds.items[100] = []string{"item1"}
+	ds.lastFlushedErr = errors.New("flushed error")
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.processDigests(context.Background())
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 0 {
+		t.Errorf("should not send digest on lastFlushed error, got %d", len(n.rawMessages))
+	}
+}
+
+func TestProcessDigests_InvalidIntervalDefaultsTo6h(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newErrDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "not-a-duration")
+	ds.items[100] = []string{"item1"}
+	ds.flushed[100] = time.Now().Add(-7 * time.Hour) // older than 6h default
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.processDigests(context.Background())
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 1 {
+		t.Errorf("should flush with default 6h interval, got %d messages", len(n.rawMessages))
+	}
+}
+
+func TestFlushAndSendDigest_FlushError(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newErrDigestStore()
+	ds.items[100] = []string{"item1"}
+	ds.flushErr = errors.New("flush failed")
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.flushAndSendDigest(context.Background(), 100)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 0 {
+		t.Errorf("should not send when flush fails, got %d messages", len(n.rawMessages))
+	}
+}
+
+func TestFlushAndSendDigest_SendError(t *testing.T) {
+	n := &errNotifier{rawErr: errors.New("send failed")}
+	ds := newMockDigestStore()
+	ds.items[100] = []string{"item1"}
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.flushAndSendDigest(context.Background(), 100)
+}
+
+func TestRunMultiTenantCycle_CatalogIngester(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+				Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	ci := &mockCatalogIngester{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore:     ss,
+		CatalogIngester: ci,
+	})
+
+	_ = s.runMultiTenantCycle(context.Background())
+
+	ci.mu.Lock()
+	defer ci.mu.Unlock()
+	if ci.ingested != 1 {
+		t.Errorf("expected 1 ingest call, got %d", ci.ingested)
+	}
+	if ci.flushed != 1 {
+		t.Errorf("expected 1 flush call, got %d", ci.flushed)
+	}
+}
+
+func TestRunMultiTenantCycle_HealthRecording(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	h := health.New()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Health:      h,
+	})
+
+	_ = s.runMultiTenantCycle(context.Background())
+
+	snap := h.Snapshot()
+	if snap["listings_found"] != int64(1) {
+		t.Errorf("expected 1 listing found, got %v", snap["listings_found"])
+	}
+	if snap["notifications_sent"] != int64(1) {
+		t.Errorf("expected 1 notification sent, got %v", snap["notifications_sent"])
+	}
+}
+
+func TestReloadConfig_ValidConfig(t *testing.T) {
+	cfg := testConfig()
+	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{
+		ConfigPath: "testdata/valid_config.yaml",
+	})
+
+	origCfg := s.cfg
+	s.reloadConfig()
+	// Config may or may not change depending on testdata existence.
+	// The key test is that it doesn't panic.
+	_ = origCfg
+}
+
+func TestReloadConfig_InvalidTimezone(t *testing.T) {
+	cfg := testConfig()
+	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{
+		ConfigPath: "testdata/bad_timezone_config.yaml",
+	})
+
+	origLoc := s.loc
+	s.reloadConfig()
+	if s.loc != origLoc {
+		t.Error("timezone should not change on failed reload")
+	}
+}
+
+func TestProcessGroup_FiltersCorrectly(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "cheap", Price: 50000, Year: 2020, EngineVolume: 2000},
+			{Token: "expensive", Price: 200000, Year: 2020, EngineVolume: 2000},
+			{Token: "old", Price: 90000, Year: 2010, EngineVolume: 2000},
+			{Token: "future", Price: 90000, Year: 2030, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	_ = s.runMultiTenantCycle(context.Background())
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(n.messages))
+	}
+	if n.messages[0].count != 1 {
+		t.Errorf("only 'cheap' should match, got %d listings", n.messages[0].count)
+	}
+}
+
+func TestProcessGroup_PriceMaxZero_NoFilter(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 999999, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 0, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	_ = s.runMultiTenantCycle(context.Background())
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("PriceMax=0 should not filter, got %d notifications", len(n.messages))
+	}
+}
+
+func TestProcessGroup_YearMaxZero_NoUpperBound(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "a", Price: 90000, Year: 2030, EngineVolume: 2000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 0, PriceMax: 150000, EngineMinCC: 1800, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	_ = s.runMultiTenantCycle(context.Background())
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("YearMax=0 should not filter, got %d notifications", len(n.messages))
+	}
+}


### PR DESCRIPTION
## Summary

- **Telegram notifier** (#136): 0% → **100%** — tests for `splitMessage` chunking, `sendMessage` error paths (invalid chat ID, API errors, partial failures), `Notify` formatting, `Connect`/`Disconnect`, and `New` with empty token
- **Scheduler error paths** (#138): ~75% → **90.5%** — tests for `ClaimNew`/`RecordPrice`/digest store/notification queue/prune errors, retry-pending failure paths, catalog ingester, health recording, config reload edge cases
- **Bot error paths** (#143): ~84% → **92.9%** — tests for `send`/`sendMarkdown`/`sendWithKeyboard` errors, `ensureUser` failure, `loadWizardData` with corrupt JSON, `saveWizardState` failure, `handleList` store error, `onConfirm`/`onDeleteSearch`/digest mode errors, callback edge cases, `SetBot`/`DefaultHandler` coverage
- **cmd/bot/main.go** (#137): ~5% → **50%** — tests for missing token, invalid DB path, invalid log level, invalid active hours, proxy pool paths, custom log levels

**Overall test coverage: 89.2%** (up from ~85%)

Closes #136, #137, #138, #143

## Test plan

- [x] `make test` passes (89.2% coverage)
- [x] All 4 new test files compile and pass
- [x] No pre-existing tests broken
- [x] Lint issues are pre-existing (local golangci-lint version, CI uses newer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded config validation tests (DB path, Telegram token, log levels, active hours, proxy handling).
  * Added message-splitting and notifier behavior tests, including chunking, Unicode, and API error handling.
  * Introduced extensive bot error-path tests covering messaging, user/search/digest store failures, and callback handling.
  * Added scheduler error-path and resilience tests for dedup, notifications, retries, digest flushes, and config reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->