### PR TITLE
fix: resolve 5 bugs found in codebase audit

### DIFF
--- a/internal/fetcher/circuitbreaker.go
+++ b/internal/fetcher/circuitbreaker.go
@@ -34,13 +34,14 @@ func (s CircuitState) String() string {
 var ErrCircuitOpen = fmt.Errorf("circuit breaker is open")
 
 type CircuitBreaker struct {
-	inner           Fetcher
-	mu              sync.Mutex
-	state           CircuitState
-	failures        int
+	inner            Fetcher
+	mu               sync.Mutex
+	state            CircuitState
+	failures         int
 	failureThreshold int
-	cooldown        time.Duration
-	openedAt        time.Time
+	cooldown         time.Duration
+	openedAt         time.Time
+	probing          bool
 }
 
 func NewCircuitBreaker(inner Fetcher, threshold int, cooldown time.Duration) *CircuitBreaker {
@@ -63,8 +64,12 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params config.SourceParams)
 			return nil, ErrCircuitOpen
 		}
 	case StateHalfOpen:
-		// Only one probe at a time — already in half-open, let it through.
+		if cb.probing {
+			cb.mu.Unlock()
+			return nil, ErrCircuitOpen
+		}
 	}
+	cb.probing = cb.state == StateHalfOpen
 	cb.mu.Unlock()
 
 	listings, err := cb.inner.Fetch(ctx, params)
@@ -78,11 +83,13 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params config.SourceParams)
 			cb.state = StateOpen
 			cb.openedAt = time.Now()
 		}
+		cb.probing = false
 		return nil, err
 	}
 
 	cb.failures = 0
 	cb.state = StateClosed
+	cb.probing = false
 	return listings, nil
 }
 

--- a/internal/fetcher/circuitbreaker.go
+++ b/internal/fetcher/circuitbreaker.go
@@ -72,6 +72,12 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params config.SourceParams)
 	cb.probing = cb.state == StateHalfOpen
 	cb.mu.Unlock()
 
+	defer func() {
+		cb.mu.Lock()
+		cb.probing = false
+		cb.mu.Unlock()
+	}()
+
 	listings, err := cb.inner.Fetch(ctx, params)
 
 	cb.mu.Lock()
@@ -83,13 +89,11 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params config.SourceParams)
 			cb.state = StateOpen
 			cb.openedAt = time.Now()
 		}
-		cb.probing = false
 		return nil, err
 	}
 
 	cb.failures = 0
 	cb.state = StateClosed
-	cb.probing = false
 	return listings, nil
 }
 

--- a/internal/scheduler/grouper.go
+++ b/internal/scheduler/grouper.go
@@ -50,7 +50,9 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 			if g.Params.YearMax == 0 || s.YearMax > g.Params.YearMax {
 				g.Params.YearMax = s.YearMax
 			}
