### PR TITLE
feat: bookmarks and listing history

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -167,6 +167,8 @@ func run(configPath string, logger *slog.Logger) error {
 		Users:    store,
 		Prices:   store,
 		Admin:    store,
+		Saved:    store,
+		Hidden:   store,
 		Logger:   logger,
 		API:      cfg.API,
 	})

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,6 +25,8 @@ type Server struct {
 	users     storage.UserStore
 	prices    storage.PriceTracker
 	admin     storage.AdminStore
+	saved     storage.SavedListingStore
+	hidden    storage.HiddenListingStore
 	logger    *slog.Logger
 	cfg       config.APIConfig
 	startTime time.Time
@@ -37,6 +39,8 @@ type Config struct {
 	Users    storage.UserStore
 	Prices   storage.PriceTracker
 	Admin    storage.AdminStore
+	Saved    storage.SavedListingStore
+	Hidden   storage.HiddenListingStore
 	Logger   *slog.Logger
 	API      config.APIConfig
 }
@@ -49,6 +53,8 @@ func New(c Config) *Server {
 		users:     c.Users,
 		prices:    c.Prices,
 		admin:     c.Admin,
+		saved:     c.Saved,
+		hidden:    c.Hidden,
 		logger:    c.Logger,
 		cfg:       c.API,
 		startTime: time.Now(),
@@ -75,6 +81,11 @@ func (s *Server) Routes() http.Handler {
 	if s.admin != nil {
 		mux.HandleFunc("GET /api/v1/admin/stats", s.adminStats)
 	}
+
+	mux.HandleFunc("GET /api/v1/saved", s.listSaved)
+	mux.HandleFunc("POST /api/v1/listings/{token}/save", s.saveListing)
+	mux.HandleFunc("DELETE /api/v1/listings/{token}/save", s.unsaveListing)
+	mux.HandleFunc("GET /api/v1/history", s.listHistory)
 
 	return s.corsMiddleware(s.authMiddleware(mux))
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -85,6 +85,8 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /api/v1/saved", s.listSaved)
 	mux.HandleFunc("POST /api/v1/listings/{token}/save", s.saveListing)
 	mux.HandleFunc("DELETE /api/v1/listings/{token}/save", s.unsaveListing)
+	mux.HandleFunc("POST /api/v1/listings/{token}/hide", s.hideListing)
+	mux.HandleFunc("DELETE /api/v1/listings/{token}/hide", s.unhideListing)
 	mux.HandleFunc("GET /api/v1/history", s.listHistory)
 
 	return s.corsMiddleware(s.authMiddleware(mux))

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -82,12 +82,14 @@ func (s *Server) Routes() http.Handler {
 		mux.HandleFunc("GET /api/v1/admin/stats", s.adminStats)
 	}
 
-	mux.HandleFunc("GET /api/v1/saved", s.listSaved)
-	mux.HandleFunc("POST /api/v1/listings/{token}/save", s.saveListing)
-	mux.HandleFunc("DELETE /api/v1/listings/{token}/save", s.unsaveListing)
-	mux.HandleFunc("POST /api/v1/listings/{token}/hide", s.hideListing)
-	mux.HandleFunc("DELETE /api/v1/listings/{token}/hide", s.unhideListing)
-	mux.HandleFunc("GET /api/v1/history", s.listHistory)
+	if s.saved != nil && s.hidden != nil {
+		mux.HandleFunc("GET /api/v1/saved", s.listSaved)
+		mux.HandleFunc("POST /api/v1/listings/{token}/save", s.saveListing)
+		mux.HandleFunc("DELETE /api/v1/listings/{token}/save", s.unsaveListing)
+		mux.HandleFunc("POST /api/v1/listings/{token}/hide", s.hideListing)
+		mux.HandleFunc("DELETE /api/v1/listings/{token}/hide", s.unhideListing)
+		mux.HandleFunc("GET /api/v1/history", s.listHistory)
+	}
 
 	return s.corsMiddleware(s.authMiddleware(mux))
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -38,6 +38,8 @@ func setupTestServer(t *testing.T) (*Server, *sqlite.Store) {
 		Users:    store,
 		Prices:   store,
 		Admin:    store,
+		Saved:    store,
+		Hidden:   store,
 		Logger:   slog.Default(),
 		API: config.APIConfig{
 			CORSOrigins: []string{"http://localhost:5173"},
@@ -600,6 +602,51 @@ func TestGetListing_NotFound(t *testing.T) {
 	}
 }
 
+func TestBookmarkCRUD(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-bm", ChatID: 999, SearchName: "test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save bookmark
+	w := doRequest(t, srv, "POST", "/api/v1/listings/tok-bm/save", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("save: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// List saved
+	w = doRequest(t, srv, "GET", "/api/v1/saved", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list saved: expected 200, got %d", w.Code)
+	}
+	var savedResp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &savedResp)
+	if savedResp.Total != 1 {
+		t.Fatalf("expected 1 saved, got %d", savedResp.Total)
+	}
+	if savedResp.Items[0].Token != "tok-bm" {
+		t.Errorf("token = %q, want tok-bm", savedResp.Items[0].Token)
+	}
+
+	// Remove bookmark
+	w = doRequest(t, srv, "DELETE", "/api/v1/listings/tok-bm/save", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("unsave: expected 204, got %d", w.Code)
+	}
+
+	// Verify removed
+	w = doRequest(t, srv, "GET", "/api/v1/saved", nil)
+	mustUnmarshal(t, w.Body.Bytes(), &savedResp)
+	if savedResp.Total != 0 {
+		t.Errorf("expected 0 saved after removal, got %d", savedResp.Total)
+	}
+}
+
 func TestGetListing_WrongOwner(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
@@ -614,6 +661,35 @@ func TestGetListing_WrongOwner(t *testing.T) {
 	w := doRequest(t, srv, "GET", "/api/v1/listings/tok-other", nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for wrong owner, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListHistory(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-h1", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-h2", ChatID: 999, SearchName: "s2",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/history", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 2 {
+		t.Errorf("expected 2 history items, got %d", resp.Total)
 	}
 }
 

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+
+	"github.com/dsionov/carwatch/internal/storage"
 )
 
 func (s *Server) saveListing(w http.ResponseWriter, r *http.Request) {
@@ -38,11 +40,7 @@ func (s *Server) unsaveListing(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
 	chatID := chatIDFromContext(r.Context())
-	limit := parseIntParam(r, "limit", 20)
-	if limit > 100 {
-		limit = 100
-	}
-	offset := parseIntParam(r, "offset", 0)
+	limit, offset := parsePagination(r)
 
 	listings, err := s.saved.ListSaved(r.Context(), chatID, limit, offset)
 	if err != nil {
@@ -58,39 +56,49 @@ func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := make([]listingResponse, 0, len(listings))
-	for _, l := range listings {
-		items = append(items, listingResponse{
-			Token:        l.Token,
-			Manufacturer: l.Manufacturer,
-			Model:        l.Model,
-			Year:         l.Year,
-			Price:        l.Price,
-			Km:           l.Km,
-			Hand:         l.Hand,
-			City:         l.City,
-			PageLink:     l.PageLink,
-			ImageURL:     l.ImageURL,
-			FitnessScore: l.FitnessScore,
-			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
-		})
-	}
-
 	writeJSON(w, http.StatusOK, listingsPageResponse{
-		Items:  items,
+		Items:  toListingResponses(listings),
 		Total:  total,
 		Limit:  limit,
 		Offset: offset,
 	})
 }
 
+func (s *Server) hideListing(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "missing token")
+		return
+	}
+
+	if err := s.hidden.HideListing(r.Context(), chatID, token); err != nil {
+		s.logger.Error("hide listing", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to hide listing")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) unhideListing(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "missing token")
+		return
+	}
+
+	if err := s.hidden.ClearHidden(r.Context(), chatID); err != nil {
+		s.logger.Error("unhide listing", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to unhide listing")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
 	chatID := chatIDFromContext(r.Context())
-	limit := parseIntParam(r, "limit", 20)
-	if limit > 100 {
-		limit = 100
-	}
-	offset := parseIntParam(r, "offset", 0)
+	limit, offset := parsePagination(r)
 
 	listings, err := s.listings.ListUserListings(r.Context(), chatID, limit, offset)
 	if err != nil {
@@ -106,8 +114,17 @@ func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := make([]listingResponse, 0, len(listings))
-	for _, l := range listings {
+	writeJSON(w, http.StatusOK, listingsPageResponse{
+		Items:  toListingResponses(listings),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+func toListingResponses(records []storage.ListingRecord) []listingResponse {
+	items := make([]listingResponse, 0, len(records))
+	for _, l := range records {
 		items = append(items, listingResponse{
 			Token:        l.Token,
 			Manufacturer: l.Manufacturer,
@@ -123,11 +140,19 @@ func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
 			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
 		})
 	}
+	return items
+}
 
-	writeJSON(w, http.StatusOK, listingsPageResponse{
-		Items:  items,
-		Total:  total,
-		Limit:  limit,
-		Offset: offset,
-	})
+func parsePagination(r *http.Request) (limit, offset int) {
+	limit = parseIntParam(r, "limit", 20)
+	if limit <= 0 {
+		limit = 20
+	} else if limit > 100 {
+		limit = 100
+	}
+	offset = parseIntParam(r, "offset", 0)
+	if offset < 0 {
+		offset = 0
+	}
+	return
 }

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -88,7 +88,7 @@ func (s *Server) unhideListing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.hidden.ClearHidden(r.Context(), chatID); err != nil {
+	if err := s.hidden.UnhideListing(r.Context(), chatID, token); err != nil {
 		s.logger.Error("unhide listing", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to unhide listing")
 		return

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"net/http"
+)
+
+func (s *Server) saveListing(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "missing token")
+		return
+	}
+
+	if err := s.saved.SaveBookmark(r.Context(), chatID, token); err != nil {
+		s.logger.Error("save bookmark", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to save bookmark")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) unsaveListing(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "missing token")
+		return
+	}
+
+	if err := s.saved.RemoveBookmark(r.Context(), chatID, token); err != nil {
+		s.logger.Error("remove bookmark", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to remove bookmark")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	limit := parseIntParam(r, "limit", 20)
+	if limit > 100 {
+		limit = 100
+	}
+	offset := parseIntParam(r, "offset", 0)
+
+	listings, err := s.saved.ListSaved(r.Context(), chatID, limit, offset)
+	if err != nil {
+		s.logger.Error("list saved", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list saved")
+		return
+	}
+
+	total, err := s.saved.CountSaved(r.Context(), chatID)
+	if err != nil {
+		s.logger.Error("count saved", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count saved")
+		return
+	}
+
+	items := make([]listingResponse, 0, len(listings))
+	for _, l := range listings {
+		items = append(items, listingResponse{
+			Token:        l.Token,
+			Manufacturer: l.Manufacturer,
+			Model:        l.Model,
+			Year:         l.Year,
+			Price:        l.Price,
+			Km:           l.Km,
+			Hand:         l.Hand,
+			City:         l.City,
+			PageLink:     l.PageLink,
+			ImageURL:     l.ImageURL,
+			FitnessScore: l.FitnessScore,
+			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, listingsPageResponse{
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	limit := parseIntParam(r, "limit", 20)
+	if limit > 100 {
+		limit = 100
+	}
+	offset := parseIntParam(r, "offset", 0)
+
+	listings, err := s.listings.ListUserListings(r.Context(), chatID, limit, offset)
+	if err != nil {
+		s.logger.Error("list history", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list history")
+		return
+	}
+
+	total, err := s.listings.CountUserListings(r.Context(), chatID)
+	if err != nil {
+		s.logger.Error("count history", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count history")
+		return
+	}
+
+	items := make([]listingResponse, 0, len(listings))
+	for _, l := range listings {
+		items = append(items, listingResponse{
+			Token:        l.Token,
+			Manufacturer: l.Manufacturer,
+			Model:        l.Model,
+			Year:         l.Year,
+			Price:        l.Price,
+			Km:           l.Km,
+			Hand:         l.Hand,
+			City:         l.City,
+			PageLink:     l.PageLink,
+			ImageURL:     l.ImageURL,
+			FitnessScore: l.FitnessScore,
+			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, listingsPageResponse{
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -633,6 +633,15 @@ func (m *mockHiddenStore) CountHidden(_ context.Context, chatID int64) (int64, e
 	return int64(len(m.hidden[chatID])), nil
 }
 
+func (m *mockHiddenStore) UnhideListing(_ context.Context, chatID int64, token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if h, ok := m.hidden[chatID]; ok {
+		delete(h, token)
+	}
+	return nil
+}
+
 func (m *mockHiddenStore) ClearHidden(_ context.Context, chatID int64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -152,6 +152,7 @@ type SavedListingStore interface {
 
 type HiddenListingStore interface {
 	HideListing(ctx context.Context, chatID int64, token string) error
+	UnhideListing(ctx context.Context, chatID int64, token string) error
 	IsHidden(ctx context.Context, chatID int64, token string) (bool, error)
 	ListHiddenTokens(ctx context.Context, chatID int64) (map[string]bool, error)
 	ListHidden(ctx context.Context, chatID int64, limit, offset int) ([]string, error)

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -295,6 +295,13 @@ func (s *Store) HideListing(ctx context.Context, chatID int64, token string) err
 	return err
 }
 
+func (s *Store) UnhideListing(ctx context.Context, chatID int64, token string) error {
+	_, err := s.db.ExecContext(ctx,
+		"DELETE FROM hidden_listings WHERE chat_id = ? AND token = ?",
+		chatID, token)
+	return err
+}
+
 func (s *Store) IsHidden(ctx context.Context, chatID int64, token string) (bool, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,8 @@ import { NewSearchPage } from "./pages/NewSearchPage";
 import { ListingsPage } from "./pages/ListingsPage";
 import { ListingDetailPage } from "./pages/ListingDetailPage";
 import { AdminPage } from "./pages/AdminPage";
+import { SavedPage } from "./pages/SavedPage";
+import { HistoryPage } from "./pages/HistoryPage";
 
 export default function App() {
   return (
@@ -15,6 +17,8 @@ export default function App() {
         <Route path="/searches/:id/listings" element={<ListingsPage />} />
         <Route path="/listings/:token" element={<ListingDetailPage />} />
         <Route path="/admin" element={<AdminPage />} />
+        <Route path="/saved" element={<SavedPage />} />
+        <Route path="/history" element={<HistoryPage />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import type { Listing } from "@/lib/api";
+
+export function ListingCardBody({
+  listing,
+  actions,
+  hoverScale,
+}: {
+  listing: Listing;
+  actions?: ReactNode;
+  hoverScale?: boolean;
+}) {
+  return (
+    <>
+      {listing.image_url ? (
+        <div className="aspect-video w-full overflow-hidden bg-muted">
+          <img
+            src={listing.image_url}
+            alt={`${listing.manufacturer} ${listing.model}`}
+            className={cn(
+              "h-full w-full object-cover",
+              hoverScale && "group-hover:scale-105 transition-transform duration-300",
+            )}
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <div className="aspect-video w-full bg-muted flex items-center justify-center">
+          <span className="text-4xl text-muted-foreground/30">🚗</span>
+        </div>
+      )}
+
+      <div className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <div>
+            <h3 className="font-semibold">
+              {listing.manufacturer} {listing.model}
+            </h3>
+            <p className="text-xs text-muted-foreground">{listing.year}</p>
+          </div>
+          <span className="text-lg font-bold text-primary">
+            {formatPrice(listing.price)}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground mb-3">
+          <span>{formatKm(listing.km)}</span>
+          <span>יד {listing.hand}</span>
+          {listing.city && <span>{listing.city}</span>}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {listing.fitness_score != null && (
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                listing.fitness_score >= 7
+                  ? "bg-green-100 text-green-800"
+                  : listing.fitness_score >= 5
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-gray-100 text-gray-600",
+              )}
+            >
+              {listing.fitness_score.toFixed(1)}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground mr-auto">
+            {relativeTime(listing.first_seen_at)}
+          </span>
+          {actions}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -1,10 +1,12 @@
 import { Outlet, Link, useLocation } from "react-router";
-import { Search, Plus, Car, Settings } from "lucide-react";
+import { Search, Plus, Car, Settings, Bookmark, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navItems = [
   { path: "/", label: "חיפושים", icon: Search },
   { path: "/searches/new", label: "חיפוש חדש", icon: Plus },
+  { path: "/saved", label: "שמורים", icon: Bookmark },
+  { path: "/history", label: "היסטוריה", icon: Clock },
   { path: "/admin", label: "ניהול", icon: Settings },
 ];
 

--- a/web/src/hooks/useBookmarks.ts
+++ b/web/src/hooks/useBookmarks.ts
@@ -1,0 +1,32 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export function useSavedListings(limit = 20, offset = 0) {
+  return useQuery({
+    queryKey: ["saved", { limit, offset }],
+    queryFn: () => api.saved.list({ limit, offset }),
+  });
+}
+
+export function useSaveBookmark() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (token: string) => api.saved.save(token),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["saved"] }),
+  });
+}
+
+export function useRemoveBookmark() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (token: string) => api.saved.remove(token),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["saved"] }),
+  });
+}
+
+export function useHistory(limit = 20, offset = 0) {
+  return useQuery({
+    queryKey: ["history", { limit, offset }],
+    queryFn: () => api.history({ limit, offset }),
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -126,6 +126,30 @@ export const api = {
       fetchAPI<void>(`/searches/${id}/resume`, { method: "POST" }),
   },
   listing: (token: string) => fetchAPI<Listing>(`/listings/${encodeURIComponent(token)}`),
+  saved: {
+    list: (params?: ListingsParams) => {
+      const query = new URLSearchParams();
+      if (params?.limit) query.set("limit", String(params.limit));
+      if (params?.offset) query.set("offset", String(params.offset));
+      const qs = query.toString();
+      return fetchAPI<ListingsResponse>(`/saved${qs ? `?${qs}` : ""}`);
+    },
+    save: (token: string) =>
+      fetchAPI<void>(`/listings/${encodeURIComponent(token)}/save`, {
+        method: "POST",
+      }),
+    remove: (token: string) =>
+      fetchAPI<void>(`/listings/${encodeURIComponent(token)}/save`, {
+        method: "DELETE",
+      }),
+  },
+  history: (params?: ListingsParams) => {
+    const query = new URLSearchParams();
+    if (params?.limit) query.set("limit", String(params.limit));
+    if (params?.offset) query.set("offset", String(params.offset));
+    const qs = query.toString();
+    return fetchAPI<ListingsResponse>(`/history${qs ? `?${qs}` : ""}`);
+  },
   listings: (searchId: number, params?: ListingsParams) => {
     const query = new URLSearchParams();
     if (params?.limit) query.set("limit", String(params.limit));

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -129,8 +129,8 @@ export const api = {
   saved: {
     list: (params?: ListingsParams) => {
       const query = new URLSearchParams();
-      if (params?.limit) query.set("limit", String(params.limit));
-      if (params?.offset) query.set("offset", String(params.offset));
+      if (params?.limit !== undefined) query.set("limit", String(params.limit));
+      if (params?.offset !== undefined) query.set("offset", String(params.offset));
       const qs = query.toString();
       return fetchAPI<ListingsResponse>(`/saved${qs ? `?${qs}` : ""}`);
     },
@@ -145,15 +145,15 @@ export const api = {
   },
   history: (params?: ListingsParams) => {
     const query = new URLSearchParams();
-    if (params?.limit) query.set("limit", String(params.limit));
-    if (params?.offset) query.set("offset", String(params.offset));
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
     const qs = query.toString();
     return fetchAPI<ListingsResponse>(`/history${qs ? `?${qs}` : ""}`);
   },
   listings: (searchId: number, params?: ListingsParams) => {
     const query = new URLSearchParams();
-    if (params?.limit) query.set("limit", String(params.limit));
-    if (params?.offset) query.set("offset", String(params.offset));
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
     if (params?.sort) query.set("sort", params.sort);
     const qs = query.toString();
     return fetchAPI<ListingsResponse>(

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -14,6 +14,16 @@ export function formatKm(km: number): string {
   return km.toLocaleString("he-IL") + " ק\"מ";
 }
 
+export function safeHref(raw: string): string | null {
+  try {
+    const u = new URL(raw);
+    if (u.protocol === "http:" || u.protocol === "https:") return u.toString();
+  } catch {
+    // invalid URL
+  }
+  return null;
+}
+
 export function relativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   if (Number.isNaN(date.getTime())) return "—";

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Clock, ExternalLink } from "lucide-react";
 import { useHistory } from "@/hooks/useBookmarks";
-import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
+import { safeHref } from "@/lib/utils";
+import { ListingCardBody } from "@/components/ListingCardBody";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
@@ -102,66 +103,16 @@ export function HistoryPage() {
 function HistoryCard({ listing }: { listing: Listing }) {
   const href = safeHref(listing.page_link);
 
-  const card = (
-    <>
-      {listing.image_url ? (
-        <div className="aspect-video w-full overflow-hidden bg-muted">
-          <img
-            src={listing.image_url}
-            alt={`${listing.manufacturer} ${listing.model}`}
-            className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-            loading="lazy"
-          />
-        </div>
-      ) : (
-        <div className="aspect-video w-full bg-muted flex items-center justify-center">
-          <span className="text-4xl text-muted-foreground/30">🚗</span>
-        </div>
-      )}
-
-      <div className="p-4">
-        <div className="flex items-start justify-between mb-2">
-          <div>
-            <h3 className="font-semibold">
-              {listing.manufacturer} {listing.model}
-            </h3>
-            <p className="text-xs text-muted-foreground">{listing.year}</p>
-          </div>
-          <span className="text-lg font-bold text-primary">
-            {formatPrice(listing.price)}
-          </span>
-        </div>
-
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground mb-3">
-          <span>{formatKm(listing.km)}</span>
-          <span>יד {listing.hand}</span>
-          {listing.city && <span>{listing.city}</span>}
-        </div>
-
-        <div className="flex items-center gap-2">
-          {listing.fitness_score != null && (
-            <span
-              className={cn(
-                "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
-                listing.fitness_score >= 7
-                  ? "bg-green-100 text-green-800"
-                  : listing.fitness_score >= 5
-                    ? "bg-yellow-100 text-yellow-800"
-                    : "bg-gray-100 text-gray-600",
-              )}
-            >
-              {listing.fitness_score.toFixed(1)}
-            </span>
-          )}
-          <span className="text-xs text-muted-foreground mr-auto">
-            {relativeTime(listing.first_seen_at)}
-          </span>
-          {href && (
-            <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
-          )}
-        </div>
-      </div>
-    </>
+  const body = (
+    <ListingCardBody
+      listing={listing}
+      hoverScale={!!href}
+      actions={
+        href ? (
+          <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+        ) : undefined
+      }
+    />
   );
 
   if (href) {
@@ -173,14 +124,14 @@ function HistoryCard({ listing }: { listing: Listing }) {
         aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
         className="group block rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
       >
-        {card}
+        {body}
       </a>
     );
   }
 
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden shadow-sm">
-      {card}
+      {body}
     </div>
   );
 }

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Clock, ExternalLink } from "lucide-react";
 import { useHistory } from "@/hooks/useBookmarks";
-import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
@@ -9,6 +9,13 @@ const PAGE_SIZE = 20;
 export function HistoryPage() {
   const [offset, setOffset] = useState(0);
   const { data, isLoading, isError } = useHistory(PAGE_SIZE, offset);
+
+  useEffect(() => {
+    if (!data || data.total === 0) return;
+    if (offset >= data.total) {
+      setOffset(Math.floor((data.total - 1) / PAGE_SIZE) * PAGE_SIZE);
+    }
+  }, [data, offset]);
 
   if (isLoading) {
     return (
@@ -46,7 +53,7 @@ export function HistoryPage() {
         )}
       </div>
 
-      {!data || data.items.length === 0 ? (
+      {!data || data.total === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-16">
           <Clock className="h-8 w-8 text-muted-foreground/30 mb-3" />
           <p className="text-muted-foreground">אין מודעות בהיסטוריה</p>
@@ -62,7 +69,7 @@ export function HistoryPage() {
             ))}
           </div>
 
-          {data.total > PAGE_SIZE && (
+          {(data.total > PAGE_SIZE || offset > 0) && (
             <div className="flex items-center justify-center gap-3 pt-4">
               {offset > 0 && (
                 <button
@@ -93,14 +100,10 @@ export function HistoryPage() {
 }
 
 function HistoryCard({ listing }: { listing: Listing }) {
-  return (
-    <a
-      href={listing.page_link}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
-      className="group block rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
-    >
+  const href = safeHref(listing.page_link);
+
+  const card = (
+    <>
       {listing.image_url ? (
         <div className="aspect-video w-full overflow-hidden bg-muted">
           <img
@@ -153,9 +156,31 @@ function HistoryCard({ listing }: { listing: Listing }) {
           <span className="text-xs text-muted-foreground mr-auto">
             {relativeTime(listing.first_seen_at)}
           </span>
-          <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+          {href && (
+            <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+          )}
         </div>
       </div>
-    </a>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
+        className="group block rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+      >
+        {card}
+      </a>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden shadow-sm">
+      {card}
+    </div>
   );
 }

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -98,6 +98,7 @@ function HistoryCard({ listing }: { listing: Listing }) {
       href={listing.page_link}
       target="_blank"
       rel="noopener noreferrer"
+      aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
       className="group block rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
     >
       {listing.image_url ? (

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { Clock, ExternalLink } from "lucide-react";
+import { useHistory } from "@/hooks/useBookmarks";
+import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import type { Listing } from "@/lib/api";
+
+const PAGE_SIZE = 20;
+
+export function HistoryPage() {
+  const [offset, setOffset] = useState(0);
+  const { data, isLoading, isError } = useHistory(PAGE_SIZE, offset);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">היסטוריה</h1>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-48 animate-pulse rounded-xl bg-muted" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">היסטוריה</h1>
+        <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+          <p className="text-destructive font-medium">שגיאה בטעינת ההיסטוריה</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 pb-20 md:pb-4">
+      <div className="flex items-center gap-2">
+        <Clock className="h-5 w-5 text-primary" />
+        <h1 className="text-2xl font-bold">היסטוריה</h1>
+        {data && (
+          <span className="text-sm text-muted-foreground">
+            ({data.total} מודעות)
+          </span>
+        )}
+      </div>
+
+      {!data || data.items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-16">
+          <Clock className="h-8 w-8 text-muted-foreground/30 mb-3" />
+          <p className="text-muted-foreground">אין מודעות בהיסטוריה</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            מודעות שנמצאו יופיעו כאן
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {data.items.map((listing) => (
+              <HistoryCard key={listing.token} listing={listing} />
+            ))}
+          </div>
+
+          {data.total > PAGE_SIZE && (
+            <div className="flex items-center justify-center gap-3 pt-4">
+              {offset > 0 && (
+                <button
+                  onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                  className="rounded-lg bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors"
+                >
+                  הקודם
+                </button>
+              )}
+              <span className="text-sm text-muted-foreground">
+                {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} מתוך{" "}
+                {data.total}
+              </span>
+              {offset + PAGE_SIZE < data.total && (
+                <button
+                  onClick={() => setOffset(offset + PAGE_SIZE)}
+                  className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+                >
+                  הבא
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function HistoryCard({ listing }: { listing: Listing }) {
+  return (
+    <a
+      href={listing.page_link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+    >
+      {listing.image_url ? (
+        <div className="aspect-video w-full overflow-hidden bg-muted">
+          <img
+            src={listing.image_url}
+            alt={`${listing.manufacturer} ${listing.model}`}
+            className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <div className="aspect-video w-full bg-muted flex items-center justify-center">
+          <span className="text-4xl text-muted-foreground/30">🚗</span>
+        </div>
+      )}
+
+      <div className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <div>
+            <h3 className="font-semibold">
+              {listing.manufacturer} {listing.model}
+            </h3>
+            <p className="text-xs text-muted-foreground">{listing.year}</p>
+          </div>
+          <span className="text-lg font-bold text-primary">
+            {formatPrice(listing.price)}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground mb-3">
+          <span>{formatKm(listing.km)}</span>
+          <span>יד {listing.hand}</span>
+          {listing.city && <span>{listing.city}</span>}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {listing.fitness_score != null && (
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                listing.fitness_score >= 7
+                  ? "bg-green-100 text-green-800"
+                  : listing.fitness_score >= 5
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-gray-100 text-gray-600",
+              )}
+            >
+              {listing.fitness_score.toFixed(1)}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground mr-auto">
+            {relativeTime(listing.first_seen_at)}
+          </span>
+          <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { useParams, Link, useNavigate } from "react-router";
-import { ArrowRight, ExternalLink, ChevronDown } from "lucide-react";
+import { ArrowRight, ExternalLink, ChevronDown, Bookmark } from "lucide-react";
 import { useListings } from "@/hooks/useListings";
+import { useSaveBookmark } from "@/hooks/useBookmarks";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 
@@ -167,6 +168,8 @@ export function ListingsPage() {
 
 function ListingCard({ listing }: { listing: Listing }) {
   const navigate = useNavigate();
+  const saveBookmark = useSaveBookmark();
+  const [saved, setSaved] = useState(false);
 
   return (
     <div
@@ -227,7 +230,32 @@ function ListingCard({ listing }: { listing: Listing }) {
           <span className="text-xs text-muted-foreground mr-auto">
             {relativeTime(listing.first_seen_at)}
           </span>
-          <ExternalLink className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors" />
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!saved) {
+                saveBookmark.mutate(listing.token);
+                setSaved(true);
+              }
+            }}
+            className={cn(
+              "p-1 rounded transition-colors",
+              saved
+                ? "text-primary"
+                : "text-muted-foreground hover:text-primary",
+            )}
+          >
+            <Bookmark className={cn("h-3.5 w-3.5", saved && "fill-current")} />
+          </button>
+          <a
+            href={listing.page_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="p-1 rounded text-muted-foreground hover:text-primary transition-colors"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
         </div>
       </div>
     </div>

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -232,6 +232,9 @@ function ListingCard({ listing }: { listing: Listing }) {
             {relativeTime(listing.first_seen_at)}
           </span>
           <button
+            type="button"
+            aria-label={saved ? "הסר משמורים" : "שמור מודעה"}
+            aria-pressed={saved}
             onClick={(e) => {
               e.stopPropagation();
               const next = !saved;
@@ -254,6 +257,7 @@ function ListingCard({ listing }: { listing: Listing }) {
             href={listing.page_link}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="פתח מודעה באתר חיצוני"
             onClick={(e) => e.stopPropagation()}
             className="p-1 rounded text-muted-foreground hover:text-primary transition-colors"
           >

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, Link, useNavigate } from "react-router";
 import { ArrowRight, ExternalLink, ChevronDown, Bookmark } from "lucide-react";
 import { useListings } from "@/hooks/useListings";
-import { useSaveBookmark } from "@/hooks/useBookmarks";
+import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 
@@ -169,6 +169,7 @@ export function ListingsPage() {
 function ListingCard({ listing }: { listing: Listing }) {
   const navigate = useNavigate();
   const saveBookmark = useSaveBookmark();
+  const removeBookmark = useRemoveBookmark();
   const [saved, setSaved] = useState(false);
 
   return (
@@ -233,10 +234,12 @@ function ListingCard({ listing }: { listing: Listing }) {
           <button
             onClick={(e) => {
               e.stopPropagation();
-              if (!saved) {
-                saveBookmark.mutate(listing.token);
-                setSaved(true);
-              }
+              const next = !saved;
+              setSaved(next);
+              const mutation = next ? saveBookmark : removeBookmark;
+              mutation.mutate(listing.token, {
+                onError: () => setSaved(!next),
+              });
             }}
             className={cn(
               "p-1 rounded transition-colors",

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import { Bookmark, ExternalLink, Trash2 } from "lucide-react";
 import { useSavedListings, useRemoveBookmark } from "@/hooks/useBookmarks";
-import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
 
 export function SavedPage() {
   const [offset, setOffset] = useState(0);
-  const [removingToken, setRemovingToken] = useState<string | null>(null);
+  const [removingTokens, setRemovingTokens] = useState<Set<string>>(new Set());
   const { data, isLoading, isError } = useSavedListings(PAGE_SIZE, offset);
   const removeBookmark = useRemoveBookmark();
 
@@ -71,12 +71,17 @@ export function SavedPage() {
                 key={listing.token}
                 listing={listing}
                 onRemove={() => {
-                  setRemovingToken(listing.token);
+                  setRemovingTokens((prev) => new Set(prev).add(listing.token));
                   removeBookmark.mutate(listing.token, {
-                    onSettled: () => setRemovingToken(null),
+                    onSettled: () =>
+                      setRemovingTokens((prev) => {
+                        const next = new Set(prev);
+                        next.delete(listing.token);
+                        return next;
+                      }),
                   });
                 }}
-                removing={removingToken === listing.token}
+                removing={removingTokens.has(listing.token)}
               />
             ))}
           </div>
@@ -120,6 +125,8 @@ function SavedCard({
   onRemove: () => void;
   removing: boolean;
 }) {
+  const externalHref = safeHref(listing.page_link);
+
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden shadow-sm">
       {listing.image_url ? (
@@ -182,15 +189,17 @@ function SavedCard({
             <Trash2 className="h-3.5 w-3.5" />
             הסר
           </button>
-          <a
-            href={listing.page_link}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
-            className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:text-primary transition-colors"
-          >
-            <ExternalLink className="h-3.5 w-3.5" />
-          </a>
+          {externalHref && (
+            <a
+              href={externalHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
+              className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -1,0 +1,184 @@
+import { useState } from "react";
+import { Bookmark, ExternalLink, Trash2 } from "lucide-react";
+import { useSavedListings, useRemoveBookmark } from "@/hooks/useBookmarks";
+import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import type { Listing } from "@/lib/api";
+
+const PAGE_SIZE = 20;
+
+export function SavedPage() {
+  const [offset, setOffset] = useState(0);
+  const { data, isLoading, isError } = useSavedListings(PAGE_SIZE, offset);
+  const removeBookmark = useRemoveBookmark();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">שמורים</h1>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[1, 2].map((i) => (
+            <div key={i} className="h-48 animate-pulse rounded-xl bg-muted" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">שמורים</h1>
+        <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+          <p className="text-destructive font-medium">שגיאה בטעינת המודעות</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 pb-20 md:pb-4">
+      <div className="flex items-center gap-2">
+        <Bookmark className="h-5 w-5 text-primary" />
+        <h1 className="text-2xl font-bold">שמורים</h1>
+        {data && (
+          <span className="text-sm text-muted-foreground">
+            ({data.total})
+          </span>
+        )}
+      </div>
+
+      {!data || data.items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-16">
+          <Bookmark className="h-8 w-8 text-muted-foreground/30 mb-3" />
+          <p className="text-muted-foreground">אין מודעות שמורות</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            לחץ על סמל השמירה במודעה כדי לשמור אותה
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {data.items.map((listing) => (
+              <SavedCard
+                key={listing.token}
+                listing={listing}
+                onRemove={() => removeBookmark.mutate(listing.token)}
+                removing={removeBookmark.isPending}
+              />
+            ))}
+          </div>
+
+          {data.total > PAGE_SIZE && (
+            <div className="flex items-center justify-center gap-3 pt-4">
+              {offset > 0 && (
+                <button
+                  onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                  className="rounded-lg bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors"
+                >
+                  הקודם
+                </button>
+              )}
+              <span className="text-sm text-muted-foreground">
+                {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} מתוך{" "}
+                {data.total}
+              </span>
+              {offset + PAGE_SIZE < data.total && (
+                <button
+                  onClick={() => setOffset(offset + PAGE_SIZE)}
+                  className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+                >
+                  הבא
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function SavedCard({
+  listing,
+  onRemove,
+  removing,
+}: {
+  listing: Listing;
+  onRemove: () => void;
+  removing: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden shadow-sm">
+      {listing.image_url ? (
+        <div className="aspect-video w-full overflow-hidden bg-muted">
+          <img
+            src={listing.image_url}
+            alt={`${listing.manufacturer} ${listing.model}`}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <div className="aspect-video w-full bg-muted flex items-center justify-center">
+          <span className="text-4xl text-muted-foreground/30">🚗</span>
+        </div>
+      )}
+
+      <div className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <div>
+            <h3 className="font-semibold">
+              {listing.manufacturer} {listing.model}
+            </h3>
+            <p className="text-xs text-muted-foreground">{listing.year}</p>
+          </div>
+          <span className="text-lg font-bold text-primary">
+            {formatPrice(listing.price)}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground mb-3">
+          <span>{formatKm(listing.km)}</span>
+          <span>יד {listing.hand}</span>
+          {listing.city && <span>{listing.city}</span>}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {listing.fitness_score != null && (
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+                listing.fitness_score >= 7
+                  ? "bg-green-100 text-green-800"
+                  : listing.fitness_score >= 5
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-gray-100 text-gray-600",
+              )}
+            >
+              {listing.fitness_score.toFixed(1)}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground mr-auto">
+            {relativeTime(listing.first_seen_at)}
+          </span>
+          <button
+            onClick={onRemove}
+            disabled={removing}
+            className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            הסר
+          </button>
+          <a
+            href={listing.page_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -8,6 +8,7 @@ const PAGE_SIZE = 20;
 
 export function SavedPage() {
   const [offset, setOffset] = useState(0);
+  const [removingToken, setRemovingToken] = useState<string | null>(null);
   const { data, isLoading, isError } = useSavedListings(PAGE_SIZE, offset);
   const removeBookmark = useRemoveBookmark();
 
@@ -69,8 +70,13 @@ export function SavedPage() {
               <SavedCard
                 key={listing.token}
                 listing={listing}
-                onRemove={() => removeBookmark.mutate(listing.token)}
-                removing={removeBookmark.isPending}
+                onRemove={() => {
+                  setRemovingToken(listing.token);
+                  removeBookmark.mutate(listing.token, {
+                    onSettled: () => setRemovingToken(null),
+                  });
+                }}
+                removing={removingToken === listing.token}
               />
             ))}
           </div>

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Bookmark, ExternalLink, Trash2 } from "lucide-react";
 import { useSavedListings, useRemoveBookmark } from "@/hooks/useBookmarks";
-import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
+import { safeHref } from "@/lib/utils";
+import { ListingCardBody } from "@/components/ListingCardBody";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
@@ -129,79 +130,32 @@ function SavedCard({
 
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden shadow-sm">
-      {listing.image_url ? (
-        <div className="aspect-video w-full overflow-hidden bg-muted">
-          <img
-            src={listing.image_url}
-            alt={`${listing.manufacturer} ${listing.model}`}
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
-        </div>
-      ) : (
-        <div className="aspect-video w-full bg-muted flex items-center justify-center">
-          <span className="text-4xl text-muted-foreground/30">🚗</span>
-        </div>
-      )}
-
-      <div className="p-4">
-        <div className="flex items-start justify-between mb-2">
-          <div>
-            <h3 className="font-semibold">
-              {listing.manufacturer} {listing.model}
-            </h3>
-            <p className="text-xs text-muted-foreground">{listing.year}</p>
-          </div>
-          <span className="text-lg font-bold text-primary">
-            {formatPrice(listing.price)}
-          </span>
-        </div>
-
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground mb-3">
-          <span>{formatKm(listing.km)}</span>
-          <span>יד {listing.hand}</span>
-          {listing.city && <span>{listing.city}</span>}
-        </div>
-
-        <div className="flex items-center gap-2">
-          {listing.fitness_score != null && (
-            <span
-              className={cn(
-                "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
-                listing.fitness_score >= 7
-                  ? "bg-green-100 text-green-800"
-                  : listing.fitness_score >= 5
-                    ? "bg-yellow-100 text-yellow-800"
-                    : "bg-gray-100 text-gray-600",
-              )}
+      <ListingCardBody
+        listing={listing}
+        actions={
+          <>
+            <button
+              onClick={onRemove}
+              disabled={removing}
+              className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
             >
-              {listing.fitness_score.toFixed(1)}
-            </span>
-          )}
-          <span className="text-xs text-muted-foreground mr-auto">
-            {relativeTime(listing.first_seen_at)}
-          </span>
-          <button
-            onClick={onRemove}
-            disabled={removing}
-            className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            הסר
-          </button>
-          {externalHref && (
-            <a
-              href={externalHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
-              className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:text-primary transition-colors"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          )}
-        </div>
-      </div>
+              <Trash2 className="h-3.5 w-3.5" />
+              הסר
+            </button>
+            {externalHref && (
+              <a
+                href={externalHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
+                className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </>
+        }
+      />
     </div>
   );
 }

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Bookmark, ExternalLink, Trash2 } from "lucide-react";
 import { useSavedListings, useRemoveBookmark } from "@/hooks/useBookmarks";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
@@ -10,6 +10,13 @@ export function SavedPage() {
   const [offset, setOffset] = useState(0);
   const { data, isLoading, isError } = useSavedListings(PAGE_SIZE, offset);
   const removeBookmark = useRemoveBookmark();
+
+  useEffect(() => {
+    if (!data || data.total === 0) return;
+    if (offset > 0 && offset >= data.total) {
+      setOffset(Math.floor((data.total - 1) / PAGE_SIZE) * PAGE_SIZE);
+    }
+  }, [data, offset]);
 
   if (isLoading) {
     return (
@@ -68,7 +75,7 @@ export function SavedPage() {
             ))}
           </div>
 
-          {data.total > PAGE_SIZE && (
+          {(data.total > PAGE_SIZE || offset > 0) && (
             <div className="flex items-center justify-center gap-3 pt-4">
               {offset > 0 && (
                 <button
@@ -173,6 +180,7 @@ function SavedCard({
             href={listing.page_link}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`פתח מודעה: ${listing.manufacturer} ${listing.model}`}
             className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:text-primary transition-colors"
           >
             <ExternalLink className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

- **Bookmark listings** — save/unsave any listing from the feed with a bookmark icon, backed by `POST/DELETE /api/v1/listings/{token}/save`
- **Saved page** (`/saved`) — browse all bookmarked listings with pagination, remove bookmarks inline
- **History page** (`/history`) — browse all past matches across all searches with pagination
- **Navigation** — added "שמורים" (Saved) and "היסטוריה" (History) items to sidebar and mobile nav

### Backend
- `internal/api/bookmarks.go` — 4 handlers: save, unsave, list saved, list history
- Wired `SavedListingStore` and `HiddenListingStore` into API server
- Storage layer was already implemented (`saved_listings` table)

### Frontend
- `SavedPage.tsx` — saved listings grid with remove button, pagination, empty state
- `HistoryPage.tsx` — full listing history grid, pagination, empty state
- `useBookmarks.ts` — React Query hooks for saved/history with cache invalidation
- Bookmark button on listing cards in `ListingsPage.tsx`

Closes #276

## Test plan
- [x] `make test` — all pass, API coverage 70.0%
- [x] `golangci-lint run ./...` — clean
- [x] `cd web && npx tsc -b` — clean
- [x] `TestBookmarkCRUD` — save, list, remove, verify removal
- [x] `TestListHistory` — multi-search history listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save/unsave (bookmarks), hide/unhide listings, and list history endpoints plus corresponding Saved and History pages.

* **UI/UX**
  * Saved and History routes in navigation; paginated pages with loading, empty, and error states; bookmark button with optimistic update and separate external link; improved listing card body (image, details, score, time, actions).

* **Tests**
  * Integration tests for bookmark CRUD and history listing.

* **Utilities**
  * Safer external-link validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->