### PR TITLE
refactor: apply Strategy pattern to notification delivery

### DIFF
--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -41,7 +41,15 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 }
 
 func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
-	return d.notifier.NotifyRaw(ctx, fmt.Sprintf("%d", chatID), message)
+	chatIDStr := fmt.Sprintf("%d", chatID)
+	err := d.notifier.NotifyRaw(ctx, chatIDStr, message)
+	if err == nil || d.queue == nil {
+		return err
+	}
+	if qErr := d.queue.EnqueueNotification(ctx, chatIDStr, "", message); qErr == nil {
+		return nil
+	}
+	return err
 }
 
 type DigestDelivery struct {

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -1,0 +1,62 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+type DeliveryStrategy interface {
+	DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error
+	DeliverRaw(ctx context.Context, chatID int64, message string) error
+}
+
+type InstantDelivery struct {
+	notifier notifier.Notifier
+	queue    storage.NotificationQueue
+}
+
+func NewInstantDelivery(n notifier.Notifier, q storage.NotificationQueue) *InstantDelivery {
+	return &InstantDelivery{notifier: n, queue: q}
+}
+
+func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {
+	chatIDStr := fmt.Sprintf("%d", chatID)
+	err := d.notifier.Notify(ctx, chatIDStr, listings)
+	if err == nil {
+		return nil
+	}
+
+	if d.queue != nil {
+		msg := notifier.FormatBatch(listings)
+		if qErr := d.queue.EnqueueNotification(ctx, chatIDStr, "", msg); qErr == nil {
+			return nil
+		}
+	}
+
+	return err
+}
+
+func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
+	return d.notifier.NotifyRaw(ctx, fmt.Sprintf("%d", chatID), message)
+}
+
+type DigestDelivery struct {
+	store storage.DigestStore
+}
+
+func NewDigestDelivery(s storage.DigestStore) *DigestDelivery {
+	return &DigestDelivery{store: s}
+}
+
+func (d *DigestDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {
+	msg := notifier.FormatBatch(listings)
+	return d.store.AddDigestItem(ctx, chatID, msg)
+}
+
+func (d *DigestDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
+	return d.store.AddDigestItem(ctx, chatID, message)
+}

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -1,0 +1,175 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+func TestInstantDelivery_DeliverBatch_Success(t *testing.T) {
+	n := &mockNotifier{}
+	d := NewInstantDelivery(n, nil)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000}},
+	}
+
+	err := d.DeliverBatch(context.Background(), 100, listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("expected 1 notification, got %d", len(n.messages))
+	}
+}
+
+func TestInstantDelivery_DeliverBatch_FallsBackToQueue(t *testing.T) {
+	n := &mockNotifier{err: errors.New("telegram down")}
+	q := &mockNotificationQueue{}
+	d := NewInstantDelivery(n, q)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a"}},
+	}
+
+	err := d.DeliverBatch(context.Background(), 100, listings)
+	if err != nil {
+		t.Errorf("should succeed with queue fallback, got: %v", err)
+	}
+}
+
+type failQueue struct {
+	mockNotificationQueue
+	enqueueErr error
+}
+
+func (q *failQueue) EnqueueNotification(_ context.Context, _, _, _ string) error {
+	return q.enqueueErr
+}
+
+type failDigestStore struct {
+	mockDigestStore
+	addErr error
+}
+
+func newFailDigestStore(err error) *failDigestStore {
+	return &failDigestStore{
+		mockDigestStore: mockDigestStore{
+			modes:   make(map[int64]struct{ mode, interval string }),
+			items:   make(map[int64][]string),
+			flushed: make(map[int64]time.Time),
+		},
+		addErr: err,
+	}
+}
+
+func (m *failDigestStore) AddDigestItem(_ context.Context, _ int64, _ string) error {
+	return m.addErr
+}
+
+func TestInstantDelivery_DeliverBatch_BothFail(t *testing.T) {
+	n := &mockNotifier{err: errors.New("telegram down")}
+	q := &failQueue{enqueueErr: errors.New("queue full")}
+	d := NewInstantDelivery(n, q)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a"}},
+	}
+
+	err := d.DeliverBatch(context.Background(), 100, listings)
+	if err == nil {
+		t.Fatal("expected error when both notifier and queue fail")
+	}
+}
+
+func TestInstantDelivery_DeliverBatch_NoQueue(t *testing.T) {
+	n := &mockNotifier{err: errors.New("telegram down")}
+	d := NewInstantDelivery(n, nil)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a"}},
+	}
+
+	err := d.DeliverBatch(context.Background(), 100, listings)
+	if err == nil {
+		t.Fatal("expected error when notifier fails and no queue")
+	}
+}
+
+func TestInstantDelivery_DeliverRaw_Success(t *testing.T) {
+	n := &mockNotifier{}
+	d := NewInstantDelivery(n, nil)
+
+	err := d.DeliverRaw(context.Background(), 100, "price drop!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 1 {
+		t.Errorf("expected 1 raw message, got %d", len(n.rawMessages))
+	}
+	if n.rawMessages[0].recipient != "100" {
+		t.Errorf("recipient = %q, want '100'", n.rawMessages[0].recipient)
+	}
+}
+
+func TestDigestDelivery_DeliverBatch(t *testing.T) {
+	ds := newMockDigestStore()
+	d := NewDigestDelivery(ds)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000}},
+	}
+
+	err := d.DeliverBatch(context.Background(), 100, listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	if len(ds.items[100]) != 1 {
+		t.Errorf("expected 1 digest item, got %d", len(ds.items[100]))
+	}
+}
+
+func TestDigestDelivery_DeliverRaw(t *testing.T) {
+	ds := newMockDigestStore()
+	d := NewDigestDelivery(ds)
+
+	err := d.DeliverRaw(context.Background(), 100, "price drop!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	if len(ds.items[100]) != 1 {
+		t.Errorf("expected 1 digest item, got %d", len(ds.items[100]))
+	}
+	if ds.items[100][0] != "price drop!" {
+		t.Errorf("item = %q, want 'price drop!'", ds.items[100][0])
+	}
+}
+
+func TestDigestDelivery_DeliverBatch_Error(t *testing.T) {
+	ds := newFailDigestStore(errors.New("write failed"))
+	d := NewDigestDelivery(ds)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a"}},
+	}
+
+	err := d.DeliverBatch(context.Background(), 100, listings)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -121,6 +121,43 @@ func TestInstantDelivery_DeliverRaw_Success(t *testing.T) {
 	}
 }
 
