### PR TITLE
fix: guard against malformed messages reaching Telegram users

### DIFF
--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -91,7 +91,12 @@ func FormatListing(l model.Listing, lang locale.Lang) string {
 func FormatPriceDrop(l model.Listing, oldPrice int, lang locale.Lang) string {
 	var b strings.Builder
 
-	title := format.EscapeMarkdown(strings.TrimSpace(l.Manufacturer + " " + l.Model))
+	mfr := strings.TrimSpace(l.Manufacturer)
+	mdl := strings.TrimSpace(l.Model)
+	if mfr == "" && mdl == "" {
+		mfr = "Unknown"
+	}
+	title := format.EscapeMarkdown(strings.TrimSpace(mfr + " " + mdl))
 	if l.SubModel != "" {
 		title += " " + format.EscapeMarkdown(l.SubModel)
 	}

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -17,7 +17,12 @@ func FormatListing(l model.Listing, lang locale.Lang) string {
 
 	b.WriteString(locale.T(lang, "fmt_new_listing"))
 
-	title := format.EscapeMarkdown(strings.TrimSpace(l.Manufacturer + " " + l.Model))
+	mfr := strings.TrimSpace(l.Manufacturer)
+	mdl := strings.TrimSpace(l.Model)
+	if mfr == "" && mdl == "" {
+		mfr = "Unknown"
+	}
+	title := format.EscapeMarkdown(strings.TrimSpace(mfr + " " + mdl))
 	if l.SubModel != "" {
 		title += " " + format.EscapeMarkdown(l.SubModel)
 	}

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -394,7 +394,8 @@ func TestIsMalformedMessage(t *testing.T) {
 		{"template syntax", "{{.SomeField}}", true},
 		{"template in long msg", "Hello world {{.Name}} how are you", true},
 		{"double braces no dot", "some {{partial}} template", true},
-		{"sprintf error", "%!s(MISSING) value", true},
+		{"sprintf error prefix", "%!s(MISSING) value", true},
+		{"sprintf error mid-string", "Hello %!s(MISSING) world", true},
 		{"valid notification", "🚗 New listing found: Toyota Corolla 2021", false},
 		{"valid price drop", "📉 Price Drop! Toyota Corolla: ₪95,000 → ₪89,000", false},
 	}
@@ -420,6 +421,19 @@ func TestFormatListing_EmptyManufacturerAndModel(t *testing.T) {
 	}
 	if IsMalformedMessage(msg) {
 		t.Errorf("formatted listing with fallback should not be malformed:\n%s", msg)
+	}
+}
+
+func TestFormatPriceDrop_EmptyManufacturerAndModel(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token: "empty-pd",
+			Price: 40000,
+		},
+	}
+	msg := FormatPriceDrop(l, 50000, locale.English)
+	if !strings.Contains(msg, "Unknown") {
+		t.Errorf("should show 'Unknown' when both manufacturer and model are empty:\n%s", msg)
 	}
 }
 

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -381,6 +381,48 @@ func TestFormatListing_WithFitnessBreakdown(t *testing.T) {
 	}
 }
 
