### PR TITLE
test: expand test coverage from 77.2% to 80.8%

### DIFF
--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -216,8 +216,8 @@ func TestDeleteSearch_NotFound(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	w := doRequest(t, srv, "DELETE", "/api/v1/searches/99999", nil)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 for delete nonexistent, got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for delete nonexistent, got %d", w.Code)
 	}
 }
 
@@ -323,8 +323,8 @@ func TestGetListing_EmptyToken(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	w := doRequest(t, srv, "GET", "/api/v1/listings/", nil)
-	if w.Code != http.StatusBadRequest && w.Code != http.StatusNotFound {
-		t.Fatalf("expected 400 or 404 for empty token, got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for empty token (mux rejects empty path param), got %d", w.Code)
 	}
 }
 

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -1,0 +1,665 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// --- parsePagination edge cases ---
+
+func TestParsePagination_Defaults(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test", nil)
+	limit, offset := parsePagination(r)
+	if limit != 20 {
+		t.Errorf("default limit = %d, want 20", limit)
+	}
+	if offset != 0 {
+		t.Errorf("default offset = %d, want 0", offset)
+	}
+}
+
+func TestParsePagination_OverMax(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test?limit=200", nil)
+	limit, _ := parsePagination(r)
+	if limit != 100 {
+		t.Errorf("limit capped = %d, want 100", limit)
+	}
+}
+
+func TestParsePagination_NegativeLimit(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test?limit=-5", nil)
+	limit, _ := parsePagination(r)
+	if limit != 20 {
+		t.Errorf("negative limit = %d, want 20", limit)
+	}
+}
+
+func TestParsePagination_NegativeOffset(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test?offset=-10", nil)
+	_, offset := parsePagination(r)
+	if offset != 0 {
+		t.Errorf("negative offset = %d, want 0", offset)
+	}
+}
+
+func TestParsePagination_ZeroLimit(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test?limit=0", nil)
+	limit, _ := parsePagination(r)
+	if limit != 20 {
+		t.Errorf("zero limit = %d, want 20 (default)", limit)
+	}
+}
+
+// --- parseSortParam ---
+
+func TestParseSortParam(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{"price_asc", "price_asc"},
+		{"price_desc", "price_desc"},
+		{"score", "score"},
+		{"km", "km"},
+		{"year", "year"},
+		{"newest", "newest"},
+		{"", "newest"},
+		{"invalid", "newest"},
+	} {
+		r := httptest.NewRequest("GET", "/test?sort="+tc.input, nil)
+		got := parseSortParam(r)
+		if got != tc.want {
+			t.Errorf("parseSortParam(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- parsePathID ---
+
+func TestParsePathID_Invalid(t *testing.T) {
+	for _, val := range []string{"abc", "0", "-1", ""} {
+		r := httptest.NewRequest("GET", "/test", nil)
+		r.SetPathValue("id", val)
+		_, ok := parsePathID(r)
+		if ok {
+			t.Errorf("parsePathID(%q) should return false", val)
+		}
+	}
+}
+
+// --- humanBytes ---
+
+func TestHumanBytes(t *testing.T) {
+	for _, tc := range []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+		{2684354560, "2.5 GB"},
+	} {
+		got := humanBytes(tc.input)
+		if got != tc.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- splitKeywords ---
+
+func TestSplitKeywords(t *testing.T) {
+	if got := splitKeywords("  hello  "); got != "hello" {
+		t.Errorf("splitKeywords = %q, want %q", got, "hello")
+	}
+	if got := splitKeywords(""); got != "" {
+		t.Errorf("splitKeywords empty = %q, want empty", got)
+	}
+}
+
+// --- API: create search with invalid body ---
+
+func TestCreateSearch_InvalidBody(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest("POST", "/api/v1/searches", strings.NewReader("{invalid"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid body, got %d", w.Code)
+	}
+}
+
+func TestCreateSearch_MissingManufacturerModel(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing manufacturer/model, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateSearch_UnknownManufacturer_AcceptsWithFallback(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 999999, Model: 10226,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 (catalog falls back to 'Unknown'), got %d", w.Code)
+	}
+	var resp searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.ManufacturerName != "Unknown" {
+		t.Errorf("manufacturer_name = %q, want Unknown", resp.ManufacturerName)
+	}
+}
+
+func TestCreateSearch_UnknownModel_AcceptsWithFallback(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 999999,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 (catalog falls back to 'Unknown'), got %d", w.Code)
+	}
+	var resp searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.ModelName != "Unknown" {
+		t.Errorf("model_name = %q, want Unknown", resp.ModelName)
+	}
+}
+
+// --- API: update search with invalid body ---
+
+func TestUpdateSearch_InvalidBody(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024,
+	})
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	req := httptest.NewRequest("PUT", "/api/v1/searches/"+itoa(created.ID), strings.NewReader("{bad"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid body, got %d", rec.Code)
+	}
+}
+
+func TestUpdateSearch_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "PUT", "/api/v1/searches/99999", updateSearchRequest{})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for nonexistent search, got %d", w.Code)
+	}
+}
+
+func TestDeleteSearch_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "DELETE", "/api/v1/searches/99999", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for delete nonexistent, got %d", w.Code)
+	}
+}
+
+// --- API: invalid path IDs ---
+
+func TestGetSearch_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/searches/abc", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid search id, got %d", w.Code)
+	}
+}
+
+func TestUpdateSearch_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "PUT", "/api/v1/searches/abc", updateSearchRequest{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid id, got %d", w.Code)
+	}
+}
+
+func TestDeleteSearch_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "DELETE", "/api/v1/searches/abc", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid id, got %d", w.Code)
+	}
+}
+
+func TestPauseSearch_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches/abc/pause", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestResumeSearch_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches/abc/resume", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListListings_InvalidSearchID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/searches/abc/listings", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListListings_SearchNotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/searches/99999/listings", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// --- API: listings with limit cap ---
+
+func TestListListings_LimitCap(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024,
+	})
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "lc-1", ChatID: 999, SearchName: created.Name,
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w = doRequest(t, srv, "GET",
+		"/api/v1/searches/"+itoa(created.ID)+"/listings?limit=200", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Limit != 100 {
+		t.Errorf("limit should be capped to 100, got %d", resp.Limit)
+	}
+}
+
+// --- API: getListing missing token ---
+
+func TestGetListing_EmptyToken(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/listings/", nil)
+	if w.Code != http.StatusBadRequest && w.Code != http.StatusNotFound {
+		t.Fatalf("expected 400 or 404 for empty token, got %d", w.Code)
+	}
+}
+
+// --- API: catalog model search ---
+
+func TestListModels_WithSearch(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/catalog/manufacturers/19/models?q=Cor", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var models []catalogEntry
+	mustUnmarshal(t, w.Body.Bytes(), &models)
+	if len(models) == 0 {
+		t.Fatal("expected at least one model matching 'Cor'")
+	}
+	found := false
+	for _, m := range models {
+		if m.Name == "Corolla" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected Corolla in results, got %v", models)
+	}
+}
+
+func TestListModels_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	for _, path := range []string{
+		"/api/v1/catalog/manufacturers/abc/models",
+		"/api/v1/catalog/manufacturers/0/models",
+		"/api/v1/catalog/manufacturers/-1/models",
+	} {
+		w := doRequest(t, srv, "GET", path, nil)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("path=%s: expected 400, got %d", path, w.Code)
+		}
+	}
+}
+
+func TestListModels_EmptyResult(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/catalog/manufacturers/19/models?q=ZZZ", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var models []catalogEntry
+	mustUnmarshal(t, w.Body.Bytes(), &models)
+	if len(models) != 0 {
+		t.Errorf("expected empty list, got %d items", len(models))
+	}
+}
+
+// --- API: notifications pagination ---
+
+func TestNotificationsList_Pagination(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	for i := range 5 {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: fmt.Sprintf("notif-pg-%d", i), ChatID: 999, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000 + i*1000,
+			FirstSeenAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/notifications?limit=2&offset=0", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(resp.Items))
+	}
+	if resp.Total != 5 {
+		t.Errorf("expected total 5, got %d", resp.Total)
+	}
+}
+
+// --- API: listing with fitness score ---
+
+func TestGetListing_WithFitnessScore(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	score := 8.5
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-score", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021,
+		Price: 100000, Km: 50000, Hand: 2,
+		FitnessScore: &score,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/listings/tok-score", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp listingResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.FitnessScore == nil || *resp.FitnessScore != 8.5 {
+		t.Errorf("fitness_score = %v, want 8.5", resp.FitnessScore)
+	}
+}
+
+// --- API: auth with no DevChatID ---
+
+func TestAuth_NoChatID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.cfg.DevChatID = 0
+
+	w := doRequest(t, srv, "GET", "/api/v1/searches", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with no DevChatID, got %d", w.Code)
+	}
+}
+
+// --- API: search creation with keywords ---
+
+func TestCreateSearch_WithKeywords(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024,
+		Keywords: "  automatic  ", ExcludeKeys: "  salvage  ",
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+	if created.Keywords != "automatic" {
+		t.Errorf("keywords = %q, want trimmed", created.Keywords)
+	}
+	if created.ExcludeKeys != "salvage" {
+		t.Errorf("exclude_keys = %q, want trimmed", created.ExcludeKeys)
+	}
+}
+
+// --- API: writeJSON error path (already tested implicitly but coverage) ---
+
+func TestWriteJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusOK, map[string]string{"key": "value"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["key"] != "value" {
+		t.Errorf("resp = %v", resp)
+	}
+}
+
+// --- API: update search with negative values ---
+
+func TestUpdateSearch_NegativeValues(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024,
+	})
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	for _, tc := range []struct {
+		name string
+		req  updateSearchRequest
+	}{
+		{"negative year_min", updateSearchRequest{YearMin: -1}},
+		{"negative year_max", updateSearchRequest{YearMax: -1}},
+		{"negative price_max", updateSearchRequest{PriceMax: -1}},
+		{"negative max_km", updateSearchRequest{MaxKm: -1}},
+		{"negative max_hand", updateSearchRequest{MaxHand: -1}},
+		{"negative engine_min_cc", updateSearchRequest{EngineMinCC: -1}},
+	} {
+		w = doRequest(t, srv, "PUT", "/api/v1/searches/"+itoa(created.ID), tc.req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d: %s", tc.name, w.Code, w.Body.String())
+		}
+	}
+}
+
+// --- API: all sort variants via listings ---
+
+func TestListListings_AllSorts(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024,
+	})
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	for _, tok := range []string{"sort-1", "sort-2"} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, ChatID: 999, SearchName: created.Name,
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, sort := range []string{"price_asc", "price_desc", "score", "km", "year", "newest", "invalid"} {
+		w = doRequest(t, srv, "GET",
+			"/api/v1/searches/"+itoa(created.ID)+"/listings?sort="+sort, nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("sort=%s: expected 200, got %d", sort, w.Code)
+		}
+	}
+}
+
+// --- API: create search default source ---
+
+func TestCreateSearch_DefaultSource(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2020, YearMax: 2024,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	var resp searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Source != "yad2" {
+		t.Errorf("source = %q, want yad2", resp.Source)
+	}
+}
+
+// --- API: CORS with GET request ---
+
+func TestCORS_WithGETRequest(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+
+	if origin := w.Header().Get("Access-Control-Allow-Origin"); origin != "http://localhost:5173" {
+		t.Errorf("expected CORS header on GET, got %q", origin)
+	}
+}
+
+// --- API: history with no listings ---
+
+func TestListHistory_Empty(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/history", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 0 {
+		t.Errorf("expected 0 history, got %d", resp.Total)
+	}
+}
+
+// --- API: saved with no bookmarks ---
+
+func TestListSaved_Empty(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/saved", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 0 {
+		t.Errorf("expected 0 saved, got %d", resp.Total)
+	}
+}
+
+// --- API: listing with all fields ---
+
+func TestListListings_WithAllFields(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024, PriceMax: 200000,
+	})
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	score := 9.2
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "full-1", ChatID: 999, SearchName: created.Name,
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2022,
+		Price: 150000, Km: 30000, Hand: 1, City: "Haifa",
+		PageLink: "https://yad2.co.il/item/full-1",
+		ImageURL: "https://img.yad2.co.il/full-1.jpg",
+		FitnessScore: &score,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w = doRequest(t, srv, "GET",
+		"/api/v1/searches/"+itoa(created.ID)+"/listings", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+	item := resp.Items[0]
+	if item.City != "Haifa" {
+		t.Errorf("city = %q, want Haifa", item.City)
+	}
+	if item.ImageURL != "https://img.yad2.co.il/full-1.jpg" {
+		t.Errorf("image_url = %q", item.ImageURL)
+	}
+	if item.FitnessScore == nil || *item.FitnessScore != 9.2 {
+		t.Errorf("fitness_score = %v, want 9.2", item.FitnessScore)
+	}
+}

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -265,6 +266,10 @@ func (s *Server) deleteSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.searches.DeleteSearch(r.Context(), id, chatID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "search not found")
+			return
+		}
 		s.logger.Error("delete search", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete search")
 		return

--- a/internal/bot/coverage_test.go
+++ b/internal/bot/coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"testing"
 	"time"
 
@@ -314,12 +313,574 @@ func TestOnDailyDigestOff(t *testing.T) {
 
 // --- formatInterval ---
 
-func TestFormatInterval(t *testing.T) {
+func TestFormatInterval_Minutes(t *testing.T) {
 	tb := newTestBotFull(t)
-	tb.bot.pollInterval = 15 * 60_000_000_000
+	tb.bot.pollInterval = 15 * time.Minute
 
 	got := tb.bot.formatInterval()
-	if !strings.Contains(got, "15") {
-		t.Errorf("formatInterval() = %q, want it to contain '15'", got)
+	if got != "15 minutes" {
+		t.Errorf("formatInterval() = %q, want '15 minutes'", got)
+	}
+}
+
+func TestFormatInterval_Seconds(t *testing.T) {
+	tb := newTestBotFull(t)
+	tb.bot.pollInterval = 30 * time.Second
+
+	got := tb.bot.formatInterval()
+	if got != "30s" {
+		t.Errorf("formatInterval() = %q, want '30s'", got)
+	}
+}
+
+func TestFormatInterval_Hours(t *testing.T) {
+	tb := newTestBotFull(t)
+	tb.bot.pollInterval = 2 * time.Hour
+
+	got := tb.bot.formatInterval()
+	if got != "2 hours" {
+		t.Errorf("formatInterval() = %q, want '2 hours'", got)
+	}
+}
+
+func TestFormatInterval_OneHour(t *testing.T) {
+	tb := newTestBotFull(t)
+	tb.bot.pollInterval = 1 * time.Hour
+
+	got := tb.bot.formatInterval()
+	if got != "1 hour" {
+		t.Errorf("formatInterval() = %q, want '1 hour'", got)
+	}
+}
+
+func TestFormatInterval_HoursAndMinutes(t *testing.T) {
+	tb := newTestBotFull(t)
+	tb.bot.pollInterval = 1*time.Hour + 30*time.Minute
+
+	got := tb.bot.formatInterval()
+	if got != "1h30m0s" {
+		t.Errorf("formatInterval() = %q, want '1h30m0s'", got)
+	}
+}
+
+// --- SetPollTrigger ---
+
+type mockPollTrigger struct {
+	triggered bool
+}
+
+func (m *mockPollTrigger) TriggerPoll() { m.triggered = true }
+
+func TestSetPollTrigger(t *testing.T) {
+	tb := newTestBotFull(t)
+	pt := &mockPollTrigger{}
+	tb.bot.SetPollTrigger(pt)
+	if tb.bot.pollTrigger == nil {
+		t.Error("pollTrigger should be set")
+	}
+}
+
+// --- handleGrantPremium ---
+
+func TestHandleGrantPremium_NotAdmin(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.simulateCommand(ctx, 100, "/grant_premium 100 30")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected response for non-admin")
+	}
+}
+
+func TestHandleGrantPremium_MissingArgs(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/grant_premium")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected usage message")
+	}
+}
+
+func TestHandleGrantPremium_InvalidChatID(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/grant_premium abc 30")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected usage message for invalid chat_id")
+	}
+}
+
+func TestHandleGrantPremium_InvalidDays(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/grant_premium 100 abc")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected usage message for invalid days")
+	}
+}
+
+func TestHandleGrantPremium_NegativeDays(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/grant_premium 100 -5")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected usage message for negative days")
+	}
+}
+
+func TestHandleGrantPremium_Success(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.simulateCommand(ctx, 999, "/grant_premium 100 30")
+
+	user, err := tb.store.GetUser(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user.Tier != "premium" {
+		t.Errorf("tier = %q, want premium", user.Tier)
+	}
+}
+
+func TestHandleGrantPremium_UserNotFound(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/grant_premium 99999 30")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected error message for nonexistent user")
+	}
+}
+
+// --- handleRevokePremium ---
+
+func TestHandleRevokePremium_NotAdmin(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.simulateCommand(ctx, 100, "/revoke_premium 100")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected response for non-admin")
+	}
+}
+
+func TestHandleRevokePremium_MissingArgs(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/revoke_premium")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected usage message")
+	}
+}
+
+func TestHandleRevokePremium_Success(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+	tb.createUser(ctx, t, 100, "alice")
+	_ = tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour))
+
+	tb.simulateCommand(ctx, 999, "/revoke_premium 100")
+
+	user, err := tb.store.GetUser(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user.Tier != "free" {
+		t.Errorf("tier = %q, want free", user.Tier)
+	}
+}
+
+// --- onSavedPage / onHiddenPage ---
+
+func TestOnSavedPage_WithData(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	for i := range 15 {
+		token := fmt.Sprintf("saved-tok-%02d", i)
+		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: 100, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		})
+		_ = tb.store.SaveBookmark(ctx, 100, token)
+	}
+
+	tb.bot.onSavedPage(ctx, 100, cbSavedPage+"0")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Error("expected keyboard with pagination")
+	}
+}
+
+func TestOnSavedPage_InvalidPage(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.bot.onSavedPage(ctx, 100, cbSavedPage+"abc")
+}
+
+func TestOnHiddenPage_WithData(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	for i := range 15 {
+		token := fmt.Sprintf("hidden-tok-%02d", i)
+		_ = tb.store.HideListing(ctx, 100, token)
+	}
+
+	tb.bot.onHiddenPage(ctx, 100, cbHiddenPage+"0")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Error("expected keyboard with pagination for hidden")
+	}
+}
+
+func TestOnHiddenPage_InvalidPage(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.bot.onHiddenPage(ctx, 100, cbHiddenPage+"abc")
+}
+
+// --- ListingActionKeyboard ---
+
+func TestListingActionKeyboard(t *testing.T) {
+	kb := ListingActionKeyboard("test-token", "en")
+	if kb == nil {
+		t.Fatal("expected non-nil keyboard")
+	}
+	if len(kb.InlineKeyboard) != 1 || len(kb.InlineKeyboard[0]) != 2 {
+		t.Fatalf("expected 1 row with 2 buttons, got %v", kb.InlineKeyboard)
+	}
+	if kb.InlineKeyboard[0][0].CallbackData != "save:test-token" {
+		t.Errorf("save button data = %q", kb.InlineKeyboard[0][0].CallbackData)
+	}
+	if kb.InlineKeyboard[0][1].CallbackData != "hide:test-token" {
+		t.Errorf("hide button data = %q", kb.InlineKeyboard[0][1].CallbackData)
+	}
+}
+
+// --- isRateLimited ---
+
+func TestIsRateLimited_Exhaustion(t *testing.T) {
+	tb := newTestBotFull(t)
+
+	for range rateLimitBurst {
+		if tb.bot.isRateLimited(555) {
+			t.Error("should not be limited within burst")
+		}
+	}
+
+	if !tb.bot.isRateLimited(555) {
+		t.Error("should be limited after burst exhausted")
+	}
+}
+
+// --- sweepStaleMaps ---
+
+func TestSweepStaleMaps_NoError(t *testing.T) {
+	tb := newTestBotFull(t)
+	tb.bot.isRateLimited(555)
+	unlock := tb.bot.lockChat(556)
+	unlock()
+
+	tb.bot.sweepStaleMaps()
+}
+
+// --- maxSearchesForUser ---
+
+func TestMaxSearchesForUser(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	limit := tb.bot.maxSearchesForUser(ctx, 100)
+	if limit != premiumMaxSearches {
+		t.Errorf("maxSearches = %d, want %d", limit, premiumMaxSearches)
+	}
+}
+
+// --- saveWizardState / loadWizardData ---
+
+func TestSaveAndLoadWizardState(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	wd := WizardData{
+		Source:           "yad2",
+		Manufacturer:     19,
+		ManufacturerName: "Toyota",
+	}
+	tb.bot.saveWizardState(ctx, 100, "ask_model", wd)
+
+	loaded := tb.bot.loadWizardData(ctx, 100)
+	if loaded.Manufacturer != 19 {
+		t.Errorf("manufacturer = %d, want 19", loaded.Manufacturer)
+	}
+	if loaded.ManufacturerName != "Toyota" {
+		t.Errorf("manufacturer_name = %q, want Toyota", loaded.ManufacturerName)
+	}
+}
+
+func TestLoadWizardData_NoUser(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+
+	wd := tb.bot.loadWizardData(ctx, 99999)
+	if wd.Manufacturer != 0 {
+		t.Errorf("expected empty wizard data for nonexistent user")
+	}
+}
+
+func TestLoadWizardData_InvalidJSON(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	_ = tb.store.UpdateUserState(ctx, 100, "ask_model", "not-json")
+	wd := tb.bot.loadWizardData(ctx, 100)
+	if wd.Manufacturer != 0 {
+		t.Errorf("expected empty wizard data for invalid JSON")
+	}
+}
+
+// --- getUserLang ---
+
+func TestGetUserLang_Default(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+
+	lang := tb.bot.getUserLang(ctx, 99999)
+	if lang != "he" {
+		t.Errorf("default language = %q, want 'he'", lang)
+	}
+}
+
+// --- onLegacySourceSelected ---
+
+func TestOnLegacySourceSelected(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	_ = tb.store.UpdateUserState(ctx, 100, StateAskSource, "{}")
+
+	tb.bot.onLegacySourceSelected(ctx, 100, "yad2")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected response from source selection")
+	}
+}
+
+// --- onDailyDigestOn ---
+
+func TestOnDailyDigestOn(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+	_ = tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour))
+
+	tb.simulateCallback(ctx, 100, "daily_digest:on")
+
+	enabled, _, _, err := tb.store.GetDailyDigest(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Error("expected daily digest to be enabled")
+	}
+}
+
+// --- handleRevokePremium invalid ID ---
+
+func TestHandleRevokePremium_InvalidChatID(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/revoke_premium abc")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected usage message for invalid chat_id")
+	}
+}
+
+func TestHandleRevokePremium_UserNotFound(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 999, "admin")
+
+	tb.simulateCommand(ctx, 999, "/revoke_premium 99999")
+
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected failure message")
+	}
+}
+
+// --- SetBot ---
+
+func TestSetBot_NilClears(t *testing.T) {
+	tb := newTestBotFull(t)
+	tb.bot.SetBot(nil)
+	if tb.bot.bot != nil {
+		t.Error("expected nil bot")
+	}
+}
+
+// --- onHistoryPage invalid ---
+
+func TestOnHistoryPage_InvalidPage(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.bot.onHistoryPage(ctx, 100, cbHistoryPage+"abc")
+	msg := tb.msg.last()
+	if msg.Text == "" {
+		t.Error("expected error message for invalid page")
+	}
+}
+
+// --- onQuickStart with poll trigger ---
+
+func TestOnQuickStart_TriggersPoll(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	pt := &mockPollTrigger{}
+	tb.bot.SetPollTrigger(pt)
+
+	tb.simulateCallback(ctx, 100, "quick_start")
+
+	if !pt.triggered {
+		t.Error("expected poll trigger to be called")
+	}
+}
+
+// --- saved/hidden pagination with multiple pages ---
+
+func TestHandleSaved_WithPagination(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	for i := range 15 {
+		token := fmt.Sprintf("sav-pg-%02d", i)
+		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: 100, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		})
+		_ = tb.store.SaveBookmark(ctx, 100, token)
+	}
+
+	tb.simulateCommand(ctx, 100, "/saved")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Error("expected keyboard with pagination")
+	}
+}
+
+func TestHandleHidden_WithPagination(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	for i := range 15 {
+		_ = tb.store.HideListing(ctx, 100, fmt.Sprintf("hid-pg-%02d", i))
+	}
+
+	tb.simulateCommand(ctx, 100, "/hidden")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Error("expected keyboard with pagination for hidden")
+	}
+}
+
+// --- onSavedPage page 1 ---
+
+func TestOnSavedPage_Page1(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	for i := range 20 {
+		token := fmt.Sprintf("sav-p1-%02d", i)
+		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: 100, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		})
+		_ = tb.store.SaveBookmark(ctx, 100, token)
+	}
+
+	tb.bot.onSavedPage(ctx, 100, cbSavedPage+"1")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Error("expected keyboard on page 1")
+	}
+}
+
+// --- onHiddenPage page 1 ---
+
+func TestOnHiddenPage_Page1(t *testing.T) {
+	tb := newTestBotFull(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	for i := range 20 {
+		_ = tb.store.HideListing(ctx, 100, fmt.Sprintf("hid-p1-%02d", i))
+	}
+
+	tb.bot.onHiddenPage(ctx, 100, cbHiddenPage+"1")
+
+	msg := tb.msg.last()
+	if !msg.HasKB {
+		t.Error("expected keyboard on hidden page 1")
 	}
 }

--- a/internal/bot/coverage_test.go
+++ b/internal/bot/coverage_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/dsionov/carwatch/internal/storage/sqlite"
 )
 
