### PR TITLE
fix: phase 1 batch 2 — storage, filtering, observability, and UX improvements

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -513,6 +513,15 @@ func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 			snap["status"], snap["uptime"], snap["cycles"], snap["errors"]))
 		sb.WriteString(fmt.Sprintf("\nListings found: %v\nNotifications sent: %v",
 			snap["listings_found"], snap["notifications_sent"]))
+
+		if sources, ok := snap["sources"].(map[string]any); ok {
+			for name, data := range sources {
+				if m, ok := data.(map[string]any); ok {
+					sb.WriteString(fmt.Sprintf("\n\n*%s:*\nFetches: %v (success: %v, errors: %v)\nAvg latency: %vms",
+						name, m["fetches"], m["successes"], m["errors"], m["avg_latency_ms"]))
+				}
+			}
+		}
 	}
 
 	b.sendMarkdown(ctx, chatID, sb.String())

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -633,22 +633,33 @@ func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 		kb = &tgmodels.InlineKeyboardMarkup{
 			InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
 				{
+					{Text: "2h", CallbackData: cbDigestInterval + "2h"},
+					{Text: "6h", CallbackData: cbDigestInterval + "6h"},
+					{Text: "12h", CallbackData: cbDigestInterval + "12h"},
+					{Text: "24h", CallbackData: cbDigestInterval + "24h"},
+				},
+				{
 					{Text: "Switch to instant", CallbackData: cbDigestOff},
 				},
 			},
 		}
 		b.sendWithKeyboard(ctx, chatID,
-			fmt.Sprintf("*Notification mode:* digest (every %s)\n\nNew listings are batched and sent periodically.", interval), kb)
+			fmt.Sprintf("*Notification mode:* digest (every %s)\n\nChoose interval or switch to instant:", interval), kb)
 	} else {
 		kb = &tgmodels.InlineKeyboardMarkup{
 			InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
 				{
-					{Text: "Switch to digest (every 6h)", CallbackData: cbDigestOn},
+					{Text: "Every 2h", CallbackData: cbDigestInterval + "2h"},
+					{Text: "Every 6h", CallbackData: cbDigestInterval + "6h"},
+				},
+				{
+					{Text: "Every 12h", CallbackData: cbDigestInterval + "12h"},
+					{Text: "Every 24h", CallbackData: cbDigestInterval + "24h"},
 				},
 			},
 		}
 		b.sendWithKeyboard(ctx, chatID,
-			"*Notification mode:* instant\n\nNew listings are sent immediately as they are found.", kb)
+			"*Notification mode:* instant\n\nSwitch to digest mode — choose how often to receive batched listings:", kb)
 	}
 }
 
@@ -708,6 +719,8 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 		b.onDigestOn(ctx, chatID)
 	case data == cbDigestOff:
 		b.onDigestOff(ctx, chatID)
+	case strings.HasPrefix(data, cbDigestInterval):
+		b.onDigestInterval(ctx, chatID, data)
 	case strings.HasPrefix(data, cbHistoryPage):
 		b.onHistoryPage(ctx, chatID, data)
 	case data == "noop":
@@ -1026,6 +1039,24 @@ func (b *Bot) onDigestOff(ctx context.Context, chatID int64) {
 		return
 	}
 	b.sendMarkdown(ctx, chatID, "Switched to *instant* mode. Listings will be sent immediately.")
+}
+
+func (b *Bot) onDigestInterval(ctx context.Context, chatID int64, data string) {
+	if b.digests == nil {
+		return
+	}
+	interval := strings.TrimPrefix(data, cbDigestInterval)
+	switch interval {
+	case "2h", "6h", "12h", "24h":
+	default:
+		b.send(ctx, chatID, "Invalid interval.")
+		return
+	}
+	if err := b.digests.SetDigestMode(ctx, chatID, "digest", interval); err != nil {
+		b.send(ctx, chatID, "Failed to update digest interval.")
+		return
+	}
+	b.sendMarkdown(ctx, chatID, fmt.Sprintf("Switched to *digest* mode — listings batched every *%s*.", interval))
 }
 
 func (b *Bot) onHistoryPage(ctx context.Context, chatID int64, data string) {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -705,6 +705,10 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 		b.onModelSelected(ctx, chatID, data)
 	case strings.HasPrefix(data, cbPrefixEngine):
 		b.onEngineSelected(ctx, chatID, data)
+	case strings.HasPrefix(data, cbPrefixMaxKm):
+		b.onMaxKmSelected(ctx, chatID, data)
+	case strings.HasPrefix(data, cbPrefixMaxHand):
+		b.onMaxHandSelected(ctx, chatID, data)
 	case data == cbConfirm:
 		b.onConfirm(ctx, chatID)
 	case data == cbEdit:
@@ -890,6 +894,36 @@ func (b *Bot) onEngineSelected(ctx context.Context, chatID int64, data string) {
 	wd := b.loadWizardData(ctx, chatID)
 	wd.EngineMinCC = cc
 	b.logger.Debug("engine selected", "chat_id", chatID, "engine_min_cc", cc)
+	b.saveWizardState(ctx, chatID, StateAskMaxKm, wd)
+
+	b.sendWithKeyboard(ctx, chatID, "Maximum kilometers?", maxKmKeyboard())
+}
+
+func (b *Bot) onMaxKmSelected(ctx context.Context, chatID int64, data string) {
+	kmStr := strings.TrimPrefix(data, cbPrefixMaxKm)
+	km, err := strconv.Atoi(kmStr)
+	if err != nil {
+		b.send(ctx, chatID, "Something went wrong. Use /cancel and try again.")
+		return
+	}
+
+	wd := b.loadWizardData(ctx, chatID)
+	wd.MaxKm = km
+	b.saveWizardState(ctx, chatID, StateAskMaxHand, wd)
+
+	b.sendWithKeyboard(ctx, chatID, "Maximum ownership hand?", maxHandKeyboard())
+}
+
+func (b *Bot) onMaxHandSelected(ctx context.Context, chatID int64, data string) {
+	handStr := strings.TrimPrefix(data, cbPrefixMaxHand)
+	hand, err := strconv.Atoi(handStr)
+	if err != nil {
+		b.send(ctx, chatID, "Something went wrong. Use /cancel and try again.")
+		return
+	}
+
+	wd := b.loadWizardData(ctx, chatID)
+	wd.MaxHand = hand
 	b.saveWizardState(ctx, chatID, StateConfirm, wd)
 
 	kb, summary := confirmKeyboard(wd)
@@ -917,6 +951,8 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 		YearMax:      wd.YearMax,
 		PriceMax:     wd.PriceMax,
 		EngineMinCC:  wd.EngineMinCC,
+		MaxKm:        wd.MaxKm,
+		MaxHand:      wd.MaxHand,
 	})
 	if err != nil {
 		b.logger.Error("create search failed", "error", err)

--- a/internal/bot/digest_test.go
+++ b/internal/bot/digest_test.go
@@ -102,6 +102,64 @@ func TestDigestOff_Callback(t *testing.T) {
 	}
 }
 
+func TestDigestInterval_Callback(t *testing.T) {
+	for _, interval := range []string{"2h", "6h", "12h", "24h"} {
+		t.Run(interval, func(t *testing.T) {
+			tb := newTestBotWithDigests(t)
+			ctx := context.Background()
+			const chatID int64 = 100
+
+			_ = tb.store.UpsertUser(ctx, chatID, "alice")
+			tb.simulateCallback(ctx, chatID, cbDigestInterval+interval)
+
+			msg := tb.msg.last()
+			if !strings.Contains(msg.Text, interval) {
+				t.Errorf("expected interval %q in message, got %q", interval, msg.Text)
+			}
+
+			mode, got, err := tb.store.GetDigestMode(ctx, chatID)
+			if err != nil {
+				t.Fatalf("get digest mode: %v", err)
+			}
+			if mode != "digest" {
+				t.Errorf("mode = %q, want 'digest'", mode)
+			}
+			if got != interval {
+				t.Errorf("interval = %q, want %q", got, interval)
+			}
+		})
+	}
+}
+
+func TestDigestInterval_Invalid(t *testing.T) {
+	tb := newTestBotWithDigests(t)
+	ctx := context.Background()
+	const chatID int64 = 100
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+	tb.simulateCallback(ctx, chatID, cbDigestInterval+"99h")
+
+	msg := tb.msg.last()
+	if !strings.Contains(msg.Text, "Invalid") {
+		t.Errorf("expected invalid interval message, got %q", msg.Text)
+	}
+}
+
+func TestDigestInterval_NilStore(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	const chatID int64 = 100
+
+	_ = tb.store.UpsertUser(ctx, chatID, "alice")
+	tb.msg.reset()
+
+	tb.simulateCallback(ctx, chatID, cbDigestInterval+"6h")
+
+	if len(tb.msg.messages) != 0 {
+		t.Error("nil digest store should silently ignore digest interval callbacks")
+	}
+}
+
 func TestDigestOn_NilStore(t *testing.T) {
 	tb := newTestBot(t)
 	ctx := context.Background()

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -410,6 +410,22 @@ func TestOnDigestOff_SetModeError(t *testing.T) {
 	}
 }
 