+func TestIsMalformedMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"empty", "", true},
+		{"whitespace only", "   \n\t  ", true},
+		{"too short", "hi", true},
+		{"exactly min length", "0123456789", false},
+		{"template syntax", "{{.SomeField}}", true},
+		{"template in long msg", "Hello world {{.Name}} how are you", true},
+		{"double braces no dot", "some {{partial}} template", true},
+		{"sprintf error", "%!s(MISSING) value", true},
+		{"valid notification", "🚗 New listing found: Toyota Corolla 2021", false},
+		{"valid price drop", "📉 Price Drop! Toyota Corolla: ₪95,000 → ₪89,000", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsMalformedMessage(tt.text); got != tt.want {
+				t.Errorf("IsMalformedMessage(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatListing_EmptyManufacturerAndModel(t *testing.T) {
+	l := model.Listing{
+		RawListing: model.RawListing{
+			Token: "empty1",
+			Price: 50000,
+		},
+	}
+	msg := FormatListing(l, locale.English)
+	if !strings.Contains(msg, "Unknown") {
+		t.Errorf("should show 'Unknown' when both manufacturer and model are empty:\n%s", msg)
+	}
+	if IsMalformedMessage(msg) {
+		t.Errorf("formatted listing with fallback should not be malformed:\n%s", msg)
+	}
+}
+
 func TestFormatDailyDigest(t *testing.T) {
 	stats := []storage.DailySearchStats{
 		{

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -33,7 +33,7 @@ func IsMalformedMessage(text string) bool {
 	if strings.Contains(trimmed, "{{") && strings.Contains(trimmed, "}}") {
 		return true
 	}
-	if strings.HasPrefix(trimmed, "%!") {
+	if strings.Contains(trimmed, "%!") {
 		return true
 	}
 	return false

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
@@ -10,9 +11,30 @@ import (
 
 var ErrRecipientBlocked = errors.New("recipient blocked the bot")
 
+// MinSafeMessageLen is the minimum length a valid formatted message should
+// have. Anything shorter is almost certainly a bug (raw template syntax,
+// partial format string, or empty payload).
+const MinSafeMessageLen = 10
+
 type Notifier interface {
 	Connect(ctx context.Context) error
 	Notify(ctx context.Context, recipient string, listings []model.Listing, lang locale.Lang) error
 	NotifyRaw(ctx context.Context, recipient string, message string) error
 	Disconnect() error
+}
+
+// IsMalformedMessage returns true when text looks like a corrupted or
+// template-leaked payload that should never be sent to a user.
+func IsMalformedMessage(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if len(trimmed) < MinSafeMessageLen {
+		return true
+	}
+	if strings.Contains(trimmed, "{{") && strings.Contains(trimmed, "}}") {
+		return true
+	}
+	if strings.HasPrefix(trimmed, "%!") {
+		return true
+	}
+	return false
 }

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -69,6 +69,11 @@ func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.L
 }
 
 func (n *Notifier) NotifyRaw(ctx context.Context, chatID string, message string) error {
+	n.logger.Debug("notifyRaw",
+		"chat_id", chatID,
+		"msg_len", len(message),
+		"msg_preview", truncate(message, 100),
+	)
 	return n.sendMessage(ctx, chatID, message)
 }
 
@@ -83,6 +88,15 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 	}
 
 	caption := notifier.FormatListing(listing, lang)
+
+	if notifier.IsMalformedMessage(caption) {
+		n.logger.Error("blocked malformed photo caption",
+			"chat_id", chatID,
+			"caption_len", len(caption),
+			"caption_preview", truncate(caption, 200),
+		)
+		return fmt.Errorf("blocked malformed photo caption (%d chars): %q", len(caption), truncate(caption, 100))
+	}
 
 	if len([]rune(caption)) > maxCaptionLen {
 		_, err = n.bot.SendPhoto(ctx, &tgbot.SendPhotoParams{
@@ -123,6 +137,15 @@ func (n *Notifier) sendMessageWithParseMode(ctx context.Context, chatID string, 
 	id, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid chat ID %q: %w", chatID, err)
+	}
+
+	if notifier.IsMalformedMessage(text) {
+		n.logger.Error("blocked malformed message",
+			"chat_id", chatID,
+			"text_len", len(text),
+			"text_preview", truncate(text, 200),
+		)
+		return fmt.Errorf("blocked malformed message (%d chars): %q", len(text), truncate(text, 100))
 	}
 
 	chunks := splitMessage(text, maxMessageLen)
@@ -204,6 +227,14 @@ func isRateLimited(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "too many requests") ||
 		strings.Contains(msg, "retry_after")
+}
+
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
 }
 
 // parseRetryAfter attempts to extract the retry-after duration from a

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -194,7 +194,7 @@ func TestSendMessage_InvalidChatID(t *testing.T) {
 		_, _ = w.Write(sendMessageOK)
 	}))
 
-	err := n.NotifyRaw(context.Background(), "not-a-number", "hello")
+	err := n.NotifyRaw(context.Background(), "not-a-number", "test message body")
 	if err == nil {
 		t.Fatal("expected error for invalid chat ID")
 	}
@@ -229,7 +229,7 @@ func TestSendMessage_APIError_Blocked(t *testing.T) {
 		_, _ = w.Write(resp)
 	}))
 
-	err := n.NotifyRaw(context.Background(), "123", "hello")
+	err := n.NotifyRaw(context.Background(), "123", "test message body")
 	if err == nil {
 		t.Fatal("expected error for API failure")
 	}
@@ -297,7 +297,7 @@ func TestSendMessage_429_RetriesAndSucceeds(t *testing.T) {
 		_, _ = w.Write(sendMessageOK)
 	}))
 
-	err := n.NotifyRaw(context.Background(), "123", "hello")
+	err := n.NotifyRaw(context.Background(), "123", "test message body")
 	if err != nil {
 		t.Fatalf("expected retry to succeed, got: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestSendMessage_429_RetryAlsoFails(t *testing.T) {
 		_, _ = w.Write(resp)
 	}))
 
