### PR TITLE
test: expand test coverage from 78.6% to 80.4%

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -693,6 +693,115 @@ func TestListHistory(t *testing.T) {
 	}
 }
 
+func TestHideUnhideListing(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-hide", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hide
+	w := doRequest(t, srv, "POST", "/api/v1/listings/tok-hide/hide", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("hide: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify hidden
+	hidden, err := store.IsHidden(ctx, 999, "tok-hide")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hidden {
+		t.Error("listing should be hidden after hide")
+	}
+
+	// Unhide
+	w = doRequest(t, srv, "DELETE", "/api/v1/listings/tok-hide/hide", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("unhide: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify unhidden
+	hidden, err = store.IsHidden(ctx, 999, "tok-hide")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hidden {
+		t.Error("listing should not be hidden after unhide")
+	}
+}
+
+func TestListHistory_Pagination(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	for i := range 5 {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: fmt.Sprintf("tok-hist-%d", i), ChatID: 999, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020 + i, Price: 100000 + i*10000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/history?limit=2&offset=0", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(resp.Items))
+	}
+	if resp.Total != 5 {
+		t.Errorf("expected total 5, got %d", resp.Total)
+	}
+
+	w = doRequest(t, srv, "GET", "/api/v1/history?limit=2&offset=4", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Items) != 1 {
+		t.Errorf("expected 1 item at offset 4, got %d", len(resp.Items))
+	}
+}
+
+func TestListSaved_Pagination(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	for i := range 3 {
+		token := fmt.Sprintf("tok-sv-%d", i)
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: 999, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.SaveBookmark(ctx, 999, token); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/saved?limit=2&offset=0", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(resp.Items))
+	}
+	if resp.Total != 3 {
+		t.Errorf("expected total 3, got %d", resp.Total)
+	}
+}
+
 func TestAdminStats(t *testing.T) {
 	srv, store := setupTestServer(t)
 

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2136,6 +2136,9 @@ func TestListSearchListings(t *testing.T) {
 	if len(listings) != 2 {
 		t.Fatalf("expected 2 listings for mazda3, got %d", len(listings))
 	}
+	if listings[0].Token != "lsl-2" || listings[1].Token != "lsl-1" {
+		t.Fatalf("newest sort order = [%s, %s], want [lsl-2, lsl-1]", listings[0].Token, listings[1].Token)
+	}
 
 	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 20, 0, "price_asc")
 	if err != nil {
@@ -2174,7 +2177,21 @@ func TestListSearchListings(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(listings) != 1 {
-		t.Errorf("pagination: expected 1, got %d", len(listings))
+		t.Fatalf("pagination: expected 1, got %d", len(listings))
+	}
+	if listings[0].Token != "lsl-2" {
+		t.Fatalf("pagination offset=0 returned %q, want lsl-2", listings[0].Token)
+	}
+
+	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 1, 1, "newest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("pagination offset=1: expected 1, got %d", len(listings))
+	}
+	if listings[0].Token != "lsl-1" {
+		t.Fatalf("pagination offset=1 returned %q, want lsl-1", listings[0].Token)
 	}
 }
 

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -1948,7 +1948,10 @@ func TestUnhideListing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hidden, _ := store.IsHidden(ctx, 100, "tok-a")
+	hidden, err := store.IsHidden(ctx, 100, "tok-a")
+	if err != nil {
+		t.Fatalf("IsHidden tok-a before unhide: %v", err)
+	}
 	if !hidden {
 		t.Fatal("tok-a should be hidden")
 	}
@@ -1957,12 +1960,18 @@ func TestUnhideListing(t *testing.T) {
 		t.Fatalf("UnhideListing: %v", err)
 	}
 
-	hidden, _ = store.IsHidden(ctx, 100, "tok-a")
+	hidden, err = store.IsHidden(ctx, 100, "tok-a")
+	if err != nil {
+		t.Fatalf("IsHidden tok-a after unhide: %v", err)
+	}
 	if hidden {
 		t.Error("tok-a should no longer be hidden")
 	}
 
-	hidden, _ = store.IsHidden(ctx, 100, "tok-b")
+	hidden, err = store.IsHidden(ctx, 100, "tok-b")
+	if err != nil {
+		t.Fatalf("IsHidden tok-b after unhide: %v", err)
+	}
 	if !hidden {
 		t.Error("tok-b should still be hidden")
 	}
@@ -1987,11 +1996,9 @@ func TestGetPriceHistory(t *testing.T) {
 	if _, _, err := store.RecordPrice(ctx, "tok-ph", 100000); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(10 * time.Millisecond)
 	if _, _, err := store.RecordPrice(ctx, "tok-ph", 95000); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(10 * time.Millisecond)
 	if _, _, err := store.RecordPrice(ctx, "tok-ph", 90000); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -1845,6 +1845,332 @@ func TestUpdateSearch_WrongOwner(t *testing.T) {
 	}
 }
 
+// --- Admin Store Tests ---
+
+func TestDBFileSize_InMemory(t *testing.T) {
+	store := newTestStore(t)
+	size, err := store.DBFileSize()
+	if err != nil {
+		t.Fatalf("DBFileSize: %v", err)
+	}
+	if size != 0 {
+		t.Errorf("expected 0 for in-memory DB, got %d", size)
+	}
+}
+
+func TestDBFileSize_OnDisk(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := dir + "/test.db"
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	ctx := context.Background()
+	if err := store.UpsertUser(ctx, 1, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := store.DBFileSize()
+	if err != nil {
+		t.Fatalf("DBFileSize: %v", err)
+	}
+	if size <= 0 {
+		t.Errorf("expected positive file size, got %d", size)
+	}
+}
+
+func TestCountAllListings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	count, err := store.CountAllListings(ctx)
+	if err != nil {
+		t.Fatalf("CountAllListings: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+
+	seedUser(t, store, 100)
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-2", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err = store.CountAllListings(ctx)
+	if err != nil {
+		t.Fatalf("CountAllListings: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestTableSizes(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	seedUser(t, store, 100)
+
+	sizes, err := store.TableSizes(ctx)
+	if err != nil {
+		t.Fatalf("TableSizes: %v", err)
+	}
+	if len(sizes) == 0 {
+		t.Fatal("expected non-empty table sizes")
+	}
+	if sizes["users"] != 1 {
+		t.Errorf("expected 1 user, got %d", sizes["users"])
+	}
+}
+
+// --- UnhideListing Tests ---
+
+func TestUnhideListing(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.HideListing(ctx, 100, "tok-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.HideListing(ctx, 100, "tok-b"); err != nil {
+		t.Fatal(err)
+	}
+
+	hidden, _ := store.IsHidden(ctx, 100, "tok-a")
+	if !hidden {
+		t.Fatal("tok-a should be hidden")
+	}
+
+	if err := store.UnhideListing(ctx, 100, "tok-a"); err != nil {
+		t.Fatalf("UnhideListing: %v", err)
+	}
+
+	hidden, _ = store.IsHidden(ctx, 100, "tok-a")
+	if hidden {
+		t.Error("tok-a should no longer be hidden")
+	}
+
+	hidden, _ = store.IsHidden(ctx, 100, "tok-b")
+	if !hidden {
+		t.Error("tok-b should still be hidden")
+	}
+}
+
+func TestUnhideListing_Nonexistent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.UnhideListing(ctx, 100, "does-not-exist"); err != nil {
+		t.Fatalf("UnhideListing nonexistent should not error: %v", err)
+	}
+}
+
+// --- GetPriceHistory Tests ---
+
+func TestGetPriceHistory(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, _, err := store.RecordPrice(ctx, "tok-ph", 100000); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, _, err := store.RecordPrice(ctx, "tok-ph", 95000); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, _, err := store.RecordPrice(ctx, "tok-ph", 90000); err != nil {
+		t.Fatal(err)
+	}
+
+	points, err := store.GetPriceHistory(ctx, "tok-ph")
+	if err != nil {
+		t.Fatalf("GetPriceHistory: %v", err)
+	}
+	if len(points) != 3 {
+		t.Fatalf("expected 3 price points, got %d", len(points))
+	}
+	if points[0].Price != 90000 {
+		t.Errorf("expected most recent price 90000 first, got %d", points[0].Price)
+	}
+	if points[2].Price != 100000 {
+		t.Errorf("expected oldest price 100000 last, got %d", points[2].Price)
+	}
+}
+
+func TestGetPriceHistory_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	points, err := store.GetPriceHistory(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetPriceHistory: %v", err)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected 0 points, got %d", len(points))
+	}
+}
+
+// --- GetSearchByShareToken Tests ---
+
+func TestGetSearchByShareToken(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "shared-search", Source: "yad2",
+		Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	search, err := store.GetSearch(ctx, id)
+	if err != nil {
+		t.Fatalf("GetSearch: %v", err)
+	}
+	if search.ShareToken == "" {
+		t.Fatal("expected non-empty share token")
+	}
+
+	found, err := store.GetSearchByShareToken(ctx, search.ShareToken)
+	if err != nil {
+		t.Fatalf("GetSearchByShareToken: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected to find search by share token")
+	}
+	if found.ID != id {
+		t.Errorf("expected ID %d, got %d", id, found.ID)
+	}
+	if found.Name != "shared-search" {
+		t.Errorf("expected name shared-search, got %s", found.Name)
+	}
+}
+
+func TestGetSearchByShareToken_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	found, err := store.GetSearchByShareToken(ctx, "nonexistent-token")
+	if err != nil {
+		t.Fatalf("GetSearchByShareToken: %v", err)
+	}
+	if found != nil {
+		t.Errorf("expected nil for nonexistent token, got %+v", found)
+	}
+}
+
+// --- UpdateLastSeenAt Tests ---
+
+func TestUpdateLastSeenAt(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.UpdateLastSeenAt(ctx, 100); err != nil {
+		t.Fatalf("UpdateLastSeenAt: %v", err)
+	}
+}
+
+func TestUpdateLastSeenAt_NonexistentUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.UpdateLastSeenAt(ctx, 99999); err != nil {
+		t.Fatalf("UpdateLastSeenAt should not error for nonexistent user: %v", err)
+	}
+}
+
+// --- ListSearchListings Tests ---
+
+func TestListSearchListings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "lsl-1", ChatID: 100, SearchName: "mazda3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 120000, Km: 50000, Hand: 2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "lsl-2", ChatID: 100, SearchName: "mazda3",
+		Manufacturer: "Mazda", Model: "3", Year: 2022, Price: 90000, Km: 30000, Hand: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "lsl-other", ChatID: 100, SearchName: "civic",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 80000, Km: 70000, Hand: 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	listings, err := store.ListSearchListings(ctx, 100, "mazda3", 20, 0, "newest")
+	if err != nil {
+		t.Fatalf("ListSearchListings: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Fatalf("expected 2 listings for mazda3, got %d", len(listings))
+	}
+
+	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 20, 0, "price_asc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listings[0].Price != 90000 {
+		t.Errorf("price_asc: expected 90000 first, got %d", listings[0].Price)
+	}
+
+	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 20, 0, "price_desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listings[0].Price != 120000 {
+		t.Errorf("price_desc: expected 120000 first, got %d", listings[0].Price)
+	}
+
+	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 20, 0, "km")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listings[0].Km != 30000 {
+		t.Errorf("km sort: expected 30000 first, got %d", listings[0].Km)
+	}
+
+	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 20, 0, "year")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listings[0].Year != 2022 {
+		t.Errorf("year sort: expected 2022 first, got %d", listings[0].Year)
+	}
+
+	listings, err = store.ListSearchListings(ctx, 100, "mazda3", 1, 0, "newest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("pagination: expected 1, got %d", len(listings))
+	}
+}
+
 // --- New() edge cases ---
 
 func TestNew_CreatesDirectory(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Storage tests** (70.4% → 79.3%): Added 13 new tests covering admin store functions (DBFileSize, CountAllListings, TableSizes), UnhideListing, GetPriceHistory, GetSearchByShareToken, UpdateLastSeenAt, and ListSearchListings with all 5 sort modes
- **API tests** (67.2% → 69.8%): Added 4 new tests covering hide/unhide endpoint CRUD, history pagination, and saved listings pagination
- **Overall**: 78.6% → 80.4%

## Addresses

Partial fix for #250 — covers the storage and API gaps; scheduler and bot handler coverage remain for a future PR.

## Test plan

- [x] `make test` — all tests pass, 80.4% coverage
- [x] `golangci-lint run ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded API tests: hide/unhide behavior and pagination correctness (limit/offset, totals).
  * Broadened storage tests: database sizing/inspection, global/table counts, hidden-listing recovery, price-history retrieval, and share-token lookup.
  * Added storage tests for last-seen updates, search listing filters/sorting (newest, price, distance, year) and pagination limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->