### PR TITLE
feat: add pagination support for Yad2 fetcher

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -85,7 +85,7 @@ func run(configPath string, logger *slog.Logger) error {
 		return fmt.Errorf("create fetcher: %w", err)
 	}
 
-	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, fetcher.DefaultMaxPages)
+	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, cfg.HTTP.MaxPages)
 	cachingFetcher := fetcher.NewCachingFetcher(paginatingFetcher, 5*time.Minute)
 	yad2CB := fetcher.NewCircuitBreaker(cachingFetcher, 5, 30*time.Minute)
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -85,7 +85,8 @@ func run(configPath string, logger *slog.Logger) error {
 		return fmt.Errorf("create fetcher: %w", err)
 	}
 
-	cachingFetcher := fetcher.NewCachingFetcher(yad2Fetcher, 5*time.Minute)
+	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, fetcher.DefaultMaxPages)
+	cachingFetcher := fetcher.NewCachingFetcher(paginatingFetcher, 5*time.Minute)
 	yad2CB := fetcher.NewCircuitBreaker(cachingFetcher, 5, 30*time.Minute)
 
 	dynCatalog := catalog.NewDynamic(store, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type HTTPConfig struct {
 	UserAgents []string `yaml:"user_agents"`
 	Proxy      string   `yaml:"proxy"`
 	Proxies    []string `yaml:"proxies"`
+	MaxPages   int      `yaml:"max_pages"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/fetcher/cache.go
+++ b/internal/fetcher/cache.go
@@ -47,6 +47,9 @@ func (c *CachingFetcher) Fetch(ctx context.Context, params config.SourceParams) 
 		if errors.Is(err, ErrChallenge) || errors.Is(err, ErrRateLimited) {
 			return nil, err
 		}
+		if errors.Is(err, ErrPartialResults) {
+			return listings, err
+		}
 		if ok {
 			return entry.listings, nil
 		}

--- a/internal/fetcher/paginating.go
+++ b/internal/fetcher/paginating.go
@@ -1,0 +1,59 @@
+package fetcher
+
+import (
+	"context"
+
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+const DefaultMaxPages = 5
+
+type PaginatingFetcher struct {
+	inner    Fetcher
+	maxPages int
+}
+
+func NewPaginatingFetcher(inner Fetcher, maxPages int) *PaginatingFetcher {
+	if maxPages <= 0 {
+		maxPages = DefaultMaxPages
+	}
+	return &PaginatingFetcher{inner: inner, maxPages: maxPages}
+}
+
+func (f *PaginatingFetcher) Fetch(ctx context.Context, params config.SourceParams) ([]model.RawListing, error) {
+	seen := make(map[string]bool)
+	var all []model.RawListing
+
+	for page := 1; page <= f.maxPages; page++ {
+		p := params
+		p.Page = page
+
+		listings, err := f.inner.Fetch(ctx, p)
+		if err != nil {
+			if page == 1 {
+				return nil, err
+			}
+			break
+		}
+
+		if len(listings) == 0 {
+			break
+		}
+
+		added := 0
+		for _, l := range listings {
+			if !seen[l.Token] {
+				seen[l.Token] = true
+				all = append(all, l)
+				added++
+			}
+		}
+
+		if added == 0 {
+			break
+		}
+	}
+
+	return all, nil
+}

--- a/internal/fetcher/paginating.go
+++ b/internal/fetcher/paginating.go
@@ -2,12 +2,15 @@ package fetcher
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/model"
 )
 
 const DefaultMaxPages = 5
+
+var ErrPartialResults = fmt.Errorf("partial paginated results")
 
 type PaginatingFetcher struct {
 	inner    Fetcher
@@ -34,7 +37,7 @@ func (f *PaginatingFetcher) Fetch(ctx context.Context, params config.SourceParam
 			if page == 1 {
 				return nil, err
 			}
-			break
+			return all, fmt.Errorf("%w: page %d: %v", ErrPartialResults, page, err)
 		}
 
 		if len(listings) == 0 {

--- a/internal/fetcher/paginating_test.go
+++ b/internal/fetcher/paginating_test.go
@@ -108,8 +108,8 @@ func TestPaginatingFetcher_DeduplicatesAcrossPages(t *testing.T) {
 	inner := &pageMockFetcher{
 		pages: map[int][]model.RawListing{
 			1: {{Token: "a"}, {Token: "b"}},
-			2: {{Token: "b"}, {Token: "c"}}, // "b" duplicated
-			3: {{Token: "c"}, {Token: "d"}}, // "c" duplicated
+			2: {{Token: "b"}, {Token: "c"}},
+			3: {{Token: "c"}, {Token: "d"}},
 		},
 	}
 	pf := NewPaginatingFetcher(inner, 5)
@@ -127,7 +127,7 @@ func TestPaginatingFetcher_StopsWhenAllDuplicates(t *testing.T) {
 	inner := &pageMockFetcher{
 		pages: map[int][]model.RawListing{
 			1: {{Token: "a"}, {Token: "b"}},
-			2: {{Token: "a"}, {Token: "b"}}, // all duplicates
+			2: {{Token: "a"}, {Token: "b"}},
 		},
 	}
 	pf := NewPaginatingFetcher(inner, 5)
@@ -152,45 +152,44 @@ func TestPaginatingFetcher_FirstPageError_Propagates(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for first page failure")
 	}
-}
-
-func TestPaginatingFetcher_LaterPageError_ReturnsPartial(t *testing.T) {
-	callCount := 0
-	inner := &pageMockFetcher{
-		pages: map[int][]model.RawListing{
-			1: {{Token: "a"}},
-		},
+	if errors.Is(err, ErrPartialResults) {
+		t.Error("first page error should not be ErrPartialResults")
 	}
-	origFetch := inner.Fetch
-	_ = origFetch
-
-	pf := NewPaginatingFetcher(&laterErrorFetcher{
-		pages: map[int][]model.RawListing{
-			1: {{Token: "a"}},
-		},
-		errPage: 2,
-	}, 5)
-
-	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
-	if err != nil {
-		t.Fatalf("later page errors should not propagate: %v", err)
-	}
-	if len(listings) != 1 {
-		t.Errorf("expected 1 listing from page 1, got %d", len(listings))
-	}
-	_ = callCount
 }
 
 type laterErrorFetcher struct {
 	pages   map[int][]model.RawListing
 	errPage int
+	calls   []int
 }
 
 func (m *laterErrorFetcher) Fetch(_ context.Context, params config.SourceParams) ([]model.RawListing, error) {
+	m.calls = append(m.calls, params.Page)
 	if params.Page == m.errPage {
 		return nil, errors.New("page error")
 	}
 	return m.pages[params.Page], nil
+}
+
+func TestPaginatingFetcher_LaterPageError_ReturnsPartialWithError(t *testing.T) {
+	inner := &laterErrorFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}},
+		},
+		errPage: 2,
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if !errors.Is(err, ErrPartialResults) {
+		t.Fatalf("expected ErrPartialResults, got: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("expected 1 listing from page 1, got %d", len(listings))
+	}
+	if len(inner.calls) < 2 || inner.calls[1] != 2 {
+		t.Fatalf("expected fetch to reach page 2, calls=%v", inner.calls)
+	}
 }
 
 func TestPaginatingFetcher_PassesParams(t *testing.T) {

--- a/internal/fetcher/paginating_test.go
+++ b/internal/fetcher/paginating_test.go
@@ -1,0 +1,223 @@
+package fetcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+type pageMockFetcher struct {
+	pages map[int][]model.RawListing
+	err   error
+	calls []int
+}
+
+func (m *pageMockFetcher) Fetch(_ context.Context, params config.SourceParams) ([]model.RawListing, error) {
+	m.calls = append(m.calls, params.Page)
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.pages[params.Page], nil
+}
+
+func TestPaginatingFetcher_SinglePage(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}, {Token: "b"}},
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 listings, got %d", len(listings))
+	}
+}
+
+func TestPaginatingFetcher_MultiplePages(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}, {Token: "b"}},
+			2: {{Token: "c"}, {Token: "d"}},
+			3: {{Token: "e"}},
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(listings) != 5 {
+		t.Errorf("expected 5 listings across 3 pages, got %d", len(listings))
+	}
+}
+
+func TestPaginatingFetcher_StopsAtEmptyPage(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}},
+			2: {},
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("expected 1 listing, got %d", len(listings))
+	}
+	if len(inner.calls) != 2 {
+		t.Errorf("expected 2 calls (page 1 + empty page 2), got %d", len(inner.calls))
+	}
+}
+
+func TestPaginatingFetcher_RespectsMaxPages(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}},
+			2: {{Token: "b"}},
+			3: {{Token: "c"}},
+			4: {{Token: "d"}},
+			5: {{Token: "e"}},
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 3)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(listings) != 3 {
+		t.Errorf("expected 3 listings (max 3 pages), got %d", len(listings))
+	}
+	if len(inner.calls) != 3 {
+		t.Errorf("expected 3 fetch calls, got %d", len(inner.calls))
+	}
+}
+
+func TestPaginatingFetcher_DeduplicatesAcrossPages(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}, {Token: "b"}},
+			2: {{Token: "b"}, {Token: "c"}}, // "b" duplicated
+			3: {{Token: "c"}, {Token: "d"}}, // "c" duplicated
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(listings) != 4 {
+		t.Errorf("expected 4 unique listings, got %d", len(listings))
+	}
+}
+
+func TestPaginatingFetcher_StopsWhenAllDuplicates(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}, {Token: "b"}},
+			2: {{Token: "a"}, {Token: "b"}}, // all duplicates
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 unique listings, got %d", len(listings))
+	}
+	if len(inner.calls) != 2 {
+		t.Errorf("should stop after all-duplicate page, got %d calls", len(inner.calls))
+	}
+}
+
+func TestPaginatingFetcher_FirstPageError_Propagates(t *testing.T) {
+	inner := &pageMockFetcher{err: errors.New("network error")}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	_, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err == nil {
+		t.Fatal("expected error for first page failure")
+	}
+}
+
+func TestPaginatingFetcher_LaterPageError_ReturnsPartial(t *testing.T) {
+	callCount := 0
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}},
+		},
+	}
+	origFetch := inner.Fetch
+	_ = origFetch
+
+	pf := NewPaginatingFetcher(&laterErrorFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}},
+		},
+		errPage: 2,
+	}, 5)
+
+	listings, err := pf.Fetch(context.Background(), config.SourceParams{})
+	if err != nil {
+		t.Fatalf("later page errors should not propagate: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("expected 1 listing from page 1, got %d", len(listings))
+	}
+	_ = callCount
+}
+
+type laterErrorFetcher struct {
+	pages   map[int][]model.RawListing
+	errPage int
+}
+
+func (m *laterErrorFetcher) Fetch(_ context.Context, params config.SourceParams) ([]model.RawListing, error) {
+	if params.Page == m.errPage {
+		return nil, errors.New("page error")
+	}
+	return m.pages[params.Page], nil
+}
+
+func TestPaginatingFetcher_PassesParams(t *testing.T) {
+	inner := &pageMockFetcher{
+		pages: map[int][]model.RawListing{
+			1: {{Token: "a"}},
+		},
+	}
+	pf := NewPaginatingFetcher(inner, 5)
+
+	_, _ = pf.Fetch(context.Background(), config.SourceParams{Manufacturer: 27, Model: 10332})
+	if len(inner.calls) < 1 {
+		t.Fatal("expected at least 1 call")
+	}
+	if inner.calls[0] != 1 {
+		t.Errorf("first call page = %d, want 1", inner.calls[0])
+	}
+}
+
+func TestPaginatingFetcher_DefaultMaxPages(t *testing.T) {
+	pf := NewPaginatingFetcher(nil, 0)
+	if pf.maxPages != DefaultMaxPages {
+		t.Errorf("maxPages = %d, want %d", pf.maxPages, DefaultMaxPages)
+	}
+
+	pf = NewPaginatingFetcher(nil, -1)
+	if pf.maxPages != DefaultMaxPages {
+		t.Errorf("negative maxPages should default to %d, got %d", DefaultMaxPages, pf.maxPages)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -194,6 +194,11 @@ func (s *Scheduler) fetchWithRetryUsing(ctx context.Context, f fetcher.Fetcher, 
 		}
 		lastErr = err
 
+		if errors.Is(err, fetcher.ErrPartialResults) && len(listings) > 0 {
+			s.logger.Warn("fetch returned partial results", "error", err, "count", len(listings))
+			return listings, nil
+		}
+
 		if errors.Is(err, fetcher.ErrChallenge) || errors.Is(err, fetcher.ErrCircuitOpen) || errors.Is(err, context.Canceled) {
 			return nil, err
 		}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -29,6 +29,17 @@ func (m *mockFetcher) Fetch(_ context.Context, _ config.SourceParams) ([]model.R
 	return m.listings, m.err
 }
 
+type partialFetcher struct {
+	listings []model.RawListing
+	err      error
+	calls    int
+}
+
+func (m *partialFetcher) Fetch(_ context.Context, _ config.SourceParams) ([]model.RawListing, error) {
+	m.calls++
+	return m.listings, m.err
+}
+
 type dedupKey struct {
 	token  string
 	chatID int64
@@ -175,6 +186,27 @@ func TestFetchWithRetryUsing_ChallengeNoRetry(t *testing.T) {
 	}
 	if f.calls != 1 {
 		t.Errorf("challenge should not retry, got %d calls", f.calls)
+	}
+}
+
+func TestFetchWithRetryUsing_PartialResults_ReturnsListings(t *testing.T) {
+	partial := &partialFetcher{
+		listings: []model.RawListing{{Token: "a"}, {Token: "b"}},
+		err:      fmt.Errorf("%w: page 3: timeout", fetcher.ErrPartialResults),
+	}
+	cfg := testConfig()
+	s, _ := New(cfg, partial, newMockDedup(), &mockNotifier{}, testLogger(), nil)
+
+	ctx := context.Background()
+	listings, err := s.fetchWithRetryUsing(ctx, partial, config.SourceParams{})
+	if err != nil {
+		t.Errorf("partial results should be returned as success, got: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 partial listings, got %d", len(listings))
+	}
+	if partial.calls != 1 {
+		t.Errorf("partial results should not retry, got %d calls", partial.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `PaginatingFetcher` decorator that fetches up to 5 pages per query
- Deduplicates listings by token across pages
- Stops early on empty pages, all-duplicate pages, or fetch errors (returns partial results)
- Wraps the raw Yad2 fetcher before caching in the decorator chain: `Yad2Fetcher → PaginatingFetcher → CachingFetcher`
- 10 comprehensive tests covering single/multi-page, dedup, max pages, error handling

Closes #129

## Test plan

- [x] All paginating fetcher tests pass
- [x] `go build ./...` succeeds
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pagination to fetch results across multiple pages (configurable, 5 by default)
  * Deduplication across pages to avoid repeated listings

* **Improvements**
  * Returns partial results when later pages fail, improving resilience
  * Early termination when no new results are found

* **Tests**
  * Added comprehensive tests covering pagination, deduplication, limits, and error scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->