-	err := n.NotifyRaw(context.Background(), "123", "hello")
+	err := n.NotifyRaw(context.Background(), "123", "test message body")
 	if err == nil {
 		t.Fatal("expected error when retry also fails")
 	}
@@ -653,3 +653,47 @@ func TestNotify_BatchListings_UsesText(t *testing.T) {
 		}
 	}
 }
+
+func TestNotifyRaw_BlocksMalformedMessage(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not reach API for malformed message")
+	}))
+
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{"template syntax", "{{.}}"},
+		{"short message", "hi"},
+		{"empty", ""},
+		{"sprintf error", "%!s(MISSING)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := n.NotifyRaw(context.Background(), "123", tt.msg)
+			if err == nil {
+				t.Error("expected error for malformed message")
+			}
+			if !strings.Contains(err.Error(), "blocked malformed") {
+				t.Errorf("expected 'blocked malformed' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestNotifyRaw_AllowsValidMessage(t *testing.T) {
+	var called atomic.Int32
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		_, _ = w.Write(sendMessageOK)
+	}))
+
+	err := n.NotifyRaw(context.Background(), "123", "This is a valid notification message")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called.Load() == 0 {
+		t.Error("API should have been called for valid message")
+	}
+}
+

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -35,7 +35,11 @@ func NewInstantDelivery(n notifier.Notifier, q storage.NotificationQueue, lang l
 }
 
 func WithLogger(l *slog.Logger) func(*InstantDelivery) {
-	return func(d *InstantDelivery) { d.logger = l }
+	return func(d *InstantDelivery) {
+		if l != nil {
+			d.logger = l
+		}
+	}
 }
 
 func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/storage"
 )
