### PR TITLE
fix: use legacy Markdown parse mode for Telegram notifications

### DIFF
--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -90,7 +90,7 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 		ChatID:    id,
 		Photo:     &tgmodels.InputFileString{Data: listing.ImageURL},
 		Caption:   caption,
-		ParseMode: tgmodels.ParseModeMarkdown,
+		ParseMode: tgmodels.ParseModeMarkdownV1,
 	})
 	if err != nil {
 		n.logger.Warn("sendPhoto failed, falling back to text", "chat_id", chatID, "error", err)
@@ -102,7 +102,7 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 }
 
 func (n *Notifier) sendMessageMarkdown(ctx context.Context, chatID string, text string) error {
-	return n.sendMessageWithParseMode(ctx, chatID, text, tgmodels.ParseModeMarkdown)
+	return n.sendMessageWithParseMode(ctx, chatID, text, tgmodels.ParseModeMarkdownV1)
 }
 
 func (n *Notifier) sendMessage(ctx context.Context, chatID string, text string) error {


### PR DESCRIPTION
## Summary

- The `go-telegram/bot` v1.20.0 library defines `ParseModeMarkdown` as `"MarkdownV2"`, not legacy `"Markdown"`
- The notifier was sending MarkdownV2 which requires escaping 18+ special characters, but `EscapeMarkdown` only handles 5 (for legacy Markdown)
- Unescaped `.` in engine volumes, URLs, and prices caused Telegram to reject messages with: `"Character '.' is reserved and must be escaped"`
- Switched to `ParseModeMarkdownV1` to match what the bot handler already uses

## Test plan

- [x] All tests pass (`make test`)
- [x] Ran bot locally, verified listing notifications send successfully without Markdown parse errors
- [x] Confirmed no `sendPhoto failed` errors in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Telegram notification formatting to ensure proper rendering of Markdown-formatted text in messages and photo captions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->