### PR TITLE
feat(web): UI/UX overhaul with component library and premium design

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "clsx": "^2.1.1",
         "firebase": "^12.12.1",
         "lucide-react": "^0.468.0",
+        "motion": "^12.38.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.0",
@@ -3523,6 +3524,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4126,6 +4154,47 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "firebase": "^12.12.1",
     "lucide-react": "^0.468.0",
+    "motion": "^12.38.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.0",

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -27,17 +27,34 @@ export function Shell() {
   const { data: notifCount } = useNotificationCount();
   const unread = notifCount?.count ?? 0;
   const { user, signOut } = useAuth();
+  const emailInitial =
+    user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") ?? "?";
 
   return (
     <div className="min-h-screen bg-background">
-      <aside className="fixed inset-y-0 right-0 z-50 hidden w-64 flex-col border-l border-border/50 bg-card/80 backdrop-blur-xl md:flex">
-        <div className="flex h-16 shrink-0 items-center gap-3 border-b border-border/50 px-6">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-            <Car className="h-4.5 w-4.5 text-primary" />
+      <aside className="fixed inset-y-0 right-0 z-50 hidden w-64 flex-col border-l border-border/40 bg-card/85 backdrop-blur-xl md:flex">
+        {/* Animated gradient accent on inner (left) edge */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-3 left-0 w-px overflow-hidden rounded-full"
+        >
+          <span className="absolute inset-y-0 left-0 w-[3px] -translate-x-px bg-gradient-to-b from-primary/70 via-primary/35 to-primary/60 opacity-80 blur-[0.5px]" />
+          <span className="absolute inset-0 motion-safe:animate-pulse bg-gradient-to-b from-transparent via-primary/50 to-transparent opacity-40 motion-safe:[animation-duration:3.25s]" />
+        </span>
+
+        <div className="relative shrink-0 bg-gradient-to-b from-primary/5 to-transparent">
+          <div className="flex h-20 shrink-0 items-center gap-3 px-6">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/12 ring-1 ring-primary/15 shadow-[0_0_20px_-4px_rgba(59,130,246,0.35)]">
+              <Car className="h-4.5 w-4.5 text-primary" />
+            </div>
+            <span className="text-lg font-semibold tracking-tight">
+              CarWatch
+            </span>
           </div>
-          <span className="text-lg font-semibold tracking-tight">
-            CarWatch
-          </span>
+          <div
+            className="h-px w-full bg-gradient-to-l from-transparent via-primary/25 to-transparent opacity-80"
+            aria-hidden
+          />
         </div>
 
         <nav className="mt-2 flex flex-1 flex-col gap-1 overflow-y-auto p-3">
@@ -56,7 +73,7 @@ export function Shell() {
                 className={cn(
                   "group relative flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-200",
                   isActive
-                    ? "bg-primary/10 text-primary shadow-[inset_0_0_0_1px_rgba(59,130,246,0.15)]"
+                    ? "bg-primary/[0.22] text-primary shadow-[inset_0_0_0_1px_rgba(59,130,246,0.28),0_1px_24px_-8px_rgba(59,130,246,0.25)]"
                     : "text-muted-foreground hover:bg-secondary hover:text-foreground",
                 )}
               >
@@ -70,20 +87,37 @@ export function Shell() {
                 </span>
                 {item.label}
                 {isActive && (
-                  <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-primary" />
+                  <>
+                    <span
+                      className="absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_16px_4px_rgba(59,130,246,0.55),0_0_6px_2px_rgba(59,130,246,0.35)]"
+                      aria-hidden
+                    />
+                    <span
+                      className="absolute left-0 top-1/2 h-8 w-5 -translate-y-1/2 rounded-full bg-primary/20 blur-md"
+                      aria-hidden
+                    />
+                  </>
                 )}
               </Link>
             );
           })}
         </nav>
 
-        <div className="shrink-0 border-t border-border/50 p-4">
-          <p
-            className="mb-3 truncate text-xs text-muted-foreground"
-            title={user?.email ?? undefined}
-          >
-            {user?.email ?? ""}
-          </p>
+        <div className="relative shrink-0 border-t border-border/50 bg-gradient-to-t from-card/95 to-card/70 p-4 backdrop-blur-sm">
+          <div className="mb-3 flex items-center gap-3">
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary/30 via-primary/10 to-primary/5 text-sm font-semibold text-primary shadow-inner ring-1 ring-primary/25"
+              aria-hidden
+            >
+              {emailInitial}
+            </div>
+            <p
+              className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+              title={user?.email ?? undefined}
+            >
+              {user?.email ?? ""}
+            </p>
+          </div>
           <button
             type="button"
             onClick={() => void signOut()}
@@ -98,16 +132,16 @@ export function Shell() {
         </div>
       </aside>
 
-      {/* Main content */}
-      <main className="pb-20 md:mr-64 md:pb-0">
-        <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8 animate-fade-in">
-          <Outlet />
+      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[5.5rem] md:mr-64 md:pb-0">
+        <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+          <div key={location.pathname} className="animate-fade-in">
+            <Outlet />
+          </div>
         </div>
       </main>
 
-      {/* Mobile bottom nav */}
-      <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/80 backdrop-blur-xl md:hidden">
-        <div className="flex justify-around py-1.5">
+      <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-white/[0.06] bg-card/55 shadow-[0_-12px_40px_-12px_rgba(0,0,0,0.55)] backdrop-blur-2xl backdrop-saturate-150 md:hidden">
+        <div className="flex justify-around px-1 py-3">
           {navItems.map((item) => {
             const Icon = item.icon;
             const isActive =
@@ -121,22 +155,30 @@ export function Shell() {
                 key={item.path}
                 to={item.path}
                 className={cn(
-                  "flex flex-col items-center gap-0.5 px-3 py-1.5 text-[11px] font-medium transition-colors duration-200",
+                  "group flex min-w-0 flex-1 flex-col items-center gap-1 px-2 py-1 text-[11px] font-medium transition-all duration-200",
+                  "active:scale-[0.94] motion-reduce:active:scale-100",
                   isActive ? "text-primary" : "text-muted-foreground",
                 )}
               >
-                <span className="relative">
-                  <Icon className="h-5 w-5" />
-                  {showBadge && (
-                    <span className="absolute -top-1 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-white animate-pulse-soft">
-                      {unread > 99 ? "99+" : unread}
-                    </span>
+                <span className="flex flex-col items-center gap-1">
+                  <span className="relative">
+                    <Icon className="h-5 w-5 transition-transform duration-200 group-active:scale-90" />
+                    {showBadge && (
+                      <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-white animate-pulse-soft">
+                        {unread > 99 ? "99+" : unread}
+                      </span>
+                    )}
+                  </span>
+                  {isActive && (
+                    <span
+                      className="h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_10px_2px_rgba(59,130,246,0.65)]"
+                      aria-hidden
+                    />
                   )}
                 </span>
-                {item.label}
-                {isActive && (
-                  <span className="h-[3px] w-4 rounded-full bg-primary mt-0.5" />
-                )}
+                <span className="line-clamp-1 text-center leading-tight">
+                  {item.label}
+                </span>
               </Link>
             );
           })}

--- a/web/src/components/ui/Badge.tsx
+++ b/web/src/components/ui/Badge.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable react-refresh/only-export-components -- badgeVariants exported for composition */
+import type { HTMLAttributes } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold",
+  {
+    variants: {
+      variant: {
+        default: "bg-secondary text-secondary-foreground",
+        success: "bg-score-great/20 text-score-great",
+        warning: "bg-score-good/20 text-score-good",
+        destructive:
+          "bg-destructive/20 text-destructive",
+        outline:
+          "border border-border bg-transparent text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof badgeVariants>;
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { badgeVariants };

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -66,6 +66,7 @@ function ButtonRender(
     return React.cloneElement(
       children as React.ReactElement<Record<string, unknown>>,
       {
+        ...rest,
         className: cn(classes, childProps.className),
         ref,
       },

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,0 +1,100 @@
+/* eslint-disable react-refresh/only-export-components -- buttonVariants exported for composition */
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md font-medium transition-all duration-200 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-primary text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] hover:opacity-90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-accent",
+        ghost: "bg-transparent text-foreground hover:bg-accent",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:opacity-90",
+      },
+      size: {
+        sm: "h-8 px-3 text-sm",
+        md: "h-10 px-4 text-sm",
+        lg: "h-12 px-6 text-base",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "md",
+    },
+  },
+);
+
+type ButtonOwnProps = VariantProps<typeof buttonVariants> & {
+  asChild?: boolean;
+};
+
+export type ButtonProps<T extends React.ElementType = "button"> =
+  ButtonOwnProps & {
+    as?: T;
+  } & Omit<
+    React.ComponentPropsWithoutRef<T>,
+    keyof ButtonOwnProps | "as"
+  >;
+
+function ButtonRender(
+  props: ButtonProps<React.ElementType>,
+  ref: React.ComponentPropsWithRef<React.ElementType>["ref"],
+): React.ReactElement {
+  const {
+    as,
+    asChild = false,
+    className,
+    variant,
+    size,
+    type,
+    children,
+    ...rest
+  } = props as ButtonProps<"button"> & { as?: React.ElementType };
+
+  const classes = cn(buttonVariants({ variant, size }), className);
+
+  if (asChild) {
+    if (!React.isValidElement(children)) {
+      throw new Error("כפתור עם asChild דורש ילד יחיד מסוג אלמנט");
+    }
+    const childProps = children.props as { className?: string };
+    return React.cloneElement(
+      children as React.ReactElement<Record<string, unknown>>,
+      {
+        className: cn(classes, childProps.className),
+        ref,
+      },
+    );
+  }
+
+  const Comp = (as ?? "button") as React.ElementType;
+  return (
+    <Comp
+      ref={ref}
+      className={classes}
+      type={Comp === "button" ? (type ?? "button") : undefined}
+      {...rest}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+const ButtonBase = React.forwardRef(ButtonRender);
+
+export const Button = ButtonBase as <
+  T extends React.ElementType = "button",
+>(
+  props: ButtonProps<T> & {
+    ref?: React.ComponentPropsWithRef<T>["ref"];
+  },
+) => React.ReactElement;
+
+ButtonBase.displayName = "Button";
+
+export { buttonVariants };

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,41 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type EmptyStateProps = {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+};
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-2xl border border-border/50 bg-card/50 px-6 py-16 text-center dir-rtl",
+        className,
+      )}
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Icon className="h-6 w-6" aria-hidden />
+      </div>
+      <div className="space-y-1">
+        <p className="text-base font-semibold text-foreground">{title}</p>
+        {description ? (
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {action ? <div className="pt-1">{action}</div> : null}
+    </div>
+  );
+}

--- a/web/src/components/ui/PageHeader.tsx
+++ b/web/src/components/ui/PageHeader.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type PageHeaderProps = {
+  title: string;
+  subtitle?: string;
+  backTo?: string;
+  backLabel?: string;
+  action?: ReactNode;
+  className?: string;
+};
+
+export function PageHeader({
+  title,
+  subtitle,
+  backTo,
+  backLabel = "חזרה",
+  action,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header
+      className={cn(
+        "flex flex-col gap-1 border-b border-border/50 pb-6 dir-rtl",
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1 text-right">
+          {backTo ? (
+            <Link
+              to={backTo}
+              className="mb-3 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span>{backLabel}</span>
+              <ArrowRight className="h-4 w-4 shrink-0" aria-hidden />
+            </Link>
+          ) : null}
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+          ) : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+    </header>
+  );
+}

--- a/web/src/components/ui/SectionHeader.tsx
+++ b/web/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router";
+import { cn } from "@/lib/utils";
+
+export type SectionHeaderProps = {
+  title: string;
+  linkTo?: string;
+  linkLabel?: string;
+  className?: string;
+};
+
+export function SectionHeader({
+  title,
+  linkTo,
+  linkLabel = "הצג הכל",
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div className={cn("flex items-center justify-between", className)}>
+      <h2 className="text-base font-semibold text-foreground">{title}</h2>
+      {linkTo && (
+        <Link
+          to={linkTo}
+          className="text-sm font-medium text-primary transition-colors hover:text-primary/80"
+        >
+          {linkLabel}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,13 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export type SkeletonProps = HTMLAttributes<HTMLDivElement>;
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn("shimmer-skeleton", className)}
+      {...props}
+    />
+  );
+}

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -6,7 +6,7 @@ export type SkeletonProps = HTMLAttributes<HTMLDivElement>;
 export function Skeleton({ className, ...props }: SkeletonProps) {
   return (
     <div
-      className={cn("shimmer-skeleton", className)}
+      className={cn("shimmer-skeleton motion-reduce:animate-none", className)}
       {...props}
     />
   );

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,0 +1,129 @@
+/* eslint-disable react-refresh/only-export-components -- useToast co-located with ToastProvider */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+export type ToastType = "success" | "error" | "info";
+
+type ToastRecord = {
+  id: string;
+  message: string;
+  type: ToastType;
+  exiting: boolean;
+};
+
+const EXIT_MS = 220;
+const AUTO_DISMISS_MS = 3000;
+
+type ToastContextValue = {
+  toast: (message: string, type?: ToastType) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast חייב לעטוף את האפליקציה ב־ToastProvider");
+  }
+  return ctx;
+}
+
+function toastTypeClass(type: ToastType): string {
+  switch (type) {
+    case "success":
+      return "border-score-great/40 bg-card text-foreground ring-1 ring-score-great/20";
+    case "error":
+      return "border-destructive/40 bg-card text-foreground ring-1 ring-destructive/20";
+    case "info":
+      return "border-primary/40 bg-card text-foreground ring-1 ring-primary/20";
+    default:
+      return "border-border bg-card text-foreground";
+  }
+}
+
+function ToastItem({
+  item,
+  onExitDone,
+}: {
+  item: ToastRecord;
+  onExitDone: (id: string) => void;
+}) {
+  useEffect(() => {
+    if (!item.exiting) return;
+    const t = window.setTimeout(() => {
+      onExitDone(item.id);
+    }, EXIT_MS);
+    return () => window.clearTimeout(t);
+  }, [item.exiting, item.id, onExitDone]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "pointer-events-auto w-full max-w-md rounded-lg border px-4 py-3 text-right text-sm shadow-lg dir-rtl",
+        toastTypeClass(item.type),
+        !item.exiting && "animate-slide-up",
+        item.exiting && "opacity-0 transition-opacity duration-200 ease-out",
+      )}
+    >
+      <p className="font-medium leading-snug">{item.message}</p>
+    </div>
+  );
+}
+
+export type ToastProviderProps = {
+  children: ReactNode;
+};
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const beginExit = useCallback((id: string) => {
+    setToasts((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, exiting: true } : t)),
+    );
+  }, []);
+
+  const toast = useCallback(
+    (message: string, type: ToastType = "info") => {
+      const id =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `toast-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      setToasts((prev) => [...prev, { id, message, type, exiting: false }]);
+      window.setTimeout(() => {
+        beginExit(id);
+      }, AUTO_DISMISS_MS);
+    },
+    [beginExit],
+  );
+
+  const value = useMemo(() => ({ toast }), [toast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        className="pointer-events-none fixed inset-x-0 bottom-0 z-[100] flex flex-col-reverse items-center gap-2 p-4"
+        aria-relevant="additions text"
+      >
+        {toasts.map((t) => (
+          <ToastItem key={t.id} item={t} onExitDone={dismiss} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -86,6 +87,15 @@ export type ToastProviderProps = {
 
 export function ToastProvider({ children }: ToastProviderProps) {
   const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const timersRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((t) => window.clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
 
   const dismiss = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -104,9 +114,11 @@ export function ToastProvider({ children }: ToastProviderProps) {
           ? crypto.randomUUID()
           : `toast-${Date.now()}-${Math.random().toString(16).slice(2)}`;
       setToasts((prev) => [...prev, { id, message, type, exiting: false }]);
-      window.setTimeout(() => {
+      const timer = window.setTimeout(() => {
+        timersRef.current.delete(timer);
         beginExit(id);
       }, AUTO_DISMISS_MS);
+      timersRef.current.add(timer);
     },
     [beginExit],
   );

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -1,0 +1,15 @@
+export { Badge, badgeVariants, type BadgeProps } from "./Badge";
+export {
+  Button,
+  buttonVariants,
+  type ButtonProps,
+} from "./Button";
+export { EmptyState, type EmptyStateProps } from "./EmptyState";
+export { PageHeader, type PageHeaderProps } from "./PageHeader";
+export { Skeleton, type SkeletonProps } from "./Skeleton";
+export {
+  ToastProvider,
+  useToast,
+  type ToastProviderProps,
+  type ToastType,
+} from "./Toast";

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./Button";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";
 export { PageHeader, type PageHeaderProps } from "./PageHeader";
+export { SectionHeader, type SectionHeaderProps } from "./SectionHeader";
 export { Skeleton, type SkeletonProps } from "./Skeleton";
 export {
   ToastProvider,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { AuthProvider } from "./contexts/AuthContext";
+import { ToastProvider } from "./components/ui/Toast";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -20,7 +21,9 @@ createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AuthProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,5 +1,6 @@
-import { Database, Cpu, Table, RefreshCw } from "lucide-react";
+import { AlertCircle, Cpu, Database, RefreshCw, Table } from "lucide-react";
 import { useAdminStats } from "@/hooks/useAdmin";
+import { EmptyState, PageHeader, Skeleton } from "@/components/ui";
 
 const TABLE_LABELS: Record<string, string> = {
   users: "משתמשים",
@@ -17,11 +18,11 @@ export function AdminPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="h-8 w-48 shimmer-skeleton rounded-lg" />
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="ניהול" />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-44 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-44 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -30,14 +31,13 @@ export function AdminPage() {
 
   if (isError || !data) {
     return (
-      <div className="space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">ניהול מערכת</h1>
-        <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
-          <p className="text-destructive font-medium">שגיאה בטעינת הנתונים</p>
-          <p className="text-sm text-muted-foreground mt-1">
-            ייתכן שאין הרשאת גישה
-          </p>
-        </div>
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="ניהול" />
+        <EmptyState
+          icon={AlertCircle}
+          title="שגיאה בטעינת הנתונים"
+          description="ייתכן שאין הרשאת גישה"
+        />
       </div>
     );
   }
@@ -46,13 +46,15 @@ export function AdminPage() {
 
   return (
     <div className="space-y-6 pb-20 md:pb-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight">ניהול מערכת</h1>
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <RefreshCw className="h-3 w-3" />
-          עדכון אחרון: {lastUpdated.toLocaleTimeString("he-IL")}
-        </div>
-      </div>
+      <PageHeader
+        title="ניהול"
+        action={
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <RefreshCw className="h-3 w-3" />
+            עדכון אחרון: {lastUpdated.toLocaleTimeString("he-IL")}
+          </div>
+        }
+      />
 
       {/* DB Storage */}
       <div className="rounded-2xl border border-border/50 bg-card p-6">

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -36,7 +36,7 @@ export function AdminPage() {
         <EmptyState
           icon={AlertCircle}
           title="שגיאה בטעינת הנתונים"
-          description="ייתכן שאין הרשאת גישה"
+          description="שגיאה בטעינת הנתונים, נסה מחדש מאוחר יותר"
         />
       </div>
     );

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -3,6 +3,7 @@ import { Clock, ExternalLink } from "lucide-react";
 import { useHistory } from "@/hooks/useBookmarks";
 import { safeHref } from "@/lib/utils";
 import { ListingCardBody } from "@/components/ListingCardBody";
+import { Button, EmptyState, PageHeader, Skeleton } from "@/components/ui";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
@@ -20,11 +21,11 @@ export function HistoryPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="h-8 w-40 shimmer-skeleton rounded-lg" />
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="היסטוריה" />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-72 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-72 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -33,8 +34,8 @@ export function HistoryPage() {
 
   if (isError) {
     return (
-      <div className="space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">היסטוריה</h1>
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="היסטוריה" />
         <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
           <p className="text-destructive font-medium">
             שגיאה בטעינת ההיסטוריה
@@ -46,26 +47,23 @@ export function HistoryPage() {
 
   return (
     <div className="space-y-6 pb-20 md:pb-4">
-      <div className="flex items-center gap-2.5">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-          <Clock className="h-4 w-4 text-primary" />
-        </div>
-        <h1 className="text-2xl font-semibold tracking-tight">היסטוריה</h1>
-        {data && (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            ({data.total} מודעות)
-          </span>
-        )}
-      </div>
+      <PageHeader
+        title="היסטוריה"
+        action={
+          data ? (
+            <span className="text-sm text-muted-foreground tabular-nums">
+              ({data.total} מודעות)
+            </span>
+          ) : null
+        }
+      />
 
       {!data || data.total === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-border/50 bg-card/50 py-20">
-          <Clock className="h-10 w-10 text-muted-foreground/20 mb-4" />
-          <p className="text-muted-foreground">אין מודעות בהיסטוריה</p>
-          <p className="text-sm text-muted-foreground mt-1">
-            מודעות שנמצאו יופיעו כאן
-          </p>
-        </div>
+        <EmptyState
+          icon={Clock}
+          title="אין מודעות בהיסטוריה"
+          description="מודעות שנמצאו יופיעו כאן"
+        />
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -77,24 +75,26 @@ export function HistoryPage() {
           {(data.total > PAGE_SIZE || offset > 0) && (
             <div className="flex items-center justify-center gap-3 pt-4">
               {offset > 0 && (
-                <button
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                  className="rounded-xl bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent active:scale-[0.97]"
                 >
                   הקודם
-                </button>
+                </Button>
               )}
               <span className="text-sm text-muted-foreground tabular-nums">
                 {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} מתוך{" "}
                 {data.total}
               </span>
               {offset + PAGE_SIZE < data.total && (
-                <button
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={() => setOffset(offset + PAGE_SIZE)}
-                  className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 active:scale-[0.97]"
                 >
                   הבא
-                </button>
+                </Button>
               )}
             </div>
           )}

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -8,10 +8,15 @@ import {
   Hand,
   MapPin,
   Clock,
+  Car,
 } from "lucide-react";
-import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 export function ListingDetailPage() {
   const location = useLocation();
@@ -46,41 +51,42 @@ export function ListingDetailPage() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 w-40 shimmer-skeleton rounded-lg" />
-        <div className="aspect-video w-full shimmer-skeleton rounded-2xl" />
-        <div className="h-12 w-60 shimmer-skeleton rounded-lg" />
+        <Skeleton className="h-8 w-40 rounded-lg" />
+        <Skeleton className="aspect-video w-full rounded-2xl" />
+        <Skeleton className="h-12 w-60 rounded-lg" />
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-24 rounded-2xl" />
+          ))}
+        </div>
       </div>
     );
   }
 
   if (error || !listing) {
     return (
-      <div className="flex flex-col items-center justify-center py-24">
-        <p className="text-lg font-medium mb-2">המודעה לא נמצאה</p>
-        <p className="text-sm text-muted-foreground mb-6">
-          ניתן לגשת למודעה דרך רשימת התוצאות
-        </p>
-        <Link
-          to="/"
-          className="inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[0_0_30px_rgba(59,130,246,0.35)] active:scale-[0.98]"
-        >
-          <ArrowRight className="h-4 w-4" />
-          חזרה לחיפושים
-        </Link>
-      </div>
+      <EmptyState
+        icon={Car}
+        title="המודעה לא נמצאה"
+        description="ניתן לגשת למודעה דרך רשימת התוצאות"
+        action={
+          <Button asChild>
+            <Link to="/">
+              <ArrowRight className="h-4 w-4" />
+              חזרה לחיפושים
+            </Link>
+          </Button>
+        }
+      />
     );
   }
 
   return (
     <div className="space-y-6 pb-20 md:pb-4">
-      {/* Back */}
-      <button
-        onClick={() => navigate(-1)}
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors duration-200"
-      >
+      <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="text-muted-foreground hover:text-foreground -mr-2">
         <ArrowRight className="h-4 w-4" />
         חזרה לתוצאות
-      </button>
+      </Button>
 
       {/* Hero image */}
       {listing.image_url ? (
@@ -122,23 +128,22 @@ export function ListingDetailPage() {
         />
       </div>
 
-      {/* Score + Seen */}
       <div className="flex items-center gap-4">
         {listing.fitness_score != null && (
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">ציון התאמה:</span>
-            <span
-              className={cn(
-                "inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold tabular-nums",
+            <Badge
+              variant={
                 listing.fitness_score >= 7
-                  ? "bg-score-great/15 text-score-great"
+                  ? "success"
                   : listing.fitness_score >= 5
-                    ? "bg-score-good/15 text-score-good"
-                    : "bg-score-low/15 text-score-low",
-              )}
+                    ? "warning"
+                    : "default"
+              }
+              className="text-sm tabular-nums"
             >
               {listing.fitness_score.toFixed(1)}
-            </span>
+            </Badge>
           </div>
         )}
         <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
@@ -147,16 +152,10 @@ export function ListingDetailPage() {
         </div>
       </div>
 
-      {/* CTA */}
-      <a
-        href={listing.page_link}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[0_0_30px_rgba(59,130,246,0.35)] active:scale-[0.98]"
-      >
+      <Button as="a" href={listing.page_link} target="_blank" rel="noopener noreferrer" size="lg" className="rounded-xl">
         <ExternalLink className="h-4 w-4" />
         צפה במודעה המקורית
-      </a>
+      </Button>
     </div>
   );
 }

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -10,7 +10,7 @@ import {
   Clock,
   Car,
 } from "lucide-react";
-import { formatPrice, formatKm, relativeTime } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, safeHref } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
@@ -152,10 +152,19 @@ export function ListingDetailPage() {
         </div>
       </div>
 
-      <Button as="a" href={listing.page_link} target="_blank" rel="noopener noreferrer" size="lg" className="rounded-xl">
-        <ExternalLink className="h-4 w-4" />
-        צפה במודעה המקורית
-      </Button>
+      {safeHref(listing.page_link) && (
+        <Button
+          as="a"
+          href={safeHref(listing.page_link)!}
+          target="_blank"
+          rel="noopener noreferrer"
+          size="lg"
+          className="rounded-xl"
+        >
+          <ExternalLink className="h-4 w-4" />
+          צפה במודעה המקורית
+        </Button>
+      )}
     </div>
   );
 }

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -1,10 +1,20 @@
 import { useState } from "react";
-import { useParams, Link, useNavigate } from "react-router";
-import { ArrowRight, ExternalLink, ChevronDown, Bookmark } from "lucide-react";
+import { useParams, useNavigate } from "react-router";
+import {
+  ExternalLink,
+  ChevronDown,
+  Bookmark,
+  Car,
+} from "lucide-react";
 import { useListings } from "@/hooks/useListings";
 import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
 import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
 
 const SORT_OPTIONS = [
   { value: "newest", label: "חדשים" },
@@ -33,18 +43,7 @@ export function ListingsPage() {
   if (!searchId || Number.isNaN(searchId)) {
     return (
       <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <Link
-            to="/"
-            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors duration-200"
-          >
-            <ArrowRight className="h-4 w-4" />
-            חזרה
-          </Link>
-          <h1 className="text-2xl font-semibold tracking-tight">
-            חיפוש לא נמצא
-          </h1>
-        </div>
+        <PageHeader backTo="/" title="חיפוש לא נמצא" />
       </div>
     );
   }
@@ -52,17 +51,8 @@ export function ListingsPage() {
   if (isError) {
     return (
       <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <Link
-            to="/"
-            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors duration-200"
-          >
-            <ArrowRight className="h-4 w-4" />
-            חזרה
-          </Link>
-          <h1 className="text-2xl font-semibold tracking-tight">תוצאות</h1>
-        </div>
-        <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
+        <PageHeader backTo="/" title="תוצאות" />
+        <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center dir-rtl">
           <p className="text-destructive font-medium">שגיאה בטעינת התוצאות</p>
           <p className="text-sm text-muted-foreground mt-1">נסה לרענן את הדף</p>
         </div>
@@ -72,70 +62,58 @@ export function ListingsPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        <div className="h-8 w-40 shimmer-skeleton rounded-lg" />
-        <div className="flex gap-2">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-9 w-16 shimmer-skeleton rounded-lg" />
+      <div className="space-y-5 pb-20 md:pb-4">
+        <PageHeader backTo="/" title="תוצאות" />
+        <div className="flex flex-wrap gap-2">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <Skeleton key={i} className="h-8 w-16 rounded-md" />
           ))}
         </div>
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-72 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-72 rounded-2xl" />
           ))}
         </div>
       </div>
     );
   }
 
+  const countSubtitle =
+    data != null ? `${data.total.toLocaleString("he-IL")} מודעות` : undefined;
+
   return (
     <div className="space-y-5 pb-20 md:pb-4">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Link
-          to="/"
-          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors duration-200"
-        >
-          <ArrowRight className="h-4 w-4" />
-          חזרה
-        </Link>
-        <h1 className="text-2xl font-semibold tracking-tight">תוצאות</h1>
-        {data && (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            ({data.total} מודעות)
-          </span>
-        )}
-      </div>
+      <PageHeader
+        backTo="/"
+        title="תוצאות"
+        subtitle={countSubtitle}
+      />
 
       {/* Sort pills */}
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2 dir-rtl">
         {SORT_OPTIONS.map((opt) => (
-          <button
+          <Button
             key={opt.value}
+            type="button"
+            size="sm"
+            variant={sort === opt.value ? "primary" : "secondary"}
             onClick={() => {
               setSort(opt.value);
               setOffset(0);
             }}
-            className={cn(
-              "rounded-lg px-3.5 py-1.5 text-sm font-medium transition-all duration-200",
-              sort === opt.value
-                ? "bg-primary text-primary-foreground shadow-[0_0_12px_rgba(59,130,246,0.3)]"
-                : "bg-secondary text-secondary-foreground hover:bg-accent",
-            )}
           >
             {opt.label}
-          </button>
+          </Button>
         ))}
       </div>
 
       {/* Grid */}
       {!data || data.items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-border/50 bg-card/50 py-20">
-          <p className="text-muted-foreground">אין תוצאות עדיין</p>
-          <p className="text-sm text-muted-foreground mt-1">
-            רכבים חדשים יופיעו כאן כשהם ימצאו
-          </p>
-        </div>
+        <EmptyState
+          icon={Car}
+          title="אין תוצאות עדיין"
+          description="רכבים חדשים יופיעו כאן כשהם ימצאו"
+        />
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -145,27 +123,31 @@ export function ListingsPage() {
           </div>
 
           {data.total > PAGE_SIZE && (
-            <div className="flex items-center justify-center gap-3 pt-4">
+            <div className="flex items-center justify-center gap-3 pt-4 dir-rtl">
               {offset > 0 && (
-                <button
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="md"
                   onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                  className="rounded-xl bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent active:scale-[0.97]"
                 >
                   הקודם
-                </button>
+                </Button>
               )}
               <span className="text-sm text-muted-foreground tabular-nums">
                 {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} מתוך{" "}
                 {data.total}
               </span>
               {offset + PAGE_SIZE < data.total && (
-                <button
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="md"
                   onClick={() => setOffset(offset + PAGE_SIZE)}
-                  className="inline-flex items-center gap-1 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 active:scale-[0.97]"
                 >
                   <ChevronDown className="h-4 w-4" />
                   הבא
-                </button>
+                </Button>
               )}
             </div>
           )}
@@ -179,6 +161,7 @@ function ListingCard({ listing }: { listing: Listing }) {
   const navigate = useNavigate();
   const saveBookmark = useSaveBookmark();
   const removeBookmark = useRemoveBookmark();
+  const { toast } = useToast();
   const [saved, setSaved] = useState(false);
 
   return (
@@ -193,7 +176,7 @@ function ListingCard({ listing }: { listing: Listing }) {
           navigate(`/listings/${listing.token}`, { state: { listing } });
         }
       }}
-      className="group block cursor-pointer rounded-2xl border border-border/50 bg-card overflow-hidden transition-all duration-300 hover:border-border hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)] hover:-translate-y-0.5"
+      className="group block cursor-pointer rounded-2xl border border-border/50 bg-card overflow-hidden transition-all duration-300 hover:border-border hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)] hover:-translate-y-0.5 dir-rtl"
     >
       {/* Image */}
       {listing.image_url ? (
@@ -258,6 +241,13 @@ function ListingCard({ listing }: { listing: Listing }) {
               setSaved(next);
               const mutation = next ? saveBookmark : removeBookmark;
               mutation.mutate(listing.token, {
+                onSuccess: () => {
+                  if (next) {
+                    toast("נשמר בהצלחה", "success");
+                  } else {
+                    toast("הוסר מהשמורים", "info");
+                  }
+                },
                 onError: () => setSaved(!next),
               });
             }}

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -4,6 +4,9 @@ import { ChevronLeft, ChevronRight, Check, Loader2 } from "lucide-react";
 import { useManufacturers, useModels } from "@/hooks/useCatalog";
 import { useCreateSearch } from "@/hooks/useSearches";
 import { formatPrice, cn } from "@/lib/utils";
+import { Button } from "@/components/ui/Button";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { useToast } from "@/components/ui/Toast";
 
 type WizardStep =
   | "manufacturer"
@@ -65,6 +68,7 @@ export function NewSearchPage() {
     excludeKeys: "",
   });
 
+  const { toast } = useToast();
   const { data: manufacturers } = useManufacturers(
     mfrSearch.length >= 1 ? mfrSearch : undefined,
   );
@@ -106,7 +110,10 @@ export function NewSearchPage() {
         exclude_keys: form.excludeKeys || undefined,
       },
       {
-        onSuccess: () => navigate("/"),
+        onSuccess: () => {
+          toast("החיפוש נוצר בהצלחה!", "success");
+          navigate("/");
+        },
         onError: () => setError("שגיאה ביצירת החיפוש, נסה שוב"),
       },
     );
@@ -114,7 +121,7 @@ export function NewSearchPage() {
 
   return (
     <div className="space-y-8">
-      <h1 className="text-2xl font-semibold tracking-tight">חיפוש חדש</h1>
+      <PageHeader title="חיפוש חדש" backTo="/" backLabel="חזרה לחיפושים" />
 
       {/* Progress bar */}
       <div className="space-y-2">
@@ -429,19 +436,17 @@ export function NewSearchPage() {
       {/* Navigation */}
       <div className="flex items-center gap-3 border-t border-border/50 pt-5">
         {canGoBack && (
-          <button
-            onClick={goBack}
-            className="inline-flex items-center gap-1.5 rounded-xl bg-secondary px-4 py-2.5 text-sm font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent active:scale-[0.97]"
-          >
+          <Button variant="secondary" onClick={goBack}>
             <ChevronRight className="h-4 w-4" />
             הקודם
-          </button>
+          </Button>
         )}
 
         <div className="mr-auto" />
 
         {step === "confirm" ? (
-          <button
+          <Button
+            variant="primary"
             onClick={handleSubmit}
             disabled={
               createSearch.isPending ||
@@ -449,7 +454,6 @@ export function NewSearchPage() {
               form.model === 0 ||
               form.yearMin > form.yearMax
             }
-            className="inline-flex items-center gap-1.5 rounded-xl bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[0_0_30px_rgba(59,130,246,0.35)] disabled:opacity-50 disabled:shadow-none active:scale-[0.98]"
           >
             {createSearch.isPending ? (
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -457,17 +461,14 @@ export function NewSearchPage() {
               <Check className="h-4 w-4" />
             )}
             צור חיפוש
-          </button>
+          </Button>
         ) : (
           step !== "manufacturer" &&
           step !== "model" && (
-            <button
-              onClick={goNext}
-              className="inline-flex items-center gap-1.5 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[0_0_30px_rgba(59,130,246,0.35)] active:scale-[0.98]"
-            >
+            <Button variant="primary" onClick={goNext}>
               הבא
               <ChevronLeft className="h-4 w-4" />
-            </button>
+            </Button>
           )
         )}
       </div>

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -6,13 +6,15 @@ import {
 } from "@/hooks/useNotifications";
 import { safeHref } from "@/lib/utils";
 import { ListingCardBody } from "@/components/ListingCardBody";
+import { Button, EmptyState, PageHeader, Skeleton } from "@/components/ui";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
 
 export function NotificationsPage() {
   const [offset, setOffset] = useState(0);
-  const { data, isLoading, isSuccess, isFetching, isError } = useNotifications(PAGE_SIZE, offset);
+  const { data, isLoading, isSuccess, isFetching, isError } =
+    useNotifications(PAGE_SIZE, offset);
   const markSeen = useMarkNotificationsSeen();
   const markedRef = useRef(false);
 
@@ -32,11 +34,11 @@ export function NotificationsPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="h-8 w-36 shimmer-skeleton rounded-lg" />
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="התראות" />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-72 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-72 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -45,8 +47,8 @@ export function NotificationsPage() {
 
   if (isError) {
     return (
-      <div className="space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">התראות</h1>
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="התראות" />
         <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
           <p className="text-destructive font-medium">
             שגיאה בטעינת ההתראות
@@ -58,26 +60,23 @@ export function NotificationsPage() {
 
   return (
     <div className="space-y-6 pb-20 md:pb-4">
-      <div className="flex items-center gap-2.5">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-          <Bell className="h-4 w-4 text-primary" />
-        </div>
-        <h1 className="text-2xl font-semibold tracking-tight">התראות</h1>
-        {data && (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            ({data.total} חדשות)
-          </span>
-        )}
-      </div>
+      <PageHeader
+        title="התראות"
+        action={
+          data ? (
+            <span className="text-sm text-muted-foreground tabular-nums">
+              ({data.total} חדשות)
+            </span>
+          ) : null
+        }
+      />
 
       {!data || data.total === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-border/50 bg-card/50 py-20">
-          <Bell className="h-10 w-10 text-muted-foreground/20 mb-4" />
-          <p className="text-muted-foreground">אין התראות חדשות</p>
-          <p className="text-sm text-muted-foreground mt-1">
-            מודעות חדשות שימצאו יופיעו כאן
-          </p>
-        </div>
+        <EmptyState
+          icon={Bell}
+          title="אין התראות חדשות"
+          description="מודעות חדשות שימצאו יופיעו כאן"
+        />
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -89,24 +88,26 @@ export function NotificationsPage() {
           {(data.total > PAGE_SIZE || offset > 0) && (
             <div className="flex items-center justify-center gap-3 pt-4">
               {offset > 0 && (
-                <button
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                  className="rounded-xl bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent active:scale-[0.97]"
                 >
                   הקודם
-                </button>
+                </Button>
               )}
               <span className="text-sm text-muted-foreground tabular-nums">
                 {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} מתוך{" "}
                 {data.total}
               </span>
               {offset + PAGE_SIZE < data.total && (
-                <button
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={() => setOffset(offset + PAGE_SIZE)}
-                  className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 active:scale-[0.97]"
                 >
                   הבא
-                </button>
+                </Button>
               )}
             </div>
           )}

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -3,11 +3,19 @@ import { Bookmark, ExternalLink, Trash2 } from "lucide-react";
 import { useSavedListings, useRemoveBookmark } from "@/hooks/useBookmarks";
 import { safeHref } from "@/lib/utils";
 import { ListingCardBody } from "@/components/ListingCardBody";
+import {
+  Button,
+  EmptyState,
+  PageHeader,
+  Skeleton,
+  useToast,
+} from "@/components/ui";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
 
 export function SavedPage() {
+  const { toast } = useToast();
   const [offset, setOffset] = useState(0);
   const [removingTokens, setRemovingTokens] = useState<Set<string>>(new Set());
   const { data, isLoading, isError } = useSavedListings(PAGE_SIZE, offset);
@@ -22,11 +30,11 @@ export function SavedPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="h-8 w-36 shimmer-skeleton rounded-lg" />
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="שמורים" />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2].map((i) => (
-            <div key={i} className="h-72 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-72 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -35,8 +43,8 @@ export function SavedPage() {
 
   if (isError) {
     return (
-      <div className="space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">שמורים</h1>
+      <div className="space-y-6 pb-20 md:pb-4">
+        <PageHeader title="שמורים" />
         <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
           <p className="text-destructive font-medium">שגיאה בטעינת המודעות</p>
         </div>
@@ -46,26 +54,23 @@ export function SavedPage() {
 
   return (
     <div className="space-y-6 pb-20 md:pb-4">
-      <div className="flex items-center gap-2.5">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-          <Bookmark className="h-4 w-4 text-primary" />
-        </div>
-        <h1 className="text-2xl font-semibold tracking-tight">שמורים</h1>
-        {data && (
-          <span className="text-sm text-muted-foreground tabular-nums">
-            ({data.total})
-          </span>
-        )}
-      </div>
+      <PageHeader
+        title="שמורים"
+        action={
+          data ? (
+            <span className="text-sm text-muted-foreground tabular-nums">
+              ({data.total})
+            </span>
+          ) : null
+        }
+      />
 
       {!data || data.items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-border/50 bg-card/50 py-20">
-          <Bookmark className="h-10 w-10 text-muted-foreground/20 mb-4" />
-          <p className="text-muted-foreground">אין מודעות שמורות</p>
-          <p className="text-sm text-muted-foreground mt-1">
-            לחץ על סמל השמירה במודעה כדי לשמור אותה
-          </p>
-        </div>
+        <EmptyState
+          icon={Bookmark}
+          title="אין מודעות שמורות"
+          description="לחץ על סמל השמירה במודעה כדי לשמור אותה"
+        />
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -78,6 +83,9 @@ export function SavedPage() {
                     new Set(prev).add(listing.token),
                   );
                   removeBookmark.mutate(listing.token, {
+                    onSuccess: () => {
+                      toast("הוסר מהשמורים", "info");
+                    },
                     onSettled: () =>
                       setRemovingTokens((prev) => {
                         const next = new Set(prev);
@@ -165,23 +173,17 @@ function Pagination({
   return (
     <div className="flex items-center justify-center gap-3 pt-4">
       {offset > 0 && (
-        <button
-          onClick={onPrev}
-          className="rounded-xl bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent active:scale-[0.97]"
-        >
+        <Button variant="secondary" size="sm" onClick={onPrev}>
           הקודם
-        </button>
+        </Button>
       )}
       <span className="text-sm text-muted-foreground tabular-nums">
         {offset + 1}–{Math.min(offset + pageSize, total)} מתוך {total}
       </span>
       {offset + pageSize < total && (
-        <button
-          onClick={onNext}
-          className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 active:scale-[0.97]"
-        >
+        <Button variant="primary" size="sm" onClick={onNext}>
           הבא
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -17,8 +17,15 @@ import {
 import { formatPrice, formatKm, cn } from "@/lib/utils";
 import { useState } from "react";
 import type { Search } from "@/lib/api";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
 
 export function SearchesPage() {
+  const { toast } = useToast();
   const { data: searches, isLoading, isError } = useSearches();
   const deleteSearch = useDeleteSearch();
   const pauseSearch = usePauseSearch();
@@ -30,15 +37,18 @@ export function SearchesPage() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 w-48 shimmer-skeleton rounded-lg" />
+        <div className="flex items-start justify-between gap-4 border-b border-border/50 pb-6">
+          <Skeleton className="h-8 w-48 rounded-lg" />
+          <Skeleton className="h-10 w-36 rounded-md" />
+        </div>
         <div className="grid gap-3 sm:grid-cols-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-24 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-24 rounded-2xl" />
           ))}
         </div>
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2].map((i) => (
-            <div key={i} className="h-52 shimmer-skeleton rounded-2xl" />
+            <Skeleton key={i} className="h-52 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -48,9 +58,7 @@ export function SearchesPage() {
   if (isError) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          החיפושים שלי
-        </h1>
+        <PageHeader title="החיפושים שלי" />
         <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
           <p className="text-destructive font-medium">
             שגיאה בטעינת החיפושים
@@ -90,35 +98,32 @@ export function SearchesPage() {
         </div>
       )}
 
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          החיפושים שלי
-        </h1>
-        <Link
-          to="/searches/new"
-          className="inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[0_0_30px_rgba(59,130,246,0.35)] active:scale-[0.98]"
-        >
-          <Plus className="h-4 w-4" />
-          חיפוש חדש
-        </Link>
-      </div>
+      <PageHeader
+        title="החיפושים שלי"
+        action={
+          <Button asChild>
+            <Link to="/searches/new">
+              <Plus className="h-4 w-4" />
+              חיפוש חדש
+            </Link>
+          </Button>
+        }
+      />
 
       {/* Search cards */}
       {!searches || searches.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-border/50 bg-card/50 py-20">
-          <SearchIcon className="h-10 w-10 text-muted-foreground/20 mb-4" />
-          <p className="text-muted-foreground mb-5">
-            אין חיפושים פעילים עדיין
-          </p>
-          <Link
-            to="/searches/new"
-            className="inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-[0_0_20px_rgba(59,130,246,0.25)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[0_0_30px_rgba(59,130,246,0.35)] active:scale-[0.98]"
-          >
-            <Plus className="h-4 w-4" />
-            צור חיפוש ראשון
-          </Link>
-        </div>
+        <EmptyState
+          icon={SearchIcon}
+          title="אין חיפושים פעילים עדיין"
+          action={
+            <Button asChild>
+              <Link to="/searches/new">
+                <Plus className="h-4 w-4" />
+                צור חיפוש ראשון
+              </Link>
+            </Button>
+          }
+        />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2">
           {searches.map((search) => (
@@ -126,11 +131,21 @@ export function SearchesPage() {
               key={search.id}
               search={search}
               disabled={isMutating}
-              onPause={() => pauseSearch.mutate(search.id)}
-              onResume={() => resumeSearch.mutate(search.id)}
+              onPause={() =>
+                pauseSearch.mutate(search.id, {
+                  onSuccess: () => toast("החיפוש הושהה", "info"),
+                })
+              }
+              onResume={() =>
+                resumeSearch.mutate(search.id, {
+                  onSuccess: () => toast("החיפוש חודש", "success"),
+                })
+              }
               onDelete={() => {
                 if (confirmDelete === search.id) {
-                  deleteSearch.mutate(search.id);
+                  deleteSearch.mutate(search.id, {
+                    onSuccess: () => toast("החיפוש נמחק", "success"),
+                  });
                   setConfirmDelete(null);
                 } else {
                   setConfirmDelete(search.id);
@@ -192,16 +207,9 @@ function SearchCard({
           </h3>
           <span className="text-xs text-muted-foreground">{search.source}</span>
         </div>
-        <span
-          className={cn(
-            "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold",
-            search.active
-              ? "bg-score-great/15 text-score-great"
-              : "bg-score-good/15 text-score-good",
-          )}
-        >
+        <Badge variant={search.active ? "success" : "warning"}>
           {search.active ? "פעיל" : "מושהה"}
-        </span>
+        </Badge>
       </div>
 
       <div className="grid grid-cols-2 gap-2 text-sm text-muted-foreground mb-4">
@@ -218,58 +226,71 @@ function SearchCard({
       </div>
 
       <div className="flex items-center gap-2 border-t border-border/50 pt-3">
-        <Link
+        <Button
+          as={Link}
           to={`/searches/${search.id}/listings`}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent active:scale-[0.97]"
+          variant="secondary"
+          size="sm"
         >
           <List className="h-3.5 w-3.5" />
           תוצאות
-        </Link>
+        </Button>
 
         {search.active ? (
-          <button
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
             onClick={onPause}
             disabled={disabled}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent disabled:opacity-50 active:scale-[0.97]"
           >
             <Pause className="h-3.5 w-3.5" />
             השהה
-          </button>
+          </Button>
         ) : (
-          <button
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
             onClick={onResume}
             disabled={disabled}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent disabled:opacity-50 active:scale-[0.97]"
           >
             <Play className="h-3.5 w-3.5" />
             חדש
-          </button>
+          </Button>
         )}
 
         <div className="mr-auto">
           {isConfirmingDelete ? (
             <div className="flex items-center gap-1">
-              <button
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
                 onClick={onDelete}
-                className="rounded-lg bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground transition-all duration-200 hover:bg-destructive/90 active:scale-[0.97]"
               >
                 אישור
-              </button>
-              <button
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
                 onClick={onCancelDelete}
-                className="rounded-lg bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground transition-all duration-200 hover:bg-accent"
               >
                 ביטול
-              </button>
+              </Button>
             </div>
           ) : (
-            <button
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
               onClick={onDelete}
-              className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-destructive transition-colors duration-200 hover:bg-destructive/10"
+              className="text-destructive hover:bg-destructive/10"
             >
               <Trash2 className="h-3.5 w-3.5" />
               מחק
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link } from "react-router";
 import {
   Plus,
@@ -7,26 +8,49 @@ import {
   List,
   Search as SearchIcon,
   Activity,
+  Bell,
+  Car,
 } from "lucide-react";
+import { motion } from "motion/react";
 import {
   useSearches,
   useDeleteSearch,
   usePauseSearch,
   useResumeSearch,
 } from "@/hooks/useSearches";
-import { formatPrice, formatKm, cn } from "@/lib/utils";
-import { useState } from "react";
-import type { Search } from "@/lib/api";
-import { PageHeader } from "@/components/ui/PageHeader";
+import {
+  useNotificationCount,
+  useNotifications,
+} from "@/hooks/useNotifications";
+import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
+import type { Search, Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { SectionHeader } from "@/components/ui/SectionHeader";
 import { useToast } from "@/components/ui/Toast";
+
+const STAGGER_DELAY = 0.06;
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 18 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: i * STAGGER_DELAY,
+      duration: 0.35,
+      ease: [0, 0, 0.2, 1] as const,
+    },
+  }),
+};
 
 export function SearchesPage() {
   const { toast } = useToast();
   const { data: searches, isLoading, isError } = useSearches();
+  const { data: notifCount } = useNotificationCount();
+  const { data: recentListings } = useNotifications(5, 0);
   const deleteSearch = useDeleteSearch();
   const pauseSearch = usePauseSearch();
   const resumeSearch = useResumeSearch();
@@ -34,18 +58,26 @@ export function SearchesPage() {
     deleteSearch.isPending || pauseSearch.isPending || resumeSearch.isPending;
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
 
+  const unread = notifCount?.count ?? 0;
+  const activeCount = searches?.filter((s) => s.active).length ?? 0;
+  const totalSearches = searches?.length ?? 0;
+
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="flex items-start justify-between gap-4 border-b border-border/50 pb-6">
-          <Skeleton className="h-8 w-48 rounded-lg" />
-          <Skeleton className="h-10 w-36 rounded-md" />
+      <div className="space-y-8">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-40 rounded-lg" />
+            <Skeleton className="h-4 w-56 rounded-md" />
+          </div>
+          <Skeleton className="h-10 w-36 rounded-xl" />
         </div>
-        <div className="grid gap-3 sm:grid-cols-3">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-24 rounded-2xl" />
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-[100px] rounded-xl" />
           ))}
         </div>
+        <Skeleton className="h-5 w-32 rounded-md" />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2].map((i) => (
             <Skeleton key={i} className="h-52 rounded-2xl" />
@@ -57,8 +89,8 @@ export function SearchesPage() {
 
   if (isError) {
     return (
-      <div className="space-y-6">
-        <PageHeader title="החיפושים שלי" />
+      <div className="space-y-8">
+        <DashboardHeader />
         <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center">
           <p className="text-destructive font-medium">
             שגיאה בטעינת החיפושים
@@ -69,94 +101,164 @@ export function SearchesPage() {
     );
   }
 
-  const activeCount = searches?.filter((s) => s.active).length ?? 0;
-  const pausedCount = (searches?.length ?? 0) - activeCount;
-
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
+      <DashboardHeader />
+
       {/* Stats row */}
-      {searches && searches.length > 0 && (
-        <div className="grid grid-cols-3 gap-3">
-          <StatCard
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {[
+          {
+            icon: SearchIcon,
+            label: "חיפושים פעילים",
+            value: activeCount,
+            color: "text-primary",
+            bg: "bg-primary/12",
+            glow: "shadow-[0_0_24px_-4px_rgba(59,130,246,0.3)]",
+          },
+          {
+            icon: Car,
+            label: "סה״כ מודעות",
+            value: recentListings?.total ?? 0,
+            color: "text-score-great",
+            bg: "bg-score-great/12",
+            glow: "shadow-[0_0_24px_-4px_rgba(16,185,129,0.25)]",
+          },
+          {
+            icon: Bell,
+            label: "מודעות חדשות",
+            value: unread,
+            color: "text-score-good",
+            bg: "bg-score-good/12",
+            glow: unread > 0
+              ? "shadow-[0_0_24px_-4px_rgba(245,158,11,0.3)]"
+              : "",
+          },
+          {
+            icon: Activity,
+            label: "סה״כ חיפושים",
+            value: totalSearches,
+            color: "text-[#A78BFA]",
+            bg: "bg-[#A78BFA]/12",
+            glow: "shadow-[0_0_24px_-4px_rgba(167,139,250,0.25)]",
+          },
+        ].map((stat, i) => (
+          <motion.div
+            key={stat.label}
+            custom={i}
+            initial="hidden"
+            animate="visible"
+            variants={fadeUp}
+          >
+            <StatCard {...stat} />
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Saved searches */}
+      <section className="space-y-4">
+        <SectionHeader title="חיפושים שמורים" />
+
+        {!searches || searches.length === 0 ? (
+          <EmptyState
             icon={SearchIcon}
-            value={searches.length}
-            label="סה״כ חיפושים"
-            color="text-primary"
+            title="אין חיפושים פעילים עדיין"
+            description="צור חיפוש ראשון כדי להתחיל לעקוב אחר מודעות רכבים"
+            action={
+              <Button asChild>
+                <Link to="/searches/new">
+                  <Plus className="h-4 w-4" />
+                  צור חיפוש
+                </Link>
+              </Button>
+            }
           />
-          <StatCard
-            icon={Activity}
-            value={activeCount}
-            label="פעילים"
-            color="text-score-great"
-          />
-          <StatCard
-            icon={Pause}
-            value={pausedCount}
-            label="מושהים"
-            color="text-score-good"
-          />
-        </div>
-      )}
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {searches.map((search, i) => (
+              <motion.div
+                key={search.id}
+                custom={i}
+                initial="hidden"
+                animate="visible"
+                variants={fadeUp}
+              >
+                <SearchCard
+                  search={search}
+                  disabled={isMutating}
+                  onPause={() =>
+                    pauseSearch.mutate(search.id, {
+                      onSuccess: () => toast("החיפוש הושהה", "info"),
+                    })
+                  }
+                  onResume={() =>
+                    resumeSearch.mutate(search.id, {
+                      onSuccess: () => toast("החיפוש חודש", "success"),
+                    })
+                  }
+                  onDelete={() => {
+                    if (confirmDelete === search.id) {
+                      deleteSearch.mutate(search.id, {
+                        onSuccess: () => toast("החיפוש נמחק", "success"),
+                      });
+                      setConfirmDelete(null);
+                    } else {
+                      setConfirmDelete(search.id);
+                    }
+                  }}
+                  isConfirmingDelete={confirmDelete === search.id}
+                  onCancelDelete={() => setConfirmDelete(null)}
+                />
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </section>
 
-      <PageHeader
-        title="החיפושים שלי"
-        action={
-          <Button asChild>
-            <Link to="/searches/new">
-              <Plus className="h-4 w-4" />
-              חיפוש חדש
-            </Link>
-          </Button>
-        }
-      />
-
-      {/* Search cards */}
-      {!searches || searches.length === 0 ? (
-        <EmptyState
-          icon={SearchIcon}
-          title="אין חיפושים פעילים עדיין"
-          action={
-            <Button asChild>
-              <Link to="/searches/new">
-                <Plus className="h-4 w-4" />
-                צור חיפוש ראשון
-              </Link>
-            </Button>
-          }
-        />
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {searches.map((search) => (
-            <SearchCard
-              key={search.id}
-              search={search}
-              disabled={isMutating}
-              onPause={() =>
-                pauseSearch.mutate(search.id, {
-                  onSuccess: () => toast("החיפוש הושהה", "info"),
-                })
-              }
-              onResume={() =>
-                resumeSearch.mutate(search.id, {
-                  onSuccess: () => toast("החיפוש חודש", "success"),
-                })
-              }
-              onDelete={() => {
-                if (confirmDelete === search.id) {
-                  deleteSearch.mutate(search.id, {
-                    onSuccess: () => toast("החיפוש נמחק", "success"),
-                  });
-                  setConfirmDelete(null);
-                } else {
-                  setConfirmDelete(search.id);
-                }
-              }}
-              isConfirmingDelete={confirmDelete === search.id}
-              onCancelDelete={() => setConfirmDelete(null)}
-            />
-          ))}
-        </div>
+      {/* Recent listings feed */}
+      {recentListings && recentListings.items.length > 0 && (
+        <section className="space-y-4">
+          <SectionHeader
+            title="מודעות אחרונות"
+            linkTo="/notifications"
+            linkLabel="הצג הכל"
+          />
+          <div className="space-y-2">
+            {recentListings.items.map((listing, i) => (
+              <motion.div
+                key={listing.token}
+                custom={i}
+                initial="hidden"
+                animate="visible"
+                variants={fadeUp}
+              >
+                <RecentListingRow listing={listing} />
+              </motion.div>
+            ))}
+          </div>
+        </section>
       )}
+    </div>
+  );
+}
+
+/* ---------- sub-components ---------- */
+
+function DashboardHeader() {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">לוח בקרה</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          מעקב אחר חיפושי רכבים שלך
+        </p>
+      </div>
+      <Button asChild className="rounded-xl">
+        <Link to="/searches/new">
+          <Plus className="h-4 w-4" />
+          חיפוש חדש
+        </Link>
+      </Button>
     </div>
   );
 }
@@ -166,17 +268,35 @@ function StatCard({
   value,
   label,
   color,
+  bg,
+  glow,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   value: number;
   label: string;
   color: string;
+  bg: string;
+  glow?: string;
 }) {
   return (
-    <div className="rounded-2xl border border-border/50 bg-card p-4 text-center transition-colors duration-200 hover:border-border">
-      <Icon className={cn("mx-auto h-5 w-5 mb-1.5", color)} />
-      <p className="text-2xl font-bold tabular-nums">{value}</p>
-      <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
+    <div
+      className={cn(
+        "rounded-xl border border-border/50 bg-card p-5 transition-all duration-200 hover:border-border hover:-translate-y-0.5",
+        glow,
+      )}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm text-muted-foreground">{label}</span>
+        <div
+          className={cn(
+            "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
+            bg,
+          )}
+        >
+          <Icon className={cn("h-[18px] w-[18px]", color)} />
+        </div>
+      </div>
+      <p className="text-3xl font-bold tabular-nums text-foreground">{value}</p>
     </div>
   );
 }
@@ -295,5 +415,41 @@ function SearchCard({
         </div>
       </div>
     </div>
+  );
+}
+
+function RecentListingRow({ listing }: { listing: Listing }) {
+  return (
+    <Link
+      to={`/listings/${listing.token}`}
+      state={{ listing }}
+      className="flex items-center gap-4 rounded-xl border border-border/50 bg-card p-4 transition-all duration-200 hover:border-primary/40 hover:shadow-[0_2px_16px_rgba(59,130,246,0.08)]"
+    >
+      <div className="h-12 w-16 shrink-0 overflow-hidden rounded-lg bg-secondary">
+        {listing.image_url ? (
+          <img
+            src={listing.image_url}
+            alt={`${listing.manufacturer} ${listing.model}`}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-xl opacity-20">
+            🚗
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">
+          {listing.manufacturer} {listing.model} {listing.year}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {listing.city || "—"} · {relativeTime(listing.first_seen_at)}
+        </p>
+      </div>
+      <span className="shrink-0 text-sm font-bold tabular-nums text-primary">
+        {formatPrice(listing.price)}
+      </span>
+    </Link>
   );
 }

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -118,7 +118,7 @@ export function SearchesPage() {
           },
           {
             icon: Car,
-            label: "סה״כ מודעות",
+            label: "מודעות שנמצאו",
             value: recentListings?.total ?? 0,
             color: "text-score-great",
             bg: "bg-score-great/12",


### PR DESCRIPTION
## Summary

- **Component library**: Added reusable `Button`, `Badge`, `Skeleton`, `PageHeader`, `EmptyState`, `SectionHeader`, and `Toast` components under `web/src/components/ui/`
- **Shell redesign**: Premium sidebar with gradient header, animated accent edge, user avatar circle, and enhanced frosted-glass mobile bottom nav with dot indicators
- **Dashboard home page**: Transformed SearchesPage into a multi-section dashboard inspired by Base44 but elevated:
  - "לוח בקרה" header with subtitle framing the page as a command center
  - 4-column stat cards (active searches, total listings, new notifications, total searches) with colored icon circles and glow shadows
  - Saved searches section with section header pattern
  - New "מודעות אחרונות" recent listings feed with compact thumbnail rows
  - Staggered entrance animations via `motion` library on all sections
- **All pages updated**: Consistent PageHeader, Skeleton loading states, EmptyState placeholders, and toast notifications for user actions
- **Page transitions**: Route-keyed `animate-fade-in` for smooth navigation

## What changed

| Area | Before | After |
|------|--------|-------|
| Home page | Flat search list titled "החיפושים שלי" | Multi-section dashboard with stats, searches, and recent listings feed |
| Stat cards | 3 centered icon-above-number cards | 4 Base44-style icon-right cards with glow and hover lift |
| Recent listings | Not shown on home | Compact row feed from notifications data |
| Animations | CSS-only fade-in | Staggered motion entrance per card/row |
| Buttons | Inline Tailwind everywhere | Shared `<Button>` with variant/size props |
| Loading | Raw shimmer divs | `<Skeleton>` component |
| Page headers | Custom per page | `<PageHeader>` + `<SectionHeader>` |
| Empty states | Plain text | `<EmptyState>` with icon and CTA |
| User feedback | None | Toast notifications on all actions |
| Sidebar | Basic card bg | Gradient header, animated edge, avatar, glow effects |
| Mobile nav | Thin bottom bar | Taller frosted glass, dot indicators, press scale |

## Test plan

- [ ] Dashboard: 4 stat cards display correct counts
- [ ] Dashboard: saved searches section shows search cards
- [ ] Dashboard: recent listings feed shows notification data with thumbnails
- [ ] Dashboard: staggered entrance animations play on load
- [ ] Search actions: pause, resume, delete with toast feedback
- [ ] Listings page: sort, paginate, bookmark with toast
- [ ] Saved/History/Notifications: pagination, empty states
- [ ] Mobile bottom nav: all items reachable, active indicator visible
- [ ] Desktop sidebar: all nav items, notification badge, sign out
- [ ] RTL layout consistent across all pages

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global toast system for success/error/info messages
  * New design-system components: Button, Badge, EmptyState, PageHeader, SectionHeader, Skeleton, ToastProvider

* **UI/UX Improvements**
  * Redesigned sidebar with stronger active indicators and a footer avatar/email area
  * Refreshed mobile bottom navigation with clearer active state visuals
  * Unified loading/empty states and standardized buttons/pagination across pages
  * Route transitions and main content smooth-scrolling for improved navigation polish
<!-- end of auto-generated comment: release notes by coderabbit.ai -->