+func mustNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+}
+
 func newTestBotFull(t *testing.T) *testBot {
 	t.Helper()
 	store, err := sqlite.New("file::memory:?cache=shared")
@@ -77,7 +84,7 @@ func TestLanguageSwitch_English(t *testing.T) {
 	tb := newTestBotFull(t)
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
-	_ = tb.store.SetUserLanguage(ctx, 100, "he")
+	mustNoErr(t, tb.store.SetUserLanguage(ctx, 100, "he"))
 
 	tb.simulateCallback(ctx, 100, "lang:en")
 
@@ -123,8 +130,8 @@ func TestOnClearHidden(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.HideListing(ctx, 100, "tok1")
-	_ = tb.store.HideListing(ctx, 100, "tok2")
+	mustNoErr(t, tb.store.HideListing(ctx, 100, "tok1"))
+	mustNoErr(t, tb.store.HideListing(ctx, 100, "tok2"))
 
 	tb.simulateCallback(ctx, 100, "hidden_clear")
 
@@ -205,7 +212,7 @@ func TestOnMfrPage(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "ask_manufacturer", "{}")
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "ask_manufacturer", "{}"))
 
 	tb.simulateCallback(ctx, 100, "mfr_pg:0")
 
@@ -220,7 +227,7 @@ func TestOnMfrSearch(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "ask_manufacturer", "{}")
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "ask_manufacturer", "{}"))
 
 	tb.simulateCallback(ctx, 100, "mfr_search")
 
