### PR TITLE
feat: add /history command to view past matched listings

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -117,6 +117,7 @@ func run(configPath string, logger *slog.Logger) error {
 		MaxSearches: cfg.Telegram.MaxSearches,
 		BotUsername:  cfg.Telegram.BotUsername,
 		Health:      h,
+		Listings:    store,
 		Catalog:     dynCatalog,
 	}, logger)
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -470,6 +470,12 @@ func (b *Bot) sendHistoryPage(ctx context.Context, chatID int64, page int) {
 		return
 	}
 
+	totalPages := int((total + int64(historyPageSize) - 1) / int64(historyPageSize))
+	if page < 0 || page >= totalPages {
+		b.send(ctx, chatID, "That history page is no longer available. Use /history to start again.")
+		return
+	}
+
 	offset := page * historyPageSize
 	listings, err := b.listings.ListUserListings(ctx, chatID, historyPageSize, offset)
 	if err != nil {
@@ -478,13 +484,11 @@ func (b *Bot) sendHistoryPage(ctx context.Context, chatID int64, page int) {
 		return
 	}
 
-	totalPages := int((total + int64(historyPageSize) - 1) / int64(historyPageSize))
-
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("*Match history (%d total):*\n", total))
 
 	for _, l := range listings {
-		title := strings.TrimSpace(l.Manufacturer + " " + l.Model)
+		title := format.EscapeMarkdown(strings.TrimSpace(l.Manufacturer + " " + l.Model))
 		if l.Year > 0 {
 			title += fmt.Sprintf(" %d", l.Year)
 		}
@@ -501,11 +505,11 @@ func (b *Bot) sendHistoryPage(ctx context.Context, chatID int64, page int) {
 		}
 		sb.WriteString("\n")
 		if l.City != "" {
-			sb.WriteString(fmt.Sprintf("📍 %s\n", l.City))
+			sb.WriteString(fmt.Sprintf("📍 %s\n", format.EscapeMarkdown(l.City)))
 		}
 		sb.WriteString(fmt.Sprintf("📅 Found: %s\n", l.FirstSeenAt.Format("02 Jan 2006 15:04")))
 		if l.PageLink != "" {
-			sb.WriteString(fmt.Sprintf("🔗 %s\n", l.PageLink))
+			sb.WriteString(fmt.Sprintf("🔗 %s\n", format.EscapeMarkdown(l.PageLink)))
 		}
 	}
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -24,6 +24,7 @@ type Bot struct {
 	msg         messenger
 	users       storage.UserStore
 	searches    storage.SearchStore
+	listings    storage.ListingStore
 	digests     storage.DigestStore
 	catalog     catalog.Catalog
 	adminChatID int64
@@ -39,6 +40,7 @@ type Config struct {
 	BotUsername  string
 	Health      *health.Status
 	Digests     storage.DigestStore
+	Listings    storage.ListingStore
 	Catalog     catalog.Catalog
 }
 
@@ -59,6 +61,7 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 		msg:         msg,
 		users:       users,
 		searches:    searches,
+		listings:    cfg.Listings,
 		digests:     cfg.Digests,
 		catalog:     cat,
 		adminChatID: cfg.AdminChatID,
@@ -90,6 +93,7 @@ func (b *Bot) RegisterHandlers() {
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/share", tgbot.MatchTypePrefix, b.handleShare)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/cancel", tgbot.MatchTypeExact, b.handleCancel)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/help", tgbot.MatchTypeExact, b.handleHelp)
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/history", tgbot.MatchTypeExact, b.handleHistory)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/digest", tgbot.MatchTypeExact, b.handleDigest)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/settings", tgbot.MatchTypeExact, b.handleSettings)
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stats", tgbot.MatchTypeExact, b.handleStats)
@@ -395,6 +399,7 @@ func (b *Bot) handleHelp(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 		"*CarWatch Commands:*\n\n"+
 			"/watch — Set up a new car search\n"+
 			"/list — Show your active searches\n"+
+			"/history — View past matched listings\n"+
 			"/pause <id> — Pause a search\n"+
 			"/resume <id> — Resume a paused search\n"+
 			"/stop <id> — Delete a search\n"+
@@ -437,6 +442,97 @@ func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	}
 
 	b.sendMarkdown(ctx, chatID, sb.String())