+
+var errMalformedMessage = errors.New("blocked malformed message")
 
 type DeliveryStrategy interface {
 	DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error
@@ -20,10 +23,19 @@ type InstantDelivery struct {
 	notifier notifier.Notifier
 	queue    storage.NotificationQueue
 	lang     locale.Lang
+	logger   *slog.Logger
 }
 
-func NewInstantDelivery(n notifier.Notifier, q storage.NotificationQueue, lang locale.Lang) *InstantDelivery {
-	return &InstantDelivery{notifier: n, queue: q, lang: lang}
+func NewInstantDelivery(n notifier.Notifier, q storage.NotificationQueue, lang locale.Lang, opts ...func(*InstantDelivery)) *InstantDelivery {
+	d := &InstantDelivery{notifier: n, queue: q, lang: lang, logger: slog.Default()}
+	for _, o := range opts {
+		o(d)
+	}
+	return d
+}
+
+func WithLogger(l *slog.Logger) func(*InstantDelivery) {
+	return func(d *InstantDelivery) { d.logger = l }
 }
 
 func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {
@@ -38,6 +50,13 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 
 	if d.queue != nil {
 		msg := notifier.FormatBatch(listings, d.lang)
+		if notifier.IsMalformedMessage(msg) {
+			d.logger.Error("blocked malformed batch message before enqueue",
+				"chat_id", chatID, "msg_len", len(msg))
+			return errMalformedMessage
+		}
+		d.logger.Debug("enqueueing batch notification after send failure",
+			"chat_id", chatID, "msg_len", len(msg))
 		if qErr := d.queue.EnqueueNotification(context.Background(), chatIDStr, "", msg); qErr == nil {
 			return nil
 		}
@@ -47,6 +66,12 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 }
 
 func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
+	if notifier.IsMalformedMessage(message) {
+		d.logger.Error("blocked malformed raw message",
+			"chat_id", chatID, "msg_len", len(message),
+			"msg_preview", truncateStr(message, 200))
+		return errMalformedMessage
+	}
 	chatIDStr := fmt.Sprintf("%d", chatID)
 	err := d.notifier.NotifyRaw(ctx, chatIDStr, message)
 	if err == nil || d.queue == nil {
@@ -72,9 +97,15 @@ func NewDigestDelivery(s storage.DigestStore, lang locale.Lang) *DigestDelivery 
 
 func (d *DigestDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {
 	msg := notifier.FormatBatch(listings, d.lang)
+	if notifier.IsMalformedMessage(msg) {
+		return errMalformedMessage
+	}
 	return d.store.AddDigestItem(ctx, chatID, msg)
 }
 
 func (d *DigestDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
+	if notifier.IsMalformedMessage(message) {
+		return errMalformedMessage
+	}
 	return d.store.AddDigestItem(ctx, chatID, message)
 }

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -262,3 +262,63 @@ func TestDigestDelivery_DeliverBatch_Error(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestInstantDelivery_DeliverRaw_BlocksMalformed(t *testing.T) {
+	n := &mockNotifier{}
+	d := NewInstantDelivery(n, nil, locale.English)
+
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{"template syntax", "{{.}}"},
+		{"too short", "hi"},
+		{"empty", ""},
+		{"sprintf error", "%!s(MISSING)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := d.DeliverRaw(context.Background(), 100, tt.msg)
+			if !errors.Is(err, errMalformedMessage) {
+				t.Errorf("expected errMalformedMessage, got: %v", err)
+			}
+		})
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 0 {
+		t.Errorf("no messages should reach notifier, got %d", len(n.rawMessages))
+	}
+}
+
+func TestInstantDelivery_DeliverRaw_AllowsValid(t *testing.T) {
+	n := &mockNotifier{}
+	d := NewInstantDelivery(n, nil, locale.English)
+
+	err := d.DeliverRaw(context.Background(), 100, "Valid notification message here")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 1 {
+		t.Errorf("expected 1 raw message, got %d", len(n.rawMessages))
+	}
+}
+
+func TestDigestDelivery_DeliverRaw_BlocksMalformed(t *testing.T) {
+	ds := newMockDigestStore()
+	d := NewDigestDelivery(ds, locale.English)
+
+	err := d.DeliverRaw(context.Background(), 100, "{{.}}")
+	if !errors.Is(err, errMalformedMessage) {
+		t.Errorf("expected errMalformedMessage, got: %v", err)
+	}
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	if len(ds.items[100]) != 0 {
+		t.Errorf("no items should be stored, got %d", len(ds.items[100]))
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -233,7 +233,7 @@ func (s *Scheduler) deliveryFor(ctx context.Context, chatID int64, lang locale.L
 			return NewDigestDelivery(s.digestStore, lang)
 		}
 	}
-	return NewInstantDelivery(s.notifier, s.queue, lang)
+	return NewInstantDelivery(s.notifier, s.queue, lang, WithLogger(s.logger))
 }
 
 func (s *Scheduler) fetcherForSource(source string) fetcher.Fetcher {
@@ -387,6 +387,24 @@ func (s *Scheduler) retryPending(ctx context.Context) {
 	}
 	s.logger.Info("retrying pending notifications", "count", len(pending))
 	for _, p := range pending {
+		if notifier.IsMalformedMessage(p.Payload) {
+			s.logger.Error("purging malformed pending notification",
+				"id", p.ID,
+				"recipient", maskPhone(p.Recipient),
+				"payload_len", len(p.Payload),
+				"payload_preview", truncateStr(p.Payload, 200),
+			)
+			if err := s.queue.AckNotification(ctx, p.ID); err != nil {
+				s.logger.Error("ack malformed notification failed", "id", p.ID, "error", err)
+			}
+			continue
+		}
+		s.logger.Debug("retrying pending notification",
+			"id", p.ID,
+			"recipient", maskPhone(p.Recipient),
+			"payload_len", len(p.Payload),
+			"payload_preview", truncateStr(p.Payload, 100),
+		)
 		if err := s.notifier.NotifyRaw(ctx, p.Recipient, p.Payload); err != nil {
 			s.logger.Error("retry notification failed",
 				"recipient", maskPhone(p.Recipient),
@@ -998,4 +1016,12 @@ func maskPhone(phone string) string {
 		return "***"
 	}
 	return phone[:len(phone)-4] + "****"
+}
+
+func truncateStr(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
 }

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -516,7 +516,7 @@ func TestRetryPending_NotifyRawFails(t *testing.T) {
 	q := &errNotificationQueue{
 		mockNotificationQueue: mockNotificationQueue{
 			pending: []storage.PendingNotification{
-				{ID: 1, Recipient: "123", Payload: "test"},
+				{ID: 1, Recipient: "123", Payload: "test notification payload"},
 			},
 		},
 	}
@@ -534,7 +534,7 @@ func TestRetryPending_AckFails(t *testing.T) {
 	q := &errNotificationQueue{
 		mockNotificationQueue: mockNotificationQueue{
 			pending: []storage.PendingNotification{
-				{ID: 1, Recipient: "123", Payload: "test"},
+				{ID: 1, Recipient: "123", Payload: "test notification payload"},
 			},
 		},
 		ackErr: errors.New("ack failed"),
@@ -904,4 +904,35 @@ func (m *errDailyDigestStore) ListDailyDigestUsers(_ context.Context) ([]storage
 
 func (m *errDailyDigestStore) DailyStats(_ context.Context, _ int64) ([]storage.DailySearchStats, error) {
 	return m.stats, nil
+}
+
+func TestRetryPending_PurgesMalformedPayloads(t *testing.T) {
+	n := &mockNotifier{}
+	q := &mockNotificationQueue{
+		pending: []storage.PendingNotification{
+			{ID: 1, Recipient: "123", Payload: "{{.}}"},
+			{ID: 2, Recipient: "123", Payload: "short"},
+			{ID: 3, Recipient: "123", Payload: "valid notification message"},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{Queue: q})
+	s.retryPending(context.Background())
+
+	if len(n.rawMessages) != 1 {
+		t.Errorf("expected only 1 valid message sent, got %d", len(n.rawMessages))
+	}
+	if n.rawMessages[0].message != "valid notification message" {
+		t.Errorf("expected valid message, got %q", n.rawMessages[0].message)
+	}
+
+	if !q.acked[1] {
+		t.Error("malformed payload id=1 should be acked (purged)")
+	}
+	if !q.acked[2] {
+		t.Error("malformed payload id=2 should be acked (purged)")
+	}
+	if !q.acked[3] {
+		t.Error("valid payload id=3 should be acked after send")
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `notifier.IsMalformedMessage()` — shared validation that catches empty/too-short messages, raw Go template syntax (`{{.}}`), and `fmt.Sprintf` errors (`%!s(MISSING)`)
- Guards every message-sending boundary: Telegram sender, delivery strategies (instant + digest), scheduler retry-pending, and the formatter's empty-listing fallback
- Malformed pending notifications are purged (acked without sending) instead of retried forever
- Adds structured debug logging at all send points for future traceability

## Context

The bot was occasionally sending raw `{{.}}` as an entire message to users. After investigating the full codebase, no Go templates are used in the notification pipeline. The most likely root cause is a corrupted payload stored in `pending_notifications` that gets retried via `NotifyRaw()` with no validation. Production DB inspection confirmed both pending tables are currently empty (the payload was already delivered).

## Test plan

- [x] 19 new tests covering all guard paths (IsMalformedMessage, telegram blocks, delivery blocks, scheduler purge)
- [x] All existing tests updated and passing (short test payloads lengthened to pass validation)
- [x] Full test suite green (`go test ./...`)
- [x] `go vet ./...` clean


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Messages containing invalid formatting patterns, template syntax, or corrupted content are now blocked and prevented from sending to prevent delivery failures.
  * Product listings with missing manufacturer or model information now display "Unknown" instead of blank values.

* **Improvements**
  * Enhanced error logging and validation for better message delivery debugging and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->