### PR TITLE
feat: add colorized pretty logging for terminal output

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
+	"github.com/lmittmann/tint"
+	"github.com/mattn/go-isatty"
 
 	cwbot "github.com/dsionov/carwatch/internal/bot"
 	"github.com/dsionov/carwatch/internal/catalog"
@@ -42,9 +44,7 @@ func main() {
 		return
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
+	logger := slog.New(newLogHandler("auto", slog.LevelInfo))
 
 	if err := run(*configPath, logger); err != nil {
 		logger.Error("fatal", "error", err)
@@ -59,10 +59,8 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 
 	logLevel, _ := config.ParseLogLevel(cfg.LogLevel)
-	logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: logLevel,
-	}))
-	logger.Info("config loaded", "log_level", cfg.LogLevel, "version", version)
+	logger = slog.New(newLogHandler(cfg.LogFormat, logLevel))
+	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
 	store, err := sqlite.New(cfg.Storage.DBPath)
 	if err != nil {
@@ -197,4 +195,19 @@ func run(configPath string, logger *slog.Logger) error {
 	)
 
 	return sched.Run(ctx)
+}
+
+func newLogHandler(format string, level slog.Level) slog.Handler {
+	usePretty := format == "pretty" ||
+		(format == "auto" && isatty.IsTerminal(os.Stdout.Fd()))
+
+	if usePretty {
+		return tint.NewHandler(os.Stdout, &tint.Options{
+			Level:      level,
+			TimeFormat: time.Kitchen,
+		})
+	}
+	return slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})
 }

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -58,7 +58,10 @@ func run(configPath string, logger *slog.Logger) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	logLevel, _ := config.ParseLogLevel(cfg.LogLevel)
+	logLevel, err := config.ParseLogLevel(cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("parse log_level %q: %w", cfg.LogLevel, err)
+	}
 	logger = slog.New(newLogHandler(cfg.LogFormat, logLevel))
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
@@ -198,8 +201,9 @@ func run(configPath string, logger *slog.Logger) error {
 }
 
 func newLogHandler(format string, level slog.Level) slog.Handler {
+	fd := os.Stdout.Fd()
 	usePretty := format == "pretty" ||
-		(format == "auto" && isatty.IsTerminal(os.Stdout.Fd()))
+		(format == "auto" && (isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)))
 
 	if usePretty {
 		return tint.NewHandler(os.Stdout, &tint.Options{

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,7 +2,8 @@
 # Users manage their searches via Telegram commands (/watch, /list, /stop)
 # No per-search config needed here — it's all in the database.
 
-log_level: info  # debug | info | warn | error
+log_level: info    # debug | info | warn | error
+log_format: auto   # auto | json | pretty (auto = pretty for terminals, json otherwise)
 
 # Telegram bot settings
 telegram:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.24.0
 require (
 	github.com/Noooste/azuretls-client v1.13.2
 	github.com/go-telegram/bot v1.20.0
+	github.com/lmittmann/tint v1.1.3
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-sqlite3 v1.14.28
 	golang.org/x/text v0.32.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -25,7 +27,6 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/refraction-networking/utls v1.8.1 // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f h1:HU1RgM6NALf/KW9HEY
 github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f/go.mod h1:67FPmZWbr+KDT/VlpWtw6sO9XSjpJmLuHpoLmWiTGgY=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
+github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,8 @@ type Config struct {
 	Telegram TelegramConfig `yaml:"telegram"`
 	Storage  StorageConfig  `yaml:"storage"`
 	HTTP     HTTPConfig     `yaml:"http"`
-	LogLevel string         `yaml:"log_level"`
+	LogLevel  string         `yaml:"log_level"`
+	LogFormat string         `yaml:"log_format"`
 }
 
 type PollingConfig struct {
@@ -146,6 +147,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.LogLevel == "" {
 		cfg.LogLevel = "info"
 	}
+	if cfg.LogFormat == "" {
+		cfg.LogFormat = "auto"
+	}
 }
 
 func validate(cfg *Config) error {
@@ -162,6 +166,11 @@ func validate(cfg *Config) error {
 	}
 	if _, err := ParseLogLevel(cfg.LogLevel); err != nil {
 		return fmt.Errorf("log_level %q: must be debug, info, warn, or error", cfg.LogLevel)
+	}
+	switch cfg.LogFormat {
+	case "auto", "json", "pretty":
+	default:
+		return fmt.Errorf("log_format %q: must be auto, json, or pretty", cfg.LogFormat)
 	}
 	if cfg.Telegram.Token == "" {
 		return fmt.Errorf("telegram.token is required")


### PR DESCRIPTION
## Summary

- Add `lmittmann/tint` for colorized, human-readable terminal log output
- New `log_format` config option: `auto` (default), `json`, `pretty`
- `auto` detects TTY and picks pretty for terminals, JSON for containers/pipes

**Before (JSON — unreadable in terminal):**
```
{"time":"2026-04-26T01:56:49","level":"INFO","msg":"config loaded","log_level":"info","version":"dev"}
```

**After (pretty — colorized in terminal):**
```
1:56AM INF config loaded log_level=info version=dev
1:56AM WRN rate limited chat_id=12345
1:56AM ERR send message failed chat_id=12345 error="timeout"
```

Production (Docker/pipes) continues using JSON unchanged.

## Test plan

- [x] `make test` passes
- [x] `golangci-lint run ./...` clean
- [x] Invalid `log_format` value rejected by config validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable log output format with three options: `auto` for intelligent terminal detection, `json` for structured machine-readable logs, and `pretty` for human-readable console output.

* **Configuration**
  * New `log_format` configuration option added with automatic detection and sensible defaults that adapt your logging output based on environment and terminal capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->