### PR TITLE
perf: batch SaveListing calls into single transaction

### DIFF
--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -254,6 +254,11 @@ func (m *mockListingStore) SaveListing(_ context.Context, r storage.ListingRecor
 	return nil
 }
 
+func (m *mockListingStore) SaveListings(_ context.Context, records []storage.ListingRecord) error {
+	m.saved = append(m.saved, records...)
+	return nil
+}
+
 func (m *mockListingStore) ListUserListings(_ context.Context, _ int64, _, _ int) ([]storage.ListingRecord, error) {
 	return nil, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -703,8 +703,9 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		if s.listingStore != nil && len(listingRecords) > 0 {
 			if err := s.listingStore.SaveListings(ctx, listingRecords); err != nil {
 				s.logger.Error("batch save listings failed", "error", err)
+				cleanupCtx := context.Background()
 				for _, rec := range listingRecords {
-					if relErr := s.dedup.ReleaseClaim(ctx, rec.Token, rec.ChatID); relErr != nil {
+					if relErr := s.dedup.ReleaseClaim(cleanupCtx, rec.Token, rec.ChatID); relErr != nil {
 						s.logger.Error("release claim after batch save failure",
 							"token", rec.Token, "chat_id", rec.ChatID, "error", relErr)
 					}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -703,6 +703,13 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		if s.listingStore != nil && len(listingRecords) > 0 {
 			if err := s.listingStore.SaveListings(ctx, listingRecords); err != nil {
 				s.logger.Error("batch save listings failed", "error", err)
+				for _, rec := range listingRecords {
+					if relErr := s.dedup.ReleaseClaim(ctx, rec.Token, rec.ChatID); relErr != nil {
+						s.logger.Error("release claim after batch save failure",
+							"token", rec.Token, "chat_id", rec.ChatID, "error", relErr)
+					}
+				}
+				continue
 			}
 		}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -626,6 +626,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 
 		var newListings []model.Listing
 		var priceDropMessages []string
+		var listingRecords []storage.ListingRecord
 		for _, l := range filtered {
 			if hiddenTokens[l.Token] {
 				continue
@@ -691,15 +692,17 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 			}
 			newListings = append(newListings, listing)
 
-			if s.listingStore != nil {
-				if err := s.listingStore.SaveListing(ctx, storage.ListingRecord{
-					Token: l.Token, ChatID: search.ChatID, SearchName: search.Name,
-					Manufacturer: l.Manufacturer, Model: l.Model,
-					Year: l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
-					City: l.City, PageLink: l.PageLink, FirstSeenAt: time.Now(),
-				}); err != nil {
-					s.logger.Warn("save listing failed", "token", l.Token, "error", err)
-				}
+			listingRecords = append(listingRecords, storage.ListingRecord{
+				Token: l.Token, ChatID: search.ChatID, SearchName: search.Name,
+				Manufacturer: l.Manufacturer, Model: l.Model,
+				Year: l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
+				City: l.City, PageLink: l.PageLink, FirstSeenAt: time.Now(),
+			})
+		}
+
+		if s.listingStore != nil && len(listingRecords) > 0 {
+			if err := s.listingStore.SaveListings(ctx, listingRecords); err != nil {
+				s.logger.Error("batch save listings failed", "error", err)
 			}
 		}
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -124,6 +124,7 @@ type ListingRecord struct {
 
 type ListingStore interface {
 	SaveListing(ctx context.Context, r ListingRecord) error
+	SaveListings(ctx context.Context, records []ListingRecord) error
 	ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]ListingRecord, error)
 	CountUserListings(ctx context.Context, chatID int64) (int64, error)
 }

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -889,6 +889,59 @@ func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error 
 	return nil
 }
 
+func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	listingStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO listing_history
+		(token, chat_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, first_seen_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(token, chat_id) DO UPDATE SET
+			price = excluded.price,
+			km = excluded.km`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = listingStmt.Close() }()
+
+	marketStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO market_cache (token, manufacturer, model, year, price)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(token) DO UPDATE SET
+			manufacturer = excluded.manufacturer,
+			model = excluded.model,
+			year = excluded.year,
+			price = excluded.price,
+			updated_at = CURRENT_TIMESTAMP`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = marketStmt.Close() }()
+
+	for _, r := range records {
+		if _, err := listingStmt.ExecContext(ctx,
+			r.Token, r.ChatID, r.SearchName, r.Manufacturer, r.Model, r.Year, r.Price,
+			r.Km, r.Hand, r.City, r.PageLink, r.FirstSeenAt); err != nil {
+			return err
+		}
+		if r.Manufacturer != "" && r.Model != "" && r.Year > 0 && r.Price > 0 {
+			if _, err := marketStmt.ExecContext(ctx,
+				r.Token, r.Manufacturer, r.Model, r.Year, r.Price); err != nil {
+				return fmt.Errorf("upsert market_cache: %w", err)
+			}
+		}
+	}
+	return tx.Commit()
+}
+
 func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price,

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -938,13 +938,21 @@ func TestSaveListings_Batch(t *testing.T) {
 func TestSaveListings_Empty(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
+	seedUser(t, store, 100)
 
-	// Empty slice should be a no-op.
 	if err := store.SaveListings(ctx, nil); err != nil {
 		t.Fatalf("empty batch save: %v", err)
 	}
 	if err := store.SaveListings(ctx, []storage.ListingRecord{}); err != nil {
 		t.Fatalf("empty slice batch save: %v", err)
+	}
+
+	listings, err := store.ListUserListings(ctx, 100, 10, 0)
+	if err != nil {
+		t.Fatalf("ListUserListings: %v", err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings after empty batch, got %d", len(listings))
 	}
 }
 

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -902,6 +902,84 @@ func TestListUserListings(t *testing.T) {
 	}
 }
 
+func TestSaveListings_Batch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	records := []storage.ListingRecord{
+		{Token: "batch-1", ChatID: 100, SearchName: "test", Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000},
+		{Token: "batch-2", ChatID: 100, SearchName: "test", Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000},
+		{Token: "batch-3", ChatID: 200, SearchName: "test2", Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 95000},
+	}
+
+	if err := store.SaveListings(ctx, records); err != nil {
+		t.Fatalf("batch save: %v", err)
+	}
+
+	// Verify all records were inserted.
+	listings, err := store.ListListings(ctx, 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(listings) != 3 {
+		t.Errorf("expected 3 listings, got %d", len(listings))
+	}
+
+	// Verify market_cache was populated.
+	marketListings, err := store.MarketListings(ctx)
+	if err != nil {
+		t.Fatalf("market listings: %v", err)
+	}
+	if len(marketListings) != 3 {
+		t.Errorf("expected 3 market listings, got %d", len(marketListings))
+	}
+}
+
+func TestSaveListings_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty slice should be a no-op.
+	if err := store.SaveListings(ctx, nil); err != nil {
+		t.Fatalf("empty batch save: %v", err)
+	}
+	if err := store.SaveListings(ctx, []storage.ListingRecord{}); err != nil {
+		t.Fatalf("empty slice batch save: %v", err)
+	}
+}
+
+func TestSaveListings_UpsertConflict(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Save initial record.
+	err := store.SaveListings(ctx, []storage.ListingRecord{
+		{Token: "upsert-1", ChatID: 100, SearchName: "test", Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000, Km: 50000},
+	})
+	if err != nil {
+		t.Fatalf("first batch save: %v", err)
+	}
+
+	// Save again with updated price and km -- should upsert.
+	err = store.SaveListings(ctx, []storage.ListingRecord{
+		{Token: "upsert-1", ChatID: 100, SearchName: "test", Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 85000, Km: 55000},
+	})
+	if err != nil {
+		t.Fatalf("upsert batch save: %v", err)
+	}
+
+	listings, _ := store.ListUserListings(ctx, 100, 10, 0)
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing after upsert, got %d", len(listings))
+	}
+	if listings[0].Price != 85000 {
+		t.Errorf("price = %d, want 85000", listings[0].Price)
+	}
+	if listings[0].Km != 55000 {
+		t.Errorf("km = %d, want 55000", listings[0].Km)
+	}
+}
+
 func TestCountUserListings(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -968,7 +968,10 @@ func TestSaveListings_UpsertConflict(t *testing.T) {
 		t.Fatalf("upsert batch save: %v", err)
 	}
 
-	listings, _ := store.ListUserListings(ctx, 100, 10, 0)
+	listings, err := store.ListUserListings(ctx, 100, 10, 0)
+	if err != nil {
+		t.Fatalf("list user listings: %v", err)
+	}
 	if len(listings) != 1 {
 		t.Fatalf("expected 1 listing after upsert, got %d", len(listings))
 	}


### PR DESCRIPTION
## Summary

- Adds `SaveListings(ctx, []ListingRecord)` to the `ListingStore` interface, wrapping all inserts (listing_history + market_cache) in a single SQLite transaction with prepared statements
- Replaces per-listing `SaveListing` calls in the scheduler's `processGroup` loop with a single batched `SaveListings` call after the loop, eliminating N+1 database round-trips
- Adds three new tests for the batch method: batch insert, empty input no-op, and upsert conflict handling

Closes #234

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New `TestSaveListings_Batch` verifies multiple records are inserted and market_cache is populated
- [x] New `TestSaveListings_Empty` verifies nil and empty slice are no-ops
- [x] New `TestSaveListings_UpsertConflict` verifies price/km updates on conflict
- [x] `TestProcessGroup_SavesListings` passes (scheduler now calls `SaveListings`)
- [x] `golangci-lint run ./...` passes with no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added batch saving for listings to optimize persistence and reduce per-listing operations; empty batches are a no-op.
  * Batch saves ensure consistent upserts so repeated saves update existing listings instead of duplicating.

* **Tests**
  * Added unit tests validating batch save behavior, no-op on empty input, and upsert/conflict semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->