### PR TITLE
fix: batch P0/P1 phase-1 fixes (8 issues)

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -113,12 +113,13 @@ func run(configPath string, logger *slog.Logger) error {
 	h.SetSearchCounter(store)
 
 	botHandler := cwbot.New(nil, store, store, cwbot.Config{
-		AdminChatID: cfg.Telegram.AdminChatID,
-		MaxSearches: cfg.Telegram.MaxSearches,
-		BotUsername:  cfg.Telegram.BotUsername,
-		Health:      h,
-		Listings:    store,
-		Catalog:     dynCatalog,
+		AdminChatID:  cfg.Telegram.AdminChatID,
+		MaxSearches:  cfg.Telegram.MaxSearches,
+		BotUsername:   cfg.Telegram.BotUsername,
+		PollInterval: cfg.Polling.Interval,
+		Health:       h,
+		Listings:     store,
+		Catalog:      dynCatalog,
 	}, logger)
 
 	tgNotif, err := telegram.New(cfg.Telegram.Token, logger,

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -171,6 +171,7 @@ func run(configPath string, logger *slog.Logger) error {
 		FetcherFactory:  fetcherFactory,
 		ListingStore:    store,
 		SearchStore:     store,
+		UserStore:       store,
 		CatalogIngester: dynCatalog,
 	})
 	if err != nil {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -68,7 +68,7 @@ func (b *Bot) isRateLimited(chatID int64) bool {
 	refill := int(elapsed / rateLimitInterval)
 	if refill > 0 {
 		rl.tokens = min(rl.tokens+refill, rateLimitBurst)
-		rl.lastTick = now
+		rl.lastTick = rl.lastTick.Add(time.Duration(refill) * rateLimitInterval)
 	}
 
 	if rl.tokens <= 0 {
@@ -146,6 +146,11 @@ func (b *Bot) rateLimited(next tgbot.HandlerFunc) tgbot.HandlerFunc {
 		}
 		if chatID != 0 && b.isRateLimited(chatID) {
 			b.logger.Warn("rate limited", "chat_id", chatID)
+			if update.CallbackQuery != nil {
+				if err := b.msg.AnswerCallback(ctx, update.CallbackQuery.ID); err != nil {
+					b.logger.Error("answer callback query failed", "chat_id", chatID, "error", err)
+				}
+			}
 			return
 		}
 		next(ctx, bot, update)
@@ -1151,6 +1156,9 @@ func (b *Bot) handleModelSearch(ctx context.Context, chatID int64, query string)
 }
 
 func (b *Bot) formatInterval() string {
+	if b.pollInterval < time.Minute {
+		return b.pollInterval.Round(time.Second).String()
+	}
 	m := int(b.pollInterval.Minutes())
 	if m < 60 {
 		return fmt.Sprintf("%d minutes", m)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -25,21 +25,22 @@ type PollTrigger interface {
 }
 
 type Bot struct {
-	bot         *tgbot.Bot
-	msg         messenger
-	users       storage.UserStore
-	searches    storage.SearchStore
-	listings    storage.ListingStore
-	digests     storage.DigestStore
-	catalog     catalog.Catalog
-	adminChatID int64
-	maxSearches int
-	botUsername  string
-	logger      *slog.Logger
-	health      *health.Status
-	chatMu      sync.Map
-	pollTrigger PollTrigger
-	rateLimiter sync.Map
+	bot          *tgbot.Bot
+	msg          messenger
+	users        storage.UserStore
+	searches     storage.SearchStore
+	listings     storage.ListingStore
+	digests      storage.DigestStore
+	catalog      catalog.Catalog
+	adminChatID  int64
+	maxSearches  int
+	botUsername   string
+	pollInterval time.Duration
+	logger       *slog.Logger
+	health       *health.Status
+	chatMu       sync.Map
+	pollTrigger  PollTrigger
+	rateLimiter  sync.Map
 }
 
 type userRateLimit struct {
@@ -78,18 +79,22 @@ func (b *Bot) isRateLimited(chatID int64) bool {
 }
 
 type Config struct {
-	AdminChatID int64
-	MaxSearches int
-	BotUsername  string
-	Health      *health.Status
-	Digests     storage.DigestStore
-	Listings    storage.ListingStore
-	Catalog     catalog.Catalog
+	AdminChatID    int64
+	MaxSearches    int
+	BotUsername     string
+	PollInterval   time.Duration
+	Health         *health.Status
+	Digests        storage.DigestStore
+	Listings       storage.ListingStore
+	Catalog        catalog.Catalog
 }
 
 func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cfg Config, logger *slog.Logger) *Bot {
 	if cfg.MaxSearches == 0 {
 		cfg.MaxSearches = 3
+	}
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = 15 * time.Minute
 	}
 	cat := cfg.Catalog
 	if cat == nil {
@@ -100,18 +105,19 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 		msg = &telegramMessenger{bot: b}
 	}
 	return &Bot{
-		bot:         b,
-		msg:         msg,
-		users:       users,
-		searches:    searches,
-		listings:    cfg.Listings,
-		digests:     cfg.Digests,
-		catalog:     cat,
-		adminChatID: cfg.AdminChatID,
-		maxSearches: cfg.MaxSearches,
-		botUsername:  cfg.BotUsername,
-		logger:      logger,
-		health:      cfg.Health,
+		bot:          b,
+		msg:          msg,
+		users:        users,
+		searches:     searches,
+		listings:     cfg.Listings,
+		digests:      cfg.Digests,
+		catalog:      cat,
+		adminChatID:  cfg.AdminChatID,
+		maxSearches:  cfg.MaxSearches,
+		botUsername:   cfg.BotUsername,
+		pollInterval: cfg.PollInterval,
+		logger:       logger,
+		health:       cfg.Health,
 	}
 }
 
@@ -991,8 +997,8 @@ func (b *Bot) onShareCopy(ctx context.Context, chatID int64, data string) {
 
 	srcDisplay := sourceDisplayName(src.Source)
 	b.send(ctx, chatID, fmt.Sprintf(
-		"Search #%d saved! I'll check %s every 15 minutes and send you new listings.\n\nUse /list to see your searches.",
-		newID, srcDisplay))
+		"Search #%d saved! I'll check %s every %s and send you new listings.\n\nUse /list to see your searches.",
+		newID, srcDisplay, b.formatInterval()))
 }
 
 func (b *Bot) onDigestOn(ctx context.Context, chatID int64) {
@@ -1142,6 +1148,21 @@ func (b *Bot) handleModelSearch(ctx context.Context, chatID int64, query string)
 	b.sendWithKeyboard(ctx, chatID,
 		"Search results:",
 		b.modelSearchResults(wd.Manufacturer, query))
+}
+
+func (b *Bot) formatInterval() string {
+	m := int(b.pollInterval.Minutes())
+	if m < 60 {
+		return fmt.Sprintf("%d minutes", m)
+	}
+	h := m / 60
+	if m%60 == 0 {
+		if h == 1 {
+			return "1 hour"
+		}
+		return fmt.Sprintf("%d hours", h)
+	}
+	return b.pollInterval.String()
 }
 
 func (b *Bot) modelDisplayName(manufacturerID, modelID int) string {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -39,6 +39,42 @@ type Bot struct {
 	health      *health.Status
 	chatMu      sync.Map
 	pollTrigger PollTrigger
+	rateLimiter sync.Map
+}
+
+type userRateLimit struct {
+	mu       sync.Mutex
+	tokens   int
+	lastTick time.Time
+}
+
+const (
+	rateLimitBurst    = 10
+	rateLimitInterval = time.Second
+)
+
+func (b *Bot) isRateLimited(chatID int64) bool {
+	v, _ := b.rateLimiter.LoadOrStore(chatID, &userRateLimit{
+		tokens:   rateLimitBurst,
+		lastTick: time.Now(),
+	})
+	rl := v.(*userRateLimit)
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(rl.lastTick)
+	refill := int(elapsed / rateLimitInterval)
+	if refill > 0 {
+		rl.tokens = min(rl.tokens+refill, rateLimitBurst)
+		rl.lastTick = now
+	}
+
+	if rl.tokens <= 0 {
+		return true
+	}
+	rl.tokens--
+	return false
 }
 
 type Config struct {
@@ -94,21 +130,37 @@ func (b *Bot) DefaultHandler() tgbot.HandlerFunc {
 	return b.handleDefault
 }
 
+func (b *Bot) rateLimited(next tgbot.HandlerFunc) tgbot.HandlerFunc {
+	return func(ctx context.Context, bot *tgbot.Bot, update *tgmodels.Update) {
+		var chatID int64
+		if update.Message != nil {
+			chatID = update.Message.Chat.ID
+		} else if update.CallbackQuery != nil && update.CallbackQuery.Message.Message != nil {
+			chatID = update.CallbackQuery.Message.Message.Chat.ID
+		}
+		if chatID != 0 && b.isRateLimited(chatID) {
+			b.logger.Warn("rate limited", "chat_id", chatID)
+			return
+		}
+		next(ctx, bot, update)
+	}
+}
+
 func (b *Bot) RegisterHandlers() {
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/start", tgbot.MatchTypePrefix, b.handleStart)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/watch", tgbot.MatchTypeExact, b.handleWatch)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/list", tgbot.MatchTypeExact, b.handleList)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stop", tgbot.MatchTypePrefix, b.handleStop)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/pause", tgbot.MatchTypePrefix, b.handlePause)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/resume", tgbot.MatchTypePrefix, b.handleResume)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/share", tgbot.MatchTypePrefix, b.handleShare)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/cancel", tgbot.MatchTypeExact, b.handleCancel)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/help", tgbot.MatchTypeExact, b.handleHelp)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/history", tgbot.MatchTypeExact, b.handleHistory)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/digest", tgbot.MatchTypeExact, b.handleDigest)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/settings", tgbot.MatchTypeExact, b.handleSettings)
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stats", tgbot.MatchTypeExact, b.handleStats)
-	b.bot.RegisterHandler(tgbot.HandlerTypeCallbackQueryData, "", tgbot.MatchTypePrefix, b.handleCallback)
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/start", tgbot.MatchTypePrefix, b.rateLimited(b.handleStart))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/watch", tgbot.MatchTypeExact, b.rateLimited(b.handleWatch))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/list", tgbot.MatchTypeExact, b.rateLimited(b.handleList))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stop", tgbot.MatchTypePrefix, b.rateLimited(b.handleStop))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/pause", tgbot.MatchTypePrefix, b.rateLimited(b.handlePause))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/resume", tgbot.MatchTypePrefix, b.rateLimited(b.handleResume))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/share", tgbot.MatchTypePrefix, b.rateLimited(b.handleShare))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/cancel", tgbot.MatchTypeExact, b.rateLimited(b.handleCancel))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/help", tgbot.MatchTypeExact, b.rateLimited(b.handleHelp))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/history", tgbot.MatchTypeExact, b.rateLimited(b.handleHistory))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/digest", tgbot.MatchTypeExact, b.rateLimited(b.handleDigest))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/settings", tgbot.MatchTypeExact, b.rateLimited(b.handleSettings))
+	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/stats", tgbot.MatchTypeExact, b.rateLimited(b.handleStats))
+	b.bot.RegisterHandler(tgbot.HandlerTypeCallbackQueryData, "", tgbot.MatchTypePrefix, b.rateLimited(b.handleCallback))
 }
 
 func (b *Bot) ensureUser(ctx context.Context, chatID int64, username string) {
@@ -984,6 +1036,10 @@ func (b *Bot) handleDefault(ctx context.Context, _ *tgbot.Bot, update *tgmodels.
 	}
 
 	chatID := update.Message.Chat.ID
+	if b.isRateLimited(chatID) {
+		b.logger.Warn("rate limited", "chat_id", chatID)
+		return
+	}
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 
 	user, err := b.users.GetUser(ctx, chatID)

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/dsionov/carwatch/internal/storage/sqlite"
 )
 
