### PR TITLE
feat: allow multiple marketplace selection per search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          args: --timeout=5m
 
   test:
     name: Test

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
@@ -32,6 +33,7 @@ type Bot struct {
 	botUsername  string
 	logger      *slog.Logger
 	health      *health.Status
+	chatMu      sync.Map
 }
 
 type Config struct {
@@ -642,7 +644,17 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	}
 }
 
+func (b *Bot) lockChat(chatID int64) func() {
+	v, _ := b.chatMu.LoadOrStore(chatID, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
 func (b *Bot) onSourceToggle(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	source := strings.TrimPrefix(data, cbSourceToggle)
 	wd := b.loadWizardData(ctx, chatID)
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -603,8 +603,7 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 
 	switch {
 	case strings.HasPrefix(data, cbPrefixSource):
-		b.onSourceToggle(ctx, chatID, cbSourceToggle+strings.TrimPrefix(data, cbPrefixSource))
-		b.onSourceDone(ctx, chatID)
+		b.onLegacySourceSelected(ctx, chatID, strings.TrimPrefix(data, cbPrefixSource))
 	case strings.HasPrefix(data, cbSourceToggle):
 		b.onSourceToggle(ctx, chatID, data)
 	case data == cbSourceDone:
@@ -667,9 +666,21 @@ func (b *Bot) onSourceToggle(ctx context.Context, chatID int64, data string) {
 		sourceKeyboard(selected))
 }
 
+func (b *Bot) onLegacySourceSelected(ctx context.Context, chatID int64, source string) {
+	unlock := b.lockChat(chatID)
+	wd := b.loadWizardData(ctx, chatID)
+	wd.Source = source
+	b.saveWizardState(ctx, chatID, StateAskSource, wd)
+	unlock()
+
+	b.onSourceDone(ctx, chatID)
+}
+
 func (b *Bot) onSourceDone(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
 	wd := b.loadWizardData(ctx, chatID)
 	if wd.Source == "" {
+		unlock()
 		b.sendWithKeyboard(ctx, chatID,
 			"Please select at least one marketplace.",
 			sourceKeyboard(""))
@@ -677,6 +688,7 @@ func (b *Bot) onSourceDone(ctx context.Context, chatID int64) {
 	}
 	b.logger.Debug("sources selected", "chat_id", chatID, "source", wd.Source)
 	b.saveWizardState(ctx, chatID, StateAskManufacturer, wd)
+	unlock()
 
 	b.sendWithKeyboard(ctx, chatID,
 		"What manufacturer are you looking for?",

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -600,6 +600,9 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	}
 
 	switch {
+	case strings.HasPrefix(data, cbPrefixSource):
+		b.onSourceToggle(ctx, chatID, cbSourceToggle+strings.TrimPrefix(data, cbPrefixSource))
+		b.onSourceDone(ctx, chatID)
 	case strings.HasPrefix(data, cbSourceToggle):
 		b.onSourceToggle(ctx, chatID, data)
 	case data == cbSourceDone:

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -249,8 +249,8 @@ func (b *Bot) handleWatch(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 
 	_ = b.users.UpdateUserState(ctx, chatID, StateAskSource, "{}")
 	b.sendWithKeyboard(ctx, chatID,
-		"Which marketplace do you want to search?",
-		sourceKeyboard())
+		"Which marketplaces do you want to search? (select one or both)",
+		sourceKeyboard(""))
 }
 
 func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
@@ -600,8 +600,10 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	}
 
 	switch {
-	case strings.HasPrefix(data, cbPrefixSource):
-		b.onSourceSelected(ctx, chatID, data)
+	case strings.HasPrefix(data, cbSourceToggle):
+		b.onSourceToggle(ctx, chatID, data)
+	case data == cbSourceDone:
+		b.onSourceDone(ctx, chatID)
 	case strings.HasPrefix(data, cbMfrPage):
 		b.onMfrPage(ctx, chatID, data)
 	case data == cbMfrSearch:
@@ -637,15 +639,54 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	}
 }
 
-func (b *Bot) onSourceSelected(ctx context.Context, chatID int64, data string) {
-	source := strings.TrimPrefix(data, cbPrefixSource)
-	b.logger.Debug("source selected", "chat_id", chatID, "source", source)
-	wd := WizardData{Source: source}
+func (b *Bot) onSourceToggle(ctx context.Context, chatID int64, data string) {
+	source := strings.TrimPrefix(data, cbSourceToggle)
+	wd := b.loadWizardData(ctx, chatID)
+
+	selected := toggleSource(wd.Source, source)
+	wd.Source = selected
+	b.saveWizardState(ctx, chatID, StateAskSource, wd)
+
+	b.sendWithKeyboard(ctx, chatID,
+		"Which marketplaces do you want to search? (select one or both)",
+		sourceKeyboard(selected))
+}
+
+func (b *Bot) onSourceDone(ctx context.Context, chatID int64) {
+	wd := b.loadWizardData(ctx, chatID)
+	if wd.Source == "" {
+		b.sendWithKeyboard(ctx, chatID,
+			"Please select at least one marketplace.",
+			sourceKeyboard(""))
+		return
+	}
+	b.logger.Debug("sources selected", "chat_id", chatID, "source", wd.Source)
 	b.saveWizardState(ctx, chatID, StateAskManufacturer, wd)
 
 	b.sendWithKeyboard(ctx, chatID,
 		"What manufacturer are you looking for?",
 		b.manufacturerKeyboard(ctx, chatID, 0))
+}
+
+func toggleSource(current, toggle string) string {
+	sources := make(map[string]bool)
+	if current != "" {
+		for _, s := range strings.Split(current, ",") {
+			sources[s] = true
+		}
+	}
+	if sources[toggle] {
+		delete(sources, toggle)
+	} else {
+		sources[toggle] = true
+	}
+	var result []string
+	for _, s := range []string{"yad2", "winwin"} {
+		if sources[s] {
+			result = append(result, s)
+		}
+	}
+	return strings.Join(result, ",")
 }
 
 func (b *Bot) onMfrPage(ctx context.Context, chatID int64, data string) {
@@ -749,7 +790,7 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 
 	source := wd.Source
 	if source == "" {
-		source = "yad2"
+		source = "yad2,winwin"
 	}
 
 	name := fmt.Sprintf("%s-%s", strings.ToLower(wd.ManufacturerName), strings.ToLower(wd.ModelName))
@@ -780,8 +821,8 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 func (b *Bot) onEdit(ctx context.Context, chatID int64) {
 	_ = b.users.UpdateUserState(ctx, chatID, StateAskSource, "{}")
 	b.sendWithKeyboard(ctx, chatID,
-		"Let's start over. Which marketplace?",
-		sourceKeyboard())
+		"Let's start over. Which marketplaces?",
+		sourceKeyboard(""))
 }
 
 func (b *Bot) onCancelCallback(ctx context.Context, chatID int64) {

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -509,7 +509,7 @@ func TestSourceDisplayName_Multi(t *testing.T) {
 		{"yad2", "Yad2"},
 		{"winwin", "WinWin"},
 		{"yad2,winwin", "Yad2, WinWin"},
-		{"", "Yad2"},
+		{"", "Yad2, WinWin"},
 	}
 	for _, tt := range tests {
 		got := sourceDisplayName(tt.source)

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -483,3 +483,94 @@ func TestMaxSearchesDefault(t *testing.T) {
 		t.Errorf("maxSearches = %d, want 5", b2.maxSearches)
 	}
 }
+
+func TestToggleSource(t *testing.T) {
+	tests := []struct {
+		current, toggle, want string
+	}{
+		{"", "yad2", "yad2"},
+		{"yad2", "winwin", "yad2,winwin"},
+		{"yad2,winwin", "yad2", "winwin"},
+		{"yad2,winwin", "winwin", "yad2"},
+		{"winwin", "winwin", ""},
+	}
+	for _, tt := range tests {
+		got := toggleSource(tt.current, tt.toggle)
+		if got != tt.want {
+			t.Errorf("toggleSource(%q, %q) = %q, want %q", tt.current, tt.toggle, got, tt.want)
+		}
+	}
+}
+
+func TestSourceDisplayName_Multi(t *testing.T) {
+	tests := []struct {
+		source, want string
+	}{
+		{"yad2", "Yad2"},
+		{"winwin", "WinWin"},
+		{"yad2,winwin", "Yad2, WinWin"},
+		{"", "Yad2"},
+	}
+	for _, tt := range tests {
+		got := sourceDisplayName(tt.source)
+		if got != tt.want {
+			t.Errorf("sourceDisplayName(%q) = %q, want %q", tt.source, got, tt.want)
+		}
+	}
+}
+
+func TestSourceKeyboard_NoneSelected(t *testing.T) {
+	kb := sourceKeyboard("")
+	if len(kb.InlineKeyboard) != 1 {
+		t.Fatalf("expected 1 row (no Done button), got %d", len(kb.InlineKeyboard))
+	}
+	if kb.InlineKeyboard[0][0].Text != "Yad2" {
+		t.Errorf("first button = %q, want Yad2 (no checkmark)", kb.InlineKeyboard[0][0].Text)
+	}
+}
+
+func TestSourceKeyboard_BothSelected(t *testing.T) {
+	kb := sourceKeyboard("yad2,winwin")
+	if len(kb.InlineKeyboard) != 2 {
+		t.Fatalf("expected 2 rows (toggles + Done), got %d", len(kb.InlineKeyboard))
+	}
+	if kb.InlineKeyboard[0][0].Text != "✅ Yad2" {
+		t.Errorf("first button = %q, want '✅ Yad2'", kb.InlineKeyboard[0][0].Text)
+	}
+	if kb.InlineKeyboard[0][1].Text != "✅ WinWin" {
+		t.Errorf("second button = %q, want '✅ WinWin'", kb.InlineKeyboard[0][1].Text)
+	}
+	if kb.InlineKeyboard[1][0].Text != "Done ✓" {
+		t.Errorf("done button = %q, want 'Done ✓'", kb.InlineKeyboard[1][0].Text)
+	}
+}
+
+func TestWizardFlow_BothSources(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 600
+
+	if err := tb.store.UpsertUser(ctx, chatID, "frank"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	tb.simulateCommand(ctx, chatID, "/watch")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"winwin")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
+	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
+	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
+	tb.simulateText(ctx, chatID, "2018")
+	tb.simulateText(ctx, chatID, "2024")
+	tb.simulateText(ctx, chatID, "150000")
+	tb.simulateCallback(ctx, chatID, cbPrefixEngine+"0")
+	tb.simulateCallback(ctx, chatID, cbConfirm)
+
+	searches, _ := tb.store.ListSearches(ctx, chatID)
+	if len(searches) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(searches))
+	}
+	if searches[0].Source != "yad2,winwin" {
+		t.Errorf("source = %q, want yad2,winwin", searches[0].Source)
+	}
+}

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -735,7 +735,8 @@ func TestOnSourceSelected_WinWin(t *testing.T) {
 	tb.simulateCommand(ctx, chatID, "/watch")
 	tb.msg.reset()
 
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"winwin")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"winwin")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 
 	user, _ := tb.store.GetUser(ctx, chatID)
 	if user.State != StateAskManufacturer {
@@ -757,7 +758,8 @@ func TestWizardFlow_WinWin(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"winwin")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"winwin")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2018")
@@ -803,8 +805,8 @@ func TestOnConfirm_EmptySourceDefaultsToYad2(t *testing.T) {
 	if len(searches) != 1 {
 		t.Fatalf("expected 1 search, got %d", len(searches))
 	}
-	if searches[0].Source != "yad2" {
-		t.Errorf("empty source should default to yad2, got %q", searches[0].Source)
+	if searches[0].Source != "yad2,winwin" {
+		t.Errorf("empty source should default to yad2,winwin, got %q", searches[0].Source)
 	}
 }
 

--- a/internal/bot/handler_extra_test.go
+++ b/internal/bot/handler_extra_test.go
@@ -239,8 +239,8 @@ func TestSourceDisplayName(t *testing.T) {
 	}{
 		{"yad2", "Yad2"},
 		{"winwin", "WinWin"},
-		{"", "Yad2"},
-		{"unknown", "Yad2"},
+		{"", "Yad2, WinWin"},
+		{"unknown", "Yad2, WinWin"},
 	}
 	for _, tt := range tests {
 		got := sourceDisplayName(tt.source)

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -49,7 +49,8 @@ func TestWizardPrompts_NoMarkdownParseMode(t *testing.T) {
 	tb.simulateCommand(ctx, chatID, "/watch")
 	tb.msg.reset()
 
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.msg.reset()
 
 	// Select a manufacturer that has models (Mazda, ID 27).
@@ -78,7 +79,8 @@ func TestWizardYearMaxPrompt_NoMarkdownParseMode(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.msg.reset()
@@ -99,7 +101,8 @@ func TestWizardPricePrompt_NoMarkdownParseMode(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2018")
@@ -269,7 +272,8 @@ func TestCallback_InvalidManufacturerID(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.msg.reset()
 
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"notanumber")
@@ -290,7 +294,8 @@ func TestCallback_InvalidModelID(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.msg.reset()
 
@@ -309,7 +314,8 @@ func TestCallback_InvalidEngineCC(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2018")
@@ -332,7 +338,8 @@ func TestManufacturerWithNoModels(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.msg.reset()
 
 	// Select a real manufacturer that exists in the catalog but has no predefined models.
@@ -355,7 +362,8 @@ func TestYearMin_InvalidInput(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.msg.reset()
@@ -381,7 +389,8 @@ func TestYearMax_LessThanMin(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2020")
@@ -406,7 +415,8 @@ func TestPrice_OutOfRange(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2018")
@@ -452,7 +462,8 @@ func TestCancel_ResetsState(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 
 	// User is mid-wizard at StateAskModel
@@ -475,7 +486,8 @@ func TestCancelCallback_ResetsState(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2018")
@@ -504,7 +516,8 @@ func TestEdit_RestartsWizard(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"27")
 	tb.simulateCallback(ctx, chatID, cbPrefixModel+"10332")
 	tb.simulateText(ctx, chatID, "2018")
@@ -564,7 +577,8 @@ func TestCatalog_ManufacturersWithoutModels_HaveAnyModelFallback(t *testing.T) {
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
 	tb.simulateCommand(ctx, chatID, "/watch")
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 
 	// Pick a manufacturer that has no models in the static catalog (e.g., Subaru=35).
 	tb.simulateCallback(ctx, chatID, cbPrefixMfr+"35")

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -134,8 +134,9 @@ func TestWizardFlow_EndToEnd(t *testing.T) {
 		t.Fatalf("step 1: state=%q, want %q", user.State, StateAskSource)
 	}
 
-	// Step 2: select source → manufacturer keyboard
-	tb.simulateCallback(ctx, chatID, cbPrefixSource+"yad2")
+	// Step 2: toggle source and confirm → manufacturer keyboard
+	tb.simulateCallback(ctx, chatID, cbSourceToggle+"yad2")
+	tb.simulateCallback(ctx, chatID, cbSourceDone)
 	msg = tb.msg.last()
 	if !msg.HasKB || msg.Buttons < 10 {
 		t.Fatalf("step 2: expected manufacturer keyboard with many buttons, got %d", msg.Buttons)

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -244,6 +244,9 @@ func engineKeyboard() *tgmodels.InlineKeyboardMarkup {
 }
 
 func sourceDisplayName(source string) string {
+	if strings.TrimSpace(source) == "" {
+		return "Yad2, WinWin"
+	}
 	parts := strings.Split(source, ",")
 	names := make([]string, 0, len(parts))
 	for _, p := range parts {
@@ -255,7 +258,7 @@ func sourceDisplayName(source string) string {
 		}
 	}
 	if len(names) == 0 {
-		return "Yad2"
+		return "Yad2, WinWin"
 	}
 	return strings.Join(names, ", ")
 }

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	tgmodels "github.com/go-telegram/bot/models"
 
@@ -31,20 +32,36 @@ const (
 	cbMdlSearch       = "mdl_search"
 	cbAnyModel        = "mdl:0"
 	cbHistoryPage     = "hist_pg:"
+	cbSourceToggle    = "src_toggle:"
+	cbSourceDone      = "src_done"
 
 	pageSize = 15
 	colsPerRow = 3
 )
 
-func sourceKeyboard() *tgmodels.InlineKeyboardMarkup {
-	return &tgmodels.InlineKeyboardMarkup{
-		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
-			{
-				{Text: "Yad2", CallbackData: cbPrefixSource + "yad2"},
-				{Text: "WinWin", CallbackData: cbPrefixSource + "winwin"},
-			},
+func sourceKeyboard(selected string) *tgmodels.InlineKeyboardMarkup {
+	yad2Label := "Yad2"
+	winwinLabel := "WinWin"
+	if strings.Contains(selected, "yad2") {
+		yad2Label = "✅ Yad2"
+	}
+	if strings.Contains(selected, "winwin") {
+		winwinLabel = "✅ WinWin"
+	}
+
+	rows := [][]tgmodels.InlineKeyboardButton{
+		{
+			{Text: yad2Label, CallbackData: cbSourceToggle + "yad2"},
+			{Text: winwinLabel, CallbackData: cbSourceToggle + "winwin"},
 		},
 	}
+	if selected != "" {
+		rows = append(rows, []tgmodels.InlineKeyboardButton{
+			{Text: "Done ✓", CallbackData: cbSourceDone},
+		})
+	}
+
+	return &tgmodels.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 func (b *Bot) manufacturerKeyboard(ctx context.Context, chatID int64, page int) *tgmodels.InlineKeyboardMarkup {
@@ -227,12 +244,20 @@ func engineKeyboard() *tgmodels.InlineKeyboardMarkup {
 }
 
 func sourceDisplayName(source string) string {
-	switch source {
-	case "winwin":
-		return "WinWin"
-	default:
+	parts := strings.Split(source, ",")
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		switch strings.TrimSpace(p) {
+		case "winwin":
+			names = append(names, "WinWin")
+		case "yad2":
+			names = append(names, "Yad2")
+		}
+	}
+	if len(names) == 0 {
 		return "Yad2"
 	}
+	return strings.Join(names, ", ")
 }
 
 func confirmKeyboard(data WizardData) (*tgmodels.InlineKeyboardMarkup, string) {
@@ -243,7 +268,7 @@ func confirmKeyboard(data WizardData) (*tgmodels.InlineKeyboardMarkup, string) {
 
 	source := data.Source
 	if source == "" {
-		source = "yad2"
+		source = "yad2,winwin"
 	}
 
 	modelDisplay := data.ModelName

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -83,7 +83,7 @@ func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
 		if err := json.Unmarshal(q.State.Data, &feed); err != nil {
 			continue
 		}
-		if len(feed.Data.Feed.FeedItems) > 0 {
+		if feed.Data.Feed.FeedItems != nil {
 			return feed.Data.Feed.FeedItems, nil
 		}
 	}

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -174,6 +174,17 @@ func TestParseNextData_EmptyFeed(t *testing.T) {
 	}
 }
 
+func TestParseNextData_FeedWithZeroItems(t *testing.T) {
+	data := []byte(`{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{"data":{"feed":{"feed_items":[]}}}}}]}}}}`)
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("unexpected error for empty feed_items: %v", err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings, got %d", len(listings))
+	}
+}
+
 func TestTextFromField_PrefersEnglish(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/scheduler/grouper.go
+++ b/internal/scheduler/grouper.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"strings"
+
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -23,39 +25,37 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 	grouped := make(map[groupKey]*CanonicalGroup)
 
 	for _, s := range searches {
-		source := s.Source
-		if source == "" {
-			source = "yad2"
-		}
-		key := groupKey{source, s.Manufacturer, s.Model}
-		g, ok := grouped[key]
-		if !ok {
-			g = &CanonicalGroup{
-				Source:       source,
-				Manufacturer: s.Manufacturer,
-				Model:        s.Model,
-				Params: config.SourceParams{
+		for _, source := range splitSources(s.Source) {
+			key := groupKey{source, s.Manufacturer, s.Model}
+			g, ok := grouped[key]
+			if !ok {
+				g = &CanonicalGroup{
+					Source:       source,
 					Manufacturer: s.Manufacturer,
 					Model:        s.Model,
-					YearMin:      s.YearMin,
-					YearMax:      s.YearMax,
-					PriceMax:     s.PriceMax,
-				},
+					Params: config.SourceParams{
+						Manufacturer: s.Manufacturer,
+						Model:        s.Model,
+						YearMin:      s.YearMin,
+						YearMax:      s.YearMax,
+						PriceMax:     s.PriceMax,
+					},
+				}
+				grouped[key] = g
 			}
-			grouped[key] = g
-		}
 
-		if g.Params.YearMin == 0 || (s.YearMin > 0 && s.YearMin < g.Params.YearMin) {
-			g.Params.YearMin = s.YearMin
-		}
-		if g.Params.YearMax == 0 || s.YearMax > g.Params.YearMax {
-			g.Params.YearMax = s.YearMax
-		}
-		if g.Params.PriceMax == 0 || s.PriceMax == 0 || s.PriceMax > g.Params.PriceMax {
-			g.Params.PriceMax = s.PriceMax
-		}
+			if g.Params.YearMin == 0 || (s.YearMin > 0 && s.YearMin < g.Params.YearMin) {
+				g.Params.YearMin = s.YearMin
+			}
+			if g.Params.YearMax == 0 || s.YearMax > g.Params.YearMax {
+				g.Params.YearMax = s.YearMax
+			}
+			if g.Params.PriceMax == 0 || s.PriceMax == 0 || s.PriceMax > g.Params.PriceMax {
+				g.Params.PriceMax = s.PriceMax
+			}
 
-		g.Searches = append(g.Searches, s)
+			g.Searches = append(g.Searches, s)
+		}
 	}
 
 	groups := make([]CanonicalGroup, 0, len(grouped))
@@ -63,4 +63,21 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 		groups = append(groups, *g)
 	}
 	return groups
+}
+
+func splitSources(source string) []string {
+	if source == "" {
+		return []string{"yad2"}
+	}
+	parts := strings.Split(source, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			result = append(result, s)
+		}
+	}
+	if len(result) == 0 {
+		return []string{"yad2"}
+	}
+	return result
 }

--- a/internal/scheduler/grouper.go
+++ b/internal/scheduler/grouper.go
@@ -67,7 +67,7 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 
 func splitSources(source string) []string {
 	if source == "" {
-		return []string{"yad2"}
+		return []string{"yad2", "winwin"}
 	}
 	parts := strings.Split(source, ",")
 	result := make([]string, 0, len(parts))
@@ -77,7 +77,7 @@ func splitSources(source string) []string {
 		}
 	}
 	if len(result) == 0 {
-		return []string{"yad2"}
+		return []string{"yad2", "winwin"}
 	}
 	return result
 }

--- a/internal/scheduler/grouper_test.go
+++ b/internal/scheduler/grouper_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestGroupSearches_SingleGroup(t *testing.T) {
 	searches := []storage.Search{
-		{ID: 1, ChatID: 100, Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024, PriceMax: 150000},
-		{ID: 2, ChatID: 200, Manufacturer: 27, Model: 10332, YearMin: 2020, YearMax: 2026, PriceMax: 200000},
+		{ID: 1, ChatID: 100, Source: "yad2", Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024, PriceMax: 150000},
+		{ID: 2, ChatID: 200, Source: "yad2", Manufacturer: 27, Model: 10332, YearMin: 2020, YearMax: 2026, PriceMax: 200000},
 	}
 
 	groups := GroupSearches(searches)
@@ -34,9 +34,9 @@ func TestGroupSearches_SingleGroup(t *testing.T) {
 
 func TestGroupSearches_MultipleGroups(t *testing.T) {
 	searches := []storage.Search{
-		{ID: 1, ChatID: 100, Manufacturer: 27, Model: 10332},
-		{ID: 2, ChatID: 200, Manufacturer: 35, Model: 10471},
-		{ID: 3, ChatID: 300, Manufacturer: 27, Model: 10332},
+		{ID: 1, ChatID: 100, Source: "yad2", Manufacturer: 27, Model: 10332},
+		{ID: 2, ChatID: 200, Source: "yad2", Manufacturer: 35, Model: 10471},
+		{ID: 3, ChatID: 300, Source: "yad2", Manufacturer: 27, Model: 10332},
 	}
 
 	groups := GroupSearches(searches)
@@ -126,20 +126,38 @@ func TestGroupSearches_MultiSource(t *testing.T) {
 	}
 }
 
-func TestGroupSearches_EmptySourceDefaultsToYad2(t *testing.T) {
+func TestGroupSearches_EmptySourceDefaultsToBoth(t *testing.T) {
+	searches := []storage.Search{
+		{ID: 1, ChatID: 100, Source: "", Manufacturer: 27, Model: 10332},
+	}
+
+	groups := GroupSearches(searches)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups (empty source defaults to both), got %d", len(groups))
+	}
+}
+
+func TestGroupSearches_EmptySourceMergesWithExplicit(t *testing.T) {
 	searches := []storage.Search{
 		{ID: 1, ChatID: 100, Source: "", Manufacturer: 27, Model: 10332},
 		{ID: 2, ChatID: 200, Source: "yad2", Manufacturer: 27, Model: 10332},
 	}
 
 	groups := GroupSearches(searches)
-	if len(groups) != 1 {
-		t.Fatalf("expected 1 group (empty source defaults to yad2), got %d", len(groups))
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
 	}
-	if groups[0].Source != "yad2" {
-		t.Errorf("Source = %q, want %q", groups[0].Source, "yad2")
+
+	var yad2Group *CanonicalGroup
+	for i := range groups {
+		if groups[i].Source == "yad2" {
+			yad2Group = &groups[i]
+		}
 	}
-	if len(groups[0].Searches) != 2 {
-		t.Errorf("expected 2 searches in group, got %d", len(groups[0].Searches))
+	if yad2Group == nil {
+		t.Fatal("expected yad2 group")
+	}
+	if len(yad2Group.Searches) != 2 {
+		t.Errorf("yad2 group should have 2 searches (empty + explicit), got %d", len(yad2Group.Searches))
 	}
 }

--- a/internal/scheduler/grouper_test.go
+++ b/internal/scheduler/grouper_test.go
@@ -98,6 +98,34 @@ func TestGroupSearches_GroupBySource(t *testing.T) {
 	}
 }
 
+func TestGroupSearches_MultiSource(t *testing.T) {
+	searches := []storage.Search{
+		{ID: 1, ChatID: 100, Source: "yad2,winwin", Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024, PriceMax: 150000},
+	}
+
+	groups := GroupSearches(searches)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups (one per source), got %d", len(groups))
+	}
+
+	var yad2, winwin *CanonicalGroup
+	for i := range groups {
+		switch groups[i].Source {
+		case "yad2":
+			yad2 = &groups[i]
+		case "winwin":
+			winwin = &groups[i]
+		}
+	}
+
+	if yad2 == nil || winwin == nil {
+		t.Fatal("expected one yad2 and one winwin group")
+	}
+	if len(yad2.Searches) != 1 || len(winwin.Searches) != 1 {
+		t.Error("each group should have 1 search")
+	}
+}
+
 func TestGroupSearches_EmptySourceDefaultsToYad2(t *testing.T) {
 	searches := []storage.Search{
 		{ID: 1, ChatID: 100, Source: "", Manufacturer: 27, Model: 10332},

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -85,7 +85,7 @@ func TestRunMultiTenantCycle_WithSearches(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -120,9 +120,9 @@ func TestRunMultiTenantCycle_SharedScraping(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "user1", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "user1", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 200000, Active: true},
-			{ID: 2, ChatID: 200, Name: "user2", Manufacturer: 27, Model: 10332,
+			{ID: 2, ChatID: 200, Name: "user2", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2020, YearMax: 2026, PriceMax: 150000, Active: true},
 		},
 	}
@@ -165,7 +165,7 @@ func TestProcessGroup_PriceDropNotification(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, Active: true},
 		},
 	}
@@ -287,7 +287,7 @@ func TestProcessGroup_DigestMode_StoresInsteadOfSending(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -339,7 +339,7 @@ func TestProcessGroup_InstantMode_SendsDirectly(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "user1-mazda3", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -76,7 +76,7 @@ func TestRunMultiTenantCycle_AllGroupsFail(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332, Active: true},
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332, Active: true},
 		},
 	}
 
@@ -100,7 +100,7 @@ func TestRunMultiTenantCycle_PrunesOldListings(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332, Active: true},
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332, Active: true},
 		},
 	}
 	h := health.New()
@@ -132,7 +132,7 @@ func TestProcessGroup_NotifyFails_ReleaseClaims(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -165,7 +165,7 @@ func TestProcessGroup_SavesListings(t *testing.T) {
 	ls := &mockListingStore{}
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -215,7 +215,7 @@ func TestProcessGroup_ClaimNewError(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -247,7 +247,7 @@ func TestProcessGroup_RecordPriceError(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -283,7 +283,7 @@ func TestProcessGroup_DigestModeError(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -321,7 +321,7 @@ func TestProcessGroup_DigestAddItemError_ReleasesClaims(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -359,7 +359,7 @@ func TestProcessGroup_PriceDropInDigestMode(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, Active: true},
 		},
 	}
@@ -399,7 +399,7 @@ func TestProcessGroup_NotifyFails_EnqueuesAndKeepsClaim(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -431,7 +431,7 @@ func TestProcessGroup_NotifyFails_EnqueueFails_ReleasesClaim(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -473,7 +473,7 @@ func TestRunMultiTenantCycle_PruneError(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332, Active: true},
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332, Active: true},
 		},
 	}
 	cfg := testConfig()
@@ -625,7 +625,7 @@ func TestRunMultiTenantCycle_CatalogIngester(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -659,7 +659,7 @@ func TestRunMultiTenantCycle_HealthRecording(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -720,7 +720,7 @@ func TestProcessGroup_FiltersCorrectly(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -749,7 +749,7 @@ func TestProcessGroup_PriceMaxZero_NoFilter(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 2024, PriceMax: 0, EngineMinCC: 1800, Active: true},
 		},
 	}
@@ -775,7 +775,7 @@ func TestProcessGroup_YearMaxZero_NoUpperBound(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "test", Manufacturer: 27, Model: 10332,
+			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332,
 				YearMin: 2018, YearMax: 0, PriceMax: 150000, EngineMinCC: 1800, Active: true},
 		},
 	}


### PR DESCRIPTION
## Summary

- Wizard source step now uses **toggle buttons** with checkmarks — users can select one or both marketplaces (Yad2, WinWin) for a single search
- Sources stored as comma-separated values (`"yad2,winwin"`) in the existing `source TEXT` column — no schema migration needed
- Scheduler grouper splits multi-source searches into separate fetch groups, one per marketplace
- Backward compatible: existing single-source searches (`"yad2"` or `"winwin"`) continue working unchanged

Closes #106

## Test plan

- [x] Toggle source on/off works correctly (5 toggle test cases)
- [x] Source display handles comma-separated values ("Yad2, WinWin")
- [x] Source keyboard shows checkmarks and Done button
- [x] Full wizard flow with both sources creates search with `"yad2,winwin"`
- [x] WinWin-only flow still works
- [x] Empty source defaults to both marketplaces
- [x] Grouper splits multi-source search into 2 groups
- [x] All existing tests pass (87.1% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-marketplace selection in the watch wizard: prompt now asks "Which marketplaces… (select one or both)", visual checkmarks, and a “Done” confirmation; selection is required.

* **Behavior Changes**
  * Empty/default selection now includes both Yad2 and WinWin.
  * Scheduler now groups and runs searches per explicit or implied marketplace, producing source-specific groups.

* **Tests**
  * Added/updated tests for multi-source selection, keyboard rendering, wizard flows, grouping, and empty-feed parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->