-			if g.Params.PriceMax == 0 || s.PriceMax == 0 || s.PriceMax > g.Params.PriceMax {
+			if s.PriceMax == 0 || g.Params.PriceMax == 0 {
+				g.Params.PriceMax = 0
+			} else if s.PriceMax > g.Params.PriceMax {
 				g.Params.PriceMax = s.PriceMax
 			}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -46,6 +46,7 @@ type Scheduler struct {
 	notifier          notifier.Notifier
 	logger            *slog.Logger
 	loc               *time.Location
+	boMu              sync.RWMutex
 	backoffMultiplier float64
 	lastPruneTime     time.Time
 	observer          CycleObserver
@@ -285,7 +286,10 @@ func (s *Scheduler) nextDelay() time.Duration {
 	interval := s.cfg.Polling.Interval
 	jitterCfg := s.cfg.Polling.Jitter
 	s.cfgMu.RUnlock()
-	base := time.Duration(float64(interval) * s.backoffMultiplier)
+	s.boMu.RLock()
+	mult := s.backoffMultiplier
+	s.boMu.RUnlock()
+	base := time.Duration(float64(interval) * mult)
 	jitter := jitterCfg
 	if jitter > 0 {
 		offset := time.Duration(rand.Int64N(int64(2*jitter))) - jitter
@@ -400,9 +404,9 @@ func (s *Scheduler) retryPending(ctx context.Context) {
 func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.logger.Info("starting poll cycle")
 
-	s.langCache = sync.Map{}
-	s.digestCache = sync.Map{}
-	s.premiumCache = sync.Map{}
+	s.langCache.Range(func(k, _ any) bool { s.langCache.Delete(k); return true })
+	s.digestCache.Range(func(k, _ any) bool { s.digestCache.Delete(k); return true })
+	s.premiumCache.Range(func(k, _ any) bool { s.premiumCache.Delete(k); return true })
 
 	searches, err := s.searchStore.ListAllActiveSearches(ctx)
 	if err != nil {
@@ -485,16 +489,18 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 					"error", err,
 				)
 				if errors.Is(err, fetcher.ErrChallenge) {
-					mu.Lock()
+					s.boMu.Lock()
 					s.backoffMultiplier = min(s.backoffMultiplier*2, maxBackoff)
-					mu.Unlock()
+					s.boMu.Unlock()
 				}
 				return
 			}
 			mu.Lock()
 			allFailed = false
-			s.backoffMultiplier = max(s.backoffMultiplier/2, minBackoff)
 			mu.Unlock()
+			s.boMu.Lock()
+			s.backoffMultiplier = max(s.backoffMultiplier/2, minBackoff)
+			s.boMu.Unlock()
 		}(group)
 	}
 	wg.Wait()
@@ -642,6 +648,14 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 					)
 					listing := model.Listing{RawListing: l, SearchName: search.Name}
 					priceDropMessages = append(priceDropMessages, notifier.FormatPriceDrop(listing, oldPrice, lang))
+					if s.listingStore != nil {
+						_ = s.listingStore.SaveListing(ctx, storage.ListingRecord{
+							Token: l.Token, ChatID: search.ChatID, SearchName: search.Name,
+							Manufacturer: l.Manufacturer, Model: l.Model,
+							Year: l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
+							City: l.City, PageLink: l.PageLink, FirstSeenAt: time.Now(),
+						})
+					}
 					continue
 				}
 			}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -926,7 +926,7 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at
 		FROM listing_history
-		GROUP BY token
+		WHERE rowid IN (SELECT MAX(rowid) FROM listing_history GROUP BY token)
 		ORDER BY first_seen_at DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Fixes 5 bugs identified during the comprehensive codebase audit:

- **PriceMax grouping** (#228): When any search in a group has no price limit, the group fetch now correctly has no price limit instead of being overwritten by a later search's concrete limit
- **Price drop + listing history** (#229): Price drop path now saves listing to history, preventing gaps in listing_history data
- **Data races** (#230): Added dedicated `boMu` RWMutex for `backoffMultiplier` and fixed `sync.Map` reassignment to use Range+Delete
- **ListListings GROUP BY** (#232): Query now returns deterministic most-recent row per token instead of arbitrary values
- **Circuit breaker half-open** (#233): Added `probing` flag to enforce single concurrent probe in half-open state

Note: #231 (nil pointer in callbacks) was investigated and found to be a false positive — `Message` is a struct, not a pointer, so it cannot be nil.

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [x] Price drop test (`TestProcessGroup_PriceDropNotification`) validates correct behavior
- [x] Grouper tests validate PriceMax merging

Closes #228, closes #229, closes #230, closes #232, closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed listing query logic to ensure accurate, deterministic results when retrieving multiple items
  * Improved price-filter consistency in grouped searches

* **Improvements**
  * Block concurrent recovery probes to improve service stability
  * Persist price-drop notifications to storage when configured
  * Refined cache clearing and backoff timing for more reliable scheduling and retries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->