+func TestOnDigestInterval_SetModeError(t *testing.T) {
+	msg := &mockMessenger{}
+	users := &errUserStore{user: &storage.User{ChatID: 100, State: StateIdle, StateData: "{}"}}
+	searches := &errSearchStore{}
+	ds := &errDigestStore{setModeErr: errors.New("db error")}
+	b := newErrBot(t, msg, users, searches)
+	b.digests = ds
+
+	b.onDigestInterval(context.Background(), 100, cbDigestInterval+"6h")
+
+	last := msg.last()
+	if !strings.Contains(last.Text, "Failed to update") {
+		t.Errorf("expected failure message, got %q", last.Text)
+	}
+}
+
 // --- handleCallback edge cases ---
 
 func TestHandleCallback_InaccessibleMessage(t *testing.T) {

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -116,12 +116,14 @@ func (m *errSearchStore) CountSearches(_ context.Context, _ int64) (int64, error
 
 func (m *errSearchStore) CountAllSearches(_ context.Context) (int64, error) { return 0, nil }
 
-func (m *errSearchStore) GetSearchBySeq(_ context.Context, _ int64, _ int) (*storage.Search, error) {
+func (m *errSearchStore) GetSearchBySeq(_ context.Context, chatID int64, seq int) (*storage.Search, error) {
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
-	if len(m.searches) > 0 {
-		return &m.searches[0], nil
+	for i := range m.searches {
+		if m.searches[i].ChatID == chatID && m.searches[i].UserSeq == seq {
+			return &m.searches[i], nil
+		}
 	}
 	return nil, nil
 }

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -116,6 +116,16 @@ func (m *errSearchStore) CountSearches(_ context.Context, _ int64) (int64, error
 
 func (m *errSearchStore) CountAllSearches(_ context.Context) (int64, error) { return 0, nil }
 
+func (m *errSearchStore) GetSearchBySeq(_ context.Context, _ int64, _ int) (*storage.Search, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if len(m.searches) > 0 {
+		return &m.searches[0], nil
+	}
+	return nil, nil
+}
+
 // errDigestStore implements DigestStore and returns errors.
 type errDigestStore struct {
 	getModeErr error

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -207,25 +207,47 @@ func TestWizardFlow_EndToEnd(t *testing.T) {
 		t.Fatalf("step 7: state=%q, want %q", user.State, StateAskEngine)
 	}
 
-	// Step 8: select engine → confirm
+	// Step 8: select engine → max km keyboard
 	tb.simulateCallback(ctx, chatID, cbPrefixEngine+"2000")
 	msg = tb.msg.last()
+	if !msg.HasKB || !strings.Contains(msg.Text, "kilometers") {
+		t.Fatalf("step 8: expected max km keyboard, got %q", msg.Text)
+	}
+	user, _ = tb.store.GetUser(ctx, chatID)
+	if user.State != StateAskMaxKm {
+		t.Fatalf("step 8: state=%q, want %q", user.State, StateAskMaxKm)
+	}
+
+	// Step 9: select max km → max hand keyboard
+	tb.simulateCallback(ctx, chatID, cbPrefixMaxKm+"100000")
+	msg = tb.msg.last()
+	if !msg.HasKB || !strings.Contains(msg.Text, "hand") {
+		t.Fatalf("step 9: expected max hand keyboard, got %q", msg.Text)
+	}
+	user, _ = tb.store.GetUser(ctx, chatID)
+	if user.State != StateAskMaxHand {
+		t.Fatalf("step 9: state=%q, want %q", user.State, StateAskMaxHand)
+	}
+
+	// Step 10: select max hand → confirm
+	tb.simulateCallback(ctx, chatID, cbPrefixMaxHand+"3")
+	msg = tb.msg.last()
 	if !msg.HasKB || !strings.Contains(msg.Text, "Mazda") {
-		t.Fatalf("step 8: expected confirm summary with Mazda, got %q", msg.Text)
+		t.Fatalf("step 10: expected confirm summary with Mazda, got %q", msg.Text)
 	}
 	if !strings.Contains(msg.Text, "150,000") {
-		t.Errorf("step 8: confirm should show formatted price 150,000, got %q", msg.Text)
+		t.Errorf("step 10: confirm should show formatted price 150,000, got %q", msg.Text)
 	}
 	user, _ = tb.store.GetUser(ctx, chatID)
 	if user.State != StateConfirm {
-		t.Fatalf("step 8: state=%q, want %q", user.State, StateConfirm)
+		t.Fatalf("step 10: state=%q, want %q", user.State, StateConfirm)
 	}
 
-	// Step 9: confirm → search created, state back to idle
+	// Step 11: confirm → search created, state back to idle
 	tb.simulateCallback(ctx, chatID, cbConfirm)
 	user, _ = tb.store.GetUser(ctx, chatID)
 	if user.State != StateIdle {
-		t.Fatalf("step 9: state=%q, want %q", user.State, StateIdle)
+		t.Fatalf("step 11: state=%q, want %q", user.State, StateIdle)
 	}
 
 	// Verify search was saved
@@ -251,6 +273,12 @@ func TestWizardFlow_EndToEnd(t *testing.T) {
 	}
 	if s.EngineMinCC != 2000 {
 		t.Errorf("engine_min_cc=%d, want 2000", s.EngineMinCC)
+	}
+	if s.MaxKm != 100000 {
+		t.Errorf("max_km=%d, want 100000", s.MaxKm)
+	}
+	if s.MaxHand != 3 {
+		t.Errorf("max_hand=%d, want 3", s.MaxHand)
 	}
 	if s.Source != "yad2" {
 		t.Errorf("source=%q, want yad2", s.Source)

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -26,6 +26,7 @@ const (
 	cbPrefixShareCopy = "share_copy:"
 	cbDigestOn        = "digest:on"
 	cbDigestOff       = "digest:off"
+	cbDigestInterval  = "digest_int:"
 	cbMfrPage         = "mfr_pg:"
 	cbMfrSearch       = "mfr_search"
 	cbMdlPage         = "mdl_pg:"

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -19,6 +19,8 @@ const (
 	cbPrefixMfr       = "mfr:"
 	cbPrefixModel     = "mdl:"
 	cbPrefixEngine    = "eng:"
+	cbPrefixMaxKm     = "maxkm:"
+	cbPrefixMaxHand   = "maxhand:"
 	cbConfirm         = "confirm:yes"
 	cbEdit            = "confirm:edit"
 	cbCancel          = "confirm:cancel"
@@ -244,6 +246,38 @@ func engineKeyboard() *tgmodels.InlineKeyboardMarkup {
 	}
 }
 
+func maxKmKeyboard() *tgmodels.InlineKeyboardMarkup {
+	return &tgmodels.InlineKeyboardMarkup{
+		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+			{
+				{Text: "Any", CallbackData: cbPrefixMaxKm + "0"},
+				{Text: "50,000", CallbackData: cbPrefixMaxKm + "50000"},
+				{Text: "100,000", CallbackData: cbPrefixMaxKm + "100000"},
+			},
+			{
+				{Text: "150,000", CallbackData: cbPrefixMaxKm + "150000"},
+				{Text: "200,000", CallbackData: cbPrefixMaxKm + "200000"},
+			},
+		},
+	}
+}
+
+func maxHandKeyboard() *tgmodels.InlineKeyboardMarkup {
+	return &tgmodels.InlineKeyboardMarkup{
+		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+			{
+				{Text: "Any", CallbackData: cbPrefixMaxHand + "0"},
+				{Text: "1st", CallbackData: cbPrefixMaxHand + "1"},
+				{Text: "2nd", CallbackData: cbPrefixMaxHand + "2"},
+			},
+			{
+				{Text: "3rd", CallbackData: cbPrefixMaxHand + "3"},
+				{Text: "4th", CallbackData: cbPrefixMaxHand + "4"},
+			},
+		},
+	}
+}
+
 func sourceDisplayName(source string) string {
 	if strings.TrimSpace(source) == "" {
 		return "Yad2, WinWin"
@@ -270,6 +304,16 @@ func confirmKeyboard(data WizardData) (*tgmodels.InlineKeyboardMarkup, string) {
 		engineStr = fmt.Sprintf("%.1fL+", float64(data.EngineMinCC)/1000)
 	}
 
+	kmStr := "Any"
+	if data.MaxKm > 0 {
+		kmStr = format.Number(data.MaxKm) + " km"
+	}
+
+	handStr := "Any"
+	if data.MaxHand > 0 {
+		handStr = strconv.Itoa(data.MaxHand)
+	}
+
 	source := data.Source
 	if source == "" {
 		source = "yad2,winwin"
@@ -286,12 +330,16 @@ func confirmKeyboard(data WizardData) (*tgmodels.InlineKeyboardMarkup, string) {
 			"Car: %s %s\n"+
 			"Year: %d–%d\n"+
 			"Max price: %s NIS\n"+
-			"Engine: %s",
+			"Engine: %s\n"+
+			"Max km: %s\n"+
+			"Max hand: %s",
 		sourceDisplayName(source),
 		data.ManufacturerName, modelDisplay,
 		data.YearMin, data.YearMax,
 		format.Number(data.PriceMax),
 		engineStr,
+		kmStr,
+		handStr,
 	)
 
 	kb := &tgmodels.InlineKeyboardMarkup{

--- a/internal/bot/state.go
+++ b/internal/bot/state.go
@@ -11,6 +11,8 @@ const (
 	StateAskYearMax         = "ask_year_max"
 	StateAskPriceMax        = "ask_price_max"
 	StateAskEngine          = "ask_engine"
+	StateAskMaxKm           = "ask_max_km"
+	StateAskMaxHand         = "ask_max_hand"
 	StateConfirm            = "confirm"
 )
 
@@ -24,4 +26,6 @@ type WizardData struct {
 	YearMax          int    `json:"year_max,omitempty"`
 	PriceMax         int    `json:"price_max,omitempty"`
 	EngineMinCC      int    `json:"engine_min_cc,omitempty"`
+	MaxKm            int    `json:"max_km,omitempty"`
+	MaxHand          int    `json:"max_hand,omitempty"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,9 @@ type SourceParams struct {
 }
 
 type FilterCriteria struct {
+	YearMin     int      `yaml:"year_min"`
+	YearMax     int      `yaml:"year_max"`
+	PriceMax    int      `yaml:"price_max"`
 	EngineMinCC float64  `yaml:"engine_min_cc"`
 	EngineMaxCC float64  `yaml:"engine_max_cc"`
 	MaxKm       int      `yaml:"max_km"`

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -97,7 +97,7 @@ func readResponseBody(resp *http.Response) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("create gzip reader: %w", err)
 		}
-		defer gr.Close()
+		defer func() { _ = gr.Close() }()
 		reader = gr
 	}
 	return io.ReadAll(reader)

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -18,6 +18,15 @@ func Apply(criteria config.FilterCriteria, listings []model.RawListing) []model.
 }
 
 func matches(c config.FilterCriteria, l model.RawListing) bool {
+	if c.PriceMax > 0 && l.Price > c.PriceMax {
+		return false
+	}
+	if c.YearMin > 0 && l.Year < c.YearMin {
+		return false
+	}
+	if c.YearMax > 0 && l.Year > c.YearMax {
+		return false
+	}
 	if c.EngineMinCC > 0 && l.EngineVolume < c.EngineMinCC {
 		return false
 	}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -87,6 +87,33 @@ func TestApply(t *testing.T) {
 			want: []string{"a"},
 		},
 		{
+			name:     "year min filter",
+			criteria: config.FilterCriteria{YearMin: 2018},
+			listings: []model.RawListing{
+				{Token: "a", Year: 2017},
+				{Token: "b", Year: 2020},
+			},
+			want: []string{"b"},
+		},
+		{
+			name:     "year max filter",
+			criteria: config.FilterCriteria{YearMax: 2022},
+			listings: []model.RawListing{
+				{Token: "a", Year: 2020},
+				{Token: "b", Year: 2025},
+			},
+			want: []string{"a"},
+		},
+		{
+			name:     "price max filter",
+			criteria: config.FilterCriteria{PriceMax: 150000},
+			listings: []model.RawListing{
+				{Token: "a", Price: 120000},
+				{Token: "b", Price: 200000},
+			},
+			want: []string{"a"},
+		},
+		{
 			name:     "zero values disable all filters",
 			criteria: config.FilterCriteria{},
 			listings: []model.RawListing{

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,11 +21,13 @@ type SearchCounter interface {
 }
 
 type SourceMetrics struct {
-	FetchCount  atomic.Int64
-	SuccessCount atomic.Int64
-	ErrorCount  atomic.Int64
-	TotalMs     atomic.Int64
-	LastSuccess atomic.Int64
+	FetchCount     atomic.Int64
+	SuccessCount   atomic.Int64
+	ErrorCount     atomic.Int64
+	ChallengeCount atomic.Int64
+	TotalMs        atomic.Int64
+	LastSuccess    atomic.Int64
+	LastError      atomic.Int64
 }
 
 type Status struct {
@@ -89,6 +92,10 @@ func (s *Status) RecordFetch(source string, duration time.Duration, err error) {
 		m.LastSuccess.Store(time.Now().UnixNano())
 	} else {
 		m.ErrorCount.Add(1)
+		m.LastError.Store(time.Now().UnixNano())
+		if strings.Contains(err.Error(), "challenge") {
+			m.ChallengeCount.Add(1)
+		}
 	}
 }
 
@@ -169,11 +176,15 @@ func (s *Status) Snapshot() map[string]any {
 				"fetches":        fetches,
 				"successes":      successes,
 				"errors":         m.ErrorCount.Load(),
+				"challenges":     m.ChallengeCount.Load(),
 				"avg_latency_ms": avgMs,
 				"success_rate":   successRate,
 			}
 			if ns := m.LastSuccess.Load(); ns > 0 {
 				entry["last_success"] = time.Unix(0, ns)
+			}
+			if ns := m.LastError.Load(); ns > 0 {
+				entry["last_error"] = time.Unix(0, ns)
 			}
 			srcMap[name] = entry
 		}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -109,6 +109,9 @@ func (s *Status) getSource(source string) *SourceMetrics {
 
 	s.sourceMu.Lock()
 	defer s.sourceMu.Unlock()
+	if s.sources == nil {
+		s.sources = make(map[string]*SourceMetrics)
+	}
 	if m, ok = s.sources[source]; ok {
 		return m
 	}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -19,6 +19,14 @@ type SearchCounter interface {
 	CountAllSearches(ctx context.Context) (int64, error)
 }
 
+type SourceMetrics struct {
+	FetchCount  atomic.Int64
+	SuccessCount atomic.Int64
+	ErrorCount  atomic.Int64
+	TotalMs     atomic.Int64
+	LastSuccess atomic.Int64
+}
+
 type Status struct {
 	startTime         time.Time
 	cycleCount        atomic.Int64
@@ -27,13 +35,19 @@ type Status struct {
 	listingsFound     atomic.Int64
 	notificationsSent atomic.Int64
 
+	sourceMu sync.RWMutex
+	sources  map[string]*SourceMetrics
+
 	mu       sync.RWMutex
 	users    UserCounter
 	searches SearchCounter
 }
 
 func New() *Status {
-	return &Status{startTime: time.Now()}
+	return &Status{
+		startTime: time.Now(),
+		sources:   make(map[string]*SourceMetrics),
+	}
 }
 
 func (s *Status) SetUserCounter(u UserCounter) {
@@ -64,6 +78,36 @@ func (s *Status) RecordListingsFound(n int) {
 
 func (s *Status) RecordNotificationSent() {
 	s.notificationsSent.Add(1)
+}
+
+func (s *Status) RecordFetch(source string, duration time.Duration, err error) {
+	m := s.getSource(source)
+	m.FetchCount.Add(1)
+	m.TotalMs.Add(duration.Milliseconds())
+	if err == nil {
+		m.SuccessCount.Add(1)
+		m.LastSuccess.Store(time.Now().UnixNano())
+	} else {
+		m.ErrorCount.Add(1)
+	}
+}
+
+func (s *Status) getSource(source string) *SourceMetrics {
+	s.sourceMu.RLock()
+	m, ok := s.sources[source]
+	s.sourceMu.RUnlock()
+	if ok {
+		return m
+	}
+
+	s.sourceMu.Lock()
+	defer s.sourceMu.Unlock()
+	if m, ok = s.sources[source]; ok {
+		return m
+	}
+	m = &SourceMetrics{}
+	s.sources[source] = m
+	return m
 }
 
 func (s *Status) Snapshot() map[string]any {
@@ -106,6 +150,36 @@ func (s *Status) Snapshot() map[string]any {
 			resp["active_searches"] = n
 		}
 	}
+
+	s.sourceMu.RLock()
+	if len(s.sources) > 0 {
+		srcMap := make(map[string]any, len(s.sources))
+		for name, m := range s.sources {
+			fetches := m.FetchCount.Load()
+			successes := m.SuccessCount.Load()
+			var avgMs int64
+			if fetches > 0 {
+				avgMs = m.TotalMs.Load() / fetches
+			}
+			var successRate float64
+			if fetches > 0 {
+				successRate = float64(successes) / float64(fetches)
+			}
+			entry := map[string]any{
+				"fetches":        fetches,
+				"successes":      successes,
+				"errors":         m.ErrorCount.Load(),
+				"avg_latency_ms": avgMs,
+				"success_rate":   successRate,
+			}
+			if ns := m.LastSuccess.Load(); ns > 0 {
+				entry["last_success"] = time.Unix(0, ns)
+			}
+			srcMap[name] = entry
+		}
+		resp["sources"] = srcMap
+	}
+	s.sourceMu.RUnlock()
 
 	return resp
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -176,6 +176,7 @@ func TestStatus_RecordFetch(t *testing.T) {
 	s.RecordFetch("yad2", 100*time.Millisecond, nil)
 	s.RecordFetch("yad2", 200*time.Millisecond, nil)
 	s.RecordFetch("yad2", 300*time.Millisecond, errors.New("timeout"))
+	s.RecordFetch("yad2", 150*time.Millisecond, errors.New("anti-bot challenge detected"))
 	s.RecordFetch("winwin", 50*time.Millisecond, nil)
 
 	snap := s.Snapshot()
@@ -188,17 +189,20 @@ func TestStatus_RecordFetch(t *testing.T) {
 	if !ok {
 		t.Fatal("expected yad2 source metrics")
 	}
-	if yad2["fetches"].(int64) != 3 {
-		t.Errorf("yad2 fetches = %v, want 3", yad2["fetches"])
+	if yad2["fetches"].(int64) != 4 {
+		t.Errorf("yad2 fetches = %v, want 4", yad2["fetches"])
 	}
 	if yad2["successes"].(int64) != 2 {
 		t.Errorf("yad2 successes = %v, want 2", yad2["successes"])
 	}
-	if yad2["errors"].(int64) != 1 {
-		t.Errorf("yad2 errors = %v, want 1", yad2["errors"])
+	if yad2["errors"].(int64) != 2 {
+		t.Errorf("yad2 errors = %v, want 2", yad2["errors"])
 	}
-	if yad2["avg_latency_ms"].(int64) != 200 {
-		t.Errorf("yad2 avg_latency_ms = %v, want 200", yad2["avg_latency_ms"])
+	if yad2["challenges"].(int64) != 1 {
+		t.Errorf("yad2 challenges = %v, want 1", yad2["challenges"])
+	}
+	if _, hasLastErr := yad2["last_error"]; !hasLastErr {
+		t.Error("expected last_error in yad2 metrics")
 	}
 
 	winwin, ok := sources["winwin"].(map[string]any)

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -3,9 +3,11 @@ package health
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestStatus_OK(t *testing.T) {
@@ -166,5 +168,85 @@ func TestSnapshot_ReturnsSameDataAsHandler(t *testing.T) {
 	}
 	if float64(snap["listings_found"].(int64)) != resp["listings_found"].(float64) {
 		t.Errorf("listings_found mismatch")
+	}
+}
+
+func TestStatus_RecordFetch(t *testing.T) {
+	s := New()
+	s.RecordFetch("yad2", 100*time.Millisecond, nil)
+	s.RecordFetch("yad2", 200*time.Millisecond, nil)
+	s.RecordFetch("yad2", 300*time.Millisecond, errors.New("timeout"))
+	s.RecordFetch("winwin", 50*time.Millisecond, nil)
+
+	snap := s.Snapshot()
+	sources, ok := snap["sources"].(map[string]any)
+	if !ok {
+		t.Fatal("expected sources in snapshot")
+	}
+
+	yad2, ok := sources["yad2"].(map[string]any)
+	if !ok {
+		t.Fatal("expected yad2 source metrics")
+	}
+	if yad2["fetches"].(int64) != 3 {
+		t.Errorf("yad2 fetches = %v, want 3", yad2["fetches"])
+	}
+	if yad2["successes"].(int64) != 2 {
+		t.Errorf("yad2 successes = %v, want 2", yad2["successes"])
+	}
+	if yad2["errors"].(int64) != 1 {
+		t.Errorf("yad2 errors = %v, want 1", yad2["errors"])
+	}
+	if yad2["avg_latency_ms"].(int64) != 200 {
+		t.Errorf("yad2 avg_latency_ms = %v, want 200", yad2["avg_latency_ms"])
+	}
+
+	winwin, ok := sources["winwin"].(map[string]any)
+	if !ok {
+		t.Fatal("expected winwin source metrics")
+	}
+	if winwin["fetches"].(int64) != 1 {
+		t.Errorf("winwin fetches = %v, want 1", winwin["fetches"])
+	}
+	if winwin["successes"].(int64) != 1 {
+		t.Errorf("winwin successes = %v, want 1", winwin["successes"])
+	}
+}
+
+func TestStatus_SourceMetricsInHealthzJSON(t *testing.T) {
+	s := New()
+	s.RecordSuccess()
+	s.RecordFetch("yad2", 150*time.Millisecond, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.Handler()(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	sources, ok := resp["sources"].(map[string]any)
+	if !ok {
+		t.Fatal("expected sources in JSON response")
+	}
+	yad2, ok := sources["yad2"].(map[string]any)
+	if !ok {
+		t.Fatal("expected yad2 in sources")
+	}
+	if yad2["fetches"].(float64) != 1 {
+		t.Errorf("yad2 fetches = %v, want 1", yad2["fetches"])
+	}
+	if yad2["success_rate"].(float64) != 1.0 {
+		t.Errorf("yad2 success_rate = %v, want 1.0", yad2["success_rate"])
+	}
+}
+
+func TestStatus_NoSourcesBeforeFetch(t *testing.T) {
+	s := New()
+	snap := s.Snapshot()
+	if _, ok := snap["sources"]; ok {
+		t.Error("sources should not be present before any RecordFetch calls")
 	}
 }

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -49,7 +49,7 @@ func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.L
 		return n.sendListingWithPhoto(ctx, chatID, listings[0])
 	}
 	msg := notifier.FormatBatch(listings)
-	return n.sendMessage(ctx, chatID, msg)
+	return n.sendMessageMarkdown(ctx, chatID, msg)
 }
 
 func (n *Notifier) NotifyRaw(ctx context.Context, chatID string, message string) error {
@@ -80,9 +80,9 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 		})
 		if err != nil {
 			n.logger.Warn("sendPhoto failed, falling back to text", "chat_id", chatID, "error", err)
-			return n.sendMessage(ctx, chatID, caption)
+			return n.sendMessageMarkdown(ctx, chatID, caption)
 		}
-		return n.sendMessage(ctx, chatID, caption)
+		return n.sendMessageMarkdown(ctx, chatID, caption)
 	}
 
 	_, err = n.bot.SendPhoto(ctx, &tgbot.SendPhotoParams{
@@ -93,14 +93,22 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 	})
 	if err != nil {
 		n.logger.Warn("sendPhoto failed, falling back to text", "chat_id", chatID, "error", err)
-		return n.sendMessage(ctx, chatID, caption)
+		return n.sendMessageMarkdown(ctx, chatID, caption)
 	}
 
 	n.logger.Info("sent telegram photo", "chat_id", chatID)
 	return nil
 }
 
+func (n *Notifier) sendMessageMarkdown(ctx context.Context, chatID string, text string) error {
+	return n.sendMessageWithParseMode(ctx, chatID, text, tgmodels.ParseModeMarkdown)
+}
+
 func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) error {
+	return n.sendMessageWithParseMode(ctx, chatID, text, "")
+}
+
+func (n *Notifier) sendMessageWithParseMode(ctx context.Context, chatID string, text string, parseMode tgmodels.ParseMode) error {
 	id, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid chat ID %q: %w", chatID, err)
@@ -108,11 +116,14 @@ func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) 
 
 	chunks := splitMessage(text, maxMessageLen)
 	for _, chunk := range chunks {
-		_, err = n.bot.SendMessage(ctx, &tgbot.SendMessageParams{
-			ChatID:    id,
-			Text:      chunk,
-			ParseMode: tgmodels.ParseModeMarkdown,
-		})
+		params := &tgbot.SendMessageParams{
+			ChatID: id,
+			Text:   chunk,
+		}
+		if parseMode != "" {
+			params.ParseMode = parseMode
+		}
+		_, err = n.bot.SendMessage(ctx, params)
 		if err != nil {
 			errMsg := strings.ToLower(err.Error())
 			if strings.Contains(errMsg, "bot was blocked by the user") ||

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -109,8 +109,9 @@ func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) 
 	chunks := splitMessage(text, maxMessageLen)
 	for _, chunk := range chunks {
 		_, err = n.bot.SendMessage(ctx, &tgbot.SendMessageParams{
-			ChatID: id,
-			Text:   chunk,
+			ChatID:    id,
+			Text:      chunk,
+			ParseMode: tgmodels.ParseModeMarkdown,
 		})
 		if err != nil {
 			errMsg := strings.ToLower(err.Error())

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -45,6 +45,9 @@ func (n *Notifier) Connect(ctx context.Context) error {
 }
 
 func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.Listing) error {
+	if len(listings) == 1 && listings[0].ImageURL != "" {
+		return n.sendListingWithPhoto(ctx, chatID, listings[0])
+	}
 	msg := notifier.FormatBatch(listings)
 	return n.sendMessage(ctx, chatID, msg)
 }
@@ -57,7 +60,45 @@ func (n *Notifier) Disconnect() error {
 	return nil
 }
 
-const maxMessageLen = 4096
+const (
+	maxMessageLen = 4096
+	maxCaptionLen = 1024
+)
+
+func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, listing model.Listing) error {
+	id, err := strconv.ParseInt(chatID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid chat ID %q: %w", chatID, err)
+	}
+
+	caption := notifier.FormatListing(listing)
+
+	if len([]rune(caption)) > maxCaptionLen {
+		_, err = n.bot.SendPhoto(ctx, &tgbot.SendPhotoParams{
+			ChatID: id,
+			Photo:  &tgmodels.InputFileString{Data: listing.ImageURL},
+		})
+		if err != nil {
+			n.logger.Warn("sendPhoto failed, falling back to text", "chat_id", chatID, "error", err)
+			return n.sendMessage(ctx, chatID, caption)
+		}
+		return n.sendMessage(ctx, chatID, caption)
+	}
+
+	_, err = n.bot.SendPhoto(ctx, &tgbot.SendPhotoParams{
+		ChatID:    id,
+		Photo:     &tgmodels.InputFileString{Data: listing.ImageURL},
+		Caption:   caption,
+		ParseMode: tgmodels.ParseModeMarkdown,
+	})
+	if err != nil {
+		n.logger.Warn("sendPhoto failed, falling back to text", "chat_id", chatID, "error", err)
+		return n.sendMessage(ctx, chatID, caption)
+	}
+
+	n.logger.Info("sent telegram photo", "chat_id", chatID)
+	return nil
+}
 
 func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) error {
 	id, err := strconv.ParseInt(chatID, 10, 64)

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -40,6 +40,10 @@ var sendMessageOK = tgResponse(map[string]any{
 	"message_id": 1, "chat": map[string]any{"id": 123}, "date": 0,
 })
 
+var sendPhotoOK = tgResponse(map[string]any{
+	"message_id": 2, "chat": map[string]any{"id": 123}, "date": 0,
+})
+
 func routingHandler(sendMessageHandler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "getMe") {
@@ -387,5 +391,164 @@ func TestNew_EmptyToken(t *testing.T) {
 	_, err := New("", testLogger())
 	if err == nil {
 		t.Fatal("expected error for empty token")
+	}
+}
+
+// --- SendPhoto tests ---
+
+func TestNotify_SingleListingWithPhoto(t *testing.T) {
+	var mu sync.Mutex
+	var endpoints []string
+
+	n := newTestNotifier(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "getMe") {
+			_, _ = w.Write(getMeResponse)
+			return
+		}
+		mu.Lock()
+		endpoints = append(endpoints, r.URL.Path)
+		mu.Unlock()
+		if strings.Contains(r.URL.Path, "sendPhoto") {
+			_, _ = w.Write(sendPhotoOK)
+		} else {
+			_, _ = w.Write(sendMessageOK)
+		}
+	}))
+
+	listings := []model.Listing{
+		{
+			RawListing: model.RawListing{
+				Token: "abc", Manufacturer: "Toyota", Model: "Corolla",
+				Year: 2021, Price: 120000, ImageURL: "https://example.com/photo.jpg",
+			},
+			SearchName: "test",
+		},
+	}
+
+	err := n.Notify(context.Background(), "123", listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	hasPhoto := false
+	for _, ep := range endpoints {
+		if strings.Contains(ep, "sendPhoto") {
+			hasPhoto = true
+		}
+	}
+	if !hasPhoto {
+		t.Error("expected sendPhoto call for listing with image")
+	}
+}
+
+func TestNotify_SingleListingNoPhoto_FallsBackToText(t *testing.T) {
+	var mu sync.Mutex
+	var endpoints []string
+
+	n := newTestNotifier(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "getMe") {
+			_, _ = w.Write(getMeResponse)
+			return
+		}
+		mu.Lock()
+		endpoints = append(endpoints, r.URL.Path)
+		mu.Unlock()
+		_, _ = w.Write(sendMessageOK)
+	}))
+
+	listings := []model.Listing{
+		{
+			RawListing: model.RawListing{
+				Token: "abc", Manufacturer: "Toyota", Model: "Corolla",
+				Year: 2021, Price: 120000,
+			},
+			SearchName: "test",
+		},
+	}
+
+	err := n.Notify(context.Background(), "123", listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ep := range endpoints {
+		if strings.Contains(ep, "sendPhoto") {
+			t.Error("should not call sendPhoto when no image URL")
+		}
+	}
+}
+
+func TestNotify_PhotoFails_FallsBackToText(t *testing.T) {
+	var sendMsgCalls atomic.Int32
+
+	n := newTestNotifier(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "getMe") {
+			_, _ = w.Write(getMeResponse)
+			return
+		}
+		if strings.Contains(r.URL.Path, "sendPhoto") {
+			w.WriteHeader(http.StatusBadRequest)
+			resp, _ := json.Marshal(map[string]any{"ok": false, "description": "Bad Request: wrong photo"})
+			_, _ = w.Write(resp)
+			return
+		}
+		sendMsgCalls.Add(1)
+		_, _ = w.Write(sendMessageOK)
+	}))
+
+	listings := []model.Listing{
+		{
+			RawListing: model.RawListing{
+				Token: "abc", Manufacturer: "Toyota", Model: "Corolla",
+				Year: 2021, Price: 120000, ImageURL: "https://example.com/bad.jpg",
+			},
+			SearchName: "test",
+		},
+	}
+
+	err := n.Notify(context.Background(), "123", listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sendMsgCalls.Load() == 0 {
+		t.Error("expected fallback to sendMessage when sendPhoto fails")
+	}
+}
+
+func TestNotify_BatchListings_UsesText(t *testing.T) {
+	var mu sync.Mutex
+	var endpoints []string
+
+	n := newTestNotifier(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "getMe") {
+			_, _ = w.Write(getMeResponse)
+			return
+		}
+		mu.Lock()
+		endpoints = append(endpoints, r.URL.Path)
+		mu.Unlock()
+		_, _ = w.Write(sendMessageOK)
+	}))
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "a", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000, ImageURL: "https://example.com/1.jpg"}, SearchName: "test"},
+		{RawListing: model.RawListing{Token: "b", Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 110000, ImageURL: "https://example.com/2.jpg"}, SearchName: "test"},
+	}
+
+	err := n.Notify(context.Background(), "123", listings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ep := range endpoints {
+		if strings.Contains(ep, "sendPhoto") {
+			t.Error("batch listings should use sendMessage, not sendPhoto")
+		}
 	}
 }

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -40,6 +40,15 @@ func (m *mockSearchStore) GetSearch(_ context.Context, id int64) (*storage.Searc
 	return nil, nil
 }
 
+func (m *mockSearchStore) GetSearchBySeq(_ context.Context, chatID int64, seq int) (*storage.Search, error) {
+	for _, s := range m.searches {
+		if s.ChatID == chatID && s.UserSeq == seq {
+			return &s, nil
+		}
+	}
+	return nil, nil
+}
+
 func (m *mockSearchStore) DeleteSearch(_ context.Context, id int64, _ int64) error    { return nil }
 func (m *mockSearchStore) SetSearchActive(_ context.Context, _ int64, _ bool) error   { return nil }
 func (m *mockSearchStore) CountSearches(_ context.Context, _ int64) (int64, error)    { return 0, nil }

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -32,18 +32,18 @@ func (m *mockSearchStore) ListSearches(_ context.Context, chatID int64) ([]stora
 }
 
 func (m *mockSearchStore) GetSearch(_ context.Context, id int64) (*storage.Search, error) {
-	for _, s := range m.searches {
-		if s.ID == id {
-			return &s, nil
+	for i := range m.searches {
+		if m.searches[i].ID == id {
+			return &m.searches[i], nil
 		}
 	}
 	return nil, nil
 }
 
 func (m *mockSearchStore) GetSearchBySeq(_ context.Context, chatID int64, seq int) (*storage.Search, error) {
-	for _, s := range m.searches {
-		if s.ChatID == chatID && s.UserSeq == seq {
-			return &s, nil
+	for i := range m.searches {
+		if m.searches[i].ChatID == chatID && m.searches[i].UserSeq == seq {
+			return &m.searches[i], nil
 		}
 	}
 	return nil, nil

--- a/internal/scheduler/observer.go
+++ b/internal/scheduler/observer.go
@@ -1,15 +1,19 @@
 package scheduler
 
+import "time"
+
 type CycleObserver interface {
 	RecordSuccess()
 	RecordError()
 	RecordListingsFound(n int)
 	RecordNotificationSent()
+	RecordFetch(source string, duration time.Duration, err error)
 }
 
 type nopObserver struct{}
 
-func (nopObserver) RecordSuccess()          {}
-func (nopObserver) RecordError()            {}
-func (nopObserver) RecordListingsFound(int) {}
-func (nopObserver) RecordNotificationSent() {}
+func (nopObserver) RecordSuccess()                                     {}
+func (nopObserver) RecordError()                                       {}
+func (nopObserver) RecordListingsFound(int)                            {}
+func (nopObserver) RecordNotificationSent()                            {}
+func (nopObserver) RecordFetch(string, time.Duration, error)           {}

--- a/internal/scheduler/observer_test.go
+++ b/internal/scheduler/observer_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"testing"
+	"time"
 )
 
 func TestNopObserver_DoesNotPanic(t *testing.T) {
@@ -10,6 +11,7 @@ func TestNopObserver_DoesNotPanic(t *testing.T) {
 	o.RecordError()
 	o.RecordListingsFound(10)
 	o.RecordNotificationSent()
+	o.RecordFetch("yad2", time.Second, nil)
 }
 
 type countingObserver struct {
@@ -17,12 +19,14 @@ type countingObserver struct {
 	errors        int
 	listingsFound int
 	notifications int
+	fetches       int
 }
 
-func (o *countingObserver) RecordSuccess()          { o.successes++ }
-func (o *countingObserver) RecordError()            { o.errors++ }
-func (o *countingObserver) RecordListingsFound(n int) { o.listingsFound += n }
-func (o *countingObserver) RecordNotificationSent() { o.notifications++ }
+func (o *countingObserver) RecordSuccess()                                 { o.successes++ }
+func (o *countingObserver) RecordError()                                   { o.errors++ }
+func (o *countingObserver) RecordListingsFound(n int)                      { o.listingsFound += n }
+func (o *countingObserver) RecordNotificationSent()                        { o.notifications++ }
+func (o *countingObserver) RecordFetch(_ string, _ time.Duration, _ error) { o.fetches++ }
 
 func TestCycleObserver_Interface(t *testing.T) {
 	var obs CycleObserver = &countingObserver{}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -428,6 +428,14 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 				s.logger.Info("pruned expired notifications", "count", pruned)
 			}
 		}
+		if s.prices != nil {
+			pruned, err := s.prices.PrunePrices(ctx, 90*24*time.Hour)
+			if err != nil {
+				s.logger.Error("prune prices failed", "error", err)
+			} else if pruned > 0 {
+				s.logger.Info("pruned old price history", "count", pruned)
+			}
+		}
 		s.lastPruneTime = time.Now()
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -483,6 +483,9 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 
 	for _, search := range group.Searches {
 		criteria := config.FilterCriteria{
+			YearMin:     search.YearMin,
+			YearMax:     search.YearMax,
+			PriceMax:    search.PriceMax,
 			EngineMinCC: float64(search.EngineMinCC),
 			MaxKm:       search.MaxKm,
 			MaxHand:     search.MaxHand,
@@ -493,13 +496,6 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 		var newListings []model.Listing
 		var priceDropMessages []string
 		for _, l := range filtered {
-			if l.Price > search.PriceMax && search.PriceMax > 0 {
-				continue
-			}
-			if l.Year < search.YearMin || (l.Year > search.YearMax && search.YearMax > 0) {
-				continue
-			}
-
 			isNew, err := s.dedup.ClaimNew(ctx, l.Token, search.ChatID, search.ID)
 			if err != nil {
 				s.logger.Error("claim failed", "token", l.Token, "error", err)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -463,7 +463,9 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 		source = "yad2"
 	}
 	activeFetcher := s.fetcherForSource(source)
+	fetchStart := time.Now()
 	raw, err := s.fetchWithRetryUsing(fetchCtx, activeFetcher, group.Params)
+	s.observer.RecordFetch(source, time.Since(fetchStart), err)
 	if err != nil {
 		return err
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -376,6 +376,8 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 		return fmt.Errorf("load searches: %w", err)
 	}
 
+	s.pruneIfDue(ctx)
+
 	if len(searches) == 0 {
 		s.logger.Info("no active searches")
 		return nil
@@ -408,37 +410,6 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 		s.backoffMultiplier = max(s.backoffMultiplier/2, minBackoff)
 	}
 
-	if time.Since(s.lastPruneTime) > pruneInterval {
-		s.cfgMu.RLock()
-		pruneAfter := s.cfg.Storage.PruneAfter
-		s.cfgMu.RUnlock()
-		if pruneAfter > 0 {
-			pruned, err := s.dedup.Prune(ctx, pruneAfter)
-			if err != nil {
-				s.logger.Error("prune failed", "error", err)
-			} else if pruned > 0 {
-				s.logger.Info("pruned old listings", "count", pruned)
-			}
-		}
-		if s.queue != nil {
-			pruned, err := s.queue.PruneNotifications(ctx, 48*time.Hour)
-			if err != nil {
-				s.logger.Error("prune notifications failed", "error", err)
-			} else if pruned > 0 {
-				s.logger.Info("pruned expired notifications", "count", pruned)
-			}
-		}
-		if s.prices != nil {
-			pruned, err := s.prices.PrunePrices(ctx, 90*24*time.Hour)
-			if err != nil {
-				s.logger.Error("prune prices failed", "error", err)
-			} else if pruned > 0 {
-				s.logger.Info("pruned old price history", "count", pruned)
-			}
-		}
-		s.lastPruneTime = time.Now()
-	}
-
 	if s.catalogIngester != nil {
 		s.catalogIngester.Flush(ctx)
 	}
@@ -452,6 +423,40 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	s.observer.RecordSuccess()
 	return nil
+}
+
+func (s *Scheduler) pruneIfDue(ctx context.Context) {
+	if time.Since(s.lastPruneTime) <= pruneInterval {
+		return
+	}
+	s.cfgMu.RLock()
+	pruneAfter := s.cfg.Storage.PruneAfter
+	s.cfgMu.RUnlock()
+	if pruneAfter > 0 {
+		pruned, err := s.dedup.Prune(ctx, pruneAfter)
+		if err != nil {
+			s.logger.Error("prune failed", "error", err)
+		} else if pruned > 0 {
+			s.logger.Info("pruned old listings", "count", pruned)
+		}
+	}
+	if s.queue != nil {
+		pruned, err := s.queue.PruneNotifications(ctx, 48*time.Hour)
+		if err != nil {
+			s.logger.Error("prune notifications failed", "error", err)
+		} else if pruned > 0 {
+			s.logger.Info("pruned expired notifications", "count", pruned)
+		}
+	}
+	if s.prices != nil {
+		pruned, err := s.prices.PrunePrices(ctx, 90*24*time.Hour)
+		if err != nil {
+			s.logger.Error("prune prices failed", "error", err)
+		} else if pruned > 0 {
+			s.logger.Info("pruned old price history", "count", pruned)
+		}
+	}
+	s.lastPruneTime = time.Now()
 }
 
 func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) error {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -135,6 +135,10 @@ func (m *mockPriceTracker) RecordPrice(_ context.Context, token string, price in
 	return 0, false, nil
 }
 
+func (m *mockPriceTracker) PrunePrices(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}
+
 func testConfig() *config.Config {
 	return &config.Config{
 		Polling: config.PollingConfig{

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -20,6 +20,7 @@ type User struct {
 type Search struct {
 	ID           int64
 	ChatID       int64
+	UserSeq      int
 	Name         string
 	Source       string
 	Manufacturer int
@@ -47,6 +48,7 @@ type SearchStore interface {
 	CreateSearch(ctx context.Context, s Search) (int64, error)
 	ListSearches(ctx context.Context, chatID int64) ([]Search, error)
 	GetSearch(ctx context.Context, id int64) (*Search, error)
+	GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*Search, error)
 	DeleteSearch(ctx context.Context, id int64, chatID int64) error
 	SetSearchActive(ctx context.Context, id int64, active bool) error
 	ListAllActiveSearches(ctx context.Context) ([]Search, error)

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -77,6 +77,7 @@ type NotificationQueue interface {
 
 type PriceTracker interface {
 	RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error)
+	PrunePrices(ctx context.Context, olderThan time.Duration) (int64, error)
 }
 
 type DigestStore interface {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -198,6 +198,28 @@ func migrate(db *sql.DB) error {
 		}
 	}
 
+	// Add user_seq column to searches table if it doesn't exist.
+	var hasUserSeq int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('searches') WHERE name = 'user_seq'",
+	).Scan(&hasUserSeq); err != nil {
+		return fmt.Errorf("check searches user_seq: %w", err)
+	}
+	if hasUserSeq == 0 {
+		if _, err := db.Exec("ALTER TABLE searches ADD COLUMN user_seq INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return fmt.Errorf("add user_seq column: %w", err)
+		}
+		// Backfill: assign sequential numbers per user based on creation order.
+		if _, err := db.Exec(`
+			UPDATE searches SET user_seq = (
+				SELECT COUNT(*) FROM searches s2
+				WHERE s2.chat_id = searches.chat_id AND s2.id <= searches.id
+			)
+		`); err != nil {
+			return fmt.Errorf("backfill user_seq: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -276,12 +298,21 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 	if source == "" {
 		source = "yad2"
 	}
+
+	var nextSeq int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(user_seq), 0) + 1 FROM searches WHERE chat_id = ?",
+		search.ChatID).Scan(&nextSeq)
+	if err != nil {
+		return 0, fmt.Errorf("next user_seq: %w", err)
+	}
+
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, user_seq)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax,
-		search.EngineMinCC, search.MaxKm, search.MaxHand)
+		search.EngineMinCC, search.MaxKm, search.MaxHand, nextSeq)
 	if err != nil {
 		return 0, err
 	}
@@ -290,7 +321,7 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
 		FROM searches WHERE chat_id = ? ORDER BY created_at DESC`, chatID)
 	if err != nil {
 		return nil, err
@@ -301,11 +332,30 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 
 func (s *Store) GetSearch(ctx context.Context, id int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
 		FROM searches WHERE id = ?`, id)
 
 	var search storage.Search
-	err := row.Scan(&search.ID, &search.ChatID, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
+	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
+		&search.YearMin, &search.YearMax, &search.PriceMax,
+		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
+		&search.Active, &search.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &search, nil
+}
+
+func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*storage.Search, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, active, created_at
+		FROM searches WHERE chat_id = ? AND user_seq = ?`, chatID, seq)
+
+	var search storage.Search
+	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Active, &search.CreatedAt)
@@ -342,7 +392,7 @@ func (s *Store) SetSearchActive(ctx context.Context, id int64, active bool) erro
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.chat_id, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.active, s.created_at
+		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.active, s.created_at
 		FROM searches s
 		JOIN users u ON s.chat_id = u.chat_id
 		WHERE s.active = true AND u.active = true
@@ -373,7 +423,7 @@ func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 	var searches []storage.Search
 	for rows.Next() {
 		var s storage.Search
-		if err := rows.Scan(&s.ID, &s.ChatID, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
+		if err := rows.Scan(&s.ID, &s.ChatID, &s.UserSeq, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
 			&s.YearMin, &s.YearMax, &s.PriceMax,
 			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
 			&s.Active, &s.CreatedAt); err != nil {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -18,13 +19,17 @@ type Store struct {
 }
 
 func New(dbPath string) (*Store, error) {
-	if dbPath != ":memory:" {
+	if dbPath != ":memory:" && !strings.HasPrefix(dbPath, "file::memory:") {
 		if err := os.MkdirAll(filepath.Dir(dbPath), 0750); err != nil {
 			return nil, fmt.Errorf("create data directory: %w", err)
 		}
 	}
 
-	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		sep = "&"
+	}
+	db, err := sql.Open("sqlite3", dbPath+sep+"_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -33,7 +38,7 @@ func New(dbPath string) (*Store, error) {
 	db.SetMaxIdleConns(4)
 
 	if err := migrate(db); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 
@@ -267,7 +272,7 @@ func (s *Store) ListActiveUsers(ctx context.Context) ([]storage.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanUsers(rows)
 }
 
@@ -346,7 +351,7 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanSearches(rows)
 }
 
@@ -420,7 +425,7 @@ func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, er
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanSearches(rows)
 }
 
@@ -497,7 +502,7 @@ func (s *Store) PendingNotifications(ctx context.Context) ([]storage.PendingNoti
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var pending []storage.PendingNotification
 	for rows.Next() {
@@ -586,7 +591,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var listings []storage.ListingRecord
 	for rows.Next() {
@@ -617,7 +622,7 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var listings []storage.ListingRecord
 	for rows.Next() {
@@ -670,7 +675,7 @@ func (s *Store) FlushDigest(ctx context.Context, chatID int64) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var payloads []string
 	for rows.Next() {
@@ -706,7 +711,7 @@ func (s *Store) PendingDigestUsers(ctx context.Context) ([]int64, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var chatIDs []int64
 	for rows.Next() {
@@ -758,7 +763,7 @@ func (s *Store) SaveCatalogEntries(ctx context.Context, entries []storage.Catalo
 	if err != nil {
 		return err
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	for _, e := range entries {
 		if _, err := stmt.ExecContext(ctx, e.ManufacturerID, e.ManufacturerName, e.ModelID, e.ModelName); err != nil {
@@ -781,7 +786,7 @@ func (s *Store) LoadCatalogEntries(ctx context.Context) ([]storage.CatalogEntry,
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var entries []storage.CatalogEntry
 	for rows.Next() {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -30,7 +30,7 @@ func New(dbPath string) (*Store, error) {
 	}
 
 	db.SetMaxOpenConns(8)
-	db.SetMaxIdleConns(8)
+	db.SetMaxIdleConns(4)
 
 	if err := migrate(db); err != nil {
 		db.Close()
@@ -218,6 +218,11 @@ func migrate(db *sql.DB) error {
 		`); err != nil {
 			return fmt.Errorf("backfill user_seq: %w", err)
 		}
+		if _, err := db.Exec(
+			"CREATE UNIQUE INDEX IF NOT EXISTS idx_searches_chat_user_seq ON searches(chat_id, user_seq)",
+		); err != nil {
+			return fmt.Errorf("create user_seq index: %w", err)
+		}
 	}
 
 	return nil
@@ -299,15 +304,21 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 		source = "yad2"
 	}
 
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	var nextSeq int
-	err := s.db.QueryRowContext(ctx,
+	err = tx.QueryRowContext(ctx,
 		"SELECT COALESCE(MAX(user_seq), 0) + 1 FROM searches WHERE chat_id = ?",
 		search.ChatID).Scan(&nextSeq)
 	if err != nil {
 		return 0, fmt.Errorf("next user_seq: %w", err)
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, user_seq)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
@@ -316,7 +327,16 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 	if err != nil {
 		return 0, err
 	}
-	return result.LastInsertId()
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	return id, nil
 }
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -29,8 +29,8 @@ func New(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
 
-	db.SetMaxOpenConns(2)
-	db.SetMaxIdleConns(2)
+	db.SetMaxOpenConns(8)
+	db.SetMaxIdleConns(8)
 
 	if err := migrate(db); err != nil {
 		db.Close()

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -481,6 +481,15 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	return prev, false, nil
 }
 
+func (s *Store) PrunePrices(ctx context.Context, olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.ExecContext(ctx, "DELETE FROM price_history WHERE observed_at < ?", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 // --- ListingStore ---
 
 func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error {

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -662,18 +662,29 @@ func (s *Store) DigestLastFlushed(ctx context.Context, chatID int64) (time.Time,
 // --- CatalogStore ---
 
 func (s *Store) SaveCatalogEntries(ctx context.Context, entries []storage.CatalogEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if _, err := tx.ExecContext(ctx, "DELETE FROM catalog_cache"); err != nil {
+	// Mark all existing entries as stale.
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE catalog_cache SET updated_at = datetime('now', '-1 year')"); err != nil {
 		return err
 	}
 
-	stmt, err := tx.PrepareContext(ctx,
-		"INSERT INTO catalog_cache (manufacturer_id, manufacturer_name, model_id, model_name) VALUES (?, ?, ?, ?)")
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO catalog_cache (manufacturer_id, manufacturer_name, model_id, model_name, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(manufacturer_id, model_id) DO UPDATE SET
+			manufacturer_name = excluded.manufacturer_name,
+			model_name = excluded.model_name,
+			updated_at = CURRENT_TIMESTAMP`)
 	if err != nil {
 		return err
 	}
@@ -684,6 +695,13 @@ func (s *Store) SaveCatalogEntries(ctx context.Context, entries []storage.Catalo
 			return err
 		}
 	}
+
+	// Remove entries not refreshed in this batch.
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM catalog_cache WHERE updated_at < datetime('now', '-1 hour')"); err != nil {
+		return err
+	}
+
 	return tx.Commit()
 }
 

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -10,7 +10,7 @@ import (
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
-	store, err := New(":memory:")
+	store, err := New("file::memory:?cache=shared")
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -277,6 +277,56 @@ func TestCountSearches(t *testing.T) {
 	}
 }
 
+func TestCreateSearch_AssignsUserSeq(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	id1, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "first", Manufacturer: 1, Model: 1})
+	id2, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "second", Manufacturer: 2, Model: 2})
+	id3, _ := store.CreateSearch(ctx, storage.Search{ChatID: 200, Name: "other-user", Manufacturer: 1, Model: 1})
+
+	s1, _ := store.GetSearch(ctx, id1)
+	s2, _ := store.GetSearch(ctx, id2)
+	s3, _ := store.GetSearch(ctx, id3)
+
+	if s1.UserSeq != 1 {
+		t.Errorf("first search UserSeq = %d, want 1", s1.UserSeq)
+	}
+	if s2.UserSeq != 2 {
+		t.Errorf("second search UserSeq = %d, want 2", s2.UserSeq)
+	}
+	if s3.UserSeq != 1 {
+		t.Errorf("other user's first search UserSeq = %d, want 1", s3.UserSeq)
+	}
+}
+
+func TestGetSearchBySeq(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	_, _ = store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "first", Manufacturer: 1, Model: 1})
+	_, _ = store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "second", Manufacturer: 2, Model: 2})
+
+	s, err := store.GetSearchBySeq(ctx, 100, 2)
+	if err != nil {
+		t.Fatalf("get by seq: %v", err)
+	}
+	if s == nil || s.Name != "second" {
+		t.Errorf("expected 'second', got %+v", s)
+	}
+
+	s, err = store.GetSearchBySeq(ctx, 100, 99)
+	if err != nil {
+		t.Fatalf("get nonexistent seq: %v", err)
+	}
+	if s != nil {
+		t.Error("expected nil for nonexistent seq")
+	}
+}
+
 // --- DedupStore (per-user) ---
 
 func TestClaimNew_PerUser(t *testing.T) {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -415,6 +415,37 @@ func TestPruneNotifications_KeepsRecent(t *testing.T) {
 
 // --- PriceTracker ---
 
+func TestPrunePrices(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, _, _ = store.RecordPrice(ctx, "token1", 100000)
+	_, _, _ = store.RecordPrice(ctx, "token1", 90000)
+
+	pruned, err := store.PrunePrices(ctx, 0)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 2 {
+		t.Errorf("expected 2 pruned, got %d", pruned)
+	}
+}
+
+func TestPrunePrices_KeepsRecent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, _, _ = store.RecordPrice(ctx, "token1", 100000)
+
+	pruned, err := store.PrunePrices(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned (recent), got %d", pruned)
+	}
+}
+
 func TestRecordPrice(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Phase 1 batch addressing 8 open issues plus a new user_seq feature:

- **perf:** Increase SQLite `MaxOpenConns` from 2 → 8 for better concurrency
- **fix:** Prune `price_history` entries older than 90 days (was unbounded)
- **fix:** Eliminate empty-catalog window during cache refresh (mark-stale-then-upsert instead of DELETE+INSERT)
- **refactor:** Unify year/price filtering into `filter.Apply` (was split across filter and scheduler)
- **feat:** Add digest interval selection (2h/6h/12h/24h) to the wizard
- **feat:** Add MaxKm and MaxHand filters to `/watch` wizard
- **feat:** Include listing photos in Telegram alerts
- **feat:** Per-source observability metrics in `/stats` and `/healthz`
- **feat:** Per-user sequential search numbering (`user_seq`) for friendly IDs

## Closes

Closes #185
Closes #167
Closes #181
Closes #170
Closes #173
Closes #161
Closes #162
Closes #180

## Test plan

- [x] All existing tests pass (`make test` — 84.9% coverage)
- [x] New tests for `user_seq` assignment and `GetSearchBySeq` lookup
- [x] Mock interfaces updated in scheduler and bot test suites
- [ ] Manual verification of digest interval wizard flow
- [ ] Manual verification of photo display in Telegram alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Digest mode: interval selection keyboard (2h/6h/12h/24h) with validation and confirmation messages.
  * Search wizard now asks for max kilometers and ownership preference and includes them in the saved search and confirmation.
  * Telegram notifications send a photo with caption for single-listing alerts, falling back to text if needed.

* **Improvements**
  * Health page shows per-source fetch metrics and success rates.
  * Filtering supports year min/max and price max; scheduler/pruning now cleans old price history.
  
* **Tests**
  * Added coverage for digest, health, notifier, scheduler, storage, and filter behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->