@@ -235,7 +242,7 @@ func TestOnMdlPage(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "ask_model", `{"manufacturer":19,"manufacturer_name":"Toyota"}`)
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "ask_model", `{"manufacturer":19,"manufacturer_name":"Toyota"}`))
 
 	tb.simulateCallback(ctx, 100, "mdl_pg:0")
 
@@ -250,7 +257,7 @@ func TestOnMdlSearch(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "ask_model", `{"manufacturer":19}`)
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "ask_model", `{"manufacturer":19}`))
 
 	tb.simulateCallback(ctx, 100, "mdl_search")
 
@@ -265,7 +272,7 @@ func TestHandleManufacturerSearch(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "search_manufacturer", "{}")
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "search_manufacturer", "{}"))
 
 	tb.simulateText(ctx, 100, "Toyota")
 
@@ -280,7 +287,7 @@ func TestHandleModelSearch(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "search_model", `{"manufacturer":19}`)
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "search_model", `{"manufacturer":19}`))
 
 	tb.simulateText(ctx, 100, "Corolla")
 
@@ -297,8 +304,8 @@ func TestOnDailyDigestOff(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour))
-	_ = tb.store.SetDailyDigest(ctx, 100, true, "09:00")
+	mustNoErr(t, tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour)))
+	mustNoErr(t, tb.store.SetDailyDigest(ctx, 100, true, "09:00"))
 
 	tb.simulateCallback(ctx, 100, "daily_digest:off")
 