+type errRawNotifier struct {
+	mockNotifier
+	rawErr error
+}
+
+func (m *errRawNotifier) NotifyRaw(_ context.Context, recipient string, message string) error {
+	if m.rawErr != nil {
+		return m.rawErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rawMessages = append(m.rawMessages, rawNotifyCall{recipient: recipient, message: message})
+	return nil
+}
+
+func TestInstantDelivery_DeliverRaw_FallsBackToQueue(t *testing.T) {
+	n := &errRawNotifier{rawErr: errors.New("telegram down")}
+	q := &mockNotificationQueue{}
+	d := NewInstantDelivery(n, q)
+
+	err := d.DeliverRaw(context.Background(), 100, "price drop!")
+	if err != nil {
+		t.Errorf("should succeed with queue fallback, got: %v", err)
+	}
+}
+
+func TestInstantDelivery_DeliverRaw_BothFail(t *testing.T) {
+	n := &errRawNotifier{rawErr: errors.New("telegram down")}
+	q := &failQueue{enqueueErr: errors.New("queue full")}
+	d := NewInstantDelivery(n, q)
+
+	err := d.DeliverRaw(context.Background(), 100, "price drop!")
+	if err == nil {
+		t.Fatal("expected error when both notifier and queue fail")
+	}
+}
+
 func TestDigestDelivery_DeliverBatch(t *testing.T) {
 	ds := newMockDigestStore()
 	d := NewDigestDelivery(ds)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -176,6 +176,18 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	}
 }
 
