### PR TITLE
fix: resolve price drop duplication and adapt to yad2 feed changes

### DIFF
--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -52,6 +52,7 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 	}
 
 	listings := make([]model.RawListing, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
 	skipped := 0
 	for _, item := range items {
 		l, err := itemToListing(item)
@@ -62,6 +63,10 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 			}
 			continue
 		}
+		if _, dup := seen[l.Token]; dup {
+			continue
+		}
+		seen[l.Token] = struct{}{}
 		listings = append(listings, l)
 	}
 
@@ -213,6 +218,9 @@ func textFromField(f field) string {
 	if f.EnglishText != "" {
 		return f.EnglishText
 	}
+	if f.TextEng != "" {
+		return f.TextEng
+	}
 	return f.Text
 }
 
@@ -269,5 +277,6 @@ type feedItem struct {
 type field struct {
 	Text        string `json:"text"`
 	EnglishText string `json:"english_text"`
+	TextEng     string `json:"textEng"`
 	ID          int    `json:"id"`
 }

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -228,8 +228,10 @@ func TestTextFromField_PrefersEnglish(t *testing.T) {
 		f    field
 		want string
 	}{
-		{"english preferred", field{Text: "Hebrew", EnglishText: "English"}, "English"},
-		{"hebrew fallback", field{Text: "Hebrew", EnglishText: ""}, "Hebrew"},
+		{"english_text preferred", field{Text: "Hebrew", EnglishText: "English"}, "English"},
+		{"textEng fallback", field{Text: "Hebrew", TextEng: "English2"}, "English2"},
+		{"english_text over textEng", field{Text: "Hebrew", EnglishText: "E1", TextEng: "E2"}, "E1"},
+		{"hebrew fallback", field{Text: "Hebrew"}, "Hebrew"},
 		{"both empty", field{}, ""},
 	}
 
@@ -240,5 +242,34 @@ func TestTextFromField_PrefersEnglish(t *testing.T) {
 				t.Errorf("textFromField() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseNextData_DeduplicatesAcrossBuckets(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "dup1", "manufacturer": {"text": "Honda"}, "model": {"text": "Civic"}, "price": 50000, "hand": 1},
+				{"token": "uniq", "manufacturer": {"text": "Honda"}, "model": {"text": "Civic"}, "price": 60000, "hand": 2}
+			],
+			"commercial": [
+				{"token": "dup1", "manufacturer": {"text": "Honda"}, "model": {"text": "Civic"}, "price": 50000, "hand": 1}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 unique listings (dup removed), got %d", len(listings))
+	}
+	tokens := map[string]bool{}
+	for _, l := range listings {
+		if tokens[l.Token] {
+			t.Errorf("duplicate token %q in results", l.Token)
+		}
+		tokens[l.Token] = true
 	}
 }

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -29,8 +29,6 @@ func FormatListing(l model.Listing, lang locale.Lang) string {
 
 	if l.Km > 0 {
 		b.WriteString(locale.Tf(lang, "fmt_mileage", format.Number(l.Km)))
-	} else {
-		b.WriteString(locale.T(lang, "fmt_mileage_unknown"))
 	}
 
 	if l.FitnessScore > 0 {
@@ -102,16 +100,18 @@ func FormatPriceDrop(l model.Listing, oldPrice int, lang locale.Lang) string {
 		format.Number(drop),
 	))
 
+	var inlineParts []string
 	if l.Km > 0 {
-		b.WriteString(fmt.Sprintf("🛣️ %s km", format.Number(l.Km)))
-	} else {
-		b.WriteString(locale.T(lang, "fmt_mileage_unknown_inline"))
+		inlineParts = append(inlineParts, fmt.Sprintf("🛣️ %s km", format.Number(l.Km)))
 	}
 	if l.Hand > 0 {
-		b.WriteString(" · " + locale.Tf(lang, "fmt_hand_inline", l.Hand))
+		inlineParts = append(inlineParts, locale.Tf(lang, "fmt_hand_inline", l.Hand))
 	}
 	if l.FitnessScore > 0 {
-		b.WriteString(fmt.Sprintf(" · 🎯 %.1f", l.FitnessScore))
+		inlineParts = append(inlineParts, fmt.Sprintf("🎯 %.1f", l.FitnessScore))
+	}
+	if len(inlineParts) > 0 {
+		b.WriteString(strings.Join(inlineParts, " · "))
 	}
 	b.WriteString("\n")
 

--- a/internal/notifier/formatter_test.go
+++ b/internal/notifier/formatter_test.go
@@ -101,8 +101,8 @@ func TestFormatPriceDrop_MinimalFields(t *testing.T) {
 	if !strings.Contains(msg, "-₪10,000") {
 		t.Errorf("should show correct drop amount:\n%s", msg)
 	}
-	if !strings.Contains(msg, "N/A") {
-		t.Errorf("should show N/A for mileage when zero:\n%s", msg)
+	if strings.Contains(msg, "N/A") || strings.Contains(msg, "km") {
+		t.Errorf("should not show mileage line when Km=0:\n%s", msg)
 	}
 }
 
@@ -312,8 +312,8 @@ func TestFormatListing_ZeroKm(t *testing.T) {
 	}
 
 	msg := FormatListing(l, locale.English)
-	if !strings.Contains(msg, "Not specified") {
-		t.Errorf("should show 'Not specified' when Km=0:\n%s", msg)
+	if strings.Contains(msg, "Mileage") || strings.Contains(msg, "Not specified") {
+		t.Errorf("should omit mileage line when Km=0:\n%s", msg)
 	}
 }
 

--- a/internal/storage/sqlite/prices.go
+++ b/internal/storage/sqlite/prices.go
@@ -21,7 +21,8 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	scanErr := row.Scan(&prev)
 
 	_, err = tx.ExecContext(ctx,
-		"INSERT OR IGNORE INTO price_history (token, price) VALUES (?, ?)", token, price)
+		"INSERT OR REPLACE INTO price_history (token, price) VALUES (?, ?)",
+		token, price)
 	if err != nil {
 		return 0, false, err
 	}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -815,6 +815,34 @@ func TestRecordPrice(t *testing.T) {
 	}
 }
 
+func TestRecordPrice_OscillationNoFalseDrop(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, _, err := store.RecordPrice(ctx, "osc1", 50000); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RecordPrice(ctx, "osc1", 60000); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RecordPrice(ctx, "osc1", 50000); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-observing 50000 should now see prev=50000 (not 60000) because the
+	// UPSERT updates observed_at, making 50000 the latest row.
+	oldPrice, changed, err := store.RecordPrice(ctx, "osc1", 50000)
+	if err != nil {
+		t.Fatalf("RecordPrice: %v", err)
+	}
+	if changed {
+		t.Error("same price re-observed should not be a change")
+	}
+	if oldPrice != 50000 {
+		t.Errorf("oldPrice = %d, want 50000", oldPrice)
+	}
+}
+
 // --- ListingStore ---
 
 // --- DigestStore ---


### PR DESCRIPTION
## Summary

- **Price drop duplication**: `RecordPrice` used `INSERT OR IGNORE` which silently skipped re-inserting a previously-seen price. When prices oscillated (50k→60k→50k), the 50k row kept its old rowid, so the latest-price query kept returning 60k — triggering the same drop notification every poll cycle. Changed to `INSERT OR REPLACE` so re-observed prices get a fresh rowid and become the "latest" correctly.

- **Cross-bucket dedup**: yad2 feed returns the same listing token across multiple buckets (`private`, `commercial`, `platinum`, etc.). The parser now tracks seen tokens and deduplicates when merging across buckets, preventing duplicate processing of the same listing.

- **km field removed from feed**: yad2 no longer includes `km` in their search feed JSON. Instead of showing "לא צוין" (not specified) for every listing, the formatter now omits the mileage line entirely when km=0.

- **textEng field support**: yad2 now uses `textEng` instead of `english_text` for some manufacturer/model fields. Parser handles both with fallback priority: `english_text` → `textEng` → `text`.

## Root Cause Investigation

Fetched a real yad2 response from the production VM and dumped the JSON structure. Findings:
1. Token `rcknnsm5` appeared in both `commercial` and `platinum` buckets
2. Feed items no longer contain the `km` field at all
3. Some `field` objects use `textEng` instead of `english_text`
4. Production logs confirmed the same price drop was triggered 3 times across consecutive poll cycles

## Test Plan

- [x] `TestRecordPrice_OscillationNoFalseDrop` — verifies price oscillation no longer triggers repeated drops
- [x] `TestParseNextData_DeduplicatesAcrossBuckets` — verifies same token in multiple buckets is deduplicated
- [x] `TestTextFromField_PrefersEnglish` — updated to cover `textEng` fallback
- [x] `TestFormatListing_ZeroKm` / `TestFormatPriceDrop_MinimalFields` — updated to verify mileage line is omitted when km=0
- [x] All existing tests pass (`go test ./...`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deduplicated duplicate listings that appeared across and within feed buckets.
  * Omitted mileage lines when mileage is not provided (no "mileage unknown" placeholder).
  * Improved price history handling to avoid reporting false price drops after oscillations.

* **Tests**
  * Expanded tests for text-field extraction precedence and deduplication.
  * Added validation for price-oscillation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->