+func TestIsRateLimited(t *testing.T) {
+	tb := newTestBot(t)
+	const chatID int64 = 900
+
+	// First rateLimitBurst calls should succeed.
+	for i := range rateLimitBurst {
+		if tb.bot.isRateLimited(chatID) {
+			t.Fatalf("call %d should not be limited", i)
+		}
+	}
+
+	// Next call should be limited.
+	if !tb.bot.isRateLimited(chatID) {
+		t.Error("should be rate limited after burst is exhausted")
+	}
+
+	// Different user should have their own bucket.
+	if tb.bot.isRateLimited(chatID + 1) {
+		t.Error("different user should not be rate limited")
+	}
+}
+
 func TestWizardData_JSON(t *testing.T) {
 	wd := WizardData{
 		Manufacturer:     27,

--- a/internal/bot/history_test.go
+++ b/internal/bot/history_test.go
@@ -28,24 +28,20 @@ func TestHistory_ShowsListings(t *testing.T) {
 	const chatID int64 = 701
 
 	_ = tb.store.UpsertUser(ctx, chatID, "alice")
-	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
+	_, _ = tb.store.CreateSearch(ctx, storage.Search{
 		ChatID: chatID, Name: "mazda-3", Manufacturer: 27, Model: 1,
 	})
 
-	// Claim listings so they appear in seen_listings for this user.
-	_, _ = tb.store.ClaimNew(ctx, "token-1", chatID, searchID)
-	_, _ = tb.store.ClaimNew(ctx, "token-2", chatID, searchID)
-
-	// Save listing details to listing_history.
+	// Save listing details to listing_history (per-user via chat_id).
 	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-		Token: "token-1", SearchName: "mazda-3",
+		Token: "token-1", ChatID: chatID, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2020,
 		Price: 120000, Km: 50000, Hand: 2,
 		City: "Tel Aviv", PageLink: "https://example.com/1",
 		FirstSeenAt: time.Now(),
 	})
 	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-		Token: "token-2", SearchName: "mazda-3",
+		Token: "token-2", ChatID: chatID, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2021,
 		Price: 140000, Km: 30000, Hand: 1,
 		City: "Haifa", PageLink: "https://example.com/2",
@@ -72,16 +68,12 @@ func TestHistory_Pagination(t *testing.T) {
 	const chatID int64 = 702
 
 	_ = tb.store.UpsertUser(ctx, chatID, "bob")
-	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
-		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
-	})
 
 	// Create more listings than one page (historyPageSize = 5).
 	for i := range 7 {
 		token := "tok-" + string(rune('a'+i))
-		_, _ = tb.store.ClaimNew(ctx, token, chatID, searchID)
 		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-			Token: token, SearchName: "test",
+			Token: token, ChatID: chatID, SearchName: "test",
 			Manufacturer: "Mazda", Model: "3", Year: 2020 + i,
 			Price: 100000 + i*10000, FirstSeenAt: time.Now(),
 		})
