### PR TITLE
ci: optimize with path-based job skipping and concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,50 @@ on:
       - 'docker-compose*.yaml'
       - 'web/**'
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      web: ${{ steps.filter.outputs.web }}
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+            web:
+              - 'web/**'
+            infra:
+              - 'Dockerfile'
+              - '.github/workflows/**'
+              - 'docker-compose*.yaml'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: Stub web/dist for embed
         run: mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
       - uses: golangci/golangci-lint-action@v7
@@ -36,7 +67,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -59,7 +91,8 @@ jobs:
   web:
     name: Web Build
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: changes
+    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.infra == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -82,7 +115,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test, web]
+    needs: [changes, lint, test, web]
+    if: |
+      always() &&
+      needs.changes.outputs.infra == 'true' &&
+      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+      (needs.test.result == 'success' || needs.test.result == 'skipped') &&
+      (needs.web.result == 'success' || needs.web.result == 'skipped')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -94,6 +133,12 @@ jobs:
         with:
           name: web-dist
           path: web/dist
+        continue-on-error: true
+      - name: Stub web/dist if not built
+        run: |
+          if [ ! -f web/dist/index.html ]; then
+            mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
+          fi
       - name: Build binary
         run: make build
       - name: Build Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ on:
       - 'web/**'
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: ci-pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary

- Add `dorny/paths-filter` to detect go/web/infra changes per PR
- Lint and Test jobs only run when Go or infra files change
- Web Build only runs when web/ or infra files change
- Docker build only runs when Dockerfile or infra files change
- Add concurrency group to cancel in-progress runs on same PR
- Enable Go module caching in lint job

## Why

All 4 CI jobs were running on every PR regardless of what changed. A web-only change would still run Go lint and tests (and vice versa), wasting CI minutes. The concurrency group also prevents queueing duplicate runs on rapid pushes.

## Test plan

- [x] CI passes on this PR (the workflow change itself triggers all jobs since it touches `.github/workflows/**`)
- [ ] Verify a future web-only PR skips Lint and Test jobs
- [ ] Verify a future Go-only PR skips Web Build job

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline efficiency with enhanced workflow concurrency control and selective job execution based on file changes. Enhanced build resilience to handle missing artifacts gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->