### PR TITLE
feat: embed SPA, listing detail page, dashboard stats, and admin panel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
         run: cd web && npx tsc -b
       - name: Build
         run: cd web && npm run build
+      - name: Upload web dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-dist
+          path: web/dist
 
   build:
     name: Build
@@ -84,8 +89,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Stub web/dist for embed
-        run: mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
+      - name: Download web dist
+        uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: web/dist
       - name: Build binary
         run: make build
       - name: Build Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Stub web/dist for embed
+        run: mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
       - uses: golangci/golangci-lint-action@v6
         with:
           version: latest
@@ -41,6 +43,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Stub web/dist for embed
+        run: mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
       - name: Install C compiler (sqlite3)
         run: sudo apt-get update && sudo apt-get install -y gcc
       - name: Run tests
@@ -80,6 +84,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Stub web/dist for embed
+        run: mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
       - name: Build binary
         run: make build
       - name: Build Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM node:22-alpine AS frontend
+WORKDIR /web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ .
+RUN npm run build
+
 FROM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev
@@ -6,6 +13,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+COPY --from=frontend /web/dist ./web/dist
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -27,7 +27,9 @@ import (
 	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/notifier/telegram"
 	"github.com/dsionov/carwatch/internal/scheduler"
+	"github.com/dsionov/carwatch/internal/spa"
 	"github.com/dsionov/carwatch/internal/storage/sqlite"
+	"github.com/dsionov/carwatch/web"
 )
 
 var (
@@ -164,6 +166,7 @@ func run(configPath string, logger *slog.Logger) error {
 		Listings: store,
 		Users:    store,
 		Prices:   store,
+		Admin:    store,
 		Logger:   logger,
 		API:      cfg.API,
 	})
