### PR TITLE
fix: prevent long manufacturer names from being truncated in Telegram buttons

### DIFF
--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -51,8 +51,8 @@ const (
 	cbDailyDigestOn   = "daily_digest:on"
 	cbDailyDigestOff  = "daily_digest:off"
 
-	pageSize   = 15
-	colsPerRow = 3
+	pageSize   = 10
+	colsPerRow = 2
 )
 
 func sourceKeyboard(selected string, lang locale.Lang) *tgmodels.InlineKeyboardMarkup {

--- a/internal/catalog/dynamic.go
+++ b/internal/catalog/dynamic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -130,7 +131,9 @@ func (d *DynamicCatalog) rebuildSlices() {
 	for id, name := range d.mfrMap {
 		mfrs = append(mfrs, Entry{ID: id, Name: name})
 	}
-	sort.Slice(mfrs, func(i, j int) bool { return mfrs[i].Name < mfrs[j].Name })
+	sort.Slice(mfrs, func(i, j int) bool {
+		return strings.ToLower(mfrs[i].Name) < strings.ToLower(mfrs[j].Name)
+	})
 	d.mfrs = mfrs
 
 	models := make(map[int][]Entry, len(d.modelMap))
@@ -139,7 +142,9 @@ func (d *DynamicCatalog) rebuildSlices() {
 		for id, name := range mdls {
 			list = append(list, Entry{ID: id, Name: name})
 		}
-		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+		sort.Slice(list, func(i, j int) bool {
+			return strings.ToLower(list[i].Name) < strings.ToLower(list[j].Name)
+		})
 		models[mfrID] = list
 	}
 	d.models = models

--- a/internal/catalog/dynamic.go
+++ b/internal/catalog/dynamic.go
@@ -132,7 +132,11 @@ func (d *DynamicCatalog) rebuildSlices() {
 		mfrs = append(mfrs, Entry{ID: id, Name: name})
 	}
 	sort.Slice(mfrs, func(i, j int) bool {
-		return strings.ToLower(mfrs[i].Name) < strings.ToLower(mfrs[j].Name)
+		li, lj := strings.ToLower(mfrs[i].Name), strings.ToLower(mfrs[j].Name)
+		if li == lj {
+			return mfrs[i].ID < mfrs[j].ID
+		}
+		return li < lj
 	})
 	d.mfrs = mfrs
 
@@ -143,7 +147,11 @@ func (d *DynamicCatalog) rebuildSlices() {
 			list = append(list, Entry{ID: id, Name: name})
 		}
 		sort.Slice(list, func(i, j int) bool {
-			return strings.ToLower(list[i].Name) < strings.ToLower(list[j].Name)
+			li, lj := strings.ToLower(list[i].Name), strings.ToLower(list[j].Name)
+			if li == lj {
+				return list[i].ID < list[j].ID
+			}
+			return li < lj
 		})
 		models[mfrID] = list
 	}


### PR DESCRIPTION
## Summary

- Reduce inline keyboard columns from 3 to 2 so longer manufacturer names (e.g. "Mercedes-Benz", "Alfa Romeo") display fully without truncation
- Reduce page size from 15 to 10 to compensate for the wider layout and keep keyboard height reasonable
- Fix catalog sorting to be case-insensitive so mixed-case names sort alphabetically

## Test plan

- [x] Unit tests pass (`go test ./internal/bot/... ./internal/catalog/...`)
- [x] Lint clean (`golangci-lint run`)
- [ ] Verify in Telegram that manufacturer/model buttons display full names
- [ ] Verify pagination still works correctly with new page size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  - Updated pagination layout for manufacturer and model selection: reduced items per page to 10 and changed button layout to 2 columns per row for improved navigation.

* **Bug Fixes**
  - Improved sorting of manufacturer and model names to be case-insensitive and deterministic when names match, ensuring consistent alphabetical order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->