### PR TITLE
refactor: apply Observer pattern for health metrics tracking

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -163,7 +163,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}()
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, tgNotif, logger, scheduler.Options{
-		Health:          h,
+		Observer:        h,
 		Queue:           store,
 		Prices:          store,
 		ConfigPath:      configPath,

--- a/internal/scheduler/observer.go
+++ b/internal/scheduler/observer.go
@@ -1,0 +1,15 @@
+package scheduler
+
+type CycleObserver interface {
+	RecordSuccess()
+	RecordError()
+	RecordListingsFound(n int)
+	RecordNotificationSent()
+}
+
+type nopObserver struct{}
+
+func (nopObserver) RecordSuccess()          {}
+func (nopObserver) RecordError()            {}
+func (nopObserver) RecordListingsFound(int) {}
+func (nopObserver) RecordNotificationSent() {}

--- a/internal/scheduler/observer_test.go
+++ b/internal/scheduler/observer_test.go
@@ -1,0 +1,59 @@
+package scheduler
+
+import (
+	"testing"
+)
+
+func TestNopObserver_DoesNotPanic(t *testing.T) {
+	var o nopObserver
+	o.RecordSuccess()
+	o.RecordError()
+	o.RecordListingsFound(10)
+	o.RecordNotificationSent()
+}
+
+type countingObserver struct {
+	successes     int
+	errors        int
+	listingsFound int
+	notifications int
+}
+
+func (o *countingObserver) RecordSuccess()          { o.successes++ }
+func (o *countingObserver) RecordError()            { o.errors++ }
+func (o *countingObserver) RecordListingsFound(n int) { o.listingsFound += n }
+func (o *countingObserver) RecordNotificationSent() { o.notifications++ }
+
+func TestCycleObserver_Interface(t *testing.T) {
+	var obs CycleObserver = &countingObserver{}
+	obs.RecordSuccess()
+	obs.RecordError()
+	obs.RecordListingsFound(5)
+	obs.RecordNotificationSent()
+
+	co := obs.(*countingObserver)
+	if co.successes != 1 {
+		t.Errorf("successes = %d, want 1", co.successes)
+	}
+	if co.errors != 1 {
+		t.Errorf("errors = %d, want 1", co.errors)
+	}
+	if co.listingsFound != 5 {
+		t.Errorf("listingsFound = %d, want 5", co.listingsFound)
+	}
+	if co.notifications != 1 {
+		t.Errorf("notifications = %d, want 1", co.notifications)
+	}
+}
+
+func TestNewScheduler_NilObserver_UsesNop(t *testing.T) {
+	cfg := testConfig()
+	s, err := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{Observer: nil})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+	_, isNop := s.observer.(nopObserver)
+	if !isNop {
+		t.Errorf("expected nopObserver when nil, got %T", s.observer)
+	}
+}

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -82,7 +82,7 @@ func TestRunMultiTenantCycle_AllGroupsFail(t *testing.T) {
 
 	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
 		SearchStore: ss,
-		Health:      h,
+		Observer:    h,
 	})
 
 	err := s.runMultiTenantCycle(context.Background())
@@ -107,7 +107,7 @@ func TestRunMultiTenantCycle_PrunesOldListings(t *testing.T) {
 
 	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
 		SearchStore: ss,
-		Health:      h,
+		Observer:    h,
 	})
 	s.lastPruneTime = time.Time{}
 
