### PR TITLE
feat: phase 2 batch — deal scoring and daily market digest

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -118,9 +118,11 @@ func run(configPath string, logger *slog.Logger) error {
 		BotUsername:   cfg.Telegram.BotUsername,
 		PollInterval: cfg.Polling.Interval,
 		Health:       h,
+		Digests:      store,
 		Listings:     store,
 		Saved:        store,
 		Hidden:       store,
+		DailyDigests: store,
 		Catalog:      dynCatalog,
 	}, logger)
 
@@ -167,16 +169,19 @@ func run(configPath string, logger *slog.Logger) error {
 	}()
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, tgNotif, logger, scheduler.Options{
-		Observer:        h,
-		Queue:           store,
-		Prices:          store,
-		ConfigPath:      configPath,
-		FetcherFactory:  fetcherFactory,
-		ListingStore:    store,
-		SearchStore:     store,
-		UserStore:       store,
-		HiddenStore:     store,
-		CatalogIngester: dynCatalog,
+		Observer:         h,
+		Queue:            store,
+		Prices:           store,
+		ConfigPath:       configPath,
+		FetcherFactory:   fetcherFactory,
+		ListingStore:     store,
+		SearchStore:      store,
+		UserStore:        store,
+		DigestStore:      store,
+		HiddenStore:      store,
+		CatalogIngester:  dynCatalog,
+		MarketStore:      store,
+		DailyDigestStore: store,
 	})
 	if err != nil {
 		return fmt.Errorf("create scheduler: %w", err)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -30,6 +30,7 @@ type Bot struct {
 	digests      storage.DigestStore
 	saved        storage.SavedListingStore
 	hidden       storage.HiddenListingStore
+	dailyDigests storage.DailyDigestStore
 	catalog      catalog.Catalog
 	adminChatID  int64
 	maxSearches  int
@@ -87,6 +88,7 @@ type Config struct {
 	Listings       storage.ListingStore
 	Saved          storage.SavedListingStore
 	Hidden         storage.HiddenListingStore
+	DailyDigests   storage.DailyDigestStore
 	Catalog        catalog.Catalog
 }
 
@@ -114,6 +116,7 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 		digests:      cfg.Digests,
 		saved:        cfg.Saved,
 		hidden:       cfg.Hidden,
+		dailyDigests: cfg.DailyDigests,
 		catalog:      cat,
 		adminChatID:  cfg.AdminChatID,
 		maxSearches:  cfg.MaxSearches,

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -99,6 +99,10 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 		b.onHiddenPage(ctx, chatID, data)
 	case data == cbHiddenClear:
 		b.onClearHidden(ctx, chatID)
+	case data == cbDailyDigestOn:
+		b.onDailyDigestOn(ctx, chatID)
+	case data == cbDailyDigestOff:
+		b.onDailyDigestOff(ctx, chatID)
 	case data == "watch":
 		b.onWatchFromCallback(ctx, chatID)
 	case data == "noop":
@@ -344,4 +348,28 @@ func (b *Bot) onClearHidden(ctx context.Context, chatID int64) {
 		return
 	}
 	b.send(ctx, chatID, locale.T(lang, "hidden_cleared"))
+}
+
+func (b *Bot) onDailyDigestOn(ctx context.Context, chatID int64) {
+	if b.dailyDigests == nil {
+		return
+	}
+	lang := b.getUserLang(ctx, chatID)
+	if err := b.dailyDigests.SetDailyDigest(ctx, chatID, true, "09:00"); err != nil {
+		b.send(ctx, chatID, locale.T(lang, "error_generic"))
+		return
+	}
+	b.sendMarkdown(ctx, chatID, locale.Tf(lang, "daily_digest_enabled", "09:00"))
+}
+
+func (b *Bot) onDailyDigestOff(ctx context.Context, chatID int64) {
+	if b.dailyDigests == nil {
+		return
+	}
+	lang := b.getUserLang(ctx, chatID)
+	if err := b.dailyDigests.SetDailyDigest(ctx, chatID, false, "09:00"); err != nil {
+		b.send(ctx, chatID, locale.T(lang, "error_generic"))
+		return
+	}
+	b.sendMarkdown(ctx, chatID, locale.T(lang, "daily_digest_disabled"))
 }

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -355,11 +355,19 @@ func (b *Bot) onDailyDigestOn(ctx context.Context, chatID int64) {
 		return
 	}
 	lang := b.getUserLang(ctx, chatID)
-	if err := b.dailyDigests.SetDailyDigest(ctx, chatID, true, "09:00"); err != nil {
+	_, digestTime, _, err := b.dailyDigests.GetDailyDigest(ctx, chatID)
+	if err != nil {
 		b.send(ctx, chatID, locale.T(lang, "error_generic"))
 		return
 	}
-	b.sendMarkdown(ctx, chatID, locale.Tf(lang, "daily_digest_enabled", "09:00"))
+	if digestTime == "" {
+		digestTime = "09:00"
+	}
+	if err := b.dailyDigests.SetDailyDigest(ctx, chatID, true, digestTime); err != nil {
+		b.send(ctx, chatID, locale.T(lang, "error_generic"))
+		return
+	}
+	b.sendMarkdown(ctx, chatID, locale.Tf(lang, "daily_digest_enabled", digestTime))
 }
 
 func (b *Bot) onDailyDigestOff(ctx context.Context, chatID int64) {
@@ -367,7 +375,15 @@ func (b *Bot) onDailyDigestOff(ctx context.Context, chatID int64) {
 		return
 	}
 	lang := b.getUserLang(ctx, chatID)
-	if err := b.dailyDigests.SetDailyDigest(ctx, chatID, false, "09:00"); err != nil {
+	_, digestTime, _, err := b.dailyDigests.GetDailyDigest(ctx, chatID)
+	if err != nil {
+		b.send(ctx, chatID, locale.T(lang, "error_generic"))
+		return
+	}
+	if digestTime == "" {
+		digestTime = "09:00"
+	}
+	if err := b.dailyDigests.SetDailyDigest(ctx, chatID, false, digestTime); err != nil {
 		b.send(ctx, chatID, locale.T(lang, "error_generic"))
 		return
 	}

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -354,39 +354,49 @@ func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 		return
 	}
 
-	var kb *tgmodels.InlineKeyboardMarkup
+	var rows [][]tgmodels.InlineKeyboardButton
+	var msgText string
 	if mode == "digest" {
-		kb = &tgmodels.InlineKeyboardMarkup{
-			InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
-				{
-					{Text: "2h", CallbackData: cbDigestInterval + "2h"},
-					{Text: "6h", CallbackData: cbDigestInterval + "6h"},
-					{Text: "12h", CallbackData: cbDigestInterval + "12h"},
-					{Text: "24h", CallbackData: cbDigestInterval + "24h"},
-				},
-				{
-					{Text: locale.T(lang, "btn_switch_instant"), CallbackData: cbDigestOff},
-				},
-			},
-		}
-		b.sendWithKeyboard(ctx, chatID,
-			locale.Tf(lang, "digest_mode_digest", interval), kb)
+		rows = append(rows, []tgmodels.InlineKeyboardButton{
+			{Text: "2h", CallbackData: cbDigestInterval + "2h"},
+			{Text: "6h", CallbackData: cbDigestInterval + "6h"},
+			{Text: "12h", CallbackData: cbDigestInterval + "12h"},
+			{Text: "24h", CallbackData: cbDigestInterval + "24h"},
+		})
+		rows = append(rows, []tgmodels.InlineKeyboardButton{
+			{Text: locale.T(lang, "btn_switch_instant"), CallbackData: cbDigestOff},
+		})
+		msgText = locale.Tf(lang, "digest_mode_digest", interval)
 	} else {
-		kb = &tgmodels.InlineKeyboardMarkup{
-			InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
-				{
-					{Text: "2h", CallbackData: cbDigestInterval + "2h"},
-					{Text: "6h", CallbackData: cbDigestInterval + "6h"},
-				},
-				{
-					{Text: "12h", CallbackData: cbDigestInterval + "12h"},
-					{Text: "24h", CallbackData: cbDigestInterval + "24h"},
-				},
-			},
-		}
-		b.sendWithKeyboard(ctx, chatID,
-			locale.T(lang, "digest_mode_instant"), kb)
+		rows = append(rows, []tgmodels.InlineKeyboardButton{
+			{Text: "2h", CallbackData: cbDigestInterval + "2h"},
+			{Text: "6h", CallbackData: cbDigestInterval + "6h"},
+		})
+		rows = append(rows, []tgmodels.InlineKeyboardButton{
+			{Text: "12h", CallbackData: cbDigestInterval + "12h"},
+			{Text: "24h", CallbackData: cbDigestInterval + "24h"},
+		})
+		msgText = locale.T(lang, "digest_mode_instant")
 	}
