### PR TITLE
fix: correct e2e price tracking test assertion

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -357,8 +357,8 @@ func TestE2E_PriceTracking(t *testing.T) {
 		t.Errorf("price drop: changed=%v oldPrice=%d", changed, oldPrice)
 	}
 
-	_, changed, _ = store.RecordPrice(ctx, "tok-1", 95000)
-	if changed {
-		t.Error("price increase should not trigger change")
+	oldPrice, changed, _ = store.RecordPrice(ctx, "tok-1", 95000)
+	if !changed || oldPrice != 90000 {
+		t.Errorf("price increase: changed=%v oldPrice=%d (want changed=true, oldPrice=90000)", changed, oldPrice)
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -347,17 +347,26 @@ func TestE2E_PriceTracking(t *testing.T) {
 	defer store.Close()
 	ctx := context.Background()
 
-	_, changed, _ := store.RecordPrice(ctx, "tok-1", 100000)
+	_, changed, err := store.RecordPrice(ctx, "tok-1", 100000)
+	if err != nil {
+		t.Fatalf("record first price: %v", err)
+	}
 	if changed {
 		t.Error("first price should not be a change")
 	}
 
-	oldPrice, changed, _ := store.RecordPrice(ctx, "tok-1", 90000)
+	oldPrice, changed, err := store.RecordPrice(ctx, "tok-1", 90000)
+	if err != nil {
+		t.Fatalf("record price drop: %v", err)
+	}
 	if !changed || oldPrice != 100000 {
 		t.Errorf("price drop: changed=%v oldPrice=%d", changed, oldPrice)
 	}
 
-	oldPrice, changed, _ = store.RecordPrice(ctx, "tok-1", 95000)
+	oldPrice, changed, err = store.RecordPrice(ctx, "tok-1", 95000)
+	if err != nil {
+		t.Fatalf("record price increase: %v", err)
+	}
 	if !changed || oldPrice != 90000 {
 		t.Errorf("price increase: changed=%v oldPrice=%d (want changed=true, oldPrice=90000)", changed, oldPrice)
 	}


### PR DESCRIPTION
## Summary

- Fixes the failing `TestE2E_PriceTracking` test that has been broken since the test was written
- The e2e test asserted that price increases should **not** be detected as changes, but `RecordPrice` correctly returns `changed=true` for **any** price difference
- The scheduler already handles this correctly by filtering with `changed && l.Price < oldPrice` — only price **drops** trigger notifications
- Updated the assertion to match the actual (correct) behavior: price increase from 90k to 95k **is** a change, with `oldPrice=90000`

Partially addresses #250 (the failing test portion — coverage gaps remain open)

## Test plan
- [x] `go test -tags e2e ./e2e/` — all 6 e2e tests pass (previously 5/6)
- [x] `make test` — full suite passes, coverage 79.9%
- [x] `golangci-lint run ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end price-tracking test to (1) fail on any price-recording errors and (2) verify that price increases are detected and the previous price value is recorded correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->