+func (s *Scheduler) deliveryFor(ctx context.Context, chatID int64) DeliveryStrategy {
+	if s.digestStore != nil {
+		mode, _, err := s.digestStore.GetDigestMode(ctx, chatID)
+		if err != nil {
+			s.logger.Error("get digest mode failed", "chat_id", chatID, "error", err)
+		} else if mode == "digest" {
+			return NewDigestDelivery(s.digestStore)
+		}
+	}
+	return NewInstantDelivery(s.notifier, s.queue)
+}
+
 func (s *Scheduler) fetcherForSource(source string) fetcher.Fetcher {
 	if s.fetcherFactory != nil {
 		if f, ok := s.fetcherFactory.Get(source); ok {
@@ -496,31 +508,14 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			}
 		}
 
-		chatIDStr := fmt.Sprintf("%d", search.ChatID)
-
-		// Check if user is in digest mode.
-		digestMode := false
-		if s.digestStore != nil {
-			mode, _, err := s.digestStore.GetDigestMode(ctx, search.ChatID)
-			if err != nil {
-				s.logger.Error("get digest mode failed", "chat_id", search.ChatID, "error", err)
-			} else if mode == "digest" {
-				digestMode = true
-			}
-		}
+		delivery := s.deliveryFor(ctx, search.ChatID)
 
 		for _, msg := range priceDropMessages {
-			if digestMode {
-				if err := s.digestStore.AddDigestItem(ctx, search.ChatID, msg); err != nil {
-					s.logger.Error("add digest item failed", "chat_id", search.ChatID, "error", err)
-				}
-			} else {
-				if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {
-					s.logger.Error("price drop notification failed",
-						"chat_id", search.ChatID,
-						"error", err,
-					)
-				}
+			if err := delivery.DeliverRaw(ctx, search.ChatID, msg); err != nil {
+				s.logger.Error("price drop delivery failed",
+					"chat_id", search.ChatID,
+					"error", err,
+				)
 			}
 		}
 
@@ -538,40 +533,16 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			"count", len(newListings),
 		)
 
-		if digestMode {
-			msg := notifier.FormatBatch(newListings)
-			if err := s.digestStore.AddDigestItem(ctx, search.ChatID, msg); err != nil {
-				s.logger.Error("add digest item failed",
-					"chat_id", search.ChatID,
-					"error", err,
-				)
-				for _, l := range newListings {
-					_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
-				}
+		if err := delivery.DeliverBatch(ctx, search.ChatID, newListings); err != nil {
+			s.logger.Error("delivery failed",
+				"chat_id", search.ChatID,
+				"error", err,
+			)
+			for _, l := range newListings {
+				_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
 			}
-		} else {
-			if err := s.notifier.Notify(ctx, chatIDStr, newListings); err != nil {
-				s.logger.Error("notification failed",
-					"chat_id", search.ChatID,
-					"error", err,
-				)
-				enqueued := false
-				if s.queue != nil {
-					msg := notifier.FormatBatch(newListings)
-					if qErr := s.queue.EnqueueNotification(ctx, chatIDStr, search.Name, msg); qErr != nil {
-						s.logger.Error("enqueue notification failed", "error", qErr)
-					} else {
-						enqueued = true
-					}
-				}
-				if !enqueued {
-					for _, l := range newListings {
-						_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
-					}
-				}
-			} else if s.health != nil {
-				s.health.RecordNotificationSent()
-			}
+		} else if s.health != nil {
+			s.health.RecordNotificationSent()
 		}
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -180,7 +180,9 @@ func (s *Scheduler) deliveryFor(ctx context.Context, chatID int64) DeliveryStrat
 	if s.digestStore != nil {
 		mode, _, err := s.digestStore.GetDigestMode(ctx, chatID)
 		if err != nil {
-			s.logger.Error("get digest mode failed", "chat_id", chatID, "error", err)
+			if !errors.Is(err, storage.ErrNotFound) {
+				s.logger.Error("get digest mode failed", "chat_id", chatID, "error", err)
+			}
 		} else if mode == "digest" {
 			return NewDigestDelivery(s.digestStore)
 		}


### PR DESCRIPTION
## Summary

- Extract `DeliveryStrategy` interface with `DeliverBatch` and `DeliverRaw` methods
- `InstantDelivery`: sends via notifier with notification queue fallback on failure
- `DigestDelivery`: stores items in digest store for later batch delivery
- Scheduler selects strategy per user via `deliveryFor()`, eliminating duplicated if/else blocks
- 8 unit tests covering both strategies, queue fallback, and error paths

Closes #135

## Test plan

- [x] All delivery strategy tests pass
- [x] Full scheduler test suite passes (existing tests validate integration)
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added flexible notification delivery modes: instant delivery with automatic queue fallback and a digest mode that persists messages for later sending; delivery mode is chosen per recipient.
  * Unified delivery flow and error handling with clearer logging; deduplication/release behavior centralized.

* **Tests**
  * Added unit tests covering instant and digest delivery paths, including success, notifier failures, queue/digest fallbacks, and persistence error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->