@@ -119,23 +111,14 @@ func TestHistory_IsolatedPerUser(t *testing.T) {
 	_ = tb.store.UpsertUser(ctx, alice, "alice")
 	_ = tb.store.UpsertUser(ctx, bob, "bob")
 
-	searchA, _ := tb.store.CreateSearch(ctx, storage.Search{
-		ChatID: alice, Name: "a-search", Manufacturer: 27, Model: 1,
-	})
-	searchB, _ := tb.store.CreateSearch(ctx, storage.Search{
-		ChatID: bob, Name: "b-search", Manufacturer: 19, Model: 1,
-	})
-
-	_, _ = tb.store.ClaimNew(ctx, "alice-tok", alice, searchA)
 	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-		Token: "alice-tok", SearchName: "a-search",
+		Token: "alice-tok", ChatID: alice, SearchName: "a-search",
 		Manufacturer: "Mazda", Model: "3", Year: 2020,
 		Price: 100000, FirstSeenAt: time.Now(),
 	})
 
-	_, _ = tb.store.ClaimNew(ctx, "bob-tok", bob, searchB)
 	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-		Token: "bob-tok", SearchName: "b-search",
+		Token: "bob-tok", ChatID: bob, SearchName: "b-search",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2019,
 		Price: 90000, FirstSeenAt: time.Now(),
 	})
@@ -168,12 +151,8 @@ func TestHistory_InvalidPage(t *testing.T) {
 	const chatID int64 = 720
 
 	_ = tb.store.UpsertUser(ctx, chatID, "dave")
-	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
-		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
-	})
-	_, _ = tb.store.ClaimNew(ctx, "tok-1", chatID, searchID)
 	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-		Token: "tok-1", SearchName: "test",
+		Token: "tok-1", ChatID: chatID, SearchName: "test",
 		Manufacturer: "Mazda", Model: "3", Year: 2020,
 		Price: 100000, FirstSeenAt: time.Now(),
 	})
@@ -194,18 +173,46 @@ func TestHistory_InvalidPage(t *testing.T) {
 	}
 }
 