+}
+
+const historyPageSize = 5
+
+func (b *Bot) handleHistory(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	chatID := update.Message.Chat.ID
+	b.ensureUser(ctx, chatID, update.Message.From.Username)
+	b.sendHistoryPage(ctx, chatID, 0)
+}
+
+func (b *Bot) sendHistoryPage(ctx context.Context, chatID int64, page int) {
+	if b.listings == nil {
+		b.send(ctx, chatID, "History is not available.")
+		return
+	}
+
+	total, err := b.listings.CountUserListings(ctx, chatID)
+	if err != nil {
+		b.logger.Error("count user listings failed", "chat_id", chatID, "error", err)
+		b.send(ctx, chatID, "Failed to load history. Please try again.")
+		return
+	}
+
+	if total == 0 {
+		b.send(ctx, chatID, "No matched listings yet. Use /watch to set up a search.")
+		return
+	}
+
+	offset := page * historyPageSize
+	listings, err := b.listings.ListUserListings(ctx, chatID, historyPageSize, offset)
+	if err != nil {
+		b.logger.Error("list user listings failed", "chat_id", chatID, "error", err)
+		b.send(ctx, chatID, "Failed to load history. Please try again.")
+		return
+	}
+
+	totalPages := int((total + int64(historyPageSize) - 1) / int64(historyPageSize))
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*Match history (%d total):*\n", total))
+
+	for _, l := range listings {
+		title := strings.TrimSpace(l.Manufacturer + " " + l.Model)
+		if l.Year > 0 {
+			title += fmt.Sprintf(" %d", l.Year)
+		}
+		sb.WriteString("\n━━━━━━━━━━━━━━━━━━━━\n")
+		sb.WriteString(fmt.Sprintf("*%s*\n", title))
+		if l.Price > 0 {
+			sb.WriteString(fmt.Sprintf("💰 ₪%s", format.Number(l.Price)))
+		}
+		if l.Km > 0 {
+			sb.WriteString(fmt.Sprintf(" · 🛣️ %s km", format.Number(l.Km)))
+		}
+		if l.Hand > 0 {
+			sb.WriteString(fmt.Sprintf(" · ✋ %d", l.Hand))
+		}
+		sb.WriteString("\n")
+		if l.City != "" {
+			sb.WriteString(fmt.Sprintf("📍 %s\n", l.City))
+		}
+		sb.WriteString(fmt.Sprintf("📅 Found: %s\n", l.FirstSeenAt.Format("02 Jan 2006 15:04")))
+		if l.PageLink != "" {
+			sb.WriteString(fmt.Sprintf("🔗 %s\n", l.PageLink))
+		}
+	}
+
+	if totalPages <= 1 {
+		b.sendMarkdown(ctx, chatID, sb.String())
+		return
+	}
+
+	var navRow []tgmodels.InlineKeyboardButton
+	if page > 0 {
+		navRow = append(navRow, tgmodels.InlineKeyboardButton{
+			Text: "← Newer", CallbackData: cbHistoryPage + strconv.Itoa(page-1),
+		})
+	}
+	navRow = append(navRow, tgmodels.InlineKeyboardButton{
+		Text: fmt.Sprintf("%d/%d", page+1, totalPages), CallbackData: "noop",
+	})
+	if page < totalPages-1 {
+		navRow = append(navRow, tgmodels.InlineKeyboardButton{
+			Text: "Older →", CallbackData: cbHistoryPage + strconv.Itoa(page+1),
+		})
+	}
+
+	kb := &tgmodels.InlineKeyboardMarkup{
+		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{navRow},
+	}
+	b.sendWithKeyboard(ctx, chatID, sb.String(), kb)
 }
 
 func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
@@ -530,6 +626,8 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 		b.onDigestOn(ctx, chatID)
 	case data == cbDigestOff:
 		b.onDigestOff(ctx, chatID)
+	case strings.HasPrefix(data, cbHistoryPage):
+		b.onHistoryPage(ctx, chatID, data)
 	case data == "noop":
 		// page indicator button, do nothing
 	}
@@ -780,6 +878,17 @@ func (b *Bot) onDigestOff(ctx context.Context, chatID int64) {
 		return
 	}
 	b.sendMarkdown(ctx, chatID, "Switched to *instant* mode. Listings will be sent immediately.")
