### PR TITLE
fix: handle null feed_items in Yad2 response as empty results

### DIFF
--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -77,24 +77,32 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 }
 
 func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
+	type feedProbe struct {
+		Data struct {
+			Feed struct {
+				FeedItems json.RawMessage `json:"feed_items"`
+			} `json:"feed"`
+		} `json:"data"`
+	}
+
 	queries := nd.Props.PageProps.DehydratedState.Queries
 	for _, q := range queries {
-		var probe struct {
-			Data struct {
-				Feed json.RawMessage `json:"feed"`
-			} `json:"data"`
-		}
+		var probe feedProbe
 		if err := json.Unmarshal(q.State.Data, &probe); err != nil {
 			continue
 		}
-		if probe.Data.Feed == nil {
+		raw := probe.Data.Feed.FeedItems
+		if raw == nil {
 			continue
 		}
-		var feed feedData
-		if err := json.Unmarshal(q.State.Data, &feed); err != nil {
+		if string(raw) == "null" {
+			return []json.RawMessage{}, nil
+		}
+		var items []json.RawMessage
+		if err := json.Unmarshal(raw, &items); err != nil {
 			continue
 		}
-		return feed.Data.Feed.FeedItems, nil
+		return items, nil
 	}
 	return nil, fmt.Errorf("no feed items found in __NEXT_DATA__")
 }
@@ -171,14 +179,6 @@ type queryEntry struct {
 	State struct {
 		Data json.RawMessage `json:"data"`
 	} `json:"state"`
-}
-
-type feedData struct {
-	Data struct {
-		Feed struct {
-			FeedItems []json.RawMessage `json:"feed_items"`
-		} `json:"feed"`
-	} `json:"data"`
 }
 
 type feedItem struct {

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -79,13 +79,22 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
 	queries := nd.Props.PageProps.DehydratedState.Queries
 	for _, q := range queries {
+		var probe struct {
+			Data struct {
+				Feed json.RawMessage `json:"feed"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(q.State.Data, &probe); err != nil {
+			continue
+		}
+		if probe.Data.Feed == nil {
+			continue
+		}
 		var feed feedData
 		if err := json.Unmarshal(q.State.Data, &feed); err != nil {
 			continue
 		}
-		if feed.Data.Feed.FeedItems != nil {
-			return feed.Data.Feed.FeedItems, nil
-		}
+		return feed.Data.Feed.FeedItems, nil
 	}
 	return nil, fmt.Errorf("no feed items found in __NEXT_DATA__")
 }

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -185,6 +185,17 @@ func TestParseNextData_FeedWithZeroItems(t *testing.T) {
 	}
 }
 
+func TestParseNextData_FeedWithNullItems(t *testing.T) {
+	data := []byte(`{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{"data":{"feed":{"feed_items":null}}}}}]}}}}`)
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("unexpected error for null feed_items: %v", err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings, got %d", len(listings))
+	}
+}
+
 func TestTextFromField_PrefersEnglish(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -191,6 +191,9 @@ func TestParseNextData_FeedWithNullItems(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error for null feed_items: %v", err)
 	}
+	if listings == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
 	if len(listings) != 0 {
 		t.Errorf("expected 0 listings, got %d", len(listings))
 	}


### PR DESCRIPTION
## Summary

- When a Yad2 search has no matching cars, the page returns `feed_items: null` (not `[]`)
- The parser now detects the feed structure via a JSON probe and returns an empty slice for null items
- This prevents the circuit breaker from tripping on valid no-result pages, which was making **all fetches fail** after a few empty-result searches

## Root cause

Yad2 returns `__NEXT_DATA__` with `"feed_items": null` when zero cars match a search. Go unmarshals JSON `null` to a `nil` slice, which the previous check `feed.Data.Feed.FeedItems != nil` treated as "feed not found" — same as a blocked/challenge page. After 3 retries this tripped the circuit breaker, blocking all subsequent fetches for 30 minutes.

## Test plan

- [x] `TestParseNextData_FeedWithNullItems` — null feed_items returns empty slice
- [x] `TestParseNextData_FeedWithZeroItems` — empty array returns empty slice  
- [x] `TestParseNextData_EmptyFeed` — no queries still errors (blocked page)
- [x] All existing tests pass (86.7% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parser now robustly handles missing or explicitly null feed payloads, avoiding errors and treating an explicit null as an empty result set.
* **Tests**
  * Added a unit test validating correct behavior when the feed payload is explicitly null, ensuring no errors and zero listings returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->