### PR TITLE
feat: config-as-code for production domain and reverse proxy

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,9 @@
+# CarWatch production environment variables
+# Copy to .env on the VM: cp .env.prod.example .env
+# docker compose reads .env automatically.
+
+# Public domain for Caddy TLS and CORS (change to switch domains)
+CARWATCH_DOMAIN=your-subdomain.duckdns.org
+
+# Telegram bot token (@BotFather)
+TELEGRAM_BOT_TOKEN=your-bot-token-here

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+{$CARWATCH_DOMAIN:localhost} {
+	reverse_proxy carwatch:8080
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,6 +39,7 @@ http:
 # REST API settings (for web frontend)
 api:
   cors_origins:
-    - "http://localhost:5173"
+    - "http://localhost:5173"              # dev (Vite)
+    - "https://${CARWATCH_DOMAIN}"         # production
   # dev_chat_id: 0       # chat_id to use in dev mode (no auth)
   # auth_token: ""       # bearer token for API auth (optional)

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -13,6 +13,7 @@ services:
     environment:
       - TZ=Asia/Jerusalem
       - CARWATCH_DOMAIN=${CARWATCH_DOMAIN}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
     restart: unless-stopped
     labels:
       - "com.centurylinklabs.watchtower.enable=true"

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -12,6 +12,7 @@ services:
       - ./firebase-sa.json:/config/firebase-sa.json:ro
     environment:
       - TZ=Asia/Jerusalem
+      - CARWATCH_DOMAIN=${CARWATCH_DOMAIN}
     restart: unless-stopped
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
@@ -28,6 +29,8 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
       - caddy-config:/config
+    environment:
+      - CARWATCH_DOMAIN=${CARWATCH_DOMAIN}
     restart: unless-stopped
 
   watchtower:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,7 @@ func applyDefaults(cfg *Config) {
 	}
 	filtered := cfg.API.CORSOrigins[:0]
 	for _, o := range cfg.API.CORSOrigins {
+		o = strings.TrimSpace(o)
 		if o != "" && o != "https://" && o != "http://" {
 			filtered = append(filtered, o)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,13 @@ func applyDefaults(cfg *Config) {
 	if cfg.LogFormat == "" {
 		cfg.LogFormat = "auto"
 	}
+	filtered := cfg.API.CORSOrigins[:0]
+	for _, o := range cfg.API.CORSOrigins {
+		if o != "" && o != "https://" && o != "http://" {
+			filtered = append(filtered, o)
+		}
+	}
+	cfg.API.CORSOrigins = filtered
 	if len(cfg.API.CORSOrigins) == 0 {
 		cfg.API.CORSOrigins = []string{"http://localhost:5173"}
 	}


### PR DESCRIPTION
## Summary

- **Add `Caddyfile` to the repo** with `{$CARWATCH_DOMAIN}` env var — Caddy natively expands it, defaulting to `localhost` for dev.
- **Add `.env.prod.example`** documenting all required env vars (`CARWATCH_DOMAIN`, `TELEGRAM_BOT_TOKEN`) — the actual `.env` stays on the VM (gitignored).
- **Pass `CARWATCH_DOMAIN`** through `docker-compose.prod.yaml` to both the `carwatch` and `caddy` containers.
- **Update `config.example.yaml`** CORS origins to include `https://${CARWATCH_DOMAIN}` (expanded at load time by `os.ExpandEnv`).
- **Filter empty CORS origins** in `applyDefaults` so dev setups without the env var don't break.

### Before (changing domains required)
1. SSH into the VM
2. Manually edit the Caddyfile
3. Manually edit config.yaml CORS
4. Restart containers

### After (changing domains requires)
1. Edit `.env` on the VM: `CARWATCH_DOMAIN=newdomain.example.com`
2. `docker compose up -d`

## Test plan

- [x] All Go unit tests pass (`go test ./internal/...`)
- [x] `go vet` clean
- [ ] Deploy to VM and verify `https://carwatch.duckdns.org` still works
- [ ] Test domain change by temporarily setting a different `CARWATCH_DOMAIN`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a production environment template for deployment and example production domain/token placeholders
  * Added reverse-proxy configuration that uses an environment-based site domain

* **Chores**
  * Updated CORS to allow both local dev and production origins
  * Sanitized CORS origin entries to remove empty or invalid entries
  * Propagated domain environment variable into deployment services
<!-- end of auto-generated comment: release notes by coderabbit.ai -->