### PR TITLE
fix: log raw feed item JSON for km debugging

### DIFF
--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -51,6 +51,10 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 		return nil, err
 	}
 
+	if logger != nil && len(items) > 0 {
+		logger.Info("raw feed item sample", "json", string(items[0]))
+	}
+
 	listings := make([]model.RawListing, 0, len(items))
 	seen := make(map[string]struct{}, len(items))
 	skipped := 0

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -100,7 +100,7 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 		return nil, fmt.Errorf("unexpected status: %d", result.StatusCode)
 	}
 
-	listings, err := ParseListingsPage(bytes.NewReader(result.Body))
+	listings, err := ParseListingsPageWithLogger(bytes.NewReader(result.Body), f.logger)
 	if err != nil {
 		return nil, fmt.Errorf("parse page: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Passes the logger through to `ParseListingsPageWithLogger` so we can see the exact JSON yad2 returns for each feed item
- Logs the first raw feed item at Info level on every fetch cycle

## Context
Yad2 search feed no longer includes a `km` field — every listing parses as `km=0` and bypasses the `MaxKm` filter. A listing with 200K km passed through a 150K limit because of this.

This logging helps confirm the feed structure and locate where km data might now live.

## Test plan
- [x] `go test ./internal/fetcher/yad2/` passes
- [ ] Deploy to VM, check logs with `make vm-logs` to see raw feed JSON

Made with [Cursor](https://cursor.com)