@@ -172,6 +175,7 @@ func run(configPath string, logger *slog.Logger) error {
 	mux.HandleFunc("/healthz", h.Handler())
 	mux.Handle("/dashboard", dashHandler)
 	mux.Handle("/api/v1/", apiServer.Routes())
+	mux.Handle("/", spa.Handler(web.DistFS()))
 	srv := &http.Server{
 		Addr:              cfg.HTTP.Bind,
 		Handler:           mux,

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+type adminStatsResponse struct {
+	DB      dbStats      `json:"db"`
+	Tables  map[string]int64 `json:"tables"`
+	Runtime runtimeStats `json:"runtime"`
+}
+
+type dbStats struct {
+	FileSizeBytes int64  `json:"file_size_bytes"`
+	FileSizeHuman string `json:"file_size_human"`
+}
+
+type runtimeStats struct {
+	Goroutines int    `json:"goroutines"`
+	MemAllocMB float64 `json:"mem_alloc_mb"`
+	MemSysMB   float64 `json:"mem_sys_mb"`
+	Uptime     string `json:"uptime"`
+}
+
+func (s *Server) adminStats(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	fileSize, err := s.admin.DBFileSize()
+	if err != nil {
+		s.logger.Error("admin: db file size", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get db file size")
+		return
+	}
+
+	tables, err := s.admin.TableSizes(ctx)
+	if err != nil {
+		s.logger.Error("admin: table sizes", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get table sizes")
+		return
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	writeJSON(w, http.StatusOK, adminStatsResponse{
+		DB: dbStats{
+			FileSizeBytes: fileSize,
+			FileSizeHuman: humanBytes(fileSize),
+		},
+		Tables: tables,
+		Runtime: runtimeStats{
+			Goroutines: runtime.NumGoroutine(),
+			MemAllocMB: float64(mem.Alloc) / 1024 / 1024,
+			MemSysMB:   float64(mem.Sys) / 1024 / 1024,
+			Uptime:     time.Since(s.startTime).Truncate(time.Second).String(),
+		},
+	})
+}
+
+func humanBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
@@ -18,13 +19,15 @@ type contextKey string
 const chatIDKey contextKey = "chatID"
 
 type Server struct {
-	catalog  catalog.Catalog
-	searches storage.SearchStore
-	listings storage.ListingStore
-	users    storage.UserStore
-	prices   storage.PriceTracker
-	logger   *slog.Logger
-	cfg      config.APIConfig
+	catalog   catalog.Catalog
+	searches  storage.SearchStore
+	listings  storage.ListingStore
+	users     storage.UserStore
+	prices    storage.PriceTracker
+	admin     storage.AdminStore
+	logger    *slog.Logger
+	cfg       config.APIConfig
+	startTime time.Time
 }
 
 type Config struct {
@@ -33,19 +36,22 @@ type Config struct {
 	Listings storage.ListingStore
 	Users    storage.UserStore
 	Prices   storage.PriceTracker
+	Admin    storage.AdminStore
 	Logger   *slog.Logger
 	API      config.APIConfig
 }
 
 func New(c Config) *Server {
 	return &Server{
-		catalog:  c.Catalog,
-		searches: c.Searches,
-		listings: c.Listings,
-		users:    c.Users,
-		prices:   c.Prices,
-		logger:   c.Logger,
-		cfg:      c.API,
+		catalog:   c.Catalog,
+		searches:  c.Searches,
+		listings:  c.Listings,
+		users:     c.Users,
+		prices:    c.Prices,
+		admin:     c.Admin,
+		logger:    c.Logger,
+		cfg:       c.API,
+		startTime: time.Now(),
 	}
 }
 
@@ -64,6 +70,8 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("POST /api/v1/searches/{id}/resume", s.resumeSearch)
 
 	mux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
+
+	mux.HandleFunc("GET /api/v1/admin/stats", s.adminStats)
 
 	return s.corsMiddleware(s.authMiddleware(mux))
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -70,8 +70,11 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("POST /api/v1/searches/{id}/resume", s.resumeSearch)
 
 	mux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
+	mux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
 
-	mux.HandleFunc("GET /api/v1/admin/stats", s.adminStats)
+	if s.admin != nil {
+		mux.HandleFunc("GET /api/v1/admin/stats", s.adminStats)
+	}
 
 	return s.corsMiddleware(s.authMiddleware(mux))
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -564,6 +564,59 @@ func TestAdminStats_TableSizesError(t *testing.T) {
 	}
 }
 
+func TestGetListing_Success(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-abc", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021,
+		Price: 100000, Km: 50000, Hand: 2, City: "Tel Aviv",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/listings/tok-abc", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp listingResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Token != "tok-abc" {
+		t.Errorf("token = %q, want tok-abc", resp.Token)
+	}
+	if resp.Manufacturer != "Toyota" {
+		t.Errorf("manufacturer = %q, want Toyota", resp.Manufacturer)
+	}
+}
+
+func TestGetListing_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/listings/nonexistent", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetListing_WrongOwner(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-other", ChatID: 777, SearchName: "s1",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/listings/tok-other", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for wrong owner, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAdminStats(t *testing.T) {
 	srv, store := setupTestServer(t)
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -36,6 +36,7 @@ func setupTestServer(t *testing.T) (*Server, *sqlite.Store) {
 		Listings: store,
 		Users:    store,
 		Prices:   store,
+		Admin:    store,
 		Logger:   slog.Default(),
 		API: config.APIConfig{
 			CORSOrigins: []string{"http://localhost:5173"},
@@ -516,5 +517,61 @@ func mustUnmarshal(t *testing.T, data []byte, v any) {
 	t.Helper()
 	if err := json.Unmarshal(data, v); err != nil {
 		t.Fatalf("unmarshal: %v", err)
+	}
+}
+
+func TestAdminStats(t *testing.T) {
+	srv, store := setupTestServer(t)
+
+	ctx := context.Background()
+	_, err := store.CreateSearch(ctx, storage.Search{
+		ChatID:       999,
+		Name:         "test-search",
+		Source:       "yad2",
+		Manufacturer: 19,
+		Model:        10226,
+		YearMin:      2018,
+		YearMax:      2024,
+		PriceMax:     150000,
+		Active:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token:      "tok-1",
+		ChatID:     999,
+		SearchName: "test-search",
+		Manufacturer: "Toyota",
+		Model:        "Corolla",
+		Year:         2020,
+		Price:        120000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/stats", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp adminStatsResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+
+	if resp.Tables["users"] < 1 {
+		t.Errorf("expected at least 1 user, got %d", resp.Tables["users"])
+	}
+	if resp.Tables["searches"] < 1 {
+		t.Errorf("expected at least 1 search, got %d", resp.Tables["searches"])
+	}
+	if resp.Tables["listing_history"] < 1 {
+		t.Errorf("expected at least 1 listing, got %d", resp.Tables["listing_history"])
+	}
+	if resp.Runtime.Goroutines < 1 {
+		t.Error("expected goroutines > 0")
+	}
+	if resp.Runtime.Uptime == "" {
+		t.Error("expected non-empty uptime")
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -517,6 +518,49 @@ func mustUnmarshal(t *testing.T, data []byte, v any) {
 	t.Helper()
 	if err := json.Unmarshal(data, v); err != nil {
 		t.Fatalf("unmarshal: %v", err)
+	}
+}
+
+type failingAdminStore struct {
+	failDBFileSize bool
+	failTableSizes bool
+}
+
+func (f *failingAdminStore) DBFileSize() (int64, error) {
+	if f.failDBFileSize {
+		return 0, fmt.Errorf("disk error")
+	}
+	return 0, nil
+}
+
+func (f *failingAdminStore) CountAllListings(_ context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (f *failingAdminStore) TableSizes(_ context.Context) (map[string]int64, error) {
+	if f.failTableSizes {
+		return nil, fmt.Errorf("query error")
+	}
+	return map[string]int64{}, nil
+}
+
+func TestAdminStats_DBFileSizeError(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.admin = &failingAdminStore{failDBFileSize: true}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/stats", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminStats_TableSizesError(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.admin = &failingAdminStore{failTableSizes: true}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/stats", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -26,6 +26,41 @@ type listingsPageResponse struct {
 	Offset int               `json:"offset"`
 }
 
+func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "missing token")
+		return
+	}
+
+	l, err := s.listings.GetListing(r.Context(), chatID, token)
+	if err != nil {
+		s.logger.Error("get listing", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get listing")
+		return
+	}
+	if l == nil {
+		writeError(w, http.StatusNotFound, "listing not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listingResponse{
+		Token:        l.Token,
+		Manufacturer: l.Manufacturer,
+		Model:        l.Model,
+		Year:         l.Year,
+		Price:        l.Price,
+		Km:           l.Km,
+		Hand:         l.Hand,
+		City:         l.City,
+		PageLink:     l.PageLink,
+		ImageURL:     l.ImageURL,
+		FitnessScore: l.FitnessScore,
+		FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
+	})
+}
+
 func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {
 	chatID := chatIDFromContext(r.Context())
 	id, ok := parsePathID(r)

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -259,6 +259,10 @@ func (m *mockListingStore) SaveListings(_ context.Context, records []storage.Lis
 	return nil
 }
 
+func (m *mockListingStore) GetListing(_ context.Context, _ int64, _ string) (*storage.ListingRecord, error) {
+	return nil, nil
+}
+
 func (m *mockListingStore) ListUserListings(_ context.Context, _ int64, _, _ int) ([]storage.ListingRecord, error) {
 	return nil, nil
 }

--- a/internal/spa/spa.go
+++ b/internal/spa/spa.go
@@ -20,6 +20,10 @@ func Handler(distFS fs.FS) http.Handler {
 				fileServer.ServeHTTP(w, r)
 				return
 			}
+			if strings.HasPrefix(path, "assets/") {
+				http.NotFound(w, r)
+				return
+			}
 		}
 
 		w.Header().Set("Cache-Control", "no-cache")

--- a/internal/spa/spa.go
+++ b/internal/spa/spa.go
@@ -1,0 +1,29 @@
+package spa
+
+import (
+	"io/fs"
+	"net/http"
+	"strings"
+)
+
+func Handler(distFS fs.FS) http.Handler {
+	fileServer := http.FileServer(http.FS(distFS))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+
+		if path != "" {
+			if _, err := fs.Stat(distFS, path); err == nil {
+				if strings.HasPrefix(path, "assets/") {
+					w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+				}
+				fileServer.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		w.Header().Set("Cache-Control", "no-cache")
+		r.URL.Path = "/"
+		fileServer.ServeHTTP(w, r)
+	})
+}

--- a/internal/spa/spa_test.go
+++ b/internal/spa/spa_test.go
@@ -17,14 +17,16 @@ func TestHandler_ServesIndexForSPARoutes(t *testing.T) {
 
 	tests := []struct {
 		path       string
+		wantStatus int
 		wantBody   string
 		wantCache  string
 	}{
-		{"/", "<html>app</html>", "no-cache"},
-		{"/searches/new", "<html>app</html>", "no-cache"},
-		{"/listings/tok-123", "<html>app</html>", "no-cache"},
-		{"/admin", "<html>app</html>", "no-cache"},
-		{"/assets/index-abc123.js", "console.log('app')", "public, max-age=31536000, immutable"},
+		{"/", http.StatusOK, "<html>app</html>", "no-cache"},
+		{"/searches/new", http.StatusOK, "<html>app</html>", "no-cache"},
+		{"/listings/tok-123", http.StatusOK, "<html>app</html>", "no-cache"},
+		{"/admin", http.StatusOK, "<html>app</html>", "no-cache"},
+		{"/assets/index-abc123.js", http.StatusOK, "console.log('app')", "public, max-age=31536000, immutable"},
+		{"/assets/missing.js", http.StatusNotFound, "", ""},
 	}
 
 	for _, tt := range tests {
@@ -33,14 +35,18 @@ func TestHandler_ServesIndexForSPARoutes(t *testing.T) {
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
 
-			if w.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d", w.Code)
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", w.Code, tt.wantStatus)
 			}
-			if got := w.Body.String(); got != tt.wantBody {
-				t.Errorf("body = %q, want %q", got, tt.wantBody)
+			if tt.wantBody != "" {
+				if got := w.Body.String(); got != tt.wantBody {
+					t.Errorf("body = %q, want %q", got, tt.wantBody)
+				}
 			}
-			if got := w.Header().Get("Cache-Control"); got != tt.wantCache {
-				t.Errorf("Cache-Control = %q, want %q", got, tt.wantCache)
+			if tt.wantCache != "" {
+				if got := w.Header().Get("Cache-Control"); got != tt.wantCache {
+					t.Errorf("Cache-Control = %q, want %q", got, tt.wantCache)
+				}
 			}
 		})
 	}

--- a/internal/spa/spa_test.go
+++ b/internal/spa/spa_test.go
@@ -1,0 +1,47 @@
+package spa
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestHandler_ServesIndexForSPARoutes(t *testing.T) {
+	fs := fstest.MapFS{
+		"index.html":             {Data: []byte("<html>app</html>")},
+		"assets/index-abc123.js": {Data: []byte("console.log('app')")},
+	}
+
+	handler := Handler(fs)
+
+	tests := []struct {
+		path       string
+		wantBody   string
+		wantCache  string
+	}{
+		{"/", "<html>app</html>", "no-cache"},
+		{"/searches/new", "<html>app</html>", "no-cache"},
+		{"/listings/tok-123", "<html>app</html>", "no-cache"},
+		{"/admin", "<html>app</html>", "no-cache"},
+		{"/assets/index-abc123.js", "console.log('app')", "public, max-age=31536000, immutable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			if got := w.Body.String(); got != tt.wantBody {
+				t.Errorf("body = %q, want %q", got, tt.wantBody)
+			}
+			if got := w.Header().Get("Cache-Control"); got != tt.wantCache {
+				t.Errorf("Cache-Control = %q, want %q", got, tt.wantCache)
+			}
+		})
+	}
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -136,6 +136,7 @@ type PricePoint struct {
 type ListingStore interface {
 	SaveListing(ctx context.Context, r ListingRecord) error
 	SaveListings(ctx context.Context, records []ListingRecord) error
+	GetListing(ctx context.Context, chatID int64, token string) (*ListingRecord, error)
 	ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]ListingRecord, error)
 	CountUserListings(ctx context.Context, chatID int64) (int64, error)
 	ListSearchListings(ctx context.Context, chatID int64, searchName string, limit, offset int, sort string) ([]ListingRecord, error)

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -192,6 +192,12 @@ type DailyDigestStore interface {
 	DailyStats(ctx context.Context, chatID int64) ([]DailySearchStats, error)
 }
 
+type AdminStore interface {
+	DBFileSize() (int64, error)
+	CountAllListings(ctx context.Context) (int64, error)
+	TableSizes(ctx context.Context) (map[string]int64, error)
+}
+
 type CatalogEntry struct {
 	ManufacturerID   int
 	ManufacturerName string

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -1,0 +1,52 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func (s *Store) DBFileSize() (int64, error) {
+	var total int64
+	for _, name := range []string{s.dbPath, s.dbPath + "-wal", s.dbPath + "-shm"} {
+		fi, err := os.Stat(name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, fmt.Errorf("stat %s: %w", filepath.Base(name), err)
+		}
+		total += fi.Size()
+	}
+	return total, nil
+}
+
+func (s *Store) CountAllListings(ctx context.Context) (int64, error) {
+	var count int64
+	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM listing_history").Scan(&count)
+	return count, err
+}
+
+func (s *Store) TableSizes(ctx context.Context) (map[string]int64, error) {
+	tables := []string{
+		"users",
+		"searches",
+		"listing_history",
+		"price_history",
+		"dedup_seen",
+		"notifications",
+		"market_cache",
+		"catalog",
+	}
+	sizes := make(map[string]int64, len(tables))
+	for _, t := range tables {
+		var count int64
+		err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+t).Scan(&count)
+		if err != nil {
+			continue
+		}
+		sizes[t] = count
+	}
+	return sizes, nil
+}

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -5,9 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func (s *Store) DBFileSize() (int64, error) {
+	if s.dbPath == ":memory:" || strings.HasPrefix(s.dbPath, "file::memory:") {
+		return 0, nil
+	}
+
 	var total int64
 	for _, name := range []string{s.dbPath, s.dbPath + "-wal", s.dbPath + "-shm"} {
 		fi, err := os.Stat(name)

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -29,22 +29,30 @@ func (s *Store) CountAllListings(ctx context.Context) (int64, error) {
 }
 
 func (s *Store) TableSizes(ctx context.Context) (map[string]int64, error) {
-	tables := []string{
-		"users",
-		"searches",
-		"listing_history",
-		"price_history",
-		"dedup_seen",
-		"notifications",
-		"market_cache",
-		"catalog",
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+	if err != nil {
+		return nil, fmt.Errorf("list tables: %w", err)
 	}
+	defer func() { _ = rows.Close() }()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan table name: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tables: %w", err)
+	}
+
 	sizes := make(map[string]int64, len(tables))
 	for _, t := range tables {
 		var count int64
-		err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+t).Scan(&count)
-		if err != nil {
-			continue
+		if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM \""+t+"\"").Scan(&count); err != nil {
+			return nil, fmt.Errorf("count rows for table %s: %w", t, err)
 		}
 		sizes[t] = count
 	}

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -97,6 +97,29 @@ func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecor
 	return tx.Commit()
 }
 
+func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {
+	var l storage.ListingRecord
+	var fs sql.NullFloat64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT token, search_name, manufacturer, model, year, price,
+			km, hand, city, page_link, image_url, fitness_score, first_seen_at
+		FROM listing_history
+		WHERE chat_id = ? AND token = ?
+		ORDER BY rowid DESC LIMIT 1`, chatID, token).
+		Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
+			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if fs.Valid {
+		l.FitnessScore = &fs.Float64
+	}
+	return &l, nil
+}
+
 func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price,

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Store struct {
-	db *sql.DB
+	db     *sql.DB
+	dbPath string
 }
 
 func New(dbPath string) (*Store, error) {
@@ -38,7 +39,7 @@ func New(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 
-	return &Store{db: db}, nil
+	return &Store{db: db, dbPath: dbPath}, nil
 }
 
 func (s *Store) Checkpoint() error {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -1072,6 +1072,73 @@ func TestListUserListings(t *testing.T) {
 	}
 }
 
+func TestGetListing_Found(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-find", ChatID: 100, SearchName: "test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021,
+		Price: 110000, Km: 40000, Hand: 1, City: "Haifa",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := store.GetListing(ctx, 100, "tok-find")
+	if err != nil {
+		t.Fatalf("get listing: %v", err)
+	}
+	if l == nil {
+		t.Fatal("expected listing, got nil")
+	}
+	if l.Token != "tok-find" {
+		t.Errorf("token = %q, want tok-find", l.Token)
+	}
+	if l.Manufacturer != "Toyota" {
+		t.Errorf("manufacturer = %q, want Toyota", l.Manufacturer)
+	}
+	if l.Price != 110000 {
+		t.Errorf("price = %d, want 110000", l.Price)
+	}
+}
+
+func TestGetListing_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	l, err := store.GetListing(ctx, 100, "nonexistent")
+	if err != nil {
+		t.Fatalf("get listing: %v", err)
+	}
+	if l != nil {
+		t.Errorf("expected nil for missing token, got %+v", l)
+	}
+}
+
+func TestGetListing_WrongOwner(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-owned", ChatID: 100, SearchName: "test",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := store.GetListing(ctx, 200, "tok-owned")
+	if err != nil {
+		t.Fatalf("get listing: %v", err)
+	}
+	if l != nil {
+		t.Errorf("expected nil for wrong owner, got %+v", l)
+	}
+}
+
 func TestSaveListings_Batch(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,17 @@
+package web
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:dist
+var distFiles embed.FS
+
+func DistFS() fs.FS {
+	sub, err := fs.Sub(distFiles, "dist")
+	if err != nil {
+		panic("web: embed dist: " + err.Error())
+	}
+	return sub
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,8 @@ import { Shell } from "./components/layout/Shell";
 import { SearchesPage } from "./pages/SearchesPage";
 import { NewSearchPage } from "./pages/NewSearchPage";
 import { ListingsPage } from "./pages/ListingsPage";
+import { ListingDetailPage } from "./pages/ListingDetailPage";
+import { AdminPage } from "./pages/AdminPage";
 
 export default function App() {
   return (
@@ -11,6 +13,8 @@ export default function App() {
         <Route path="/" element={<SearchesPage />} />
         <Route path="/searches/new" element={<NewSearchPage />} />
         <Route path="/searches/:id/listings" element={<ListingsPage />} />
+        <Route path="/listings/:token" element={<ListingDetailPage />} />
+        <Route path="/admin" element={<AdminPage />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -1,10 +1,11 @@
 import { Outlet, Link, useLocation } from "react-router";
-import { Search, Plus, Car } from "lucide-react";
+import { Search, Plus, Car, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navItems = [
   { path: "/", label: "חיפושים", icon: Search },
   { path: "/searches/new", label: "חיפוש חדש", icon: Plus },
+  { path: "/admin", label: "ניהול", icon: Settings },
 ];
 
 export function Shell() {

--- a/web/src/hooks/useAdmin.ts
+++ b/web/src/hooks/useAdmin.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/api";
+
+export function useAdminStats() {
+  return useQuery({
+    queryKey: ["admin", "stats"],
+    queryFn: adminApi.stats,
+    refetchInterval: 30_000,
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -125,6 +125,7 @@ export const api = {
     resume: (id: number) =>
       fetchAPI<void>(`/searches/${id}/resume`, { method: "POST" }),
   },
+  listing: (token: string) => fetchAPI<Listing>(`/listings/${encodeURIComponent(token)}`),
   listings: (searchId: number, params?: ListingsParams) => {
     const query = new URLSearchParams();
     if (params?.limit) query.set("limit", String(params.limit));

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -137,4 +137,22 @@ export const api = {
   },
 };
 
+export interface AdminStats {
+  db: {
+    file_size_bytes: number;
+    file_size_human: string;
+  };
+  tables: Record<string, number>;
+  runtime: {
+    goroutines: number;
+    mem_alloc_mb: number;
+    mem_sys_mb: number;
+    uptime: string;
+  };
+}
+
+export const adminApi = {
+  stats: () => fetchAPI<AdminStats>("/admin/stats"),
+};
+
 export { ApiError };

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,0 +1,161 @@
+import {
+  Database,
+  Cpu,
+  Table,
+  RefreshCw,
+} from "lucide-react";
+import { useAdminStats } from "@/hooks/useAdmin";
+
+const TABLE_LABELS: Record<string, string> = {
+  users: "משתמשים",
+  searches: "חיפושים",
+  listing_history: "מודעות",
+  price_history: "היסטוריית מחירים",
+  dedup_seen: "מודעות שזוהו",
+  notifications: "התראות",
+  market_cache: "מטמון שוק",
+  catalog: "קטלוג",
+};
+
+export function AdminPage() {
+  const { data, isLoading, isError, dataUpdatedAt } = useAdminStats();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">ניהול מערכת</h1>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-40 animate-pulse rounded-xl bg-muted"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">ניהול מערכת</h1>
+        <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+          <p className="text-destructive font-medium">שגיאה בטעינת הנתונים</p>
+          <p className="text-sm text-muted-foreground mt-1">ייתכן שאין הרשאת גישה</p>
+        </div>
+      </div>
+    );
+  }
+
+  const lastUpdated = new Date(dataUpdatedAt);
+
+  return (
+    <div className="space-y-6 pb-20 md:pb-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ניהול מערכת</h1>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className="h-3 w-3" />
+          עדכון אחרון: {lastUpdated.toLocaleTimeString("he-IL")}
+        </div>
+      </div>
+
+      {/* DB Storage */}
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Database className="h-5 w-5 text-primary" />
+          <h2 className="text-lg font-semibold">אחסון בסיס נתונים</h2>
+        </div>
+        <div className="flex items-baseline gap-2 mb-3">
+          <span className="text-3xl font-bold">{data.db.file_size_human}</span>
+          <span className="text-sm text-muted-foreground">
+            ({data.db.file_size_bytes.toLocaleString("he-IL")} bytes)
+          </span>
+        </div>
+        <StorageBar sizeBytes={data.db.file_size_bytes} />
+      </div>
+
+      {/* Table sizes */}
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Table className="h-5 w-5 text-primary" />
+          <h2 className="text-lg font-semibold">גודל טבלאות</h2>
+        </div>
+        <div className="space-y-2">
+          {Object.entries(data.tables)
+            .sort(([, a], [, b]) => b - a)
+            .map(([table, count]) => (
+              <div
+                key={table}
+                className="flex items-center justify-between rounded-lg bg-muted/50 px-4 py-2.5"
+              >
+                <span className="text-sm font-medium">
+                  {TABLE_LABELS[table] ?? table}
+                </span>
+                <span className="text-sm font-mono font-semibold">
+                  {count.toLocaleString("he-IL")}
+                </span>
+              </div>
+            ))}
+        </div>
+      </div>
+
+      {/* Runtime */}
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Cpu className="h-5 w-5 text-primary" />
+          <h2 className="text-lg font-semibold">סטטוס מערכת</h2>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <StatBox label="זמן פעילות" value={data.runtime.uptime} />
+          <StatBox
+            label="Goroutines"
+            value={String(data.runtime.goroutines)}
+          />
+          <StatBox
+            label="זיכרון (Alloc)"
+            value={`${data.runtime.mem_alloc_mb.toFixed(1)} MB`}
+          />
+          <StatBox
+            label="זיכרון (Sys)"
+            value={`${data.runtime.mem_sys_mb.toFixed(1)} MB`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StorageBar({ sizeBytes }: { sizeBytes: number }) {
+  const maxBytes = 500 * 1024 * 1024; // 500 MB reference cap
+  const percent = Math.min((sizeBytes / maxBytes) * 100, 100);
+  const color =
+    percent > 80
+      ? "bg-destructive"
+      : percent > 50
+        ? "bg-yellow-500"
+        : "bg-green-500";
+
+  return (
+    <div>
+      <div className="h-3 w-full rounded-full bg-muted overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${color}`}
+          style={{ width: `${Math.max(percent, 1)}%` }}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground mt-1 text-left" dir="ltr">
+        {percent.toFixed(1)}% of 500 MB
+      </p>
+    </div>
+  );
+}
+
+function StatBox({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-background p-3 text-center">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-sm font-semibold mt-1 font-mono">{value}</p>
+    </div>
+  );
+}

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -141,7 +141,7 @@ function StorageBar({ sizeBytes }: { sizeBytes: number }) {
       <div className="h-3 w-full rounded-full bg-muted overflow-hidden">
         <div
           className={`h-full rounded-full transition-all ${color}`}
-          style={{ width: `${Math.max(percent, 1)}%` }}
+          style={{ width: `${percent}%` }}
         />
       </div>
       <p className="text-xs text-muted-foreground mt-1 text-left" dir="ltr">

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -1,4 +1,5 @@
-import { useLocation, Link, useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import { useLocation, Link, useNavigate, useParams } from "react-router";
 import {
   ArrowRight,
   ExternalLink,
@@ -9,14 +10,40 @@ import {
   Clock,
 } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import { api } from "@/lib/api";
 import type { Listing } from "@/lib/api";
 
 export function ListingDetailPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const listing = location.state?.listing as Listing | undefined;
+  const { token } = useParams();
+  const [listing, setListing] = useState<Listing | undefined>(
+    location.state?.listing as Listing | undefined,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
 
-  if (!listing) {
+  useEffect(() => {
+    if (listing || !token) return;
+    setLoading(true);
+    api
+      .listing(token)
+      .then((data) => setListing(data))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, [listing, token]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-40 animate-pulse rounded bg-muted" />
+        <div className="aspect-video w-full animate-pulse rounded-xl bg-muted" />
+        <div className="h-12 w-60 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (error || !listing) {
     return (
       <div className="flex flex-col items-center justify-center py-20">
         <p className="text-lg font-medium mb-2">המודעה לא נמצאה</p>

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -17,11 +17,18 @@ export function ListingDetailPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const { token } = useParams();
-  const [listing, setListing] = useState<Listing | undefined>(
-    location.state?.listing as Listing | undefined,
-  );
+  const stateListingRaw = location.state?.listing as Listing | undefined;
+  const stateListingForToken =
+    stateListingRaw?.token === token ? stateListingRaw : undefined;
+
+  const [listing, setListing] = useState<Listing | undefined>(stateListingForToken);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setListing(stateListingForToken);
+    setError(false);
+  }, [token]);
 
   useEffect(() => {
     if (listing || !token) return;

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -1,0 +1,155 @@
+import { useLocation, Link, useNavigate } from "react-router";
+import {
+  ArrowRight,
+  ExternalLink,
+  Calendar,
+  Gauge,
+  Hand,
+  MapPin,
+  Clock,
+} from "lucide-react";
+import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import type { Listing } from "@/lib/api";
+
+export function ListingDetailPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const listing = location.state?.listing as Listing | undefined;
+
+  if (!listing) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <p className="text-lg font-medium mb-2">המודעה לא נמצאה</p>
+        <p className="text-sm text-muted-foreground mb-6">
+          ניתן לגשת למודעה דרך רשימת התוצאות
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <ArrowRight className="h-4 w-4" />
+          חזרה לחיפושים
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pb-20 md:pb-4">
+      {/* Back button */}
+      <button
+        onClick={() => navigate(-1)}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowRight className="h-4 w-4" />
+        חזרה לתוצאות
+      </button>
+
+      {/* Cover image */}
+      {listing.image_url ? (
+        <div className="aspect-video w-full overflow-hidden rounded-xl bg-muted">
+          <img
+            src={listing.image_url}
+            alt={`${listing.manufacturer} ${listing.model}`}
+            className="h-full w-full object-cover"
+          />
+        </div>
+      ) : (
+        <div className="aspect-video w-full rounded-xl bg-muted flex items-center justify-center">
+          <span className="text-6xl text-muted-foreground/20">🚗</span>
+        </div>
+      )}
+
+      {/* Title + Price */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">
+            {listing.manufacturer} {listing.model}
+          </h1>
+          <p className="text-muted-foreground">{listing.year}</p>
+        </div>
+        <span className="text-2xl font-bold text-primary">
+          {formatPrice(listing.price)}
+        </span>
+      </div>
+
+      {/* Specs grid */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <SpecCard
+          icon={Gauge}
+          label='ק"מ'
+          value={formatKm(listing.km)}
+        />
+        <SpecCard
+          icon={Hand}
+          label="יד"
+          value={String(listing.hand)}
+        />
+        <SpecCard
+          icon={MapPin}
+          label="עיר"
+          value={listing.city || "—"}
+        />
+        <SpecCard
+          icon={Calendar}
+          label="שנה"
+          value={String(listing.year)}
+        />
+      </div>
+
+      {/* Score + Seen */}
+      <div className="flex items-center gap-4">
+        {listing.fitness_score != null && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">ציון התאמה:</span>
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium",
+                listing.fitness_score >= 7
+                  ? "bg-green-100 text-green-800"
+                  : listing.fitness_score >= 5
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-gray-100 text-gray-600",
+              )}
+            >
+              {listing.fitness_score.toFixed(1)}
+            </span>
+          </div>
+        )}
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Clock className="h-4 w-4" />
+          {relativeTime(listing.first_seen_at)}
+        </div>
+      </div>
+
+      {/* External link */}
+      <a
+        href={listing.page_link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        <ExternalLink className="h-4 w-4" />
+        צפה במודעה המקורית
+      </a>
+    </div>
+  );
+}
+
+function SpecCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 text-center">
+      <Icon className="mx-auto h-5 w-5 text-muted-foreground mb-1" />
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-sm font-semibold mt-0.5">{value}</p>
+    </div>
+  );
+}

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -22,12 +22,13 @@ export function ListingDetailPage() {
     stateListingRaw?.token === token ? stateListingRaw : undefined;
 
   const [listing, setListing] = useState<Listing | undefined>(stateListingForToken);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(!stateListingForToken && !!token);
   const [error, setError] = useState(false);
 
   useEffect(() => {
     setListing(stateListingForToken);
     setError(false);
+    setLoading(!stateListingForToken && !!token);
   }, [token]);
 
   useEffect(() => {

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, Link } from "react-router";
+import { useParams, Link, useNavigate } from "react-router";
 import { ArrowRight, ExternalLink, ChevronDown } from "lucide-react";
 import { useListings } from "@/hooks/useListings";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
@@ -166,12 +166,21 @@ export function ListingsPage() {
 }
 
 function ListingCard({ listing }: { listing: Listing }) {
+  const navigate = useNavigate();
+
   return (
-    <a
-      href={listing.page_link}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group block rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() =>
+        navigate(`/listings/${listing.token}`, { state: { listing } })
+      }
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          navigate(`/listings/${listing.token}`, { state: { listing } });
+        }
+      }}
+      className="group block cursor-pointer rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
     >
       {/* Image */}
       {listing.image_url ? (
@@ -221,7 +230,7 @@ function ListingCard({ listing }: { listing: Listing }) {
           <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
         </div>
       </div>
-    </a>
+    </div>
   );
 }
 

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -64,13 +64,11 @@ export function SearchesPage() {
             <p className="text-2xl font-bold">{activeCount}</p>
             <p className="text-xs text-muted-foreground">פעילים</p>
           </div>
-          {pausedCount > 0 && (
-            <div className="rounded-xl border border-border bg-card p-4 text-center">
-              <Pause className="mx-auto h-5 w-5 text-yellow-600 mb-1" />
-              <p className="text-2xl font-bold">{pausedCount}</p>
-              <p className="text-xs text-muted-foreground">מושהים</p>
-            </div>
-          )}
+          <div className="rounded-xl border border-border bg-card p-4 text-center">
+            <Pause className="mx-auto h-5 w-5 text-yellow-600 mb-1" />
+            <p className="text-2xl font-bold">{pausedCount}</p>
+            <p className="text-xs text-muted-foreground">מושהים</p>
+          </div>
         </div>
       )}
 

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { Plus, Play, Pause, Trash2, List } from "lucide-react";
+import { Plus, Play, Pause, Trash2, List, Search as SearchIcon, Activity } from "lucide-react";
 import {
   useSearches,
   useDeleteSearch,
@@ -46,8 +46,34 @@ export function SearchesPage() {
     );
   }
 
+  const activeCount = searches?.filter((s) => s.active).length ?? 0;
+  const pausedCount = (searches?.length ?? 0) - activeCount;
+
   return (
     <div className="space-y-4">
+      {/* Stats summary */}
+      {searches && searches.length > 0 && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <div className="rounded-xl border border-border bg-card p-4 text-center">
+            <SearchIcon className="mx-auto h-5 w-5 text-primary mb-1" />
+            <p className="text-2xl font-bold">{searches.length}</p>
+            <p className="text-xs text-muted-foreground">סה״כ חיפושים</p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-4 text-center">
+            <Activity className="mx-auto h-5 w-5 text-green-600 mb-1" />
+            <p className="text-2xl font-bold">{activeCount}</p>
+            <p className="text-xs text-muted-foreground">פעילים</p>
+          </div>
+          {pausedCount > 0 && (
+            <div className="rounded-xl border border-border bg-card p-4 text-center">
+              <Pause className="mx-auto h-5 w-5 text-yellow-600 mb-1" />
+              <p className="text-2xl font-bold">{pausedCount}</p>
+              <p className="text-xs text-muted-foreground">מושהים</p>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">החיפושים שלי</h1>
         <Link


### PR DESCRIPTION
## Summary

- **Embed React SPA** into the Go binary via `go:embed` — the website now works in production without separate static hosting. SPA routing falls back to `index.html` for client-side routes, with immutable cache headers for hashed assets.
- **Listing detail page** (#274) — clicking a listing card opens a full detail view with cover image, specs grid, fitness score, and link to the original ad.
- **Dashboard stats** (#275) — the home page now shows summary cards (total searches, active, paused) above the search list.
- **Admin panel** (#286) — new `/admin` page with DB storage monitoring (file size with visual bar), table row counts, and Go runtime stats (goroutines, memory, uptime). Auto-refreshes every 30s.

## What changed

### Backend
- `internal/spa/` — new package serving embedded frontend with SPA fallback routing
- `web/embed.go` — `go:embed` directive for `web/dist/`
- `internal/api/admin.go` — `GET /api/v1/admin/stats` endpoint returning DB size, table counts, runtime stats
- `internal/storage/interfaces.go` — new `AdminStore` interface
- `internal/storage/sqlite/admin.go` — SQLite implementation (file size, table row counts)
- `Dockerfile` — added Node.js frontend build stage before Go build

### Frontend
- `ListingDetailPage.tsx` — full listing view with specs, score, and external link
- `AdminPage.tsx` — DB storage bar, table sizes, runtime stats
- `SearchesPage.tsx` — added stats summary cards at top
- `Shell.tsx` — added admin nav item
- Updated `ListingsPage` cards to navigate to detail page instead of external link

Closes #274, #275, #286

## Test plan
- [x] `make test` — all pass, coverage up from 79.1% to 79.4%
- [x] `golangci-lint run ./...` — clean
- [x] `cd web && npx tsc -b && npm run build` — clean
- [x] New tests: `TestAdminStats`, `TestHandler_ServesIndexForSPARoutes` (SPA 100% coverage)
- [ ] Manual: start server, visit `http://localhost:8080/` — SPA loads
- [ ] Manual: click a listing card → detail page renders
- [ ] Manual: visit `/admin` → DB stats display

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard showing DB storage, per-table sizes and runtime stats
  * Listing detail page to view an individual listing
  * API endpoint to fetch a single listing by token
  * Frontend served from an embedded SPA

* **Improvements**
  * Admin navigation menu item added
  * Search page shows aggregate stats summary
  * Listing cards navigate in-app to detail routes
  * Admin stats auto-refetching hook

* **Tests**
  * Admin stats, listing retrieval and SPA handler tests added

* **Chores**
  * CI/Docker updated to build and include frontend assets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->