+}
+
+func (b *Bot) onHistoryPage(ctx context.Context, chatID int64, data string) {
+	pageStr := strings.TrimPrefix(data, cbHistoryPage)
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		b.logger.Warn("invalid history page callback", "chat_id", chatID, "raw", pageStr, "error", err)
+		b.send(ctx, chatID, "Something went wrong. Please try again.")
+		return
+	}
+	b.sendHistoryPage(ctx, chatID, page)
 }
 
 // --- Default Handler (free text during wizard) ---

--- a/internal/bot/history_test.go
+++ b/internal/bot/history_test.go
@@ -1,0 +1,163 @@
+package bot
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func TestHistory_Empty(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 700
+
+	tb.simulateCommand(ctx, chatID, "/history")
+
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "No matched listings") {
+		t.Errorf("expected empty history message, got: %s", msg.Text)
+	}
+}
+
+func TestHistory_ShowsListings(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 701
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: chatID, Name: "mazda-3", Manufacturer: 27, Model: 1,
+	})
+
+	// Claim listings so they appear in seen_listings for this user.
+	_, _ = tb.store.ClaimNew(ctx, "token-1", chatID, searchID)
+	_, _ = tb.store.ClaimNew(ctx, "token-2", chatID, searchID)
+
+	// Save listing details to listing_history.
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "token-1", SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2020,
+		Price: 120000, Km: 50000, Hand: 2,
+		City: "Tel Aviv", PageLink: "https://example.com/1",
+		FirstSeenAt: time.Now(),
+	})
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "token-2", SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021,
+		Price: 140000, Km: 30000, Hand: 1,
+		City: "Haifa", PageLink: "https://example.com/2",
+		FirstSeenAt: time.Now(),
+	})
+
+	tb.simulateCommand(ctx, chatID, "/history")
+
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "Match history (2 total)") {
+		t.Errorf("expected history header with count 2, got: %s", msg.Text)
+	}
+	if !strings.Contains(msg.Text, "Mazda 3") {
+		t.Errorf("expected car name in history, got: %s", msg.Text)
+	}
+	if !strings.Contains(msg.Text, "120,000") {
+		t.Errorf("expected formatted price in history, got: %s", msg.Text)
+	}
+}
+
+func TestHistory_Pagination(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 702
+
+	_ = tb.store.UpsertUser(ctx, chatID, "bob")
+	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
+	})
+
+	// Create more listings than one page (historyPageSize = 5).
+	for i := range 7 {
+		token := "tok-" + string(rune('a'+i))
+		_, _ = tb.store.ClaimNew(ctx, token, chatID, searchID)
+		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3", Year: 2020 + i,
+			Price: 100000 + i*10000, FirstSeenAt: time.Now(),
+		})
+	}
+
+	tb.simulateCommand(ctx, chatID, "/history")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Fatal("expected keyboard with pagination buttons")
+	}
+	if !strings.Contains(msg.Text, "7 total") {
+		t.Errorf("expected 7 total, got: %s", msg.Text)
+	}
+	if msg.Buttons < 2 {
+		t.Errorf("expected at least 2 pagination buttons (page indicator + next), got %d", msg.Buttons)
+	}
+
+	// Navigate to page 2 via callback.
+	tb.msg.reset()
+	tb.simulateCallback(ctx, chatID, cbHistoryPage+"1")
+
+	msg = tb.msg.last()
+	if !strings.Contains(msg.Text, "Match history") {
+		t.Errorf("page 2 should still show history header, got: %s", msg.Text)
+	}
+}
+
+func TestHistory_IsolatedPerUser(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const alice int64 = 710
+	const bob int64 = 711
+
+	_ = tb.store.UpsertUser(ctx, alice, "alice")
+	_ = tb.store.UpsertUser(ctx, bob, "bob")
+
+	searchA, _ := tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: alice, Name: "a-search", Manufacturer: 27, Model: 1,
+	})
+	searchB, _ := tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: bob, Name: "b-search", Manufacturer: 19, Model: 1,
+	})
+
+	_, _ = tb.store.ClaimNew(ctx, "alice-tok", alice, searchA)
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "alice-tok", SearchName: "a-search",
+		Manufacturer: "Mazda", Model: "3", Year: 2020,
+		Price: 100000, FirstSeenAt: time.Now(),
+	})
+
+	_, _ = tb.store.ClaimNew(ctx, "bob-tok", bob, searchB)
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "bob-tok", SearchName: "b-search",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2019,
+		Price: 90000, FirstSeenAt: time.Now(),
+	})
+
+	// Alice should see only her listing.
+	tb.simulateCommand(ctx, alice, "/history")
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "Mazda") {
+		t.Errorf("alice should see Mazda, got: %s", msg.Text)
+	}
+	if strings.Contains(msg.Text, "Toyota") {
+		t.Errorf("alice should not see bob's Toyota listing")
+	}
+
+	// Bob should see only his listing.
+	tb.msg.reset()
+	tb.simulateCommand(ctx, bob, "/history")
+	msg = tb.msg.last()
+	if !strings.Contains(msg.Text, "Toyota") {
+		t.Errorf("bob should see Toyota, got: %s", msg.Text)
+	}
+	if strings.Contains(msg.Text, "Mazda") {
+		t.Errorf("bob should not see alice's Mazda listing")
+	}
+}