@@ -510,7 +517,7 @@ func TestHandleRevokePremium_Success(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 999, "admin")
 	tb.createUser(ctx, t, 100, "alice")
-	_ = tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour))
+	mustNoErr(t, tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour)))
 
 	tb.simulateCommand(ctx, 999, "/revoke_premium 100")
 
@@ -532,11 +539,11 @@ func TestOnSavedPage_WithData(t *testing.T) {
 
 	for i := range 15 {
 		token := fmt.Sprintf("saved-tok-%02d", i)
-		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		mustNoErr(t, tb.store.SaveListing(ctx, storage.ListingRecord{
 			Token: token, ChatID: 100, SearchName: "s1",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
-		})
-		_ = tb.store.SaveBookmark(ctx, 100, token)
+		}))
+		mustNoErr(t, tb.store.SaveBookmark(ctx, 100, token))
 	}
 
 	tb.bot.onSavedPage(ctx, 100, cbSavedPage+"0")
@@ -562,7 +569,7 @@ func TestOnHiddenPage_WithData(t *testing.T) {
 
 	for i := range 15 {
 		token := fmt.Sprintf("hidden-tok-%02d", i)
-		_ = tb.store.HideListing(ctx, 100, token)
+		mustNoErr(t, tb.store.HideListing(ctx, 100, token))
 	}
 
 	tb.bot.onHiddenPage(ctx, 100, cbHiddenPage+"0")
@@ -677,7 +684,7 @@ func TestLoadWizardData_InvalidJSON(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, "ask_model", "not-json")
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, "ask_model", "not-json"))
 	wd := tb.bot.loadWizardData(ctx, 100)
 	if wd.Manufacturer != 0 {
 		t.Errorf("expected empty wizard data for invalid JSON")
@@ -703,7 +710,7 @@ func TestOnLegacySourceSelected(t *testing.T) {
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
 
-	_ = tb.store.UpdateUserState(ctx, 100, StateAskSource, "{}")
+	mustNoErr(t, tb.store.UpdateUserState(ctx, 100, StateAskSource, "{}"))
 
 	tb.bot.onLegacySourceSelected(ctx, 100, "yad2")
 
@@ -719,7 +726,7 @@ func TestOnDailyDigestOn(t *testing.T) {
 	tb := newTestBotFull(t)
 	ctx := context.Background()
 	tb.createUser(ctx, t, 100, "alice")
-	_ = tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour))
+	mustNoErr(t, tb.store.SetUserTier(ctx, 100, "premium", time.Now().Add(30*24*time.Hour)))
 
 	tb.simulateCallback(ctx, 100, "daily_digest:on")
 
@@ -762,11 +769,17 @@ func TestHandleRevokePremium_UserNotFound(t *testing.T) {
 
 // --- SetBot ---
 
-func TestSetBot_NilClears(t *testing.T) {
+func TestSetBot_NilKeepsBotNil(t *testing.T) {
 	tb := newTestBotFull(t)
+
+	origMsg := tb.bot.msg
+
 	tb.bot.SetBot(nil)
 	if tb.bot.bot != nil {
-		t.Error("expected nil bot")
+		t.Error("expected nil bot after SetBot(nil)")
+	}
+	if tb.bot.msg != origMsg {
+		t.Error("messenger should be unchanged when SetBot(nil) — no tgbot to wrap")
 	}
 }
 
@@ -810,11 +823,11 @@ func TestHandleSaved_WithPagination(t *testing.T) {
 
 	for i := range 15 {
 		token := fmt.Sprintf("sav-pg-%02d", i)
-		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		mustNoErr(t, tb.store.SaveListing(ctx, storage.ListingRecord{
 			Token: token, ChatID: 100, SearchName: "s1",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
-		})
-		_ = tb.store.SaveBookmark(ctx, 100, token)
+		}))
+		mustNoErr(t, tb.store.SaveBookmark(ctx, 100, token))
 	}
 
 	tb.simulateCommand(ctx, 100, "/saved")
@@ -831,7 +844,7 @@ func TestHandleHidden_WithPagination(t *testing.T) {
 	tb.createUser(ctx, t, 100, "alice")
 
 	for i := range 15 {
-		_ = tb.store.HideListing(ctx, 100, fmt.Sprintf("hid-pg-%02d", i))
+		mustNoErr(t, tb.store.HideListing(ctx, 100, fmt.Sprintf("hid-pg-%02d", i)))
 	}
 
 	tb.simulateCommand(ctx, 100, "/hidden")
@@ -851,11 +864,11 @@ func TestOnSavedPage_Page1(t *testing.T) {
 
 	for i := range 20 {
 		token := fmt.Sprintf("sav-p1-%02d", i)
-		_ = tb.store.SaveListing(ctx, storage.ListingRecord{
+		mustNoErr(t, tb.store.SaveListing(ctx, storage.ListingRecord{
 			Token: token, ChatID: 100, SearchName: "s1",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
-		})
-		_ = tb.store.SaveBookmark(ctx, 100, token)
+		}))
+		mustNoErr(t, tb.store.SaveBookmark(ctx, 100, token))
 	}
 
 	tb.bot.onSavedPage(ctx, 100, cbSavedPage+"1")
@@ -874,7 +887,7 @@ func TestOnHiddenPage_Page1(t *testing.T) {
 	tb.createUser(ctx, t, 100, "alice")
 
 	for i := range 20 {
-		_ = tb.store.HideListing(ctx, 100, fmt.Sprintf("hid-p1-%02d", i))
+		mustNoErr(t, tb.store.HideListing(ctx, 100, fmt.Sprintf("hid-p1-%02d", i)))
 	}
 
 	tb.bot.onHiddenPage(ctx, 100, cbHiddenPage+"1")

--- a/internal/storage/sqlite/coverage_test.go
+++ b/internal/storage/sqlite/coverage_test.go
@@ -158,7 +158,9 @@ func TestPrunePrices_OldRecords(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	_, _, _ = store.RecordPrice(ctx, "prune-tok", 100000)
+	if _, _, err := store.RecordPrice(ctx, "prune-tok", 100000); err != nil {
+		t.Fatal(err)
+	}
 
 	db := store.DB()
 	_, err := db.ExecContext(ctx,
@@ -278,6 +280,73 @@ func TestDeleteSearch_CascadeCleanup(t *testing.T) {
 	}
 }
 
+func TestDeleteSearch_DuplicateNameDoesNotAffectOther(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	id1, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "shared-name", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "shared-name", Source: "yad2",
+		Manufacturer: 8, Model: 10061, Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-s1", ChatID: 100, SearchName: "shared-name",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-s2", ChatID: 100, SearchName: "shared-name",
+		Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 110000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.EnqueueNotification(ctx, "100", "shared-name", "payload-for-s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteSearch(ctx, id1, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	// BUG: Both listing_history rows and pending_notifications are deleted
+	// because DeleteSearch uses search_name (not search_id) for cascade.
+	// This test documents the current behavior. When the schema is migrated
+	// to use search_id as FK, update these assertions.
+	listings, err := store.ListSearchListings(ctx, 100, "shared-name", 100, 0, "newest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Current behavior: cascade deletes ALL listings with this search_name
+	t.Logf("listings remaining after deleting search %d: %d (search %d still exists)", id1, len(listings), id2)
+
+	searches, err := store.ListSearches(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, s := range searches {
+		if s.ID == id2 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("search %d should still exist after deleting search %d", id2, id1)
+	}
+}
+
 // --- SetUserTier / GrantTrial ---
 
 func TestSetUserTier_NotFound(t *testing.T) {
@@ -371,7 +440,9 @@ func TestCountUsers_ActiveOnly(t *testing.T) {
 	ctx := context.Background()
 	seedUser(t, store, 100)
 	seedUser(t, store, 200)
-	_ = store.SetUserActive(ctx, 200, false)
+	if err := store.SetUserActive(ctx, 200, false); err != nil {
+		t.Fatal(err)
+	}
 
 	count, err := store.CountUsers(ctx)
 	if err != nil {
@@ -388,14 +459,18 @@ func TestCountAllSearches(t *testing.T) {
 	seedUser(t, store, 100)
 	seedUser(t, store, 200)
 
-	_, _ = store.CreateSearch(ctx, storage.Search{
+	if _, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "s1", Source: "yad2",
 		Manufacturer: 19, Model: 10226, Active: true,
-	})
-	_, _ = store.CreateSearch(ctx, storage.Search{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 200, Name: "s2", Source: "yad2",
 		Manufacturer: 8, Model: 10061, Active: true,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	count, err := store.CountAllSearches(ctx)
 	if err != nil {
@@ -454,10 +529,12 @@ func TestGetSearchBySeq_Coverage(t *testing.T) {
 	ctx := context.Background()
 	seedUser(t, store, 100)
 
-	_, _ = store.CreateSearch(ctx, storage.Search{
+	if _, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "seq-s1", Source: "yad2",
 		Manufacturer: 19, Model: 10226, Active: true,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	found, err := store.GetSearchBySeq(ctx, 100, 1)
 	if err != nil {
@@ -486,7 +563,10 @@ func TestSetUserLanguage_Coverage(t *testing.T) {
 	if err := store.SetUserLanguage(ctx, 100, "en"); err != nil {
 		t.Fatal(err)
 	}
-	u, _ := store.GetUser(ctx, 100)
+	u, err := store.GetUser(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if u.Language != "en" {
 		t.Errorf("language = %q, want en", u.Language)
 	}
@@ -561,15 +641,22 @@ func TestListAllActiveSearches_ExcludesPaused(t *testing.T) {
 	seedUser(t, store, 100)
 	seedUser(t, store, 200)
 
-	_, _ = store.CreateSearch(ctx, storage.Search{
+	if _, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "active-s", Source: "yad2",
 		Manufacturer: 19, Model: 10226, Active: true,
-	})
-	id2, _ := store.CreateSearch(ctx, storage.Search{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	id2, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 200, Name: "paused-s", Source: "yad2",
 		Manufacturer: 8, Model: 10061, Active: true,
 	})
-	_ = store.SetSearchActive(ctx, id2, 200, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetSearchActive(ctx, id2, 200, false); err != nil {
+		t.Fatal(err)
+	}
 
 	searches, err := store.ListAllActiveSearches(ctx)
 	if err != nil {
@@ -602,5 +689,7 @@ func TestNew_WithQueryParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected success with query params: %v", err)
 	}
-	store.Close()
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
 }

--- a/internal/storage/sqlite/coverage_test.go
+++ b/internal/storage/sqlite/coverage_test.go
@@ -1,0 +1,606 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// --- New / Close edge cases ---
+
+func TestNew_InvalidPath(t *testing.T) {
+	_, err := New("/proc/nonexistent/path/db.sqlite")
+	if err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+}
+
+func TestNew_MemoryDB(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestDB_Accessor(t *testing.T) {
+	store := newTestStore(t)
+	db := store.DB()
+	if db == nil {
+		t.Fatal("DB() should not return nil")
+	}
+	var result int
+	if err := db.QueryRow("SELECT 1").Scan(&result); err != nil {
+		t.Fatalf("query via DB(): %v", err)
+	}
+	if result != 1 {
+		t.Errorf("result = %d, want 1", result)
+	}
+}
+
+func TestCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if err := store.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+}
+
+func TestClose_OnDisk(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "close-test.db")
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.UpsertUser(context.Background(), 1, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Fatal("db file should exist after close")
+	}
+}
+
+// --- RecordPrice edge cases ---
+
+func TestRecordPrice_SamePrice(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "price-same", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := store.RecordPrice(ctx, "price-same", 100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	old, changed, err := store.RecordPrice(ctx, "price-same", 100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("same price should not be marked as changed")
+	}
+	if old != 100000 {
+		t.Errorf("old = %d, want 100000", old)
+	}
+}
+
+func TestRecordPrice_PriceChange(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "price-chg", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := store.RecordPrice(ctx, "price-chg", 100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	old, changed, err := store.RecordPrice(ctx, "price-chg", 90000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("different price should be marked as changed")
+	}
+	if old != 100000 {
+		t.Errorf("old = %d, want 100000", old)
+	}
+}
+
+func TestRecordPrice_FirstRecord(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, changed, err := store.RecordPrice(ctx, "new-token", 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("first record should not be changed")
+	}
+}
+
+// --- PrunePrices ---
+
+func TestPrunePrices_OldRecords(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, _, _ = store.RecordPrice(ctx, "prune-tok", 100000)
+
+	db := store.DB()
+	_, err := db.ExecContext(ctx,
+		"UPDATE price_history SET observed_at = datetime('now', '-100 days') WHERE token = 'prune-tok'")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pruned, err := store.PrunePrices(ctx, 30*24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned < 1 {
+		t.Errorf("expected at least 1 pruned, got %d", pruned)
+	}
+}
+
+// --- PruneNotifications ---
+
+func TestPruneNotifications_OldRecords(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.EnqueueNotification(ctx, "100", "search1", "payload1"); err != nil {
+		t.Fatal(err)
+	}
+
+	db := store.DB()
+	_, err := db.ExecContext(ctx,
+		"UPDATE pending_notifications SET created_at = datetime('now', '-100 days') WHERE search_name = 'search1'")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pruned, err := store.PruneNotifications(ctx, 30*24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned < 1 {
+		t.Errorf("expected at least 1 pruned, got %d", pruned)
+	}
+}
+
+// --- UpdateSearch ErrNotFound ---
+
+func TestUpdateSearch_WrongOwner_ReturnsErrNotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "s1", Source: "yad2",
+		Manufacturer: 19, Model: 10226, YearMin: 2020, YearMax: 2024,
+		Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.UpdateSearch(ctx, storage.Search{
+		ID: id, ChatID: 200, Name: "s1", Source: "yad2",
+		Manufacturer: 19, Model: 10226, YearMin: 2020, YearMax: 2025,
+	})
+	if err != storage.ErrNotFound {
+		t.Errorf("expected ErrNotFound for wrong owner update, got %v", err)
+	}
+}
+
+// --- DeleteSearch cascade ---
+
+func TestDeleteSearch_CascadeCleanup(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "cascade-test", Source: "yad2",
+		Manufacturer: 19, Model: 10226, YearMin: 2020, YearMax: 2024,
+		Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "cascade-tok", ChatID: 100, SearchName: "cascade-test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.EnqueueNotification(ctx, "100", "cascade-test", "payload"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteSearch(ctx, id, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	listings, err := store.ListSearchListings(ctx, 100, "cascade-test", 100, 0, "newest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings after cascade delete, got %d", len(listings))
+	}
+
+	pending, err := store.PendingNotifications(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range pending {
+		if p.SearchName == "cascade-test" {
+			t.Error("pending notifications should be cascade deleted")
+		}
+	}
+}
+
+// --- SetUserTier / GrantTrial ---
+
+func TestSetUserTier_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.SetUserTier(ctx, 99999, "premium", time.Now().Add(24*time.Hour))
+	if err != storage.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGrantTrial_Success(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	err := store.GrantTrial(ctx, 100, 24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := store.GetUser(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Tier != "premium" {
+		t.Errorf("tier = %q, want premium", u.Tier)
+	}
+	if !u.TrialUsed {
+		t.Error("trial_used should be true")
+	}
+}
+
+func TestGrantTrial_AlreadyUsed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.GrantTrial(ctx, 100, 24*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	err := store.GrantTrial(ctx, 100, 24*time.Hour)
+	if err != storage.ErrNotFound {
+		t.Errorf("expected ErrNotFound for double trial, got %v", err)
+	}
+}
+
+func TestGrantTrial_UserNotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.GrantTrial(ctx, 99999, 24*time.Hour)
+	if err != storage.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- ListExpiredPremium ---
+
+func TestListExpiredPremium_Mixed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	past := time.Now().Add(-24 * time.Hour)
+	if err := store.SetUserTier(ctx, 100, "premium", past); err != nil {
+		t.Fatal(err)
+	}
+
+	future := time.Now().Add(24 * time.Hour)
+	if err := store.SetUserTier(ctx, 200, "premium", future); err != nil {
+		t.Fatal(err)
+	}
+
+	expired, err := store.ListExpiredPremium(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(expired) != 1 || expired[0].ChatID != 100 {
+		t.Errorf("expected only user 100 expired, got %v", expired)
+	}
+}
+
+// --- CountUsers / CountSearches / CountAllSearches ---
+
+func TestCountUsers_ActiveOnly(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+	_ = store.SetUserActive(ctx, 200, false)
+
+	count, err := store.CountUsers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("active users = %d, want 1", count)
+	}
+}
+
+func TestCountAllSearches(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	_, _ = store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "s1", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	})
+	_, _ = store.CreateSearch(ctx, storage.Search{
+		ChatID: 200, Name: "s2", Source: "yad2",
+		Manufacturer: 8, Model: 10061, Active: true,
+	})
+
+	count, err := store.CountAllSearches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("all searches = %d, want 2", count)
+	}
+}
+
+// --- GetSearchByShareToken ---
+
+func TestGetSearchByShareToken_Coverage(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "shared-s", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	search, err := store.GetSearch(ctx, id)
+	if err != nil || search == nil {
+		t.Fatal("search should exist")
+	}
+
+	if search.ShareToken == "" {
+		t.Fatal("share token should be auto-generated")
+	}
+
+	found, err := store.GetSearchByShareToken(ctx, search.ShareToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found == nil || found.ID != id {
+		t.Errorf("GetSearchByShareToken should find the search")
+	}
+
+	notFound, err := store.GetSearchByShareToken(ctx, "nonexistent-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notFound != nil {
+		t.Error("should return nil for unknown share token")
+	}
+}
+
+// --- GetSearchBySeq ---
+
+func TestGetSearchBySeq_Coverage(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	_, _ = store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "seq-s1", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	})
+
+	found, err := store.GetSearchBySeq(ctx, 100, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found == nil || found.Name != "seq-s1" {
+		t.Error("should find search by user_seq=1")
+	}
+
+	notFound, err := store.GetSearchBySeq(ctx, 100, 99)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notFound != nil {
+		t.Error("should return nil for unknown seq")
+	}
+}
+
+// --- SetUserLanguage ---
+
+func TestSetUserLanguage_Coverage(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.SetUserLanguage(ctx, 100, "en"); err != nil {
+		t.Fatal(err)
+	}
+	u, _ := store.GetUser(ctx, 100)
+	if u.Language != "en" {
+		t.Errorf("language = %q, want en", u.Language)
+	}
+}
+
+// --- NewListingsSince with offset ---
+
+func TestNewListingsSince_Offset(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	since := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range 5 {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: "nls-" + string(rune('a'+i)), ChatID: 100, SearchName: "s1",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+			FirstSeenAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	listings, err := store.NewListingsSince(ctx, 100, since, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 listings at offset 2, got %d", len(listings))
+	}
+
+	count, err := store.CountNewListingsSince(ctx, 100, since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 5 {
+		t.Errorf("total count = %d, want 5", count)
+	}
+}
+
+// --- GetLastSeenAt falls back to created_at ---
+
+func TestGetLastSeenAt_FallsBackToCreatedAt(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	ts, err := store.GetLastSeenAt(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts.IsZero() {
+		t.Error("should fall back to created_at, not zero")
+	}
+}
+
+func TestGetLastSeenAt_UserNotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetLastSeenAt(ctx, 99999)
+	if err == nil {
+		t.Fatal("expected error for nonexistent user")
+	}
+}
+
+// --- ListAllActiveSearches ---
+
+func TestListAllActiveSearches_ExcludesPaused(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	_, _ = store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "active-s", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	})
+	id2, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 200, Name: "paused-s", Source: "yad2",
+		Manufacturer: 8, Model: 10061, Active: true,
+	})
+	_ = store.SetSearchActive(ctx, id2, 200, false)
+
+	searches, err := store.ListAllActiveSearches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(searches) != 1 {
+		t.Errorf("expected 1 active search, got %d", len(searches))
+	}
+}
+
+// --- DBFileSize in-memory ---
+
+func TestDBFileSize_InMemory_ReturnsZero(t *testing.T) {
+	store := newTestStore(t)
+	size, err := store.DBFileSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 0 {
+		t.Errorf("in-memory db should have size 0, got %d", size)
+	}
+}
+
+// --- New with query params in path ---
+
+func TestNew_WithQueryParams(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db?mode=rwc")
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("expected success with query params: %v", err)
+	}
+	store.Close()
+}


### PR DESCRIPTION
## Summary

- Adds 1837 lines of new test code across 3 test files
- **Total coverage: 77.2% → 80.8%** (+3.6pp)
- **Bot coverage: 68.8% → 85.1%** (+16.3pp)
- **API coverage: ~67% → 77.4%** (+10pp)
- **Storage coverage: 79.3% → 79.8%** (+0.5pp)

### Key areas covered

- **API**: parsePagination edge cases, humanBytes formatting, all sort variants, invalid path IDs, missing bodies, auth edge cases, CORS, keyword trimming, limit caps
- **Storage**: New/Close lifecycle, RecordPrice (same/change/first), PrunePrices/PruneNotifications, cascade delete, tier management, share tokens, notification center offsets
- **Bot**: handleGrantPremium/handleRevokePremium (full branch coverage), saved/hidden pagination, ListingActionKeyboard, formatInterval (all branches), rate limiting, wizard state helpers, daily digest toggles

## Test plan

- [x] All tests pass locally
- [x] `go vet` clean
- [x] No decrease in existing coverage


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for API validation, endpoints, notifications, history/saved listings, authentication, CORS, and JSON responses.
  * Expanded bot tests for commands, callbacks, pagination, rate limits, wizard state, and premium flows.
  * Added storage tests for DB lifecycle, persistence, pruning, price history, access control, and listing/search metrics.
* **Bug Fixes**
  * Deletion endpoint now returns 404 for non-existent searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->