+func TestHistory_SurvivesPrune(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 740
+
+	_ = tb.store.UpsertUser(ctx, chatID, "frank")
+	_, _ = tb.store.CreateSearch(ctx, storage.Search{
+		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
+	})
+
+	// Claim a listing (populates seen_listings) and save history.
+	_, _ = tb.store.ClaimNew(ctx, "tok-prune", chatID, 1)
+	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-prune", ChatID: chatID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2020,
+		Price: 100000, FirstSeenAt: time.Now(),
+	})
+
+	// Prune all seen_listings (simulates 30-day expiry).
+	_, _ = tb.store.Prune(ctx, 0)
+
+	// History should still work because it no longer depends on seen_listings.
+	tb.simulateCommand(ctx, chatID, "/history")
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "Match history (1 total)") {
+		t.Errorf("history should survive prune, got: %s", msg.Text)
+	}
+	if !strings.Contains(msg.Text, "Mazda 3") {
+		t.Errorf("expected car name after prune, got: %s", msg.Text)
+	}
+}
+
 func TestHistory_MarkdownEscaping(t *testing.T) {
 	tb := newTestBot(t)
 	ctx := context.Background()
 	const chatID int64 = 730
 
 	_ = tb.store.UpsertUser(ctx, chatID, "eve")
-	searchID, _ := tb.store.CreateSearch(ctx, storage.Search{
-		ChatID: chatID, Name: "test", Manufacturer: 27, Model: 1,
-	})
-	_, _ = tb.store.ClaimNew(ctx, "tok-md", chatID, searchID)
 	_ = tb.store.SaveListing(ctx, storage.ListingRecord{
-		Token: "tok-md", SearchName: "test",
+		Token: "tok-md", ChatID: chatID, SearchName: "test",
 		Manufacturer: "Land_Rover", Model: "Range*Rover", Year: 2020,
 		Price: 200000, City: "Tel_Aviv",
 		FirstSeenAt: time.Now(),

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -41,7 +41,7 @@ func TestDashboard_WithListings(t *testing.T) {
 	store := newTestStore(t)
 
 	_ = store.SaveListing(context.Background(), storage.ListingRecord{
-		Token: "abc", SearchName: "test", Manufacturer: "Mazda", Model: "3",
+		Token: "abc", ChatID: 100, SearchName: "test", Manufacturer: "Mazda", Model: "3",
 		Year: 2021, Price: 95000, Km: 85000, Hand: 2, City: "Tel Aviv",
 		PageLink: "https://example.com/abc",
 	})
@@ -68,7 +68,7 @@ func TestDashboard_LimitParam(t *testing.T) {
 
 	for i := range 5 {
 		_ = store.SaveListing(context.Background(), storage.ListingRecord{
-			Token: string(rune('a' + i)), SearchName: "test",
+			Token: string(rune('a' + i)), ChatID: int64(100 + i), SearchName: "test",
 			Manufacturer: "Test", Model: "Car", Year: 2021, Price: 100000,
 		})
 	}

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -13,9 +13,9 @@ func FormatListing(l model.Listing) string {
 
 	b.WriteString("🚗 *New Car Listing*\n\n")
 
-	title := strings.TrimSpace(l.Manufacturer + " " + l.Model)
+	title := format.EscapeMarkdown(strings.TrimSpace(l.Manufacturer + " " + l.Model))
 	if l.SubModel != "" {
-		title += " " + l.SubModel
+		title += " " + format.EscapeMarkdown(l.SubModel)
 	}
 	b.WriteString("*" + title + "*\n\n")
 
@@ -30,7 +30,7 @@ func FormatListing(l model.Listing) string {
 	if l.EngineVolume > 0 {
 		b.WriteString(fmt.Sprintf("⚙️ Engine: %.1fL", l.EngineVolume/1000))
 		if l.GearBox != "" {
-			b.WriteString(", " + l.GearBox)
+			b.WriteString(", " + format.EscapeMarkdown(l.GearBox))
 		}
 		b.WriteString("\n")
 	}
@@ -48,9 +48,9 @@ func FormatListing(l model.Listing) string {
 	}
 
 	if l.City != "" {
-		location := l.City
+		location := format.EscapeMarkdown(l.City)
 		if l.Area != "" {
-			location += ", " + l.Area
+			location += ", " + format.EscapeMarkdown(l.Area)
 		}
 		b.WriteString(fmt.Sprintf("📍 Location: %s\n", location))
 	}
@@ -60,7 +60,7 @@ func FormatListing(l model.Listing) string {
 	}
 
 	if l.PageLink != "" {
-		b.WriteString(fmt.Sprintf("\n🔗 %s", l.PageLink))
+		b.WriteString(fmt.Sprintf("\n🔗 %s", format.EscapeMarkdown(l.PageLink)))
 	}
 
 	return b.String()
@@ -69,9 +69,9 @@ func FormatListing(l model.Listing) string {
 func FormatPriceDrop(l model.Listing, oldPrice int) string {
 	var b strings.Builder
 
-	title := strings.TrimSpace(l.Manufacturer + " " + l.Model)
+	title := format.EscapeMarkdown(strings.TrimSpace(l.Manufacturer + " " + l.Model))
 	if l.SubModel != "" {
-		title += " " + l.SubModel
+		title += " " + format.EscapeMarkdown(l.SubModel)
 	}
 	if l.Year > 0 {
 		title += fmt.Sprintf(" %d", l.Year)
@@ -94,7 +94,7 @@ func FormatPriceDrop(l model.Listing, oldPrice int) string {
 	}
 
 	if l.PageLink != "" {
-		b.WriteString(fmt.Sprintf("🔗 %s", l.PageLink))
+		b.WriteString(fmt.Sprintf("🔗 %s", format.EscapeMarkdown(l.PageLink)))
 	}
 
 	return b.String()

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -104,6 +104,76 @@ func TestFormatPriceDrop_MinimalFields(t *testing.T) {
 }
 
 
+func TestFormatListing_EscapesMarkdown(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token:        "md1",
+			Manufacturer: "Land_Rover",
+			Model:        "Range*Rover",
+			SubModel:     "Sport`Ed",
+			Year:         2022,
+			City:         "Tel_Aviv",
+			Area:         "Center[South]",
+			GearBox:      "Auto_matic",
+			EngineVolume: 3000,
+			Price:        300000,
+			PageLink:     "https://example.com/item_123",
+		},
+	}
+
+	msg := FormatListing(l)
+
+	if strings.Contains(msg, "Land_Rover") {
+		t.Error("underscore in manufacturer should be escaped")
+	}
+	if !strings.Contains(msg, "Land\\_Rover") {
+		t.Errorf("expected escaped manufacturer, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Range\\*Rover") {
+		t.Errorf("expected escaped model, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Sport\\`Ed") {
+		t.Errorf("expected escaped submodel, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Tel\\_Aviv") {
+		t.Errorf("expected escaped city, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Center\\[South\\]") {
+		t.Errorf("expected escaped area, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Auto\\_matic") {
+		t.Errorf("expected escaped gearbox, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "item\\_123") {
+		t.Errorf("expected escaped page link, got:\n%s", msg)
+	}
+}
+
+func TestFormatPriceDrop_EscapesMarkdown(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token:        "md2",
+			Manufacturer: "Land_Rover",
+			Model:        "Range*Rover",
+			Year:         2022,
+			Price:        280000,
+			PageLink:     "https://example.com/item_456",
+		},
+	}
+
+	msg := FormatPriceDrop(l, 300000)
+
+	if !strings.Contains(msg, "Land\\_Rover") {
+		t.Errorf("expected escaped manufacturer in price drop, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Range\\*Rover") {
+		t.Errorf("expected escaped model in price drop, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "item\\_456") {
+		t.Errorf("expected escaped page link in price drop, got:\n%s", msg)
+	}
+}
+
 func TestFormatBatch_SingleListing(t *testing.T) {
 	listings := []model.Listing{{
 		RawListing: model.RawListing{Token: "a", Manufacturer: "Mazda", Model: "3", Price: 90000},

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -2,9 +2,12 @@ package notifier
 
 import (
 	"context"
+	"errors"
 
 	"github.com/dsionov/carwatch/internal/model"
 )
+
+var ErrRecipientBlocked = errors.New("recipient blocked the bot")
 
 type Notifier interface {
 	Connect(ctx context.Context) error

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
@@ -71,6 +72,10 @@ func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) 
 			Text:   chunk,
 		})
 		if err != nil {
+			errMsg := strings.ToLower(err.Error())
+			if strings.Contains(errMsg, "forbidden") || strings.Contains(errMsg, "blocked") {
+				return fmt.Errorf("%w: %v", notifier.ErrRecipientBlocked, err)
+			}
 			return fmt.Errorf("telegram sendMessage: %w", err)
 		}
 	}

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -73,7 +73,8 @@ func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) 
 		})
 		if err != nil {
 			errMsg := strings.ToLower(err.Error())
-			if strings.Contains(errMsg, "forbidden") || strings.Contains(errMsg, "blocked") {
+			if strings.Contains(errMsg, "bot was blocked by the user") ||
+				strings.Contains(errMsg, "user is deactivated") {
 				return fmt.Errorf("%w: %v", notifier.ErrRecipientBlocked, err)
 			}
 			return fmt.Errorf("telegram sendMessage: %w", err)

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	tgbot "github.com/go-telegram/bot"
 
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/notifier"
 )
 
 type discardWriter struct{}
@@ -208,7 +210,7 @@ func TestSendMessage_Success(t *testing.T) {
 	}
 }
 
-func TestSendMessage_APIError(t *testing.T) {
+func TestSendMessage_APIError_Blocked(t *testing.T) {
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		resp, _ := json.Marshal(map[string]any{
@@ -222,8 +224,8 @@ func TestSendMessage_APIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for API failure")
 	}
-	if !strings.Contains(err.Error(), "telegram sendMessage") {
-		t.Errorf("expected 'telegram sendMessage' error, got: %v", err)
+	if !errors.Is(err, notifier.ErrRecipientBlocked) {
+		t.Errorf("expected ErrRecipientBlocked, got: %v", err)
 	}
 }
 

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/dsionov/carwatch/internal/model"
@@ -29,6 +30,9 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, notifier.ErrRecipientBlocked) {
+		return err
+	}
 
 	// Use background context so the enqueue succeeds even during shutdown.
 	if d.queue != nil {
@@ -45,6 +49,9 @@ func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message 
 	chatIDStr := fmt.Sprintf("%d", chatID)
 	err := d.notifier.NotifyRaw(ctx, chatIDStr, message)
 	if err == nil || d.queue == nil {
+		return err
+	}
+	if errors.Is(err, notifier.ErrRecipientBlocked) {
 		return err
 	}
 	if qErr := d.queue.EnqueueNotification(context.Background(), chatIDStr, "", message); qErr == nil {

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -30,9 +30,10 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 		return nil
 	}
 
+	// Use background context so the enqueue succeeds even during shutdown.
 	if d.queue != nil {
 		msg := notifier.FormatBatch(listings)
-		if qErr := d.queue.EnqueueNotification(ctx, chatIDStr, "", msg); qErr == nil {
+		if qErr := d.queue.EnqueueNotification(context.Background(), chatIDStr, "", msg); qErr == nil {
 			return nil
 		}
 	}
@@ -46,7 +47,7 @@ func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message 
 	if err == nil || d.queue == nil {
 		return err
 	}
-	if qErr := d.queue.EnqueueNotification(ctx, chatIDStr, "", message); qErr == nil {
+	if qErr := d.queue.EnqueueNotification(context.Background(), chatIDStr, "", message); qErr == nil {
 		return nil
 	}
 	return err

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -197,9 +197,22 @@ func TestDigestDelivery_DeliverRaw(t *testing.T) {
 	}
 }
 
+type ctxSensitiveQueue struct {
+	mockNotificationQueue
+	enqueued int
+}
+
+func (q *ctxSensitiveQueue) EnqueueNotification(ctx context.Context, _, _, _ string) error {
+	q.enqueued++
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return nil
+}
+
 func TestInstantDelivery_DeliverBatch_QueueOnCancelledCtx(t *testing.T) {
 	n := &mockNotifier{err: context.Canceled}
-	q := &mockNotificationQueue{}
+	q := &ctxSensitiveQueue{}
 	d := NewInstantDelivery(n, q)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -213,11 +226,14 @@ func TestInstantDelivery_DeliverBatch_QueueOnCancelledCtx(t *testing.T) {
 	if err != nil {
 		t.Errorf("should enqueue even with cancelled ctx, got: %v", err)
 	}
+	if q.enqueued != 1 {
+		t.Fatalf("expected one enqueue attempt, got %d", q.enqueued)
+	}
 }
 
 func TestInstantDelivery_DeliverRaw_QueueOnCancelledCtx(t *testing.T) {
 	n := &errRawNotifier{rawErr: context.Canceled}
-	q := &mockNotificationQueue{}
+	q := &ctxSensitiveQueue{}
 	d := NewInstantDelivery(n, q)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -226,6 +242,9 @@ func TestInstantDelivery_DeliverRaw_QueueOnCancelledCtx(t *testing.T) {
 	err := d.DeliverRaw(ctx, 100, "price drop!")
 	if err != nil {
 		t.Errorf("should enqueue even with cancelled ctx, got: %v", err)
+	}
+	if q.enqueued != 1 {
+		t.Fatalf("expected one enqueue attempt, got %d", q.enqueued)
 	}
 }
 

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -197,6 +197,38 @@ func TestDigestDelivery_DeliverRaw(t *testing.T) {
 	}
 }
 
+func TestInstantDelivery_DeliverBatch_QueueOnCancelledCtx(t *testing.T) {
+	n := &mockNotifier{err: context.Canceled}
+	q := &mockNotificationQueue{}
+	d := NewInstantDelivery(n, q)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a"}},
+	}
+
+	err := d.DeliverBatch(ctx, 100, listings)
+	if err != nil {
+		t.Errorf("should enqueue even with cancelled ctx, got: %v", err)
+	}
+}
+
+func TestInstantDelivery_DeliverRaw_QueueOnCancelledCtx(t *testing.T) {
+	n := &errRawNotifier{rawErr: context.Canceled}
+	q := &mockNotificationQueue{}
+	d := NewInstantDelivery(n, q)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := d.DeliverRaw(ctx, 100, "price drop!")
+	if err != nil {
+		t.Errorf("should enqueue even with cancelled ctx, got: %v", err)
+	}
+}
+
 func TestDigestDelivery_DeliverBatch_Error(t *testing.T) {
 	ds := newFailDigestStore(errors.New("write failed"))
 	d := NewDigestDelivery(ds)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -417,6 +417,14 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 				s.logger.Info("pruned old listings", "count", pruned)
 			}
 		}
+		if s.queue != nil {
+			pruned, err := s.queue.PruneNotifications(ctx, 48*time.Hour)
+			if err != nil {
+				s.logger.Error("prune notifications failed", "error", err)
+			} else if pruned > 0 {
+				s.logger.Info("pruned expired notifications", "count", pruned)
+			}
+		}
 		s.lastPruneTime = time.Now()
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -549,7 +549,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 				"error", err,
 			)
 			for _, l := range newListings {
-				_ = s.dedup.ReleaseClaim(ctx, l.Token, search.ChatID)
+				_ = s.dedup.ReleaseClaim(context.Background(), l.Token, search.ChatID)
 			}
 		} else {
 			s.observer.RecordNotificationSent()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -512,7 +512,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 
 			if s.listingStore != nil {
 				_ = s.listingStore.SaveListing(ctx, storage.ListingRecord{
-					Token: l.Token, SearchName: search.Name,
+					Token: l.Token, ChatID: search.ChatID, SearchName: search.Name,
 					Manufacturer: l.Manufacturer, Model: l.Model,
 					Year: l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
 					City: l.City, PageLink: l.PageLink, FirstSeenAt: time.Now(),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -52,6 +52,7 @@ type Scheduler struct {
 	fetcherFactory    *fetcher.Factory
 	listingStore      storage.ListingStore
 	searchStore       storage.SearchStore
+	userStore         storage.UserStore
 	digestStore       storage.DigestStore
 	catalogIngester   CatalogIngester
 	triggerCh         chan struct{}
@@ -65,6 +66,7 @@ type Options struct {
 	FetcherFactory  *fetcher.Factory
 	ListingStore    storage.ListingStore
 	SearchStore     storage.SearchStore
+	UserStore       storage.UserStore
 	DigestStore     storage.DigestStore
 	CatalogIngester CatalogIngester
 }
@@ -111,6 +113,7 @@ func NewWithOptions(
 		fetcherFactory:    opts.FetcherFactory,
 		listingStore:      opts.ListingStore,
 		searchStore:       opts.SearchStore,
+		userStore:         opts.UserStore,
 		digestStore:       opts.DigestStore,
 		catalogIngester:   opts.CatalogIngester,
 		triggerCh:         make(chan struct{}, 1),
@@ -532,6 +535,15 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 
 		for _, msg := range priceDropMessages {
 			if err := delivery.DeliverRaw(ctx, search.ChatID, msg); err != nil {
+				if errors.Is(err, notifier.ErrRecipientBlocked) {
+					s.logger.Warn("user blocked bot, deactivating",
+						"chat_id", search.ChatID,
+					)
+					if s.userStore != nil {
+						_ = s.userStore.SetUserActive(context.Background(), search.ChatID, false)
+					}
+					break
+				}
 				s.logger.Error("price drop delivery failed",
 					"chat_id", search.ChatID,
 					"error", err,
@@ -552,10 +564,19 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 		)
 
 		if err := delivery.DeliverBatch(ctx, search.ChatID, newListings); err != nil {
-			s.logger.Error("delivery failed",
-				"chat_id", search.ChatID,
-				"error", err,
-			)
+			if errors.Is(err, notifier.ErrRecipientBlocked) {
+				s.logger.Warn("user blocked bot, deactivating",
+					"chat_id", search.ChatID,
+				)
+				if s.userStore != nil {
+					_ = s.userStore.SetUserActive(context.Background(), search.ChatID, false)
+				}
+			} else {
+				s.logger.Error("delivery failed",
+					"chat_id", search.ChatID,
+					"error", err,
+				)
+			}
 			for _, l := range newListings {
 				_ = s.dedup.ReleaseClaim(context.Background(), l.Token, search.ChatID)
 			}

--- a/internal/scheduler/scheduler_extra_test.go
+++ b/internal/scheduler/scheduler_extra_test.go
@@ -206,3 +206,7 @@ func (m *mockNotificationQueue) AckNotification(_ context.Context, id int64) err
 	m.acked[id] = true
 	return nil
 }
+
+func (m *mockNotificationQueue) PruneNotifications(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -89,6 +89,7 @@ type DigestStore interface {
 
 type ListingRecord struct {
 	Token        string
+	ChatID       int64
 	SearchName   string
 	Manufacturer string
 	Model        string

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -72,6 +72,7 @@ type NotificationQueue interface {
 	EnqueueNotification(ctx context.Context, recipient, searchName, payload string) error
 	PendingNotifications(ctx context.Context) ([]PendingNotification, error)
 	AckNotification(ctx context.Context, id int64) error
+	PruneNotifications(ctx context.Context, olderThan time.Duration) (int64, error)
 }
 
 type PriceTracker interface {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -186,8 +186,11 @@ func migrate(db *sql.DB) error {
 			);
 			INSERT INTO listing_history_v2
 				(token, chat_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at)
-			SELECT token, 0, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at
-			FROM listing_history;
+			SELECT DISTINCT
+				lh.token, COALESCE(sl.chat_id, 0), lh.search_name, lh.manufacturer, lh.model,
+				lh.year, lh.price, lh.km, lh.hand, lh.city, lh.page_link, lh.first_seen_at
+			FROM listing_history lh
+			LEFT JOIN seen_listings sl ON sl.token = lh.token;
 			DROP TABLE listing_history;
 			ALTER TABLE listing_history_v2 RENAME TO listing_history;
 		`); err != nil {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -92,7 +92,8 @@ func migrate(db *sql.DB) error {
 		);
 
 		CREATE TABLE IF NOT EXISTS listing_history (
-			token TEXT PRIMARY KEY,
+			token TEXT NOT NULL,
+			chat_id INTEGER NOT NULL DEFAULT 0,
 			search_name TEXT NOT NULL,
 			manufacturer TEXT,
 			model TEXT,
@@ -102,7 +103,8 @@ func migrate(db *sql.DB) error {
 			hand INTEGER,
 			city TEXT,
 			page_link TEXT,
-			first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (token, chat_id)
 		);
 
 		CREATE TABLE IF NOT EXISTS pending_digest (
@@ -157,6 +159,42 @@ func migrate(db *sql.DB) error {
 			}
 		}
 	}
+
+	// Migrate listing_history to per-user: add chat_id to PK.
+	var hasChatID int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('listing_history') WHERE name = 'chat_id'",
+	).Scan(&hasChatID); err != nil {
+		return fmt.Errorf("check listing_history chat_id: %w", err)
+	}
+	if hasChatID == 0 {
+		if _, err := db.Exec(`
+			CREATE TABLE listing_history_v2 (
+				token TEXT NOT NULL,
+				chat_id INTEGER NOT NULL DEFAULT 0,
+				search_name TEXT NOT NULL,
+				manufacturer TEXT,
+				model TEXT,
+				year INTEGER,
+				price INTEGER,
+				km INTEGER,
+				hand INTEGER,
+				city TEXT,
+				page_link TEXT,
+				first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (token, chat_id)
+			);
+			INSERT INTO listing_history_v2
+				(token, chat_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at)
+			SELECT token, 0, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at
+			FROM listing_history;
+			DROP TABLE listing_history;
+			ALTER TABLE listing_history_v2 RENAME TO listing_history;
+		`); err != nil {
+			return fmt.Errorf("migrate listing_history: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -436,24 +474,23 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO listing_history
-		(token, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(token) DO UPDATE SET
+		(token, chat_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(token, chat_id) DO UPDATE SET
 			price = excluded.price,
 			km = excluded.km`,
-		r.Token, r.SearchName, r.Manufacturer, r.Model, r.Year, r.Price,
+		r.Token, r.ChatID, r.SearchName, r.Manufacturer, r.Model, r.Year, r.Price,
 		r.Km, r.Hand, r.City, r.PageLink, r.FirstSeenAt)
 	return err
 }
 
 func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.year, lh.price,
-			lh.km, lh.hand, lh.city, lh.page_link, sl.first_seen_at
-		FROM listing_history lh
-		JOIN seen_listings sl ON lh.token = sl.token
-		WHERE sl.chat_id = ?
-		ORDER BY sl.first_seen_at DESC, lh.token DESC
+		SELECT token, search_name, manufacturer, model, year, price,
+			km, hand, city, page_link, first_seen_at
+		FROM listing_history
+		WHERE chat_id = ?
+		ORDER BY first_seen_at DESC, token DESC
 		LIMIT ? OFFSET ?`, chatID, limit, offset)
 	if err != nil {
 		return nil, err
@@ -475,16 +512,17 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 func (s *Store) CountUserListings(ctx context.Context, chatID int64) (int64, error) {
 	var count int64
 	err := s.db.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM listing_history lh
-		JOIN seen_listings sl ON lh.token = sl.token
-		WHERE sl.chat_id = ?`, chatID).Scan(&count)
+		SELECT COUNT(*) FROM listing_history
+		WHERE chat_id = ?`, chatID).Scan(&count)
 	return count, err
 }
 
 func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at
-		FROM listing_history ORDER BY first_seen_at DESC LIMIT ?`, limit)
+		FROM listing_history
+		GROUP BY token
+		ORDER BY first_seen_at DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -442,6 +442,15 @@ func (s *Store) AckNotification(ctx context.Context, id int64) error {
 	return err
 }
 
+func (s *Store) PruneNotifications(ctx context.Context, olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.ExecContext(ctx, "DELETE FROM pending_notifications WHERE created_at < ?", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 // --- PriceTracker ---
 
 func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error) {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -376,6 +376,43 @@ func TestNotificationQueue(t *testing.T) {
 	}
 }
 
+func TestPruneNotifications(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.EnqueueNotification(ctx, "100", "search1", "hello")
+	_ = store.EnqueueNotification(ctx, "200", "search2", "world")
+
+	// Prune with zero duration removes all.
+	pruned, err := store.PruneNotifications(ctx, 0)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 2 {
+		t.Errorf("expected 2 pruned, got %d", pruned)
+	}
+
+	remaining, _ := store.PendingNotifications(ctx)
+	if len(remaining) != 0 {
+		t.Errorf("expected 0 remaining, got %d", len(remaining))
+	}
+}
+
+func TestPruneNotifications_KeepsRecent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_ = store.EnqueueNotification(ctx, "100", "search1", "hello")
+
+	pruned, err := store.PruneNotifications(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned (recent), got %d", pruned)
+	}
+}
+
 // --- PriceTracker ---
 
 func TestRecordPrice(t *testing.T) {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -593,7 +593,7 @@ func TestSaveAndListListings(t *testing.T) {
 	ctx := context.Background()
 
 	err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "abc", SearchName: "test", Manufacturer: "Mazda", Model: "3",
+		Token: "abc", ChatID: 100, SearchName: "test", Manufacturer: "Mazda", Model: "3",
 		Year: 2021, Price: 95000, Km: 85000, Hand: 2, City: "Tel Aviv",
 		PageLink: "https://example.com",
 	})
@@ -613,21 +613,19 @@ func TestListUserListings(t *testing.T) {
 	seedUser(t, store, 100)
 	seedUser(t, store, 200)
 
-	// Claim tokens for user 100.
-	_, _ = store.ClaimNew(ctx, "tok-a", 100, 1)
-	_, _ = store.ClaimNew(ctx, "tok-b", 100, 1)
-
-	// Claim a different token for user 200.
-	_, _ = store.ClaimNew(ctx, "tok-c", 200, 1)
-
-	// Save listing details.
-	for _, tok := range []string{"tok-a", "tok-b", "tok-c"} {
-		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: tok, SearchName: "test",
-			Manufacturer: "Mazda", Model: "3", Year: 2020,
-			Price: 100000,
-		})
-	}
+	// Save listings per user — listing_history is now per-user via chat_id.
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-a", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2020, Price: 100000,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-b", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2020, Price: 100000,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-c", ChatID: 200, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2020, Price: 100000,
+	})
 
 	// User 100 should see 2 listings.
 	listings, err := store.ListUserListings(ctx, 100, 10, 0)
@@ -664,9 +662,8 @@ func TestCountUserListings(t *testing.T) {
 
 	// Add some.
 	for _, tok := range []string{"t1", "t2", "t3"} {
-		_, _ = store.ClaimNew(ctx, tok, 100, 1)
 		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: tok, SearchName: "test",
+			Token: tok, ChatID: 100, SearchName: "test",
 			Manufacturer: "Mazda", Model: "3",
 		})
 	}
@@ -687,9 +684,8 @@ func TestListUserListings_Pagination(t *testing.T) {
 
 	for i := range 5 {
 		tok := "tok-" + string(rune('a'+i))
-		_, _ = store.ClaimNew(ctx, tok, 100, 1)
 		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: tok, SearchName: "test",
+			Token: tok, ChatID: 100, SearchName: "test",
 			Manufacturer: "Test", Model: "Car",
 			Price: 100000 + i*1000,
 		})


### PR DESCRIPTION
## Summary

Batch of 8 P0/P1 phase-1 fixes, organized as one commit per issue:

- **#160 + #164** — Make `listing_history` per-user (add `chat_id` to PK) and decouple `/history` from `seen_listings`, so history survives the 30-day prune
- **#171** — Escape Markdown in notification messages (`FormatListing`, `FormatPriceDrop`) to prevent rendering breakage from underscores, asterisks, etc. in listing data
- **#186** — Use `context.Background()` for notification queue fallback and claim release, so in-flight work completes during graceful shutdown
- **#168** — Add `PruneNotifications` (48h TTL) to the notification queue, called during the existing daily prune cycle
- **#169** — Detect Telegram 403 ("bot was blocked") and auto-deactivate the user so future cycles skip them
- **#166** — Add per-user token-bucket rate limiter (10 burst, 1/s refill) on all bot commands, callbacks, and free-text input
- **#163** — Replace hardcoded "15 minutes" in shared-search confirmation with the actual configured polling interval

## Test plan

- [x] All existing tests pass (`go test ./...` — 17 packages)
- [x] New test: `TestHistory_SurvivesPrune` — verifies history works after seen_listings prune
- [x] New test: `TestFormatListing_EscapesMarkdown` / `TestFormatPriceDrop_EscapesMarkdown`
- [x] New test: `TestInstantDelivery_*_QueueOnCancelledCtx` — verifies enqueue works with cancelled context
- [x] New test: `TestPruneNotifications` / `TestPruneNotifications_KeepsRecent`
- [x] New test: `TestSendMessage_APIError_Blocked` — verifies 403 → `ErrRecipientBlocked`
- [x] New test: `TestIsRateLimited` — verifies token bucket behavior
- [x] Lint clean (pre-existing golangci-lint/Go 1.24 import issues only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-chat rate limiting to reduce abuse.
  * Configurable polling cadence for searches (default preserved).

* **Bug Fixes**
  * Escapes Markdown in notifications to prevent formatting issues.
  * Delivery now treats permanently blocked recipients as terminal to avoid retries.

* **Improvements**
  * Listing history and visibility are user-scoped.
  * Notification queue pruning removes expired pending messages.

* **Tests**
  * Added tests for rate limiting, formatting, delivery, pruning, and storage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->