@@ -233,7 +233,7 @@ func TestFlushAndSendDigest_WithHealth(t *testing.T) {
 
 	s, _ := NewWithOptions(cfg, nil, nil, n, testLogger(), Options{
 		DigestStore: ds,
-		Health:      h,
+		Observer:    h,
 	})
 
 	s.flushAndSendDigest(context.Background(), 100)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/filter"
-	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/storage"
@@ -47,7 +46,7 @@ type Scheduler struct {
 	loc               *time.Location
 	backoffMultiplier float64
 	lastPruneTime     time.Time
-	health            *health.Status
+	observer          CycleObserver
 	queue             storage.NotificationQueue
 	prices            storage.PriceTracker
 	fetcherFactory    *fetcher.Factory
@@ -58,7 +57,7 @@ type Scheduler struct {
 }
 
 type Options struct {
-	Health          *health.Status
+	Observer        CycleObserver
 	Queue           storage.NotificationQueue
 	Prices          storage.PriceTracker
 	ConfigPath      string
@@ -75,9 +74,9 @@ func New(
 	d storage.DedupStore,
 	n notifier.Notifier,
 	logger *slog.Logger,
-	h *health.Status,
+	observer CycleObserver,
 ) (*Scheduler, error) {
-	return NewWithOptions(cfg, f, d, n, logger, Options{Health: h})
+	return NewWithOptions(cfg, f, d, n, logger, Options{Observer: observer})
 }
 
 func NewWithOptions(
@@ -92,6 +91,10 @@ func NewWithOptions(
 	if err != nil {
 		return nil, err
 	}
+	obs := opts.Observer
+	if obs == nil {
+		obs = nopObserver{}
+	}
 	return &Scheduler{
 		cfg:               cfg,
 		configPath:        opts.ConfigPath,
@@ -101,7 +104,7 @@ func NewWithOptions(
 		logger:            logger,
 		loc:               loc,
 		backoffMultiplier: 1.0,
-		health:            opts.Health,
+		observer:          obs,
 		queue:             opts.Queue,
 		prices:            opts.Prices,
 		fetcherFactory:    opts.FetcherFactory,
@@ -413,15 +416,11 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.processDigests(ctx)
 
 	if allFailed && len(groups) > 0 {
-		if s.health != nil {
-			s.health.RecordError()
-		}
+		s.observer.RecordError()
 		return fmt.Errorf("all %d groups failed", len(groups))
 	}
 
-	if s.health != nil {
-		s.health.RecordSuccess()
-	}
+	s.observer.RecordSuccess()
 	return nil
 }
 
@@ -525,9 +524,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			continue
 		}
 
-		if s.health != nil {
-			s.health.RecordListingsFound(len(newListings))
-		}
+		s.observer.RecordListingsFound(len(newListings))
 
 		s.logger.Info("new listings for user",
 			"chat_id", search.ChatID,
@@ -543,8 +540,8 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			for _, l := range newListings {
 				_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
 			}
-		} else if s.health != nil {
-			s.health.RecordNotificationSent()
+		} else {
+			s.observer.RecordNotificationSent()
 		}
 	}
 
@@ -623,9 +620,7 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 		"chat_id", chatID,
 		"items", len(payloads),
 	)
-	if s.health != nil {
-		s.health.RecordNotificationSent()
-	}
+	s.observer.RecordNotificationSent()
 }
 
 func maskPhone(phone string) string {

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -481,7 +481,7 @@ func TestRunMultiTenantCycle_PruneError(t *testing.T) {
 
 	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
 		SearchStore: ss,
-		Health:      h,
+		Observer:    h,
 	})
 	s.lastPruneTime = time.Time{} // force prune
 
@@ -666,7 +666,7 @@ func TestRunMultiTenantCycle_HealthRecording(t *testing.T) {
 
 	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
 		SearchStore: ss,
-		Health:      h,
+		Observer:    h,
 	})
 
 	_ = s.runMultiTenantCycle(context.Background())

--- a/internal/scheduler/scheduler_extra_test.go
+++ b/internal/scheduler/scheduler_extra_test.go
@@ -153,12 +153,12 @@ func TestRetryPending_WithPending(t *testing.T) {
 func TestNewWithOptions_HealthStatus(t *testing.T) {
 	cfg := testConfig()
 	h := health.New()
-	s, err := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{Health: h})
+	s, err := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{Observer: h})
 	if err != nil {
 		t.Fatalf("create scheduler: %v", err)
 	}
-	if s.health != h {
-		t.Error("health status not set")
+	if s.observer != h {
+		t.Error("observer not set")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Define `CycleObserver` interface with `RecordSuccess`, `RecordError`, `RecordListingsFound`, `RecordNotificationSent`
- `health.Status` already satisfies this interface (no wrapper needed)
- Replace `*health.Status` field with `CycleObserver` in scheduler, removing all nil checks
- `nopObserver` used when no observer is configured
- Decouples scheduler from the health package — new metrics sinks can be added by implementing `CycleObserver`

Closes #140

## Test plan

- [x] Observer interface and nopObserver tests pass
- [x] Full test suite passes
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched scheduler monitoring to an observer-style interface for recording cycle outcomes (successes, errors, listings found, notifications sent).
  * Scheduler now accepts an observer and defaults to a safe no-op observer when none is provided; metric recording is performed via the observer.

* **Tests**
  * Added and updated tests to validate observer methods, the no-op fallback, and scheduler integration with the observer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->