+
+	if b.dailyDigests != nil {
+		enabled, digestTime, _, ddErr := b.dailyDigests.GetDailyDigest(ctx, chatID)
+		if ddErr == nil {
+			if enabled {
+				rows = append(rows, []tgmodels.InlineKeyboardButton{
+					{Text: locale.T(lang, "btn_daily_digest_off"), CallbackData: cbDailyDigestOff},
+				})
+				msgText += "\n\n" + locale.Tf(lang, "daily_digest_enabled", digestTime)
+			} else {
+				rows = append(rows, []tgmodels.InlineKeyboardButton{
+					{Text: locale.T(lang, "btn_daily_digest_on"), CallbackData: cbDailyDigestOn},
+				})
+			}
+		}
+	}
+
+	kb := &tgmodels.InlineKeyboardMarkup{InlineKeyboard: rows}
+	b.sendWithKeyboard(ctx, chatID, msgText, kb)
 }
 
 func (b *Bot) handleLanguage(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -48,6 +48,8 @@ const (
 	cbHiddenPage      = "hidden_pg:"
 	cbSkipKeywords    = "skip_keywords"
 	cbSkipExcludeKeys = "skip_exclude_keys"
+	cbDailyDigestOn   = "daily_digest:on"
+	cbDailyDigestOff  = "daily_digest:off"
 
 	pageSize   = 15
 	colsPerRow = 3

--- a/internal/locale/locale.go
+++ b/internal/locale/locale.go
@@ -49,7 +49,7 @@ var he = map[string]string{
 		"/share <מספר> — שתף חיפוש בקישור\n" +
 		"/saved — צפה ברכבים שמורים\n" +
 		"/hidden — צפה ברכבים מוסתרים\n" +
-		"/digest — החלף מצב התראות (מיידי/סיכום)\n" +
+		"/digest — התראות וסיכום שוק יומי\n" +
 		"/language — שנה שפה\n" +
 		"/settings — הצג הגדרות\n" +
 		"/cancel — בטל אשף נוכחי\n" +
@@ -270,6 +270,30 @@ var he = map[string]string{
 	"fmt_batch_item":       "*[%d/%d]*\n",
 	"fmt_digest_header":    "*סיכום יומי (%d פריטים):*\n",
 
+	// deal scoring
+	"fmt_deal_score":        "📊 ציון עסקה: %d/100\n",
+	"fmt_deal_below_market": "%d%% מתחת לשוק (חציון ₪%s · %d מודעות)\n",
+	"fmt_deal_near_market":  "קרוב למחיר השוק (חציון ₪%s · %d מודעות)\n",
+	"fmt_deal_above_market": "מעל מחיר השוק (חציון ₪%s · %d מודעות)\n",
+	"fmt_deal_no_data":      "📊 _אין מספיק נתוני שוק עדיין_\n",
+
+	// daily market digest
+	"fmt_market_digest_header":     "📈 *סיכום שוק יומי* — %s\n\n",
+	"fmt_market_digest_search":     "*%s:*\n",
+	"fmt_market_digest_new":        "  🆕 חדשות (24ש): %d\n",
+	"fmt_market_digest_avg":        "  💰 מחיר ממוצע: ₪%s\n",
+	"fmt_market_digest_best":       "  ⭐ הכי טוב: ₪%s\n",
+	"fmt_market_digest_best_link":  "    🔗 %s\n",
+	"fmt_market_digest_trend_up":   "  📈 מגמה עולה %.1f%%\n",
+	"fmt_market_digest_trend_down": "  📉 מגמה יורדת %.1f%%\n",
+	"fmt_market_digest_trend_flat": "  ➡️ מחירים יציבים\n",
+
+	// daily digest settings
+	"daily_digest_enabled":  "סיכום שוק יומי *מופעל* בשעה %s.",
+	"daily_digest_disabled": "סיכום שוק יומי *כבוי*.",
+	"btn_daily_digest_on":   "📈 הפעל סיכום יומי",
+	"btn_daily_digest_off":  "📈 כבה סיכום יומי",
+
 	// onboarding
 	"onboarding_welcome": "ברוכים הבאים ל-*CarWatch*! 🚗\n\n" +
 		"אני עוקב אחרי מודעות רכב ביד2 ו-WinWin ושולח לך התראות כשמופיעים רכבים חדשים.\n\n" +
@@ -296,7 +320,7 @@ var en = map[string]string{
 		"/share <id> — Share a search via link\n" +
 		"/saved — View saved listings\n" +
 		"/hidden — View hidden listings\n" +
-		"/digest — Toggle notification mode (instant/digest)\n" +
+		"/digest — Notifications & daily market summary\n" +
 		"/language — Change language\n" +
 		"/settings — View your settings\n" +
 		"/cancel — Cancel current wizard\n" +
@@ -516,6 +540,30 @@ var en = map[string]string{
 	"fmt_batch_header":     "🚗 *%d New Listings Found*\n",
 	"fmt_batch_item":       "*[%d/%d]*\n",
 	"fmt_digest_header":    "*Digest Summary (%d items):*\n",
+
+	// deal scoring
+	"fmt_deal_score":        "📊 Deal Score: %d/100\n",
+	"fmt_deal_below_market": "%d%% below market (₪%s median · %d listings)\n",
+	"fmt_deal_near_market":  "Near market price (₪%s median · %d listings)\n",
+	"fmt_deal_above_market": "Above market price (₪%s median · %d listings)\n",
+	"fmt_deal_no_data":      "📊 _Not enough market data yet_\n",
+
+	// daily market digest
+	"fmt_market_digest_header":     "📈 *Daily Market Summary* — %s\n\n",
+	"fmt_market_digest_search":     "*%s:*\n",
+	"fmt_market_digest_new":        "  🆕 New (24h): %d\n",
+	"fmt_market_digest_avg":        "  💰 Avg price: ₪%s\n",
+	"fmt_market_digest_best":       "  ⭐ Best: ₪%s\n",
+	"fmt_market_digest_best_link":  "    🔗 %s\n",
+	"fmt_market_digest_trend_up":   "  📈 Trending up %.1f%%\n",
+	"fmt_market_digest_trend_down": "  📉 Trending down %.1f%%\n",
+	"fmt_market_digest_trend_flat": "  ➡️ Prices stable\n",
+
+	// daily digest settings
+	"daily_digest_enabled":  "Daily market summary *enabled* at %s IST.",
+	"daily_digest_disabled": "Daily market summary *disabled*.",
+	"btn_daily_digest_on":   "📈 Enable Daily Summary",
+	"btn_daily_digest_off":  "📈 Disable Daily Summary",
 
 	// onboarding
 	"onboarding_welcome": "Welcome to *CarWatch*! 🚗\n\n" +

--- a/internal/locale/locale.go
+++ b/internal/locale/locale.go
@@ -289,7 +289,7 @@ var he = map[string]string{
 	"fmt_market_digest_trend_flat": "  ➡️ מחירים יציבים\n",
 
 	// daily digest settings
-	"daily_digest_enabled":  "סיכום שוק יומי *מופעל* בשעה %s.",
+	"daily_digest_enabled":  "סיכום שוק יומי *מופעל* בשעה %s (שעון ישראל).",
 	"daily_digest_disabled": "סיכום שוק יומי *כבוי*.",
 	"btn_daily_digest_on":   "📈 הפעל סיכום יומי",
 	"btn_daily_digest_off":  "📈 כבה סיכום יומי",
@@ -560,7 +560,7 @@ var en = map[string]string{
 	"fmt_market_digest_trend_flat": "  ➡️ Prices stable\n",
 
 	// daily digest settings
-	"daily_digest_enabled":  "Daily market summary *enabled* at %s IST.",
+	"daily_digest_enabled":  "Daily market summary *enabled* at %s Israel time.",
 	"daily_digest_disabled": "Daily market summary *disabled*.",
 	"btn_daily_digest_on":   "📈 Enable Daily Summary",
 	"btn_daily_digest_off":  "📈 Disable Daily Summary",

--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -27,7 +27,14 @@ type RawListing struct {
 	UpdatedAt    time.Time
 }
 
+type ScoreInfo struct {
+	Score       int
+	MedianPrice int
+	CohortSize  int
+}
+
 type Listing struct {
 	RawListing
 	SearchName string
+	DealScore  *ScoreInfo
 }

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -128,9 +129,9 @@ func FormatBatch(listings []model.Listing, lang locale.Lang) string {
 
 func dealExplanation(lang locale.Lang, score *model.ScoreInfo, price int) string {
 	medianStr := format.Number(score.MedianPrice)
-	pctBelow := 100.0 * (1.0 - float64(price)/float64(score.MedianPrice))
+	pctBelow := int(math.Round(100.0 * (1.0 - float64(price)/float64(score.MedianPrice))))
 	if pctBelow > 5 {
-		return locale.Tf(lang, "fmt_deal_below_market", int(pctBelow), medianStr, score.CohortSize)
+		return locale.Tf(lang, "fmt_deal_below_market", pctBelow, medianStr, score.CohortSize)
 	}
 	if pctBelow >= -5 {
 		return locale.Tf(lang, "fmt_deal_near_market", medianStr, score.CohortSize)
@@ -138,10 +139,10 @@ func dealExplanation(lang locale.Lang, score *model.ScoreInfo, price int) string
 	return locale.Tf(lang, "fmt_deal_above_market", medianStr, score.CohortSize)
 }
 
-func FormatDailyDigest(stats []storage.DailySearchStats, lang locale.Lang) string {
+func FormatDailyDigest(stats []storage.DailySearchStats, lang locale.Lang, now time.Time) string {
 	var b strings.Builder
 
-	dateStr := time.Now().Format("02/01/2006")
+	dateStr := now.Format("02/01/2006")
 	b.WriteString(locale.Tf(lang, "fmt_market_digest_header", dateStr))
 
 	for _, s := range stats {

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -3,10 +3,12 @@ package notifier
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/format"
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
 )
 
 func FormatListing(l model.Listing, lang locale.Lang) string {
@@ -19,6 +21,12 @@ func FormatListing(l model.Listing, lang locale.Lang) string {
 		title += " " + format.EscapeMarkdown(l.SubModel)
 	}
 	b.WriteString("*" + title + "*\n\n")
+
+	if l.DealScore != nil {
+		b.WriteString(locale.Tf(lang, "fmt_deal_score", l.DealScore.Score))
+		b.WriteString(dealExplanation(lang, l.DealScore, l.Price))
+		b.WriteString("\n")
+	}
 
 	if l.Year > 0 {
 		b.WriteString(locale.Tf(lang, "fmt_year", l.Year))
@@ -113,6 +121,48 @@ func FormatBatch(listings []model.Listing, lang locale.Lang) string {
 		b.WriteString("\n━━━━━━━━━━━━━━━━━━━━\n")
 		b.WriteString(locale.Tf(lang, "fmt_batch_item", i+1, len(listings)))
 		b.WriteString(FormatListing(l, lang))
+	}
+
+	return b.String()
+}
+
+func dealExplanation(lang locale.Lang, score *model.ScoreInfo, price int) string {
+	medianStr := format.Number(score.MedianPrice)
+	pctBelow := 100.0 * (1.0 - float64(price)/float64(score.MedianPrice))
+	if pctBelow > 5 {
+		return locale.Tf(lang, "fmt_deal_below_market", int(pctBelow), medianStr, score.CohortSize)
+	}
+	if pctBelow >= -5 {
+		return locale.Tf(lang, "fmt_deal_near_market", medianStr, score.CohortSize)
+	}
+	return locale.Tf(lang, "fmt_deal_above_market", medianStr, score.CohortSize)
+}
+
+func FormatDailyDigest(stats []storage.DailySearchStats, lang locale.Lang) string {
+	var b strings.Builder
+
+	dateStr := time.Now().Format("02/01/2006")
+	b.WriteString(locale.Tf(lang, "fmt_market_digest_header", dateStr))
+
+	for _, s := range stats {
+		b.WriteString(locale.Tf(lang, "fmt_market_digest_search", format.EscapeMarkdown(s.SearchName)))
+		b.WriteString(locale.Tf(lang, "fmt_market_digest_new", s.NewCount))
+		b.WriteString(locale.Tf(lang, "fmt_market_digest_avg", format.Number(s.AvgPrice)))
+		b.WriteString(locale.Tf(lang, "fmt_market_digest_best", format.Number(s.BestPrice)))
+
+		if s.BestPriceLink != "" {
+			b.WriteString(locale.Tf(lang, "fmt_market_digest_best_link", format.EscapeMarkdown(s.BestPriceLink)))
+		}
+
+		if s.PriceTrend > 1.0 {
+			b.WriteString(locale.Tf(lang, "fmt_market_digest_trend_up", s.PriceTrend))
+		} else if s.PriceTrend < -1.0 {
+			b.WriteString(locale.Tf(lang, "fmt_market_digest_trend_down", -s.PriceTrend))
+		} else {
+			b.WriteString(locale.T(lang, "fmt_market_digest_trend_flat"))
+		}
+
+		b.WriteString("\n")
 	}
 
 	return b.String()

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
 )
 
 func TestFormatListing(t *testing.T) {
@@ -198,5 +199,114 @@ func TestFormatBatch_MultipleListing(t *testing.T) {
 	}
 	if !strings.Contains(msg, "[1/2]") || !strings.Contains(msg, "[2/2]") {
 		t.Error("batch should contain numbered entries")
+	}
+}
+
+func TestFormatListing_WithScore(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token: "s1", Manufacturer: "Toyota", Model: "Corolla",
+			Year: 2022, Price: 80000,
+		},
+		DealScore: &model.ScoreInfo{Score: 20, MedianPrice: 100000, CohortSize: 15},
+	}
+
+	msg := FormatListing(l, locale.English)
+
+	checks := []string{
+		"Deal Score: 20/100",
+		"below market",
+		"100,000",
+	}
+	for _, check := range checks {
+		if !strings.Contains(msg, check) {
+			t.Errorf("message missing %q:\n%s", check, msg)
+		}
+	}
+}
+
+func TestFormatListing_WithoutScore_NoChange(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token: "ns1", Manufacturer: "Mazda", Model: "3",
+			Year: 2021, Price: 95000,
+		},
+	}
+
+	msg := FormatListing(l, locale.English)
+	if strings.Contains(msg, "Deal Score") {
+		t.Errorf("should not show score when DealScore is nil:\n%s", msg)
+	}
+}
+
+func TestFormatListing_ScoreAtMedian(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token: "s2", Manufacturer: "Honda", Model: "Civic",
+			Year: 2020, Price: 100000,
+		},
+		DealScore: &model.ScoreInfo{Score: 0, MedianPrice: 100000, CohortSize: 12},
+	}
+
+	msg := FormatListing(l, locale.English)
+	if !strings.Contains(msg, "Deal Score: 0/100") {
+		t.Errorf("expected score 0:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Near market price") {
+		t.Errorf("expected near market text:\n%s", msg)
+	}
+}
+
+func TestFormatListing_ScoreAboveMedian(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token: "s3", Manufacturer: "BMW", Model: "3",
+			Year: 2019, Price: 150000,
+		},
+		DealScore: &model.ScoreInfo{Score: 0, MedianPrice: 100000, CohortSize: 20},
+	}
+
+	msg := FormatListing(l, locale.English)
+	if !strings.Contains(msg, "Above market price") {
+		t.Errorf("expected above market text:\n%s", msg)
+	}
+}
+
+func TestFormatDailyDigest(t *testing.T) {
+	stats := []storage.DailySearchStats{
+		{
+			SearchName:    "toyota-corolla",
+			NewCount:      7,
+			AvgPrice:      165000,
+			BestPrice:     148000,
+			BestPriceLink: "https://www.yad2.co.il/item/abc",
+			PriceTrend:    -2.5,
+		},
+		{
+			SearchName: "honda-civic",
+			NewCount:   3,
+			AvgPrice:   120000,
+			BestPrice:  110000,
+			PriceTrend: 0.5,
+		},
+	}
+
+	msg := FormatDailyDigest(stats, locale.English)
+
+	checks := []string{
+		"Daily Market Summary",
+		"toyota-corolla",
+		"New (24h): 7",
+		"165,000",
+		"148,000",
+		"yad2.co.il",
+		"Trending down 2.5%",
+		"honda-civic",
+		"Prices stable",
+	}
+	for _, check := range checks {
+		if !strings.Contains(msg, check) {
+			t.Errorf("digest missing %q:\n%s", check, msg)
+		}
 	}
 }

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
@@ -291,7 +292,7 @@ func TestFormatDailyDigest(t *testing.T) {
 		},
 	}
 
-	msg := FormatDailyDigest(stats, locale.English)
+	msg := FormatDailyDigest(stats, locale.English, time.Date(2026, 4, 24, 9, 0, 0, 0, time.UTC))
 
 	checks := []string{
 		"Daily Market Summary",

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/scoring"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -57,6 +58,8 @@ type Scheduler struct {
 	digestStore       storage.DigestStore
 	hiddenStore       storage.HiddenListingStore
 	catalogIngester   CatalogIngester
+	marketStore       storage.MarketStore
+	dailyDigestStore  storage.DailyDigestStore
 	triggerCh         chan struct{}
 }
 
@@ -70,8 +73,10 @@ type Options struct {
 	SearchStore     storage.SearchStore
 	UserStore       storage.UserStore
 	DigestStore     storage.DigestStore
-	HiddenStore     storage.HiddenListingStore
-	CatalogIngester CatalogIngester
+	HiddenStore      storage.HiddenListingStore
+	CatalogIngester  CatalogIngester
+	MarketStore      storage.MarketStore
+	DailyDigestStore storage.DailyDigestStore
 }
 
 func New(
@@ -120,6 +125,8 @@ func NewWithOptions(
 		digestStore:       opts.DigestStore,
 		hiddenStore:       opts.HiddenStore,
 		catalogIngester:   opts.CatalogIngester,
+		marketStore:       opts.MarketStore,
+		dailyDigestStore:  opts.DailyDigestStore,
 		triggerCh:         make(chan struct{}, 1),
 	}, nil
 }
@@ -387,6 +394,25 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 		return nil
 	}
 
+	var marketCache *scoring.MarketCache
+	if s.marketStore != nil {
+		listings, err := s.marketStore.MarketListings(ctx)
+		if err != nil {
+			s.logger.Error("load market data failed", "error", err)
+		} else {
+			data := make([]scoring.ListingData, len(listings))
+			for i, l := range listings {
+				data[i] = scoring.ListingData{
+					Manufacturer: l.Manufacturer,
+					Model:        l.Model,
+					Year:         l.Year,
+					Price:        l.Price,
+				}
+			}
+			marketCache = scoring.NewMarketCache(data)
+		}
+	}
+
 	groups := GroupSearches(searches)
 	s.logger.Info("grouped searches", "groups", len(groups), "total_searches", len(searches))
 
@@ -419,7 +445,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			if err := s.processGroup(ctx, g); err != nil {
+			if err := s.processGroup(ctx, g, marketCache); err != nil {
 				s.logger.Error("group failed",
 					"manufacturer", g.Manufacturer,
 					"model", g.Model,
@@ -445,6 +471,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	}
 
 	s.processDigests(ctx)
+	s.processDailyDigests(ctx)
 
 	if allFailed && len(groups) > 0 {
 		s.observer.RecordError()
@@ -489,7 +516,7 @@ func (s *Scheduler) pruneIfDue(ctx context.Context) {
 	s.lastPruneTime = time.Now()
 }
 
-func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) error {
+func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, marketCache *scoring.MarketCache) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
@@ -588,6 +615,16 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup) erro
 			}
 
 			listing := model.Listing{RawListing: l, SearchName: search.Name}
+			if marketCache != nil && l.Price > 0 {
+				median, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
+				if ok {
+					listing.DealScore = &model.ScoreInfo{
+						Score:       scoring.Score(l.Price, median),
+						MedianPrice: median,
+						CohortSize:  cohort,
+					}
+				}
+			}
 			newListings = append(newListings, listing)
 
 			if s.listingStore != nil {
@@ -731,6 +768,69 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 		"items", len(payloads),
 	)
 	s.observer.RecordNotificationSent()
+}
+
+func (s *Scheduler) processDailyDigests(ctx context.Context) {
+	if s.dailyDigestStore == nil || s.marketStore == nil {
+		return
+	}
+
+	users, err := s.dailyDigestStore.ListDailyDigestUsers(ctx)
+	if err != nil {
+		s.logger.Error("list daily digest users failed", "error", err)
+		return
+	}
+
+	now := time.Now().In(s.loc)
+
+	for _, u := range users {
+		targetMinutes := parseTimeOfDayOrZero(u.DigestTime)
+		currentMinutes := now.Hour()*60 + now.Minute()
+
+		diff := currentMinutes - targetMinutes
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 15 {
+			continue
+		}
+
+		lastSentLocal := u.LastSent.In(s.loc)
+		if lastSentLocal.Year() == now.Year() &&
+			lastSentLocal.Month() == now.Month() &&
+			lastSentLocal.Day() == now.Day() {
+			continue
+		}
+
+		s.sendDailyDigest(ctx, u.ChatID)
+	}
+}
+
+func (s *Scheduler) sendDailyDigest(ctx context.Context, chatID int64) {
+	stats, err := s.dailyDigestStore.DailyStats(ctx, chatID)
+	if err != nil {
+		s.logger.Error("compute daily stats failed", "chat_id", chatID, "error", err)
+		return
+	}
+
+	if len(stats) == 0 {
+		return
+	}
+
+	lang := s.userLang(ctx, chatID)
+	msg := notifier.FormatDailyDigest(stats, lang)
+
+	chatIDStr := fmt.Sprintf("%d", chatID)
+	if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {
+		s.logger.Error("send daily digest failed", "chat_id", chatID, "error", err)
+		return
+	}
+
+	if err := s.dailyDigestStore.UpdateDailyDigestLastSent(ctx, chatID); err != nil {
+		s.logger.Error("update daily digest last sent failed", "chat_id", chatID, "error", err)
+	}
+
+	s.logger.Info("daily digest sent", "chat_id", chatID, "searches", len(stats))
 }
 
 func (s *Scheduler) userLang(ctx context.Context, chatID int64) locale.Lang {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -771,7 +771,7 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 }
 
 func (s *Scheduler) processDailyDigests(ctx context.Context) {
-	if s.dailyDigestStore == nil || s.marketStore == nil {
+	if s.dailyDigestStore == nil {
 		return
 	}
 
@@ -790,6 +790,9 @@ func (s *Scheduler) processDailyDigests(ctx context.Context) {
 		diff := currentMinutes - targetMinutes
 		if diff < 0 {
 			diff = -diff
+		}
+		if diff > 12*60 {
+			diff = 24*60 - diff
 		}
 		if diff > 15 {
 			continue
@@ -818,7 +821,7 @@ func (s *Scheduler) sendDailyDigest(ctx context.Context, chatID int64) {
 	}
 
 	lang := s.userLang(ctx, chatID)
-	msg := notifier.FormatDailyDigest(stats, lang)
+	msg := notifier.FormatDailyDigest(stats, lang, time.Now().In(s.loc))
 
 	chatIDStr := fmt.Sprintf("%d", chatID)
 	if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -1,0 +1,80 @@
+package scoring
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+const MinCohortSize = 10
+
+type ListingData struct {
+	Manufacturer string
+	Model        string
+	Year         int
+	Price        int
+}
+
+type entry struct {
+	Year  int
+	Price int
+}
+
+type MarketCache struct {
+	data map[string][]entry
+}
+
+func NewMarketCache(listings []ListingData) *MarketCache {
+	m := make(map[string][]entry)
+	for _, l := range listings {
+		key := cacheKey(l.Manufacturer, l.Model)
+		m[key] = append(m[key], entry{Year: l.Year, Price: l.Price})
+	}
+	return &MarketCache{data: m}
+}
+
+func (mc *MarketCache) Lookup(manufacturer, model string, year int) (median int, cohortSize int, ok bool) {
+	entries := mc.data[cacheKey(manufacturer, model)]
+	var prices []int
+	for _, e := range entries {
+		if abs(e.Year-year) <= 1 {
+			prices = append(prices, e.Price)
+		}
+	}
+	if len(prices) < MinCohortSize {
+		return 0, len(prices), false
+	}
+	sort.Ints(prices)
+	n := len(prices)
+	if n%2 == 0 {
+		median = (prices[n/2-1] + prices[n/2]) / 2
+	} else {
+		median = prices[n/2]
+	}
+	return median, n, true
+}
+
+func Score(listingPrice, medianPrice int) int {
+	if medianPrice <= 0 || listingPrice <= 0 {
+		return 0
+	}
+	raw := 100.0 * (1.0 - float64(listingPrice)/float64(medianPrice))
+	if raw < 0 {
+		return 0
+	}
+	if raw > 100 {
+		return 100
+	}
+	return int(math.Round(raw))
+}
+
+func cacheKey(manufacturer, model string) string {
+	return strings.ToLower(manufacturer) + "|" + strings.ToLower(model)
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -1,0 +1,160 @@
+package scoring
+
+import (
+	"testing"
+)
+
+func TestScore_BelowMedian(t *testing.T) {
+	s := Score(80000, 100000)
+	if s != 20 {
+		t.Errorf("expected 20, got %d", s)
+	}
+}
+
+func TestScore_AtMedian(t *testing.T) {
+	s := Score(100000, 100000)
+	if s != 0 {
+		t.Errorf("expected 0, got %d", s)
+	}
+}
+
+func TestScore_AboveMedian(t *testing.T) {
+	s := Score(120000, 100000)
+	if s != 0 {
+		t.Errorf("expected 0 (clamped), got %d", s)
+	}
+}
+
+func TestScore_VeryLow(t *testing.T) {
+	s := Score(1000, 100000)
+	if s != 99 {
+		t.Errorf("expected 99, got %d", s)
+	}
+}
+
+func TestScore_ZeroMedian(t *testing.T) {
+	s := Score(80000, 0)
+	if s != 0 {
+		t.Errorf("expected 0 for zero median, got %d", s)
+	}
+}
+
+func TestScore_ZeroPrice(t *testing.T) {
+	s := Score(0, 100000)
+	if s != 0 {
+		t.Errorf("expected 0 for zero price, got %d", s)
+	}
+}
+
+func TestMarketCache_LookupSufficient(t *testing.T) {
+	var data []ListingData
+	for i := range 15 {
+		data = append(data, ListingData{
+			Manufacturer: "Toyota",
+			Model:        "Corolla",
+			Year:         2020,
+			Price:        90000 + i*2000,
+		})
+	}
+
+	mc := NewMarketCache(data)
+	median, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if cohort != 15 {
+		t.Errorf("expected cohort=15, got %d", cohort)
+	}
+	if median != 104000 {
+		t.Errorf("expected median=104000, got %d", median)
+	}
+}
+
+func TestMarketCache_LookupInsufficientData(t *testing.T) {
+	data := []ListingData{
+		{Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 100000},
+		{Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 110000},
+	}
+
+	mc := NewMarketCache(data)
+	_, _, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	if ok {
+		t.Error("expected ok=false for insufficient data")
+	}
+}
+
+func TestMarketCache_LookupYearBand(t *testing.T) {
+	var data []ListingData
+	for i := range 12 {
+		data = append(data, ListingData{
+			Manufacturer: "Honda",
+			Model:        "Civic",
+			Year:         2019 + (i % 3), // years 2019, 2020, 2021
+			Price:        80000 + i*1000,
+		})
+	}
+
+	mc := NewMarketCache(data)
+	// Looking up year 2020 should include 2019, 2020, 2021
+	_, cohort, ok := mc.Lookup("Honda", "Civic", 2020)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if cohort != 12 {
+		t.Errorf("expected cohort=12, got %d", cohort)
+	}
+
+	// Looking up year 2022 should only include 2021 (year+-1)
+	_, _, ok = mc.Lookup("Honda", "Civic", 2022)
+	if ok {
+		t.Error("expected ok=false for year 2022 (only 4 listings in range)")
+	}
+}
+
+func TestMarketCache_CaseInsensitive(t *testing.T) {
+	var data []ListingData
+	for i := range 10 {
+		data = append(data, ListingData{
+			Manufacturer: "TOYOTA",
+			Model:        "COROLLA",
+			Year:         2020,
+			Price:        100000 + i*1000,
+		})
+	}
+
+	mc := NewMarketCache(data)
+	_, _, ok := mc.Lookup("toyota", "corolla", 2020)
+	if !ok {
+		t.Error("expected case-insensitive lookup to work")
+	}
+}
+
+func TestMarketCache_Empty(t *testing.T) {
+	mc := NewMarketCache(nil)
+	_, _, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	if ok {
+		t.Error("expected ok=false for empty cache")
+	}
+}
+
+func TestMarketCache_MedianEven(t *testing.T) {
+	var data []ListingData
+	for i := range 10 {
+		data = append(data, ListingData{
+			Manufacturer: "Mazda",
+			Model:        "3",
+			Year:         2021,
+			Price:        (i + 1) * 10000, // 10k, 20k, ..., 100k
+		})
+	}
+
+	mc := NewMarketCache(data)
+	median, _, ok := mc.Lookup("Mazda", "3", 2021)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	// Even count: average of 5th (50000) and 6th (60000) = 55000
+	if median != 55000 {
+		t.Errorf("expected median=55000, got %d", median)
+	}
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -132,6 +132,40 @@ type HiddenListingStore interface {
 	ClearHidden(ctx context.Context, chatID int64) error
 }
 
+type MarketListing struct {
+	Manufacturer string
+	Model        string
+	Year         int
+	Price        int
+}
+
+type MarketStore interface {
+	MarketListings(ctx context.Context) ([]MarketListing, error)
+}
+
+type DailyDigestUser struct {
+	ChatID     int64
+	DigestTime string
+	LastSent   time.Time
+}
+
+type DailySearchStats struct {
+	SearchName    string
+	NewCount      int
+	AvgPrice      int
+	BestPrice     int
+	BestPriceLink string
+	PriceTrend    float64
+}
+
+type DailyDigestStore interface {
+	SetDailyDigest(ctx context.Context, chatID int64, enabled bool, digestTime string) error
+	GetDailyDigest(ctx context.Context, chatID int64) (enabled bool, digestTime string, lastSent time.Time, err error)
+	UpdateDailyDigestLastSent(ctx context.Context, chatID int64) error
+	ListDailyDigestUsers(ctx context.Context) ([]DailyDigestUser, error)
+	DailyStats(ctx context.Context, chatID int64) ([]DailySearchStats, error)
+}
+
 type CatalogEntry struct {
 	ManufacturerID   int
 	ManufacturerName string

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -280,6 +280,30 @@ func migrate(db *sql.DB) error {
 		}
 	}
 
+	// Add daily digest columns to users table if they don't exist.
+	for _, col := range []struct {
+		name string
+		def  string
+	}{
+		{"daily_digest", "BOOLEAN NOT NULL DEFAULT false"},
+		{"daily_digest_time", "TEXT NOT NULL DEFAULT '09:00'"},
+		{"daily_digest_last_sent", "TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00'"},
+	} {
+		var ddCount int
+		err := db.QueryRow(
+			"SELECT COUNT(*) FROM pragma_table_info('users') WHERE name = ?", col.name,
+		).Scan(&ddCount)
+		if err != nil {
+			return fmt.Errorf("check column %s: %w", col.name, err)
+		}
+		if ddCount == 0 {
+			_, err = db.Exec(fmt.Sprintf("ALTER TABLE users ADD COLUMN %s %s", col.name, col.def))
+			if err != nil {
+				return fmt.Errorf("add column %s: %w", col.name, err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1000,6 +1024,142 @@ func (s *Store) ClearHidden(ctx context.Context, chatID int64) error {
 	_, err := s.db.ExecContext(ctx,
 		"DELETE FROM hidden_listings WHERE chat_id = ?", chatID)
 	return err
+}
+
+// --- MarketStore ---
+
+func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT manufacturer, model, year, price
+		FROM listing_history
+		WHERE manufacturer IS NOT NULL AND manufacturer != ''
+		  AND model IS NOT NULL AND model != ''
+		  AND year > 0 AND price > 0
+		GROUP BY token`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var listings []storage.MarketListing
+	for rows.Next() {
+		var l storage.MarketListing
+		if err := rows.Scan(&l.Manufacturer, &l.Model, &l.Year, &l.Price); err != nil {
+			return nil, err
+		}
+		listings = append(listings, l)
+	}
+	return listings, rows.Err()
+}
+
+// --- DailyDigestStore ---
+
+func (s *Store) SetDailyDigest(ctx context.Context, chatID int64, enabled bool, digestTime string) error {
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE users SET daily_digest = ?, daily_digest_time = ? WHERE chat_id = ?",
+		enabled, digestTime, chatID)
+	return err
+}
+
+func (s *Store) GetDailyDigest(ctx context.Context, chatID int64) (bool, string, time.Time, error) {
+	var enabled bool
+	var digestTime string
+	var lastSent time.Time
+	err := s.db.QueryRowContext(ctx,
+		"SELECT daily_digest, daily_digest_time, daily_digest_last_sent FROM users WHERE chat_id = ?",
+		chatID).Scan(&enabled, &digestTime, &lastSent)
+	if err == sql.ErrNoRows {
+		return false, "09:00", time.Time{}, nil
+	}
+	return enabled, digestTime, lastSent, err
+}
+
+func (s *Store) UpdateDailyDigestLastSent(ctx context.Context, chatID int64) error {
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE users SET daily_digest_last_sent = ? WHERE chat_id = ?",
+		time.Now(), chatID)
+	return err
+}
+
+func (s *Store) ListDailyDigestUsers(ctx context.Context) ([]storage.DailyDigestUser, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT chat_id, daily_digest_time, daily_digest_last_sent
+		FROM users
+		WHERE daily_digest = true AND active = true`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var users []storage.DailyDigestUser
+	for rows.Next() {
+		var u storage.DailyDigestUser
+		if err := rows.Scan(&u.ChatID, &u.DigestTime, &u.LastSent); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}
+
+func (s *Store) DailyStats(ctx context.Context, chatID int64) ([]storage.DailySearchStats, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		WITH search_listings AS (
+			SELECT lh.search_name, lh.price, lh.page_link, lh.first_seen_at
+			FROM listing_history lh
+			JOIN searches s ON s.name = lh.search_name AND s.chat_id = lh.chat_id
+			WHERE lh.chat_id = ? AND s.active = true AND lh.price > 0
+		)
+		SELECT
+			sl.search_name,
+			SUM(CASE WHEN sl.first_seen_at >= datetime('now', '-1 day') THEN 1 ELSE 0 END),
+			CAST(AVG(sl.price) AS INTEGER),
+			MIN(sl.price),
+			(SELECT sl2.page_link FROM search_listings sl2
+			 WHERE sl2.search_name = sl.search_name
+			 ORDER BY sl2.price ASC LIMIT 1)
+		FROM search_listings sl
+		GROUP BY sl.search_name
+		HAVING COUNT(*) >= 5`, chatID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var stats []storage.DailySearchStats
+	for rows.Next() {
+		var s storage.DailySearchStats
+		if err := rows.Scan(&s.SearchName, &s.NewCount, &s.AvgPrice,
+			&s.BestPrice, &s.BestPriceLink); err != nil {
+			return nil, err
+		}
+		stats = append(stats, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Compute 7-day price trend for each search
+	for i, stat := range stats {
+		var recentAvg, olderAvg sql.NullFloat64
+		_ = s.db.QueryRowContext(ctx, `
+			SELECT AVG(price) FROM listing_history
+			WHERE chat_id = ? AND search_name = ? AND price > 0
+			  AND first_seen_at >= datetime('now', '-1 day')`,
+			chatID, stat.SearchName).Scan(&recentAvg)
+		_ = s.db.QueryRowContext(ctx, `
+			SELECT AVG(price) FROM listing_history
+			WHERE chat_id = ? AND search_name = ? AND price > 0
+			  AND first_seen_at >= datetime('now', '-7 days')
+			  AND first_seen_at < datetime('now', '-1 day')`,
+			chatID, stat.SearchName).Scan(&olderAvg)
+
+		if recentAvg.Valid && olderAvg.Valid && olderAvg.Float64 > 0 {
+			stats[i].PriceTrend = ((recentAvg.Float64 - olderAvg.Float64) / olderAvg.Float64) * 100
+		}
+	}
+
+	return stats, nil
 }
 
 // --- Close ---

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -1030,7 +1030,7 @@ func (s *Store) ClearHidden(ctx context.Context, chatID int64) error {
 
 func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT manufacturer, model, year, price
+		SELECT MAX(manufacturer), MAX(model), MAX(year), MAX(price)
 		FROM listing_history
 		WHERE manufacturer IS NOT NULL AND manufacturer != ''
 		  AND model IS NOT NULL AND model != ''
@@ -1105,7 +1105,8 @@ func (s *Store) ListDailyDigestUsers(ctx context.Context) ([]storage.DailyDigest
 func (s *Store) DailyStats(ctx context.Context, chatID int64) ([]storage.DailySearchStats, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		WITH search_listings AS (
-			SELECT lh.search_name, lh.price, lh.page_link, lh.first_seen_at
+			SELECT s.id AS search_id, s.name AS search_name,
+			       lh.price, lh.page_link, lh.first_seen_at
 			FROM listing_history lh
 			JOIN searches s ON s.name = lh.search_name AND s.chat_id = lh.chat_id
 			WHERE lh.chat_id = ? AND s.active = true AND lh.price > 0
@@ -1116,10 +1117,10 @@ func (s *Store) DailyStats(ctx context.Context, chatID int64) ([]storage.DailySe
 			CAST(AVG(sl.price) AS INTEGER),
 			MIN(sl.price),
 			(SELECT sl2.page_link FROM search_listings sl2
-			 WHERE sl2.search_name = sl.search_name
+			 WHERE sl2.search_id = sl.search_id
 			 ORDER BY sl2.price ASC LIMIT 1)
 		FROM search_listings sl
-		GROUP BY sl.search_name
+		GROUP BY sl.search_id
 		HAVING COUNT(*) >= 5`, chatID)
 	if err != nil {
 		return nil, err
@@ -1128,31 +1129,34 @@ func (s *Store) DailyStats(ctx context.Context, chatID int64) ([]storage.DailySe
 
 	var stats []storage.DailySearchStats
 	for rows.Next() {
-		var s storage.DailySearchStats
-		if err := rows.Scan(&s.SearchName, &s.NewCount, &s.AvgPrice,
-			&s.BestPrice, &s.BestPriceLink); err != nil {
+		var ds storage.DailySearchStats
+		if err := rows.Scan(&ds.SearchName, &ds.NewCount, &ds.AvgPrice,
+			&ds.BestPrice, &ds.BestPriceLink); err != nil {
 			return nil, err
 		}
-		stats = append(stats, s)
+		stats = append(stats, ds)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	// Compute 7-day price trend for each search
 	for i, stat := range stats {
 		var recentAvg, olderAvg sql.NullFloat64
-		_ = s.db.QueryRowContext(ctx, `
+		if err := s.db.QueryRowContext(ctx, `
 			SELECT AVG(price) FROM listing_history
 			WHERE chat_id = ? AND search_name = ? AND price > 0
 			  AND first_seen_at >= datetime('now', '-1 day')`,
-			chatID, stat.SearchName).Scan(&recentAvg)
-		_ = s.db.QueryRowContext(ctx, `
+			chatID, stat.SearchName).Scan(&recentAvg); err != nil {
+			return nil, err
+		}
+		if err := s.db.QueryRowContext(ctx, `
 			SELECT AVG(price) FROM listing_history
 			WHERE chat_id = ? AND search_name = ? AND price > 0
 			  AND first_seen_at >= datetime('now', '-7 days')
 			  AND first_seen_at < datetime('now', '-1 day')`,
-			chatID, stat.SearchName).Scan(&olderAvg)
+			chatID, stat.SearchName).Scan(&olderAvg); err != nil {
+			return nil, err
+		}
 
 		if recentAvg.Valid && olderAvg.Valid && olderAvg.Float64 > 0 {
 			stats[i].PriceTrend = ((recentAvg.Float64 - olderAvg.Float64) / olderAvg.Float64) * 100

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -827,3 +827,135 @@ func TestListUserListings_Pagination(t *testing.T) {
 		t.Errorf("page 3: expected 1 item, got %d", len(page3))
 	}
 }
+
+// --- MarketStore Tests ---
+
+func TestMarketListings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	// Insert listings for two users with same token (should deduplicate)
+	for _, chatID := range []int64{100, 200} {
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: "tok1", ChatID: chatID, SearchName: "toyota-corolla",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
+			Price: 100000, FirstSeenAt: time.Now(),
+		})
+	}
+	// Another listing
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok2", ChatID: 100, SearchName: "toyota-corolla",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021,
+		Price: 110000, FirstSeenAt: time.Now(),
+	})
+	// Listing with empty manufacturer (should be excluded)
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok3", ChatID: 100, SearchName: "test",
+		Manufacturer: "", Model: "X", Year: 2020,
+		Price: 50000, FirstSeenAt: time.Now(),
+	})
+
+	listings, err := store.MarketListings(ctx)
+	if err != nil {
+		t.Fatalf("MarketListings: %v", err)
+	}
+	// tok1 should appear once (deduplicated), tok2 once, tok3 excluded
+	if len(listings) != 2 {
+		t.Errorf("expected 2 deduplicated listings, got %d", len(listings))
+	}
+}
+
+// --- DailyDigestStore Tests ---
+
+func TestDailyDigest_SetAndGet(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	// Default state
+	enabled, digestTime, _, err := store.GetDailyDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("GetDailyDigest: %v", err)
+	}
+	if enabled {
+		t.Error("expected daily digest disabled by default")
+	}
+	if digestTime != "09:00" {
+		t.Errorf("expected default time 09:00, got %q", digestTime)
+	}
+
+	// Enable
+	if err := store.SetDailyDigest(ctx, 100, true, "08:30"); err != nil {
+		t.Fatalf("SetDailyDigest: %v", err)
+	}
+
+	enabled, digestTime, _, err = store.GetDailyDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("GetDailyDigest after set: %v", err)
+	}
+	if !enabled {
+		t.Error("expected daily digest enabled")
+	}
+	if digestTime != "08:30" {
+		t.Errorf("expected time 08:30, got %q", digestTime)
+	}
+}
+
+func TestDailyDigest_ListUsers(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	_ = store.SetDailyDigest(ctx, 100, true, "09:00")
+	// User 200 not enabled
+
+	users, err := store.ListDailyDigestUsers(ctx)
+	if err != nil {
+		t.Fatalf("ListDailyDigestUsers: %v", err)
+	}
+	if len(users) != 1 {
+		t.Errorf("expected 1 user, got %d", len(users))
+	}
+	if len(users) > 0 && users[0].ChatID != 100 {
+		t.Errorf("expected chatID 100, got %d", users[0].ChatID)
+	}
+}
+
+func TestDailyDigest_UpdateLastSent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	_ = store.SetDailyDigest(ctx, 100, true, "09:00")
+
+	if err := store.UpdateDailyDigestLastSent(ctx, 100); err != nil {
+		t.Fatalf("UpdateDailyDigestLastSent: %v", err)
+	}
+
+	_, _, lastSent, err := store.GetDailyDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("GetDailyDigest: %v", err)
+	}
+	if time.Since(lastSent) > time.Minute {
+		t.Errorf("expected lastSent to be recent, got %v", lastSent)
+	}
+}
+
+func TestDailyDigest_NonexistentUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	enabled, digestTime, _, err := store.GetDailyDigest(ctx, 999)
+	if err != nil {
+		t.Fatalf("GetDailyDigest nonexistent: %v", err)
+	}
+	if enabled {
+		t.Error("expected disabled for nonexistent user")
+	}
+	if digestTime != "09:00" {
+		t.Errorf("expected default time, got %q", digestTime)
+	}
+}


### PR DESCRIPTION
## Summary

Users seeing a listing at ₪150k had no way to know if that was a good deal or not. Now every notification includes a deal score (0-100) showing where the price sits relative to the market median, and users can opt into a daily digest summarizing market conditions across their active searches.

Closes #172 (Phase A), #184. Also fixes missing `Digests`/`DigestStore` wiring in `main.go` that was silently preventing digest mode from working.

## Deal scoring

New `internal/scoring` package computes a market cache from `listing_history` once per poll cycle. For each new listing, the cache looks up the median price across all deduplicated listings matching the same manufacturer, model, and year (±1). Listings below the median get a score proportional to the discount; listings at or above the median score 0.

Score display is backward-compatible: the `DealScore` field on `model.Listing` is a pointer, nil by default. `FormatListing` only renders the score block when populated. Existing callers (batch format, digest format, price drop) are unaffected.

Minimum cohort size is 10 listings. Below that threshold, no score appears.

## Daily market digest

Users opt in via the `/digest` command, which now shows an additional "Enable/Disable Daily Summary" button. When enabled, the scheduler checks each poll cycle whether the current time (in `Asia/Jerusalem`) is within 15 minutes of the user's configured digest time (default 09:00). A `daily_digest_last_sent` timestamp prevents duplicate sends on the same day.

Per-search stats: new listing count (24h), average price, best deal with link, and 7-day price trend computed by comparing the last-24h average against the prior-6-day average.

Searches with fewer than 5 listings in history are skipped.

## Key files

| Area | Files |
|------|-------|
| Scoring engine | `internal/scoring/scoring.go`, `scoring_test.go` |
| Storage interfaces | `internal/storage/interfaces.go` (MarketStore, DailyDigestStore) |
| SQLite implementation | `internal/storage/sqlite/sqlite.go` (market queries, daily digest columns + CRUD) |
| Notification formatting | `internal/notifier/formatter.go` (score display, `FormatDailyDigest`) |
| Scheduler integration | `internal/scheduler/scheduler.go` (market cache per cycle, `processDailyDigests`) |
| Bot UI | `internal/bot/commands.go`, `callbacks.go` (daily digest toggle) |
| Translations | `internal/locale/locale.go` (Hebrew + English, 20 new keys) |

## Test plan

- `internal/scoring`: score clamping, cache lookup with year band, insufficient data, case-insensitive keys, even/odd median
- `internal/notifier`: score display present/absent, above/near/below market text, daily digest formatting
- `internal/storage/sqlite`: market listing deduplication, daily digest CRUD, nonexistent user defaults

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 4.6 (1M context)](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deal scoring added to listings (market-relative score and explanatory text).
  * Daily digest: scheduled per-user market summaries (default 09:00) with enable/disable and last-sent handling.

* **UI Updates**
  * `/digest` command updated with daily-digest toggle buttons and revised help text.

* **Tests**
  * New tests for scoring, listing formatting, daily-digest formatting, and SQLite store behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->