### PR TITLE
refactor: disable premium gating and cascade delete on watch removal

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -189,8 +189,6 @@ func (b *Bot) RegisterHandlers() {
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/saved", tgbot.MatchTypeExact, b.rateLimited(b.handleSaved))
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/hidden", tgbot.MatchTypeExact, b.rateLimited(b.handleHidden))
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/upgrade", tgbot.MatchTypeExact, b.rateLimited(b.handleUpgrade))
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/grant_premium", tgbot.MatchTypePrefix, b.rateLimited(b.handleGrantPremium))
-	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/revoke_premium", tgbot.MatchTypePrefix, b.rateLimited(b.handleRevokePremium))
 	b.bot.RegisterHandler(tgbot.HandlerTypeCallbackQueryData, "", tgbot.MatchTypePrefix, b.rateLimited(b.handleCallback))
 }
 
@@ -316,16 +314,12 @@ const (
 	TierFree    = "free"
 	TierPremium = "premium"
 
-	freeMaxSearches    = 1
+	freeMaxSearches    = 10
 	premiumMaxSearches = 10
 )
 
-func (b *Bot) isPremium(ctx context.Context, chatID int64) bool {
-	user, err := b.users.GetUser(ctx, chatID)
-	if err != nil || user == nil {
-		return false
-	}
-	return user.Tier == TierPremium && (user.TierExpires.IsZero() || user.TierExpires.After(time.Now()))
+func (b *Bot) isPremium(_ context.Context, _ int64) bool {
+	return true
 }
 
 func (b *Bot) maxSearchesForUser(ctx context.Context, chatID int64) int {
@@ -344,11 +338,7 @@ func (b *Bot) checkSearchLimit(ctx context.Context, chatID int64, lang locale.La
 	}
 	limit := b.maxSearchesForUser(ctx, chatID)
 	if count >= int64(limit) {
-		if !b.isPremium(ctx, chatID) {
-			b.sendMarkdown(ctx, chatID, locale.Tf(lang, "upgrade_search_limit", count, limit))
-		} else {
-			b.send(ctx, chatID, locale.Tf(lang, limitKey+"_reached", count, limit))
-		}
+		b.send(ctx, chatID, locale.Tf(lang, limitKey+"_reached", count, limit))
 		return true
 	}
 	return false

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -382,10 +382,6 @@ func (b *Bot) onDailyDigestOn(ctx context.Context, chatID int64) {
 		return
 	}
 	lang := b.getUserLang(ctx, chatID)
-	if !b.isPremium(ctx, chatID) {
-		b.sendMarkdown(ctx, chatID, locale.T(lang, "upgrade_prompt"))
-		return
-	}
 	_, digestTime, _, err := b.dailyDigests.GetDailyDigest(ctx, chatID)
 	if err != nil {
 		b.send(ctx, chatID, locale.T(lang, "error_generic"))

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -293,7 +293,12 @@ func (b *Bot) handleSettings(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
-	count, _ := b.searches.CountSearches(ctx, chatID)
+	count, err := b.searches.CountSearches(ctx, chatID)
+	if err != nil {
+		b.logger.Error("count searches failed", "chat_id", chatID, "error", err)
+		b.send(ctx, chatID, locale.T(lang, "error_generic"))
+		return
+	}
 	limit := b.maxSearchesForUser(ctx, chatID)
 	msg := locale.Tf(lang, "settings", count, limit)
 

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -20,12 +20,6 @@ func (b *Bot) handleStart(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	chatID := update.Message.Chat.ID
 	username := update.Message.From.Username
 
-	existing, err := b.users.GetUser(ctx, chatID)
-	if err != nil {
-		b.logger.Error("get user failed", "chat_id", chatID, "error", err)
-	}
-	isNewUser := err == nil && existing == nil
-
 	b.ensureUser(ctx, chatID, username)
 
 	parts := strings.Fields(update.Message.Text)
@@ -35,16 +29,6 @@ func (b *Bot) handleStart(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	}
 
 	lang := b.getUserLang(ctx, chatID)
-
-	if isNewUser {
-		trialDays := 7
-		if err := b.users.GrantTrial(ctx, chatID, time.Duration(trialDays)*24*time.Hour); err != nil {
-			b.logger.Error("grant trial failed", "chat_id", chatID, "error", err)
-		} else {
-			expires := time.Now().AddDate(0, 0, trialDays)
-			b.sendMarkdown(ctx, chatID, locale.Tf(lang, "trial_welcome", expires.Format("2006-01-02")))
-		}
-	}
 
 	kb := &tgmodels.InlineKeyboardMarkup{
 		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
@@ -313,17 +297,6 @@ func (b *Bot) handleSettings(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	limit := b.maxSearchesForUser(ctx, chatID)
 	msg := locale.Tf(lang, "settings", count, limit)
 
-	user, err := b.users.GetUser(ctx, chatID)
-	if err == nil && user != nil {
-		now := time.Now()
-		if user.Tier == TierPremium && (user.TierExpires.IsZero() || user.TierExpires.After(now)) {
-			msg += locale.Tf(lang, "settings_tier_premium",
-				locale.T(lang, "tier_premium"), user.TierExpires.Format("2006-01-02"))
-		} else {
-			msg += locale.Tf(lang, "settings_tier", locale.T(lang, "tier_free"))
-		}
-	}
-
 	b.sendMarkdown(ctx, chatID, msg)
 }
 
@@ -403,7 +376,7 @@ func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 		msgText = locale.T(lang, "digest_mode_instant")
 	}
 
-	if b.dailyDigests != nil && b.isPremium(ctx, chatID) {
+	if b.dailyDigests != nil {
 		enabled, digestTime, _, ddErr := b.dailyDigests.GetDailyDigest(ctx, chatID)
 		if ddErr == nil {
 			if enabled {
@@ -491,7 +464,7 @@ func (b *Bot) handleUpgrade(ctx context.Context, _ *tgbot.Bot, update *tgmodels.
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
-	b.sendMarkdown(ctx, chatID, locale.T(lang, "upgrade_info"))
+	b.sendMarkdown(ctx, chatID, locale.T(lang, "upgrade_disabled"))
 }
 
 func (b *Bot) handleGrantPremium(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {

--- a/internal/bot/coverage_test.go
+++ b/internal/bot/coverage_test.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -163,9 +164,9 @@ func TestOnQuickStart_AtLimit(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	for i := range 3 {
+	for i := range 10 {
 		if _, err := tb.store.CreateSearch(ctx, storage.Search{
-			ChatID: 100, Name: "s" + string(rune('0'+i)), Source: "yad2",
+			ChatID: 100, Name: fmt.Sprintf("s%d", i), Source: "yad2",
 			Manufacturer: 27, Model: 10332, Active: true,
 		}); err != nil {
 			t.Fatalf("create search: %v", err)
@@ -178,7 +179,7 @@ func TestOnQuickStart_AtLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSearches: %v", err)
 	}
-	if len(searches) != 3 {
+	if len(searches) != 10 {
 		t.Errorf("should not create beyond limit, got %d searches", len(searches))
 	}
 }

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -493,7 +493,7 @@ func TestWatch_AtMaxSearches(t *testing.T) {
 
 	tb.createUser(ctx, t, chatID, "alice")
 
-	for i := range 3 {
+	for i := range 10 {
 		_, _ = tb.store.CreateSearch(ctx, newFakeSearch(chatID, i+1))
 	}
 	tb.msg.reset()
@@ -501,7 +501,7 @@ func TestWatch_AtMaxSearches(t *testing.T) {
 	tb.simulateCommand(ctx, chatID, "/watch")
 
 	msg := tb.msg.last()
-	if !strings.Contains(msg.Text, "max") || !strings.Contains(msg.Text, "3") {
+	if !strings.Contains(msg.Text, "max") || !strings.Contains(msg.Text, "10") {
 		t.Errorf("expected max-searches warning, got %q", msg.Text)
 	}
 }

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -494,7 +494,9 @@ func TestWatch_AtMaxSearches(t *testing.T) {
 	tb.createUser(ctx, t, chatID, "alice")
 
 	for i := range 10 {
-		_, _ = tb.store.CreateSearch(ctx, newFakeSearch(chatID, i+1))
+		if _, err := tb.store.CreateSearch(ctx, newFakeSearch(chatID, i+1)); err != nil {
+			t.Fatalf("seed search %d: %v", i+1, err)
+		}
 	}
 	tb.msg.reset()
 

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -493,7 +493,7 @@ func TestWatch_AtMaxSearches(t *testing.T) {
 
 	tb.createUser(ctx, t, chatID, "alice")
 
-	for i := range 10 {
+	for i := range freeMaxSearches {
 		if _, err := tb.store.CreateSearch(ctx, newFakeSearch(chatID, i+1)); err != nil {
 			t.Fatalf("seed search %d: %v", i+1, err)
 		}
@@ -503,7 +503,8 @@ func TestWatch_AtMaxSearches(t *testing.T) {
 	tb.simulateCommand(ctx, chatID, "/watch")
 
 	msg := tb.msg.last()
-	if !strings.Contains(msg.Text, "max") || !strings.Contains(msg.Text, "10") {
+	limit := fmt.Sprintf("%d", freeMaxSearches)
+	if !strings.Contains(msg.Text, "max") || !strings.Contains(msg.Text, limit) {
 		t.Errorf("expected max-searches warning, got %q", msg.Text)
 	}
 }
@@ -828,8 +829,8 @@ func TestHandleSettings(t *testing.T) {
 	tb.simulateCommand(ctx, chatID, "/settings")
 
 	msg := tb.msg.last()
-	if !strings.Contains(msg.Text, "0/10") {
-		t.Errorf("settings should show 0/10 search limit, got %q", msg.Text)
+	if !strings.Contains(msg.Text, fmt.Sprintf("0/%d", freeMaxSearches)) {
+		t.Errorf("settings should show 0/%d search limit, got %q", freeMaxSearches, msg.Text)
 	}
 }
 

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -826,8 +826,8 @@ func TestHandleSettings(t *testing.T) {
 	tb.simulateCommand(ctx, chatID, "/settings")
 
 	msg := tb.msg.last()
-	if !strings.Contains(msg.Text, "0/1") {
-		t.Errorf("settings should show 0/1 (free tier limit), got %q", msg.Text)
+	if !strings.Contains(msg.Text, "0/10") {
+		t.Errorf("settings should show 0/10 search limit, got %q", msg.Text)
 	}
 }
 

--- a/internal/bot/share_handler_test.go
+++ b/internal/bot/share_handler_test.go
@@ -216,7 +216,7 @@ func TestOnShareCopy_AtMaxSearches(t *testing.T) {
 	})
 	search, _ := tb.store.GetSearch(ctx, srcID)
 
-	for i := range 3 {
+	for i := range 10 {
 		_, _ = tb.store.CreateSearch(ctx, storage.Search{
 			ChatID: 200, Name: fmt.Sprintf("bob-%d", i), Manufacturer: i + 1, Model: 1,
 		})

--- a/internal/bot/tier_test.go
+++ b/internal/bot/tier_test.go
@@ -2,32 +2,63 @@ package bot
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-func TestSearchLimitAllUsersGet10(t *testing.T) {
+func TestSearchLimit_AllowsUpTo10(t *testing.T) {
 	tb := newTestBot(t)
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	// Create 1 search
-	_, err := tb.store.CreateSearch(ctx, newTestSearch(100))
-	if err != nil {
-		t.Fatal(err)
+	for i := range 9 {
+		_, err := tb.store.CreateSearch(ctx, storage.Search{
+			ChatID: 100, Name: fmt.Sprintf("search-%d", i),
+			Source: "yad2", Manufacturer: 19, Model: 8640,
+			YearMin: 2018, YearMax: 2024, PriceMax: 200000,
+		})
+		if err != nil {
+			t.Fatalf("create search %d: %v", i, err)
+		}
 	}
 
-	// User should still be able to create more (no upgrade prompt)
+	// 10th search should still be allowed
 	tb.msg.reset()
 	tb.simulateCommand(ctx, 100, "/watch")
 	last := tb.msg.last()
 	if strings.Contains(last.Text, "Upgrade") || strings.Contains(last.Text, "upgrade") {
-		t.Fatalf("should not see upgrade prompt, got: %s", last.Text)
+		t.Fatalf("should not see upgrade prompt with 9 searches, got: %s", last.Text)
 	}
 	if !last.HasKB {
-		t.Fatal("expected source keyboard — user should be allowed to create more searches")
+		t.Fatal("expected source keyboard — 10th search should be allowed")
+	}
+}
+
+func TestSearchLimit_BlocksAt10(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "user1")
+
+	for i := range 10 {
+		_, err := tb.store.CreateSearch(ctx, storage.Search{
+			ChatID: 100, Name: fmt.Sprintf("search-%d", i),
+			Source: "yad2", Manufacturer: 19, Model: 8640,
+			YearMin: 2018, YearMax: 2024, PriceMax: 200000,
+		})
+		if err != nil {
+			t.Fatalf("create search %d: %v", i, err)
+		}
+	}
+
+	// 11th search should be blocked
+	tb.msg.reset()
+	tb.simulateCommand(ctx, 100, "/watch")
+	last := tb.msg.last()
+	if !strings.Contains(last.Text, "max") && !strings.Contains(last.Text, "10") {
+		t.Fatalf("expected limit-reached message, got: %s", last.Text)
 	}
 }
 
@@ -55,43 +86,41 @@ func TestSettingsDoesNotShowTier(t *testing.T) {
 	}
 }
 
-func TestDailyDigestAvailableToAllUsers(t *testing.T) {
+func TestDailyDigestVisibleToFreeUsers(t *testing.T) {
 	tb := newTestBotWithDigests(t)
 	tb.bot.dailyDigests = tb.store
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	// Free user should see daily digest controls
 	tb.simulateCommand(ctx, 100, "/digest")
 	last := tb.msg.last()
 	if last.Buttons < 3 {
 		t.Fatalf("expected daily digest button for all users, only got %d buttons", last.Buttons)
 	}
+	text := strings.ToLower(last.Text)
+	if !strings.Contains(text, "digest") && !strings.Contains(text, "daily") &&
+		!strings.Contains(text, "סיכום") {
+		t.Fatalf("expected digest-related content in response, got: %s", last.Text)
+	}
 }
 
-func TestDailyDigestCallbackWorksForAllUsers(t *testing.T) {
+func TestDailyDigestCallbackEnablesDigest(t *testing.T) {
 	tb := newTestBotWithDigests(t)
 	tb.bot.dailyDigests = tb.store
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	// Free user enabling daily digest should succeed (no upgrade prompt)
 	tb.simulateCallback(ctx, 100, cbDailyDigestOn)
 	last := tb.msg.last()
 	if strings.Contains(last.Text, "Premium") || strings.Contains(last.Text, "upgrade") {
 		t.Fatalf("should not see upgrade prompt, got: %s", last.Text)
 	}
-}
 
-func newTestSearch(chatID int64) storage.Search {
-	return storage.Search{
-		ChatID:       chatID,
-		Name:         "test-search",
-		Source:       "yad2",
-		Manufacturer: 19,
-		Model:        8640,
-		YearMin:      2018,
-		YearMax:      2024,
-		PriceMax:     200000,
+	enabled, _, _, err := tb.store.GetDailyDigest(ctx, 100)
+	if err != nil {
+		t.Fatalf("GetDailyDigest: %v", err)
+	}
+	if !enabled {
+		t.Fatal("daily digest should be enabled after callback")
 	}
 }

--- a/internal/bot/tier_test.go
+++ b/internal/bot/tier_test.go
@@ -14,7 +14,7 @@ func TestSearchLimit_AllowsUpTo10(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	for i := range 9 {
+	for i := range freeMaxSearches - 1 {
 		_, err := tb.store.CreateSearch(ctx, storage.Search{
 			ChatID: 100, Name: fmt.Sprintf("search-%d", i),
 			Source: "yad2", Manufacturer: 19, Model: 8640,
@@ -42,7 +42,7 @@ func TestSearchLimit_BlocksAt10(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	for i := range 10 {
+	for i := range freeMaxSearches {
 		_, err := tb.store.CreateSearch(ctx, storage.Search{
 			ChatID: 100, Name: fmt.Sprintf("search-%d", i),
 			Source: "yad2", Manufacturer: 19, Model: 8640,
@@ -60,8 +60,9 @@ func TestSearchLimit_BlocksAt10(t *testing.T) {
 	if last.HasKB {
 		t.Fatal("expected no keyboard — 11th search should be blocked")
 	}
-	if !strings.Contains(last.Text, "10") || !strings.Contains(last.Text, "max") {
-		t.Fatalf("expected limit-reached message mentioning max and 10, got: %s", last.Text)
+	limit := fmt.Sprintf("%d", freeMaxSearches)
+	if !strings.Contains(last.Text, limit) || !strings.Contains(last.Text, "max") {
+		t.Fatalf("expected limit-reached message mentioning max and %s, got: %s", limit, last.Text)
 	}
 }
 

--- a/internal/bot/tier_test.go
+++ b/internal/bot/tier_test.go
@@ -57,8 +57,11 @@ func TestSearchLimit_BlocksAt10(t *testing.T) {
 	tb.msg.reset()
 	tb.simulateCommand(ctx, 100, "/watch")
 	last := tb.msg.last()
-	if !strings.Contains(last.Text, "max") && !strings.Contains(last.Text, "10") {
-		t.Fatalf("expected limit-reached message, got: %s", last.Text)
+	if last.HasKB {
+		t.Fatal("expected no keyboard — 11th search should be blocked")
+	}
+	if !strings.Contains(last.Text, "10") || !strings.Contains(last.Text, "max") {
+		t.Fatalf("expected limit-reached message mentioning max and 10, got: %s", last.Text)
 	}
 }
 

--- a/internal/bot/tier_test.go
+++ b/internal/bot/tier_test.go
@@ -4,47 +4,14 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-func TestFreeUserSearchLimit(t *testing.T) {
+func TestSearchLimitAllUsersGet10(t *testing.T) {
 	tb := newTestBot(t)
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
-
-	// Free user should be able to create 1 search
-	tb.simulateCommand(ctx, 100, "/watch")
-	if !tb.msg.last().HasKB {
-		t.Fatal("expected source keyboard for first search")
-	}
-
-	// Create a search manually
-	_, err := tb.store.CreateSearch(ctx, newTestSearch(100))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Second search should be blocked for free user
-	tb.msg.reset()
-	tb.simulateCommand(ctx, 100, "/watch")
-	last := tb.msg.last()
-	if !strings.Contains(last.Text, "Upgrade") && !strings.Contains(last.Text, "upgrade") {
-		t.Fatalf("expected upgrade prompt, got: %s", last.Text)
-	}
-}
-
-func TestPremiumUserSearchLimit(t *testing.T) {
-	tb := newTestBot(t)
-	ctx := context.Background()
-	tb.createUser(ctx, t, 100, "user1")
-
-	// Grant premium
-	expires := time.Now().Add(30 * 24 * time.Hour)
-	if err := tb.store.SetUserTier(ctx, 100, TierPremium, expires); err != nil {
-		t.Fatal(err)
-	}
 
 	// Create 1 search
 	_, err := tb.store.CreateSearch(ctx, newTestSearch(100))
@@ -52,228 +19,67 @@ func TestPremiumUserSearchLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Premium user should be able to create more
+	// User should still be able to create more (no upgrade prompt)
 	tb.msg.reset()
 	tb.simulateCommand(ctx, 100, "/watch")
 	last := tb.msg.last()
 	if strings.Contains(last.Text, "Upgrade") || strings.Contains(last.Text, "upgrade") {
-		t.Fatal("premium user should not see upgrade prompt")
+		t.Fatalf("should not see upgrade prompt, got: %s", last.Text)
 	}
 	if !last.HasKB {
-		t.Fatal("expected source keyboard for premium user")
+		t.Fatal("expected source keyboard — user should be allowed to create more searches")
 	}
 }
 
-func TestUpgradeCommand(t *testing.T) {
+func TestUpgradeCommandShowsAllFeaturesAvailable(t *testing.T) {
 	tb := newTestBot(t)
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
 	tb.simulateCommand(ctx, 100, "/upgrade")
 	last := tb.msg.last()
-	if !strings.Contains(last.Text, "Premium") {
-		t.Fatalf("expected premium info, got: %s", last.Text)
-	}
-	if !strings.Contains(last.Text, "29") {
-		t.Fatalf("expected price in upgrade info, got: %s", last.Text)
+	if !strings.Contains(last.Text, "available") && !strings.Contains(last.Text, "זמינות") {
+		t.Fatalf("expected all-features-available message, got: %s", last.Text)
 	}
 }
 
-func TestSettingsShowsTier(t *testing.T) {
+func TestSettingsDoesNotShowTier(t *testing.T) {
 	tb := newTestBot(t)
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	// Free user
 	tb.simulateCommand(ctx, 100, "/settings")
 	last := tb.msg.last()
-	if !strings.Contains(last.Text, "Free") {
-		t.Fatalf("expected Free tier in settings, got: %s", last.Text)
-	}
-
-	// Grant premium
-	expires := time.Now().Add(30 * 24 * time.Hour)
-	if err := tb.store.SetUserTier(ctx, 100, TierPremium, expires); err != nil {
-		t.Fatal(err)
-	}
-
-	tb.msg.reset()
-	tb.simulateCommand(ctx, 100, "/settings")
-	last = tb.msg.last()
-	if !strings.Contains(last.Text, "Premium") {
-		t.Fatalf("expected Premium tier in settings, got: %s", last.Text)
+	if strings.Contains(last.Text, "Free") || strings.Contains(last.Text, "Premium") {
+		t.Fatalf("settings should not show tier info, got: %s", last.Text)
 	}
 }
 
-func TestGrantPremiumAdmin(t *testing.T) {
-	tb := newTestBot(t)
-	ctx := context.Background()
-	tb.createUser(ctx, t, 999, "admin")
-	tb.createUser(ctx, t, 100, "user1")
-
-	// Admin grants premium for 30 days
-	tb.simulateCommand(ctx, 999, "/grant_premium 100 30")
-	last := tb.msg.last()
-	if !strings.Contains(last.Text, "activated") {
-		t.Fatalf("expected grant success, got: %s", last.Text)
-	}
-
-	// Verify user is now premium
-	user, err := tb.store.GetUser(ctx, 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if user.Tier != TierPremium {
-		t.Fatalf("expected premium tier, got: %s", user.Tier)
-	}
-}
-
-func TestGrantPremiumNonAdmin(t *testing.T) {
-	tb := newTestBot(t)
-	ctx := context.Background()
-	tb.createUser(ctx, t, 100, "user1")
-
-	tb.simulateCommand(ctx, 100, "/grant_premium 100 30")
-	last := tb.msg.last()
-	if !strings.Contains(last.Text, "understand") {
-		t.Fatalf("expected unknown command for non-admin, got: %s", last.Text)
-	}
-}
-
-func TestRevokePremiumAdmin(t *testing.T) {
-	tb := newTestBot(t)
-	ctx := context.Background()
-	tb.createUser(ctx, t, 999, "admin")
-	tb.createUser(ctx, t, 100, "user1")
-
-	// Grant then revoke
-	expires := time.Now().Add(30 * 24 * time.Hour)
-	if err := tb.store.SetUserTier(ctx, 100, TierPremium, expires); err != nil {
-		t.Fatal(err)
-	}
-
-	tb.simulateCommand(ctx, 999, "/revoke_premium 100")
-	last := tb.msg.last()
-	if !strings.Contains(last.Text, "revoked") {
-		t.Fatalf("expected revoke success, got: %s", last.Text)
-	}
-
-	user, err := tb.store.GetUser(ctx, 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if user.Tier != TierFree {
-		t.Fatalf("expected free tier after revoke, got: %s", user.Tier)
-	}
-}
-
-func TestTrialGrantOnStart(t *testing.T) {
-	tb := newTestBot(t)
-	ctx := context.Background()
-
-	tb.simulateCommand(ctx, 100, "/start")
-
-	// Check trial message was sent (Hebrew: "ניסיון" or "פרימיום")
-	found := false
-	for _, m := range tb.msg.messages {
-		if strings.Contains(m.Text, "trial") || strings.Contains(m.Text, "Trial") ||
-			strings.Contains(m.Text, "Premium") || strings.Contains(m.Text, "פרימיום") ||
-			strings.Contains(m.Text, "🎉") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("expected trial welcome message on first /start")
-	}
-
-	// User should be premium
-	user, err := tb.store.GetUser(ctx, 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if user.Tier != TierPremium {
-		t.Fatalf("expected premium tier after trial grant, got: %s", user.Tier)
-	}
-	if !user.TrialUsed {
-		t.Fatal("expected trial_used to be true")
-	}
-}
-
-func TestTrialNotGrantedOnSecondStart(t *testing.T) {
-	tb := newTestBot(t)
-	ctx := context.Background()
-
-	// First /start grants trial
-	tb.simulateCommand(ctx, 100, "/start")
-
-	user, err := tb.store.GetUser(ctx, 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if user.Tier != TierPremium {
-		t.Fatalf("expected premium after first /start, got: %s", user.Tier)
-	}
-	firstExpiry := user.TierExpires
-
-	// Downgrade to free (simulating expiry)
-	if err := tb.store.SetUserTier(ctx, 100, TierFree, time.Time{}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Second /start should NOT re-grant trial (trial_used is already true)
-	tb.msg.reset()
-	tb.simulateCommand(ctx, 100, "/start")
-
-	user, err = tb.store.GetUser(ctx, 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if user.Tier == TierPremium {
-		t.Fatal("should not re-grant trial on second /start")
-	}
-	_ = firstExpiry
-}
-
-func TestDailyDigestGatedBehindPremium(t *testing.T) {
+func TestDailyDigestAvailableToAllUsers(t *testing.T) {
 	tb := newTestBotWithDigests(t)
 	tb.bot.dailyDigests = tb.store
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	// Free user should not see daily digest button
+	// Free user should see daily digest controls
 	tb.simulateCommand(ctx, 100, "/digest")
 	last := tb.msg.last()
-	if strings.Contains(last.Text, "Daily") || strings.Contains(last.Text, "daily") {
-		t.Fatalf("free user should not see daily digest option, got: %s", last.Text)
-	}
-
-	// Grant premium
-	expires := time.Now().Add(30 * 24 * time.Hour)
-	if err := tb.store.SetUserTier(ctx, 100, TierPremium, expires); err != nil {
-		t.Fatal(err)
-	}
-
-	// Premium user should see daily digest button
-	tb.msg.reset()
-	tb.simulateCommand(ctx, 100, "/digest")
-	last = tb.msg.last()
 	if last.Buttons < 3 {
-		t.Fatalf("expected daily digest button for premium user, only got %d buttons", last.Buttons)
+		t.Fatalf("expected daily digest button for all users, only got %d buttons", last.Buttons)
 	}
 }
 
-func TestDailyDigestCallbackGatedBehindPremium(t *testing.T) {
+func TestDailyDigestCallbackWorksForAllUsers(t *testing.T) {
 	tb := newTestBotWithDigests(t)
 	tb.bot.dailyDigests = tb.store
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "user1")
 
-	// Free user trying to enable daily digest should get upgrade prompt
+	// Free user enabling daily digest should succeed (no upgrade prompt)
 	tb.simulateCallback(ctx, 100, cbDailyDigestOn)
 	last := tb.msg.last()
-	if !strings.Contains(last.Text, "Premium") && !strings.Contains(last.Text, "upgrade") {
-		t.Fatalf("expected upgrade prompt for free user, got: %s", last.Text)
+	if strings.Contains(last.Text, "Premium") || strings.Contains(last.Text, "upgrade") {
+		t.Fatalf("should not see upgrade prompt, got: %s", last.Text)
 	}
 }
 

--- a/internal/locale/locale.go
+++ b/internal/locale/locale.go
@@ -50,7 +50,6 @@ var he = map[string]string{
 		"/saved — צפה ברכבים שמורים\n" +
 		"/hidden — צפה ברכבים מוסתרים\n" +
 		"/digest — התראות וסיכום שוק יומי\n" +
-		"/upgrade — שדרוג לפרימיום\n" +
 		"/language — שנה שפה\n" +
 		"/settings — הצג הגדרות\n" +
 		"/cancel — בטל אשף נוכחי\n" +
@@ -347,6 +346,8 @@ var he = map[string]string{
 	"trial_expired":  "תקופת הניסיון הסתיימה. חזרת למנוי *חינמי*.\nהשתמש ב /upgrade כדי להמשיך ליהנות מתכונות פרימיום.",
 	"premium_expired":"מנוי הפרימיום שלך פג. חזרת למנוי *חינמי*.\nהשתמש ב /upgrade לחידוש.",
 
+	"upgrade_disabled": "כל התכונות זמינות כרגע לכל המשתמשים בחינם!",
+
 	"admin_grant_usage":   "שימוש: /grant\\_premium <chat\\_id> <days>",
 	"admin_grant_success": "פרימיום הופעל למשתמש %d עד %s.",
 	"admin_grant_failed":  "הפעלת פרימיום נכשלה.",
@@ -375,7 +376,6 @@ var en = map[string]string{
 		"/saved — View saved listings\n" +
 		"/hidden — View hidden listings\n" +
 		"/digest — Notifications & daily market summary\n" +
-		"/upgrade — Upgrade to Premium\n" +
 		"/language — Change language\n" +
 		"/settings — View your settings\n" +
 		"/cancel — Cancel current wizard\n" +
@@ -671,6 +671,8 @@ var en = map[string]string{
 	"trial_welcome":  "🎉 You've received a 7-day *Premium* trial! All features unlocked until %s.",
 	"trial_expired":  "Your trial has ended. You're back on the *Free* plan.\nUse /upgrade to keep enjoying Premium features.",
 	"premium_expired":"Your Premium subscription has expired. You're back on the *Free* plan.\nUse /upgrade to renew.",
+
+	"upgrade_disabled": "All features are currently available to everyone for free!",
 
 	"admin_grant_usage":   "Usage: /grant\\_premium <chat\\_id> <days>",
 	"admin_grant_success": "Premium activated for user %d until %s.",

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -63,9 +63,8 @@ type Scheduler struct {
 	dailyDigestStore  storage.DailyDigestStore
 	triggerCh         chan struct{}
 
-	langCache    sync.Map
-	digestCache  sync.Map
-	premiumCache sync.Map
+	langCache   sync.Map
+	digestCache sync.Map
 }
 
 type digestMeta struct {
@@ -407,7 +406,6 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	s.langCache.Range(func(k, _ any) bool { s.langCache.Delete(k); return true })
 	s.digestCache.Range(func(k, _ any) bool { s.digestCache.Delete(k); return true })
-	s.premiumCache.Range(func(k, _ any) bool { s.premiumCache.Delete(k); return true })
 
 	searches, err := s.searchStore.ListAllActiveSearches(ctx)
 	if err != nil {
@@ -415,7 +413,6 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	}
 
 	s.pruneIfDue(ctx)
-	s.processExpiredPremium(ctx)
 
 	if len(searches) == 0 {
 		s.logger.Info("no active searches")
@@ -613,7 +610,6 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		filtered := filter.Apply(criteria, raw)
 
 		lang := s.userLang(ctx, search.ChatID)
-		isPremium := s.isUserPremium(ctx, search.ChatID)
 
 		var hiddenTokens map[string]bool
 		if s.hiddenStore != nil {
@@ -642,7 +638,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 				oldPrice, changed, err := s.prices.RecordPrice(ctx, l.Token, l.Price)
 				if err != nil {
 					s.logger.Error("record price failed", "token", l.Token, "error", err)
-				} else if changed && l.Price < oldPrice && isPremium {
+				} else if changed && l.Price < oldPrice {
 					s.logger.Info("price drop detected",
 						"token", l.Token,
 						"old_price", oldPrice,
@@ -701,7 +697,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 					Name: d.Name, Score: d.Score, Weight: d.Weight,
 				}
 			}
-			if marketCache != nil && l.Price > 0 && isPremium {
+			if marketCache != nil && l.Price > 0 {
 				median, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
 				if ok {
 					listing.DealScore = &model.ScoreInfo{
@@ -975,51 +971,11 @@ func (s *Scheduler) deactivateExcessSearches(ctx context.Context, chatID int64, 
 		"chat_id", chatID, "paused", len(active)-maxActive, "kept", maxActive)
 }
 
-func (s *Scheduler) isUserPremium(ctx context.Context, chatID int64) bool {
-	if v, ok := s.premiumCache.Load(chatID); ok {
-		return v.(bool)
-	}
-	premium := false
-	if s.userStore != nil {
-		user, err := s.userStore.GetUser(ctx, chatID)
-		if err != nil {
-			s.logger.Error("premium check failed, defaulting to free", "chat_id", chatID, "error", err)
-			return false
-		} else if user != nil {
-			premium = user.Tier == "premium" && (user.TierExpires.IsZero() || user.TierExpires.After(time.Now()))
-		}
-	}
-	s.premiumCache.Store(chatID, premium)
-	return premium
+func (s *Scheduler) isUserPremium(_ context.Context, _ int64) bool {
+	return true
 }
 
-func (s *Scheduler) processExpiredPremium(ctx context.Context) {
-	if s.userStore == nil {
-		return
-	}
-	expired, err := s.userStore.ListExpiredPremium(ctx)
-	if err != nil {
-		s.logger.Error("list expired premium failed", "error", err)
-		return
-	}
-	for _, u := range expired {
-		if err := s.userStore.SetUserTier(ctx, u.ChatID, "free", time.Time{}); err != nil {
-			s.logger.Error("downgrade user failed", "chat_id", u.ChatID, "error", err)
-			continue
-		}
-		if s.dailyDigestStore != nil {
-			if err := s.dailyDigestStore.SetDailyDigest(ctx, u.ChatID, false, "09:00"); err != nil {
-				s.logger.Error("disable daily digest on downgrade failed", "chat_id", u.ChatID, "error", err)
-			}
-		}
-		s.deactivateExcessSearches(ctx, u.ChatID, 1)
-		lang := s.userLang(ctx, u.ChatID)
-		chatIDStr := fmt.Sprintf("%d", u.ChatID)
-		if err := s.notifier.NotifyRaw(ctx, chatIDStr, locale.T(lang, "premium_expired")); err != nil {
-			s.logger.Error("send expiry notification failed", "chat_id", u.ChatID, "error", err)
-		}
-		s.logger.Info("premium expired, downgraded to free", "chat_id", u.ChatID)
-	}
+func (s *Scheduler) processExpiredPremium(_ context.Context) {
 }
 
 func (s *Scheduler) userLang(ctx context.Context, chatID int64) locale.Lang {

--- a/internal/scheduler/scheduler_extra_test.go
+++ b/internal/scheduler/scheduler_extra_test.go
@@ -312,63 +312,10 @@ func TestTriggerPoll_DoesNotBlock(t *testing.T) {
 
 // --- processExpiredPremium tests ---
 
-func TestProcessExpiredPremium_NilUserStore(t *testing.T) {
+func TestProcessExpiredPremium_IsNoOp(t *testing.T) {
 	cfg := testConfig()
 	s, _ := New(cfg, nil, nil, nil, testLogger(), nil)
 	s.processExpiredPremium(context.Background())
-}
-
-func TestProcessExpiredPremium_NoExpired(t *testing.T) {
-	cfg := testConfig()
-	us := newMockUserStore()
-	n := &mockNotifier{}
-	s, _ := NewWithOptions(cfg, nil, nil, n, testLogger(), Options{UserStore: us})
-
-	s.processExpiredPremium(context.Background())
-
-	if len(n.rawMessages) != 0 {
-		t.Error("expected no notifications for no expired users")
-	}
-}
-
-func TestProcessExpiredPremium_DowngradesUser(t *testing.T) {
-	cfg := testConfig()
-	us := &mockUserStoreWithExpired{
-		mockUserStore: newMockUserStore(),
-		expired:       []storage.User{{ChatID: 100, Tier: "premium", Language: "he"}},
-	}
-	us.users[100] = &storage.User{ChatID: 100, Tier: "premium", Language: "he"}
-	n := &mockNotifier{}
-	ss := &mockSearchStore{
-		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Active: true},
-		},
-	}
-	dds := newMockDailyDigestStore()
-
-	s, _ := NewWithOptions(cfg, nil, nil, n, testLogger(), Options{
-		UserStore:        us,
-		SearchStore:      ss,
-		DailyDigestStore: dds,
-	})
-
-	s.processExpiredPremium(context.Background())
-
-	if us.users[100].Tier != "free" {
-		t.Errorf("expected tier 'free', got %q", us.users[100].Tier)
-	}
-	if len(n.rawMessages) != 1 {
-		t.Errorf("expected 1 expiry notification, got %d", len(n.rawMessages))
-	}
-}
-
-type mockUserStoreWithExpired struct {
-	*mockUserStore
-	expired []storage.User
-}
-
-func (m *mockUserStoreWithExpired) ListExpiredPremium(_ context.Context) ([]storage.User, error) {
-	return m.expired, nil
 }
 
 // --- deactivateExcessSearches tests ---
@@ -597,56 +544,11 @@ func (m *mockNotifierWithRawErr) NotifyRaw(_ context.Context, _ string, _ string
 
 // --- isUserPremium tests ---
 
-func TestIsUserPremium_NilUserStore(t *testing.T) {
+func TestIsUserPremium_AlwaysTrue(t *testing.T) {
 	cfg := testConfig()
 	s, _ := New(cfg, nil, nil, nil, testLogger(), nil)
 
-	if s.isUserPremium(context.Background(), 100) {
-		t.Error("expected false when no user store")
-	}
-}
-
-func TestIsUserPremium_PremiumUser(t *testing.T) {
-	cfg := testConfig()
-	us := newMockUserStore()
-	us.users[100] = &storage.User{ChatID: 100, Tier: "premium"}
-	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
-
 	if !s.isUserPremium(context.Background(), 100) {
-		t.Error("expected true for premium user with no expiry")
-	}
-}
-
-func TestIsUserPremium_ExpiredPremium(t *testing.T) {
-	cfg := testConfig()
-	us := newMockUserStore()
-	us.users[100] = &storage.User{ChatID: 100, Tier: "premium", TierExpires: time.Now().Add(-1 * time.Hour)}
-	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
-
-	if s.isUserPremium(context.Background(), 100) {
-		t.Error("expected false for expired premium")
-	}
-}
-
-func TestIsUserPremium_CachesResult(t *testing.T) {
-	cfg := testConfig()
-	us := newMockUserStore()
-	us.users[100] = &storage.User{ChatID: 100, Tier: "premium"}
-	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
-
-	s.isUserPremium(context.Background(), 100)
-	delete(us.users, 100)
-	if !s.isUserPremium(context.Background(), 100) {
-		t.Error("second call should use cache even after user deleted from store")
-	}
-}
-
-func TestIsUserPremium_UnknownUser(t *testing.T) {
-	cfg := testConfig()
-	us := newMockUserStore()
-	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
-
-	if s.isUserPremium(context.Background(), 999) {
-		t.Error("expected false for unknown user")
+		t.Error("expected true for all users (premium gating disabled)")
 	}
 }

--- a/internal/storage/sqlite/searches.go
+++ b/internal/storage/sqlite/searches.go
@@ -154,19 +154,49 @@ func (s *Store) UpdateSearch(ctx context.Context, search storage.Search) error {
 }
 
 func (s *Store) DeleteSearch(ctx context.Context, id int64, chatID int64) error {
-	result, err := s.db.ExecContext(ctx,
-		"DELETE FROM searches WHERE id = ? AND chat_id = ?", id, chatID)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("begin tx: %w", err)
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
+	defer func() { _ = tx.Rollback() }()
+
+	var searchName string
+	err = tx.QueryRowContext(ctx,
+		"SELECT name FROM searches WHERE id = ? AND chat_id = ?", id, chatID,
+	).Scan(&searchName)
+	if err == sql.ErrNoRows {
 		return storage.ErrNotFound
 	}
-	return nil
+	if err != nil {
+		return fmt.Errorf("fetch search name: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM seen_listings WHERE search_id = ? AND chat_id = ?",
+		id, chatID); err != nil {
+		return fmt.Errorf("delete seen_listings: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM listing_history WHERE search_name = ? AND chat_id = ?",
+		searchName, chatID); err != nil {
+		return fmt.Errorf("delete listing_history: %w", err)
+	}
+
+	recipientStr := fmt.Sprintf("%d", chatID)
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM pending_notifications WHERE search_name = ? AND recipient = ?",
+		searchName, recipientStr); err != nil {
+		return fmt.Errorf("delete pending_notifications: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM searches WHERE id = ? AND chat_id = ?",
+		id, chatID); err != nil {
+		return fmt.Errorf("delete search: %w", err)
+	}
+
+	return tx.Commit()
 }
 
 func (s *Store) SetSearchActive(ctx context.Context, id int64, chatID int64, active bool) error {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -346,27 +346,43 @@ func TestDeleteSearch_CascadesRelatedRecords(t *testing.T) {
 	}
 
 	// Seed seen_listings for both users.
-	_, _ = store.ClaimNew(ctx, "tok1", 100, id1)
-	_, _ = store.ClaimNew(ctx, "tok2", 100, id1)
-	_, _ = store.ClaimNew(ctx, "tok1", 200, id2)
+	if _, err := store.ClaimNew(ctx, "tok1", 100, id1); err != nil {
+		t.Fatalf("claim tok1 user 100: %v", err)
+	}
+	if _, err := store.ClaimNew(ctx, "tok2", 100, id1); err != nil {
+		t.Fatalf("claim tok2 user 100: %v", err)
+	}
+	if _, err := store.ClaimNew(ctx, "tok1", 200, id2); err != nil {
+		t.Fatalf("claim tok1 user 200: %v", err)
+	}
 
 	// Seed listing_history for both users.
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "tok1", ChatID: 100, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatalf("save listing tok1 user 100: %v", err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "tok2", ChatID: 100, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2020, Price: 90000,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatalf("save listing tok2 user 100: %v", err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "tok1", ChatID: 200, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
-	})
+	}); err != nil {
+		t.Fatalf("save listing tok1 user 200: %v", err)
+	}
 
 	// Seed pending_notifications for both users.
-	_ = store.EnqueueNotification(ctx, "100", "mazda-3", "payload1")
-	_ = store.EnqueueNotification(ctx, "200", "mazda-3", "payload2")
+	if err := store.EnqueueNotification(ctx, "100", "mazda-3", "payload1"); err != nil {
+		t.Fatalf("enqueue notification user 100: %v", err)
+	}
+	if err := store.EnqueueNotification(ctx, "200", "mazda-3", "payload2"); err != nil {
+		t.Fatalf("enqueue notification user 200: %v", err)
+	}
 
 	// Delete user 100's search — should cascade.
 	if err := store.DeleteSearch(ctx, id1, 100); err != nil {
@@ -374,37 +390,55 @@ func TestDeleteSearch_CascadesRelatedRecords(t *testing.T) {
 	}
 
 	// Search itself should be gone.
-	s, _ := store.GetSearch(ctx, id1)
+	s, err := store.GetSearch(ctx, id1)
+	if err != nil {
+		t.Fatalf("get deleted search: %v", err)
+	}
 	if s != nil {
 		t.Error("search should be deleted")
 	}
 
 	// seen_listings for user 100 should be cleaned up.
-	isNew, _ := store.ClaimNew(ctx, "tok1", 100, id1)
+	isNew, err := store.ClaimNew(ctx, "tok1", 100, id1)
+	if err != nil {
+		t.Fatalf("claim tok1 after delete: %v", err)
+	}
 	if !isNew {
 		t.Error("tok1 claim for user 100 should be released after cascade delete")
 	}
 
 	// User 200's seen_listings should be untouched.
-	isNew, _ = store.ClaimNew(ctx, "tok1", 200, id2)
+	isNew, err = store.ClaimNew(ctx, "tok1", 200, id2)
+	if err != nil {
+		t.Fatalf("claim tok1 user 200 after delete: %v", err)
+	}
 	if isNew {
 		t.Error("user 200's tok1 claim should NOT be affected by user 100's delete")
 	}
 
 	// listing_history for user 100 should be cleaned up.
-	count100, _ := store.CountSearchListings(ctx, 100, "mazda-3")
+	count100, err := store.CountSearchListings(ctx, 100, "mazda-3")
+	if err != nil {
+		t.Fatalf("count listings user 100: %v", err)
+	}
 	if count100 != 0 {
 		t.Errorf("expected 0 listings for user 100 after cascade, got %d", count100)
 	}
 
 	// User 200's listing_history should be untouched.
-	count200, _ := store.CountSearchListings(ctx, 200, "mazda-3")
+	count200, err := store.CountSearchListings(ctx, 200, "mazda-3")
+	if err != nil {
+		t.Fatalf("count listings user 200: %v", err)
+	}
 	if count200 != 1 {
 		t.Errorf("expected 1 listing for user 200, got %d", count200)
 	}
 
 	// pending_notifications for user 100 should be cleaned up.
-	pending, _ := store.PendingNotifications(ctx)
+	pending, err := store.PendingNotifications(ctx)
+	if err != nil {
+		t.Fatalf("pending notifications: %v", err)
+	}
 	for _, p := range pending {
 		if p.Recipient == "100" && p.SearchName == "mazda-3" {
 			t.Error("pending notification for user 100 should have been deleted")
@@ -426,9 +460,36 @@ func TestDeleteSearch_CascadeNotFound(t *testing.T) {
 	ctx := context.Background()
 	seedUser(t, store, 100)
 
-	err := store.DeleteSearch(ctx, 999, 100)
+	// Seed dependent rows that should NOT be affected by a failed delete.
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "existing", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+	if _, err := store.ClaimNew(ctx, "tok1", 100, id); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 100, SearchName: "existing",
+		Manufacturer: "Test", Model: "Car", Year: 2020, Price: 50000,
+	}); err != nil {
+		t.Fatalf("save listing: %v", err)
+	}
+
+	// Delete a non-existent search — should return ErrNotFound.
+	err = store.DeleteSearch(ctx, 999, 100)
 	if err != storage.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+
+	// Verify dependent rows for the real search are still intact.
+	count, err := store.CountSearchListings(ctx, 100, "existing")
+	if err != nil {
+		t.Fatalf("count listings: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 listing still present, got %d", count)
 	}
 }
 

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -323,6 +323,115 @@ func TestDeleteSearch_WrongOwner(t *testing.T) {
 	}
 }
 
+func TestDeleteSearch_CascadesRelatedRecords(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	id1, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "mazda-3", Manufacturer: 27, Model: 10332,
+		YearMin: 2018, YearMax: 2024, PriceMax: 150000,
+	})
+	if err != nil {
+		t.Fatalf("create search user 100: %v", err)
+	}
+
+	id2, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 200, Name: "mazda-3", Manufacturer: 27, Model: 10332,
+		YearMin: 2018, YearMax: 2024, PriceMax: 150000,
+	})
+	if err != nil {
+		t.Fatalf("create search user 200: %v", err)
+	}
+
+	// Seed seen_listings for both users.
+	_, _ = store.ClaimNew(ctx, "tok1", 100, id1)
+	_, _ = store.ClaimNew(ctx, "tok2", 100, id1)
+	_, _ = store.ClaimNew(ctx, "tok1", 200, id2)
+
+	// Seed listing_history for both users.
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 100, SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok2", ChatID: 100, SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2020, Price: 90000,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 200, SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
+	})
+
+	// Seed pending_notifications for both users.
+	_ = store.EnqueueNotification(ctx, "100", "mazda-3", "payload1")
+	_ = store.EnqueueNotification(ctx, "200", "mazda-3", "payload2")
+
+	// Delete user 100's search — should cascade.
+	if err := store.DeleteSearch(ctx, id1, 100); err != nil {
+		t.Fatalf("delete search: %v", err)
+	}
+
+	// Search itself should be gone.
+	s, _ := store.GetSearch(ctx, id1)
+	if s != nil {
+		t.Error("search should be deleted")
+	}
+
+	// seen_listings for user 100 should be cleaned up.
+	isNew, _ := store.ClaimNew(ctx, "tok1", 100, id1)
+	if !isNew {
+		t.Error("tok1 claim for user 100 should be released after cascade delete")
+	}
+
+	// User 200's seen_listings should be untouched.
+	isNew, _ = store.ClaimNew(ctx, "tok1", 200, id2)
+	if isNew {
+		t.Error("user 200's tok1 claim should NOT be affected by user 100's delete")
+	}
+
+	// listing_history for user 100 should be cleaned up.
+	count100, _ := store.CountSearchListings(ctx, 100, "mazda-3")
+	if count100 != 0 {
+		t.Errorf("expected 0 listings for user 100 after cascade, got %d", count100)
+	}
+
+	// User 200's listing_history should be untouched.
+	count200, _ := store.CountSearchListings(ctx, 200, "mazda-3")
+	if count200 != 1 {
+		t.Errorf("expected 1 listing for user 200, got %d", count200)
+	}
+
+	// pending_notifications for user 100 should be cleaned up.
+	pending, _ := store.PendingNotifications(ctx)
+	for _, p := range pending {
+		if p.Recipient == "100" && p.SearchName == "mazda-3" {
+			t.Error("pending notification for user 100 should have been deleted")
+		}
+	}
+	found200 := false
+	for _, p := range pending {
+		if p.Recipient == "200" && p.SearchName == "mazda-3" {
+			found200 = true
+		}
+	}
+	if !found200 {
+		t.Error("user 200's pending notification should NOT be affected")
+	}
+}
+
+func TestDeleteSearch_CascadeNotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	err := store.DeleteSearch(ctx, 999, 100)
+	if err != storage.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestSetSearchActive(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- **Disable premium tier gating**: All features (10 searches, daily digest, price drop alerts, deal scores) are now available to every user. The free tier was too restrictive (1 search, no premium features), driving users away instead of converting them. Tier infrastructure is kept dormant for potential re-enablement.
- **Cascade delete on watch removal**: `DeleteSearch` now transactionally cleans up `seen_listings`, `listing_history`, and `pending_notifications` before deleting the search itself, preventing orphaned records from accumulating.

## Key changes

- `freeMaxSearches` raised from 1 to 10
- `isPremium()` short-circuited to always return `true`
- Premium gates removed from daily digest, price drops, and deal score
- Trial grant on `/start` removed
- Premium expiry processing disabled
- `/grant_premium` and `/revoke_premium` commands de-registered
- `/upgrade` now informs users all features are free
- Settings no longer displays tier info
- `DeleteSearch` uses a transaction with cascading cleanup scoped by `chat_id`

## Test plan

- [x] All existing tests updated and passing (`make test`)
- [x] New cascade delete tests verify cross-user isolation (user B's data untouched when user A deletes)
- [x] `golangci-lint run ./...` passes clean
- [x] Coverage maintained at 79.9%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily digest now available to all users
  * Search limit increased to 10 per user

* **Refactor**
  * Subscription gating removed — features now universally accessible
  * Settings interface simplified and tier labels removed
  * Upgrade command disabled/hidden and help text updated

* **Bug Fixes**
  * Improved cascading data cleanup when deleting searches

* **Tests**
  * Tests updated to reflect new limits and digest/upgrade behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->