### PR TITLE
feat: in-app notification center with unread badge

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -169,6 +169,7 @@ func run(configPath string, logger *slog.Logger) error {
 		Admin:    store,
 		Saved:    store,
 		Hidden:   store,
+		Notifs:   store,
 		Logger:   logger,
 		API:      cfg.API,
 	})

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -27,6 +27,7 @@ type Server struct {
 	admin     storage.AdminStore
 	saved     storage.SavedListingStore
 	hidden    storage.HiddenListingStore
+	notifs    storage.NotificationStore
 	logger    *slog.Logger
 	cfg       config.APIConfig
 	startTime time.Time
@@ -41,6 +42,7 @@ type Config struct {
 	Admin    storage.AdminStore
 	Saved    storage.SavedListingStore
 	Hidden   storage.HiddenListingStore
+	Notifs   storage.NotificationStore
 	Logger   *slog.Logger
 	API      config.APIConfig
 }
@@ -55,6 +57,7 @@ func New(c Config) *Server {
 		admin:     c.Admin,
 		saved:     c.Saved,
 		hidden:    c.Hidden,
+		notifs:    c.Notifs,
 		logger:    c.Logger,
 		cfg:       c.API,
 		startTime: time.Now(),
@@ -80,6 +83,12 @@ func (s *Server) Routes() http.Handler {
 
 	if s.admin != nil {
 		mux.HandleFunc("GET /api/v1/admin/stats", s.adminStats)
+	}
+
+	if s.notifs != nil {
+		mux.HandleFunc("GET /api/v1/notifications", s.listNotifications)
+		mux.HandleFunc("GET /api/v1/notifications/count", s.notificationCount)
+		mux.HandleFunc("POST /api/v1/notifications/seen", s.markNotificationsSeen)
 	}
 
 	if s.saved != nil && s.hidden != nil {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
@@ -40,6 +41,7 @@ func setupTestServer(t *testing.T) (*Server, *sqlite.Store) {
 		Admin:    store,
 		Saved:    store,
 		Hidden:   store,
+		Notifs:   store,
 		Logger:   slog.Default(),
 		API: config.APIConfig{
 			CORSOrigins: []string{"http://localhost:5173"},
@@ -746,5 +748,110 @@ func TestAdminStats(t *testing.T) {
 	}
 	if resp.Runtime.Uptime == "" {
 		t.Error("expected non-empty uptime")
+	}
+}
+
+func setLastSeenAt(t *testing.T, store *sqlite.Store, chatID int64, when time.Time) {
+	t.Helper()
+	db := store.DB()
+	if _, err := db.Exec("UPDATE users SET last_seen_at = ? WHERE chat_id = ?", when, chatID); err != nil {
+		t.Fatalf("set last_seen_at: %v", err)
+	}
+}
+
+func TestNotificationCount(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	// Set last_seen_at to now so no listings are new
+	if err := store.UpdateLastSeenAt(ctx, 999); err != nil {
+		t.Fatal(err)
+	}
+	// Then move it back to the past so future inserts appear as new
+	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	w := doRequest(t, srv, "GET", "/api/v1/notifications/count", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp notifCountResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Count != 0 {
+		t.Errorf("expected 0 initially, got %d", resp.Count)
+	}
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "notif-1", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w = doRequest(t, srv, "GET", "/api/v1/notifications/count", nil)
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Errorf("expected 1 after adding listing, got %d", resp.Count)
+	}
+}
+
+func TestNotificationsList(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "notif-list-1", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/notifications", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 1 {
+		t.Errorf("expected 1 notification, got %d", resp.Total)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(resp.Items))
+	}
+}
+
+func TestNotificationsMarkSeen(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "notif-seen-1", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var countResp notifCountResponse
+	w := doRequest(t, srv, "GET", "/api/v1/notifications/count", nil)
+	mustUnmarshal(t, w.Body.Bytes(), &countResp)
+	if countResp.Count != 1 {
+		t.Fatalf("expected 1 before mark seen, got %d", countResp.Count)
+	}
+
+	w = doRequest(t, srv, "POST", "/api/v1/notifications/seen", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("mark seen: expected 204, got %d", w.Code)
+	}
+
+	w = doRequest(t, srv, "GET", "/api/v1/notifications/count", nil)
+	mustUnmarshal(t, w.Body.Bytes(), &countResp)
+	if countResp.Count != 0 {
+		t.Errorf("expected 0 after mark seen, got %d", countResp.Count)
 	}
 }

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -1,0 +1,72 @@
+package api
+
+import "net/http"
+
+type notifCountResponse struct {
+	Count int64 `json:"count"`
+}
+
+func (s *Server) notificationCount(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+
+	since, err := s.notifs.GetLastSeenAt(r.Context(), chatID)
+	if err != nil {
+		s.logger.Error("get last seen at", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get notification count")
+		return
+	}
+
+	count, err := s.notifs.CountNewListingsSince(r.Context(), chatID, since)
+	if err != nil {
+		s.logger.Error("count notifications", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count notifications")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, notifCountResponse{Count: count})
+}
+
+func (s *Server) listNotifications(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+	limit, offset := parsePagination(r)
+
+	since, err := s.notifs.GetLastSeenAt(r.Context(), chatID)
+	if err != nil {
+		s.logger.Error("get last seen at", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list notifications")
+		return
+	}
+
+	listings, err := s.notifs.NewListingsSince(r.Context(), chatID, since, limit, offset)
+	if err != nil {
+		s.logger.Error("list notifications", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list notifications")
+		return
+	}
+
+	total, err := s.notifs.CountNewListingsSince(r.Context(), chatID, since)
+	if err != nil {
+		s.logger.Error("count notifications", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count notifications")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listingsPageResponse{
+		Items:  toListingResponses(listings),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+func (s *Server) markNotificationsSeen(w http.ResponseWriter, r *http.Request) {
+	chatID := chatIDFromContext(r.Context())
+
+	if err := s.users.UpdateLastSeenAt(r.Context(), chatID); err != nil {
+		s.logger.Error("update last seen at", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to mark as seen")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -200,6 +200,12 @@ type AdminStore interface {
 	TableSizes(ctx context.Context) (map[string]int64, error)
 }
 
+type NotificationStore interface {
+	NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]ListingRecord, error)
+	CountNewListingsSince(ctx context.Context, chatID int64, since time.Time) (int64, error)
+	GetLastSeenAt(ctx context.Context, chatID int64) (time.Time, error)
+}
+
 type CatalogEntry struct {
 	ManufacturerID   int
 	ManufacturerName string

--- a/internal/storage/sqlite/notifications_center.go
+++ b/internal/storage/sqlite/notifications_center.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
@@ -58,5 +59,5 @@ func (s *Store) GetLastSeenAt(ctx context.Context, chatID int64) (time.Time, err
 			return t, nil
 		}
 	}
-	return time.Time{}, nil
+	return time.Time{}, errors.New("invalid last_seen_at/created_at timestamp: " + raw)
 }

--- a/internal/storage/sqlite/notifications_center.go
+++ b/internal/storage/sqlite/notifications_center.go
@@ -1,0 +1,62 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]storage.ListingRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT token, search_name, manufacturer, model, year, price,
+			km, hand, city, page_link, image_url, fitness_score, first_seen_at
+		FROM listing_history
+		WHERE chat_id = ? AND first_seen_at > ?
+		ORDER BY first_seen_at DESC, token DESC
+		LIMIT ? OFFSET ?`, chatID, since, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var listings []storage.ListingRecord
+	for rows.Next() {
+		var l storage.ListingRecord
+		var fs sql.NullFloat64
+		if err := rows.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
+			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt); err != nil {
+			return nil, err
+		}
+		if fs.Valid {
+			l.FitnessScore = &fs.Float64
+		}
+		listings = append(listings, l)
+	}
+	return listings, rows.Err()
+}
+
+func (s *Store) CountNewListingsSince(ctx context.Context, chatID int64, since time.Time) (int64, error) {
+	var count int64
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM listing_history WHERE chat_id = ? AND first_seen_at > ?",
+		chatID, since).Scan(&count)
+	return count, err
+}
+
+func (s *Store) GetLastSeenAt(ctx context.Context, chatID int64) (time.Time, error) {
+	var raw string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COALESCE(last_seen_at, created_at) FROM users WHERE chat_id = ?",
+		chatID).Scan(&raw)
+	if err != nil {
+		return time.Time{}, err
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999-07:00", "2006-01-02 15:04:05", "2006-01-02T15:04:05Z"} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, nil
+}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -42,6 +42,8 @@ func New(dbPath string) (*Store, error) {
 	return &Store{db: db, dbPath: dbPath}, nil
 }
 
+func (s *Store) DB() *sql.DB { return s.db }
+
 func (s *Store) Checkpoint() error {
 	_, err := s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 	return err

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -1862,3 +1862,121 @@ func TestNew_CreatesDirectory(t *testing.T) {
 	}
 }
 
+// --- Notification Center Tests ---
+
+func TestNewListingsSince(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	// Use a cutoff well in the past so all inserts are after it
+	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	now := time.Now().UTC()
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "new-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "new-2", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+		FirstSeenAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	listings, err := store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if err != nil {
+		t.Fatalf("NewListingsSince: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Fatalf("expected 2, got %d", len(listings))
+	}
+
+	listings, err = store.NewListingsSince(ctx, 100, cutoff, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("pagination: expected 1, got %d", len(listings))
+	}
+
+	listings, err = store.NewListingsSince(ctx, 200, cutoff, 20, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("wrong user: expected 0, got %d", len(listings))
+	}
+
+	futureCutoff := time.Now().Add(time.Hour)
+	listings, err = store.NewListingsSince(ctx, 100, futureCutoff, 20, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("future cutoff: expected 0, got %d", len(listings))
+	}
+}
+
+func TestCountNewListingsSince(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "cnt-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := store.CountNewListingsSince(ctx, 100, cutoff)
+	if err != nil {
+		t.Fatalf("CountNewListingsSince: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+
+	count, err = store.CountNewListingsSince(ctx, 100, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("future cutoff: expected 0, got %d", count)
+	}
+}
+
+func TestGetLastSeenAt(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	lastSeen, err := store.GetLastSeenAt(ctx, 100)
+	if err != nil {
+		t.Fatalf("GetLastSeenAt: %v", err)
+	}
+	if lastSeen.IsZero() {
+		t.Error("expected non-zero time (should fallback to created_at)")
+	}
+
+	if err := store.UpdateLastSeenAt(ctx, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	lastSeen2, err := store.GetLastSeenAt(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lastSeen2.After(lastSeen) && !lastSeen2.Equal(lastSeen) {
+		t.Error("last_seen_at should be >= after UpdateLastSeenAt")
+	}
+}
+

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ListingDetailPage } from "./pages/ListingDetailPage";
 import { AdminPage } from "./pages/AdminPage";
 import { SavedPage } from "./pages/SavedPage";
 import { HistoryPage } from "./pages/HistoryPage";
+import { NotificationsPage } from "./pages/NotificationsPage";
 
 export default function App() {
   return (
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/saved" element={<SavedPage />} />
         <Route path="/history" element={<HistoryPage />} />
+        <Route path="/notifications" element={<NotificationsPage />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -86,7 +86,7 @@ export function Shell() {
       {/* Mobile bottom nav */}
       <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/80 backdrop-blur-xl md:hidden">
         <div className="flex justify-around py-1.5">
-          {navItems.slice(0, 5).map((item) => {
+          {navItems.map((item) => {
             const Icon = item.icon;
             const isActive =
               item.path === "/"

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -3,23 +3,26 @@ import { notificationsApi } from "@/lib/api";
 
 export function useNotificationCount() {
   return useQuery({
-    queryKey: ["notifications", "count"],
+    queryKey: ["notification-count"],
     queryFn: () => notificationsApi.count(),
     refetchInterval: 60_000,
   });
 }
 
-export function useNotifications(limit = 20, offset = 0) {
+export function useNotifications(limit: number, offset: number) {
   return useQuery({
-    queryKey: ["notifications", { limit, offset }],
+    queryKey: ["notifications", limit, offset],
     queryFn: () => notificationsApi.list({ limit, offset }),
   });
 }
 
 export function useMarkNotificationsSeen() {
-  const qc = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => notificationsApi.markSeen(),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: () => {
+      queryClient.setQueryData(["notification-count"], { count: 0 });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -200,24 +200,4 @@ export const adminApi = {
   stats: () => fetchAPI<AdminStats>("/admin/stats"),
 };
 
-export interface NotificationCount {
-  count: number;
-}
-
-export const notificationsApi = {
-  count: () => fetchAPI<NotificationCount>("/notifications/count"),
-  list: (params?: ListingsParams) => {
-    const query = new URLSearchParams();
-    if (params?.limit !== undefined) query.set("limit", String(params.limit));
-    if (params?.offset !== undefined)
-      query.set("offset", String(params.offset));
-    const qs = query.toString();
-    return fetchAPI<ListingsResponse>(
-      `/notifications${qs ? `?${qs}` : ""}`,
-    );
-  },
-  markSeen: () =>
-    fetchAPI<void>("/notifications/seen", { method: "POST" }),
-};
-
 export { ApiError };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -162,6 +162,26 @@ export const api = {
   },
 };
 
+export interface NotificationCount {
+  count: number;
+}
+
+export const notificationsApi = {
+  count: () => fetchAPI<NotificationCount>("/notifications/count"),
+  list: (params?: ListingsParams) => {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined)
+      query.set("offset", String(params.offset));
+    const qs = query.toString();
+    return fetchAPI<ListingsResponse>(
+      `/notifications${qs ? `?${qs}` : ""}`,
+    );
+  },
+  markSeen: () =>
+    fetchAPI<void>("/notifications/seen", { method: "POST" }),
+};
+
 export interface AdminStats {
   db: {
     file_size_bytes: number;

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -12,16 +12,16 @@ const PAGE_SIZE = 20;
 
 export function NotificationsPage() {
   const [offset, setOffset] = useState(0);
-  const { data, isLoading, isError } = useNotifications(PAGE_SIZE, offset);
+  const { data, isLoading, isSuccess, isFetching, isError } = useNotifications(PAGE_SIZE, offset);
   const markSeen = useMarkNotificationsSeen();
   const markedRef = useRef(false);
 
   useEffect(() => {
-    if (!markedRef.current) {
+    if (!markedRef.current && isSuccess && !isFetching) {
       markedRef.current = true;
       markSeen.mutate();
     }
-  }, [markSeen]);
+  }, [isSuccess, isFetching, markSeen]);
 
   useEffect(() => {
     if (!data || data.total === 0) return;


### PR DESCRIPTION
## Summary

- **Backend**: `NotificationStore` interface with SQLite implementation — queries `listing_history` for listings newer than `last_seen_at`, with count and mark-seen endpoints
- **API**: 3 new endpoints — `GET /notifications` (paginated list), `GET /notifications/count` (badge polling), `POST /notifications/seen` (mark read)
- **Frontend**: Bell icon with red unread badge in sidebar and mobile nav, notification page showing new listings with `ListingCardBody` cards, 60s polling for count updates
- **Tests**: 6 new tests covering storage layer and API endpoints

## Closes

- #277

## Test plan

- [x] `make test` — all tests pass
- [x] `golangci-lint run ./...` — clean
- [x] `cd web && npx tsc -b && npm run build` — builds
- [ ] Bell icon shows unread count badge when new listings exist
- [ ] Clicking bell navigates to notifications page
- [ ] Opening notifications page marks them as seen, badge clears
- [ ] Count endpoint polls every 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications center page showing new listings since your last visit (paginated)
  * Unread count badge in navigation (displays unread, caps at 99+)
  * Mark-as-seen behavior clears unread count and tracks last-seen time
  * Client hooks and API endpoints for count, list, and mark-seen; page auto-marks seen on view

* **Tests**
  * Added unit and integration tests covering notification endpoints and storage behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->