--- a/internal/bot/history_test.go
+++ b/internal/bot/history_test.go
@@ -161,3 +161,66 @@ func TestHistory_IsolatedPerUser(t *testing.T) {
 		t.Errorf("bob should not see alice's Mazda listing")
 	}
 }
+
+func TestHistory_InvalidPage(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 720
+
+	_ = tb.store.UpsertUser(ctx, chatID, "dave")
+	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
+	})
+	_, _ = tb.store.ClaimNew(ctx, "tok-1", chatID, searchID)
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-1", SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2020,
+		Price: 100000, FirstSeenAt: time.Now(),
+	})
+
+	// Out-of-range page should show friendly error.
+	tb.simulateCallback(ctx, chatID, cbHistoryPage+"999")
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "no longer available") {
+		t.Errorf("expected out-of-range message, got: %s", msg.Text)
+	}
+
+	// Negative page should show friendly error.
+	tb.msg.reset()
+	tb.simulateCallback(ctx, chatID, cbHistoryPage+"-1")
+	msg = tb.msg.last()
+	if !strings.Contains(msg.Text, "no longer available") {
+		t.Errorf("expected out-of-range message for negative page, got: %s", msg.Text)
+	}
+}
+
+func TestHistory_MarkdownEscaping(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 730
+
+	_ = tb.store.UpsertUser(ctx, chatID, "eve")
+	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
+	})
+	_, _ = tb.store.ClaimNew(ctx, "tok-md", chatID, searchID)
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-md", SearchName: "test",
+		Manufacturer: "Land_Rover", Model: "Range*Rover", Year: 2020,
+		Price: 200000, City: "Tel_Aviv",
+		FirstSeenAt: time.Now(),
+	})
+
+	tb.simulateCommand(ctx, chatID, "/history")
+	msg := tb.msg.last()
+
+	if strings.Contains(msg.Text, "Land_Rover") {
+		t.Error("underscores in manufacturer should be escaped")
+	}
+	if !strings.Contains(msg.Text, "Land\\_Rover") {
+		t.Errorf("expected escaped manufacturer, got: %s", msg.Text)
+	}
+	if !strings.Contains(msg.Text, "Tel\\_Aviv") {
+		t.Errorf("expected escaped city, got: %s", msg.Text)
+	}
+}

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -27,6 +27,7 @@ const (
 	cbMdlPage         = "mdl_pg:"
 	cbMdlSearch       = "mdl_search"
 	cbAnyModel        = "mdl:0"
+	cbHistoryPage     = "hist_pg:"
 
 	pageSize = 15
 	colsPerRow = 3

--- a/internal/bot/testhelpers_test.go
+++ b/internal/bot/testhelpers_test.go
@@ -80,6 +80,7 @@ func newTestBot(t *testing.T) *testBot {
 		msg:         mm,
 		users:       store,
 		searches:    store,
+		listings:    store,
 		catalog:     catalog.NewStatic(),
 		adminChatID: 999,
 		maxSearches: 3,
@@ -134,6 +135,7 @@ func newTestBotWithDigests(t *testing.T) *testBot {
 		msg:         mm,
 		users:       store,
 		searches:    store,
+		listings:    store,
 		digests:     store,
 		catalog:     catalog.NewStatic(),
 		adminChatID: 999,
@@ -160,6 +162,8 @@ func (tb *testBot) simulateCommand(ctx context.Context, chatID int64, text strin
 		tb.bot.handleHelp(ctx, nilBot, update)
 	case text == "/settings":
 		tb.bot.handleSettings(ctx, nilBot, update)
+	case text == "/history":
+		tb.bot.handleHistory(ctx, nilBot, update)
 	case text == "/digest":
 		tb.bot.handleDigest(ctx, nilBot, update)
 	case strings.HasPrefix(text, "/start"):

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -5,6 +5,18 @@ import (
 	"strings"
 )
 
+var telegramMarkdownEscaper = strings.NewReplacer(
+	"_", "\\_",
+	"*", "\\*",
+	"[", "\\[",
+	"]", "\\]",
+	"`", "\\`",
+)
+
+func EscapeMarkdown(s string) string {
+	return telegramMarkdownEscaper.Replace(s)
+}
+
 func Number(n int) string {
 	s := strconv.Itoa(n)
 	sign := ""

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -24,3 +24,22 @@ func TestNumber(t *testing.T) {
 		}
 	}
 }
+
+func TestEscapeMarkdown(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"plain text", "plain text"},
+		{"under_score", "under\\_score"},
+		{"*bold*", "\\*bold\\*"},
+		{"[link](url)", "\\[link\\](url)"},
+		{"`code`", "\\`code\\`"},
+		{"a_b*c[d]e`f", "a\\_b\\*c\\[d\\]e\\`f"},
+	}
+	for _, tt := range tests {
+		got := EscapeMarkdown(tt.input)
+		if got != tt.want {
+			t.Errorf("EscapeMarkdown(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -253,3 +253,11 @@ func (m *mockListingStore) SaveListing(_ context.Context, r storage.ListingRecor
 	m.saved = append(m.saved, r)
 	return nil
 }
+
+func (m *mockListingStore) ListUserListings(_ context.Context, _ int64, _, _ int) ([]storage.ListingRecord, error) {
+	return nil, nil
+}
+
+func (m *mockListingStore) CountUserListings(_ context.Context, _ int64) (int64, error) {
+	return 0, nil
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -103,6 +103,8 @@ type ListingRecord struct {
 
 type ListingStore interface {
 	SaveListing(ctx context.Context, r ListingRecord) error
+	ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]ListingRecord, error)
+	CountUserListings(ctx context.Context, chatID int64) (int64, error)
 }
 
 type CatalogEntry struct {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -443,6 +443,41 @@ func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error 
 	return err
 }
 
+func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.year, lh.price,
+			lh.km, lh.hand, lh.city, lh.page_link, sl.first_seen_at
+		FROM listing_history lh
+		JOIN seen_listings sl ON lh.token = sl.token
+		WHERE sl.chat_id = ?
+		ORDER BY sl.first_seen_at DESC
+		LIMIT ? OFFSET ?`, chatID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var listings []storage.ListingRecord
+	for rows.Next() {
+		var l storage.ListingRecord
+		if err := rows.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
+			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.FirstSeenAt); err != nil {
+			return nil, err
+		}
+		listings = append(listings, l)
+	}
+	return listings, rows.Err()
+}
+
+func (s *Store) CountUserListings(ctx context.Context, chatID int64) (int64, error) {
+	var count int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM listing_history lh
+		JOIN seen_listings sl ON lh.token = sl.token
+		WHERE sl.chat_id = ?`, chatID).Scan(&count)
+	return count, err
+}
+
 func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -123,6 +123,9 @@ func migrate(db *sql.DB) error {
 
 		CREATE INDEX IF NOT EXISTS idx_seen_listings_first_seen_at
 			ON seen_listings(first_seen_at);
+
+		CREATE INDEX IF NOT EXISTS idx_seen_listings_chatid_firstseen
+			ON seen_listings(chat_id, first_seen_at DESC);
 	`)
 	if err != nil {
 		return err
@@ -450,7 +453,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 		FROM listing_history lh
 		JOIN seen_listings sl ON lh.token = sl.token
 		WHERE sl.chat_id = ?
-		ORDER BY sl.first_seen_at DESC
+		ORDER BY sl.first_seen_at DESC, lh.token DESC
 		LIMIT ? OFFSET ?`, chatID, limit, offset)
 	if err != nil {
 		return nil, err

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -606,3 +606,110 @@ func TestSaveAndListListings(t *testing.T) {
 		t.Errorf("listings = %+v", listings)
 	}
 }
+
+func TestListUserListings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	// Claim tokens for user 100.
+	_, _ = store.ClaimNew(ctx, "tok-a", 100, 1)
+	_, _ = store.ClaimNew(ctx, "tok-b", 100, 1)
+
+	// Claim a different token for user 200.
+	_, _ = store.ClaimNew(ctx, "tok-c", 200, 1)
+
+	// Save listing details.
+	for _, tok := range []string{"tok-a", "tok-b", "tok-c"} {
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3", Year: 2020,
+			Price: 100000,
+		})
+	}
+
+	// User 100 should see 2 listings.
+	listings, err := store.ListUserListings(ctx, 100, 10, 0)
+	if err != nil {
+		t.Fatalf("list user listings: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 listings for user 100, got %d", len(listings))
+	}
+
+	// User 200 should see 1 listing.
+	listings, err = store.ListUserListings(ctx, 200, 10, 0)
+	if err != nil {
+		t.Fatalf("list user listings: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("expected 1 listing for user 200, got %d", len(listings))
+	}
+}
+
+func TestCountUserListings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	// No listings yet.
+	count, err := store.CountUserListings(ctx, 100)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+
+	// Add some.
+	for _, tok := range []string{"t1", "t2", "t3"} {
+		_, _ = store.ClaimNew(ctx, tok, 100, 1)
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3",
+		})
+	}
+
+	count, err = store.CountUserListings(ctx, 100)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3, got %d", count)
+	}
+}
+
+func TestListUserListings_Pagination(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	for i := range 5 {
+		tok := "tok-" + string(rune('a'+i))
+		_, _ = store.ClaimNew(ctx, tok, 100, 1)
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, SearchName: "test",
+			Manufacturer: "Test", Model: "Car",
+			Price: 100000 + i*1000,
+		})
+	}
+
+	// Page 1: limit 2, offset 0.
+	page1, _ := store.ListUserListings(ctx, 100, 2, 0)
+	if len(page1) != 2 {
+		t.Errorf("page 1: expected 2 items, got %d", len(page1))
+	}
+
+	// Page 2: limit 2, offset 2.
+	page2, _ := store.ListUserListings(ctx, 100, 2, 2)
+	if len(page2) != 2 {
+		t.Errorf("page 2: expected 2 items, got %d", len(page2))
+	}
+
+	// Page 3: limit 2, offset 4.
+	page3, _ := store.ListUserListings(ctx, 100, 2, 4)
+	if len(page3) != 1 {
+		t.Errorf("page 3: expected 1 item, got %d", len(page3))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `/history` bot command that shows paginated match history per user
- Queries `listing_history` joined with `seen_listings` for per-user isolation
- Each entry shows car name, year, price, mileage, hand, city, discovery date, and listing link
- Paginated with "← Newer" / "Older →" inline buttons (5 per page)
- Updates `/help` text to include the new command

## Changes

- `storage.ListingStore` interface: added `ListUserListings` and `CountUserListings`
- SQLite implementation: JOIN query on `listing_history` + `seen_listings`
- Bot: `/history` handler, `sendHistoryPage` with pagination, `onHistoryPage` callback
- Wired `ListingStore` into bot config and `main.go`

## Test plan

- [x] `TestHistory_Empty` — shows helpful message when no matches exist
- [x] `TestHistory_ShowsListings` — displays car details and formatted prices
- [x] `TestHistory_Pagination` — keyboard buttons appear when >5 results, page navigation works
- [x] `TestHistory_IsolatedPerUser` — each user sees only their own matches
- [x] `TestListUserListings` — storage-level per-user isolation
- [x] `TestCountUserListings` — correct counts
- [x] `TestListUserListings_Pagination` — offset/limit works correctly
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /history command to view your matched car listings with pagination, navigation buttons, and total count; /help updated to mention it.
* **Storage**
  * Backing store now supports per-user paginated history and counts for accurate history retrieval.
* **Formatting**
  * History text is safely escaped for Telegram Markdown to prevent formatting issues.
* **Tests**
  * Comprehensive tests added for history rendering, pagination, isolation per user, invalid-page handling, and markdown escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->