### PR TITLE
feat: light/dark mode, sidebar restyle, search name field

### DIFF
--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -172,6 +172,19 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 		name = strings.ToLower(fmt.Sprintf("%s-%s", mfrName, modelName))
 	}
 
+	existing, err := s.searches.ListSearches(r.Context(), chatID)
+	if err != nil {
+		s.logger.Error("list searches for duplicate check", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to validate search name")
+		return
+	}
+	for _, ex := range existing {
+		if strings.EqualFold(strings.TrimSpace(ex.Name), name) {
+			writeError(w, http.StatusConflict, "search name already exists")
+			return
+		}
+	}
+
 	search := storage.Search{
 		ChatID:       chatID,
 		Name:         name,

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -12,6 +12,7 @@ import (
 )
 
 type createSearchRequest struct {
+	Name         string `json:"name"`
 	Source       string `json:"source"`
 	Manufacturer int    `json:"manufacturer"`
 	Model        int    `json:"model"`
@@ -166,7 +167,10 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "unknown model id")
 		return
 	}
-	name := strings.ToLower(fmt.Sprintf("%s-%s", mfrName, modelName))
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = strings.ToLower(fmt.Sprintf("%s-%s", mfrName, modelName))
+	}
 
 	search := storage.Search{
 		ChatID:       chatID,

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,9 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0B0D14" />
+    <script>
+      (function(){var t=localStorage.getItem('theme');if(t==='light'||(!t&&matchMedia('(prefers-color-scheme:light)').matches)){document.documentElement.classList.remove('dark');document.querySelector('meta[name=theme-color]').content='#F8FAFC'}else{document.documentElement.classList.add('dark')}})();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -119,7 +119,7 @@ export function Shell() {
               <span className="text-xs text-sidebar-primary font-medium">
                 התראות פעילות
               </span>
-              <span className="mr-auto text-xs bg-sidebar-primary text-white rounded-full w-5 h-5 flex items-center justify-center font-bold shadow shadow-sidebar-primary/30">
+              <span className="mr-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-sidebar-primary px-1 text-xs font-bold text-white shadow shadow-sidebar-primary/30">
                 {unread > 99 ? "99+" : unread}
               </span>
             </Link>
@@ -199,6 +199,23 @@ export function Shell() {
               </Link>
             );
           })}
+          <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label={theme === "dark" ? "הפעל מצב בהיר" : "הפעל מצב כהה"}
+            className="flex min-w-0 flex-1 flex-col items-center gap-1 px-2 py-1 text-[11px] font-medium text-muted-foreground transition-all duration-200 active:scale-[0.94]"
+          >
+            <span className="flex flex-col items-center gap-1">
+              {theme === "dark" ? (
+                <Sun className="h-5 w-5" />
+              ) : (
+                <Moon className="h-5 w-5" />
+              )}
+            </span>
+            <span className="line-clamp-1 text-center leading-tight">
+              {theme === "dark" ? "בהיר" : "כהה"}
+            </span>
+          </button>
         </div>
       </nav>
     </div>

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -53,6 +53,7 @@ export function Shell() {
           <button
             type="button"
             onClick={toggleTheme}
+            aria-label={theme === "dark" ? "הפעל מצב בהיר" : "הפעל מצב כהה"}
             className="w-7 h-7 shrink-0 rounded-lg bg-sidebar-accent flex items-center justify-center text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent/80 transition-all"
             title={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
           >

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -32,7 +32,7 @@ export function Shell() {
   const { user, signOut } = useAuth();
   const { theme, toggle: toggleTheme } = useTheme();
   const emailInitial =
-    user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") ?? "?";
+    user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
 
   return (
     <div className="min-h-screen bg-background">

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -8,9 +8,12 @@ import {
   Clock,
   Bell,
   LogOut,
+  Sun,
+  Moon,
 } from "lucide-react";
 import { useNotificationCount } from "@/hooks/useNotifications";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTheme } from "@/contexts/ThemeContext";
 import { cn } from "@/lib/utils";
 
 const navItems = [
@@ -27,42 +30,37 @@ export function Shell() {
   const { data: notifCount } = useNotificationCount();
   const unread = notifCount?.count ?? 0;
   const { user, signOut } = useAuth();
+  const { theme, toggle: toggleTheme } = useTheme();
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") ?? "?";
 
   return (
     <div className="min-h-screen bg-background">
-      <aside className="fixed inset-y-0 right-0 z-50 hidden w-64 flex-col border-l border-border/40 bg-card/85 backdrop-blur-xl md:flex">
-        {/* Animated gradient accent on inner (left) edge */}
-        <span
-          aria-hidden
-          className="pointer-events-none absolute inset-y-3 left-0 w-px overflow-hidden rounded-full"
-        >
-          <span className="absolute inset-y-0 left-0 w-[3px] -translate-x-px bg-gradient-to-b from-primary/70 via-primary/35 to-primary/60 opacity-80 blur-[0.5px]" />
-          <span className="absolute inset-0 motion-safe:animate-pulse bg-gradient-to-b from-transparent via-primary/50 to-transparent opacity-40 motion-safe:[animation-duration:3.25s]" />
-        </span>
-
-        <div className="relative shrink-0 bg-gradient-to-b from-primary/5 to-transparent">
-          <div className="flex h-20 shrink-0 items-center gap-3 px-6">
-            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/12 ring-1 ring-primary/15 shadow-[0_0_20px_-4px_rgba(59,130,246,0.35)]">
-              <Car className="h-4.5 w-4.5 text-primary" />
-            </div>
-            <div className="flex flex-col">
-              <span className="text-lg font-semibold tracking-tight leading-tight">
-                CarWatch
-              </span>
-              <span className="text-[11px] text-muted-foreground leading-tight">
-                מעקב רכבים
-              </span>
-            </div>
+      <aside className="fixed inset-y-0 right-0 z-50 hidden w-64 flex-col border-l border-sidebar-border bg-sidebar md:flex">
+        <div className="flex items-center gap-3 px-5 py-5 border-b border-sidebar-border">
+          <div className="relative w-10 h-10 shrink-0 rounded-xl bg-sidebar-primary flex items-center justify-center shadow-lg shadow-sidebar-primary/40">
+            <Car className="w-5 h-5 text-white" />
+            <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-white/20 to-transparent" />
           </div>
-          <div
-            className="h-px w-full bg-gradient-to-l from-transparent via-primary/25 to-transparent opacity-80"
-            aria-hidden
-          />
+          <div className="flex-1 min-w-0">
+            <h1 className="font-bold text-base text-white leading-none tracking-tight">
+              CarWatch
+            </h1>
+            <p className="text-xs text-sidebar-foreground/60 mt-0.5">
+              מעקב רכבים חכם
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="w-7 h-7 shrink-0 rounded-lg bg-sidebar-accent flex items-center justify-center text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent/80 transition-all"
+            title={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
+          >
+            {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
+          </button>
         </div>
 
-        <nav className="mt-2 flex flex-1 flex-col gap-1 overflow-y-auto p-3">
+        <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
           {navItems.map((item) => {
             const Icon = item.icon;
             const isActive =
@@ -76,48 +74,64 @@ export function Shell() {
                 key={item.path}
                 to={item.path}
                 className={cn(
-                  "group relative flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-200",
+                  "flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-150",
                   isActive
-                    ? "bg-primary/[0.22] text-primary shadow-[inset_0_0_0_1px_rgba(59,130,246,0.28),0_1px_24px_-8px_rgba(59,130,246,0.25)]"
-                    : "text-muted-foreground hover:bg-secondary hover:text-foreground",
+                    ? "bg-sidebar-primary/15 text-white"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-white",
                 )}
               >
+                <Icon
+                  size={17}
+                  className={cn(
+                    "shrink-0 transition-colors",
+                    isActive
+                      ? "text-sidebar-primary"
+                      : "text-sidebar-foreground/70",
+                  )}
+                />
                 <span className="relative">
-                  <Icon className="h-[18px] w-[18px]" />
+                  {item.label}
                   {showBadge && (
-                    <span className="absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
+                    <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
                       {unread > 99 ? "99+" : unread}
                     </span>
                   )}
                 </span>
-                {item.label}
                 {isActive && (
-                  <>
-                    <span
-                      className="absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_16px_4px_rgba(59,130,246,0.55),0_0_6px_2px_rgba(59,130,246,0.35)]"
-                      aria-hidden
-                    />
-                    <span
-                      className="absolute left-0 top-1/2 h-8 w-5 -translate-y-1/2 rounded-full bg-primary/20 blur-md"
-                      aria-hidden
-                    />
-                  </>
+                  <div className="mr-auto w-1.5 h-1.5 rounded-full bg-sidebar-primary shadow-sm shadow-sidebar-primary/60" />
                 )}
               </Link>
             );
           })}
         </nav>
 
-        <div className="relative shrink-0 border-t border-border/50 bg-gradient-to-t from-card/95 to-card/70 p-4 backdrop-blur-sm">
-          <div className="mb-3 flex items-center gap-3">
-            <div
-              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary/30 via-primary/10 to-primary/5 text-sm font-semibold text-primary shadow-inner ring-1 ring-primary/25"
-              aria-hidden
+        {unread > 0 && (
+          <div className="px-4 py-4 border-t border-sidebar-border">
+            <Link
+              to="/notifications"
+              className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl bg-sidebar-primary/10 border border-sidebar-primary/20 transition-colors hover:bg-sidebar-primary/15"
             >
+              <div className="relative">
+                <Bell className="w-4 h-4 text-sidebar-primary" />
+                <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-sidebar-primary animate-pulse-soft" />
+              </div>
+              <span className="text-xs text-sidebar-primary font-medium">
+                התראות פעילות
+              </span>
+              <span className="mr-auto text-xs bg-sidebar-primary text-white rounded-full w-5 h-5 flex items-center justify-center font-bold shadow shadow-sidebar-primary/30">
+                {unread > 99 ? "99+" : unread}
+              </span>
+            </Link>
+          </div>
+        )}
+
+        <div className="shrink-0 border-t border-sidebar-border p-4">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-sm font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
               {emailInitial}
             </div>
             <p
-              className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+              className="min-w-0 flex-1 truncate text-xs text-sidebar-foreground/60"
               title={user?.email ?? undefined}
             >
               {user?.email ?? ""}
@@ -126,12 +140,9 @@ export function Shell() {
           <button
             type="button"
             onClick={() => void signOut()}
-            className={cn(
-              "flex w-full items-center justify-center gap-2 rounded-xl border border-border/60 bg-secondary/50 px-3 py-2.5 text-sm font-medium text-foreground transition-colors",
-              "hover:bg-secondary hover:border-border",
-            )}
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent/50 px-3 py-2.5 text-sm font-medium text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-white"
           >
-            <LogOut className="h-4 w-4 text-muted-foreground" aria-hidden />
+            <LogOut className="h-4 w-4" aria-hidden />
             התנתק
           </button>
         </div>
@@ -145,7 +156,7 @@ export function Shell() {
         </div>
       </main>
 
-      <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-white/[0.06] bg-card/55 shadow-[0_-12px_40px_-12px_rgba(0,0,0,0.55)] backdrop-blur-2xl backdrop-saturate-150 md:hidden">
+      <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/40 bg-card/80 shadow-[0_-4px_24px_-8px_rgba(0,0,0,0.15)] dark:shadow-[0_-12px_40px_-12px_rgba(0,0,0,0.55)] backdrop-blur-2xl backdrop-saturate-150 md:hidden">
         <div className="flex justify-around px-1 py-3">
           {navItems.filter((item) => item.mobile).map((item) => {
             const Icon = item.icon;

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -1,0 +1,63 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+  const stored = localStorage.getItem("theme");
+  if (stored === "light" || stored === "dark") return stored;
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  const metaColor = document.querySelector('meta[name="theme-color"]');
+  if (metaColor) {
+    metaColor.setAttribute("content", theme === "dark" ? "#0B0D14" : "#F8FAFC");
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const toggle = useCallback(() => {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      localStorage.setItem("theme", next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,32 +1,34 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:is(.dark *));
+
 @theme {
-  --color-background: #0B0D14;
-  --color-foreground: #F8FAFC;
+  --color-background: var(--bg);
+  --color-foreground: var(--fg);
 
-  --color-card: #141720;
-  --color-card-foreground: #F8FAFC;
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-fg);
 
-  --color-popover: #141720;
-  --color-popover-foreground: #F8FAFC;
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-fg);
 
   --color-primary: #3B82F6;
   --color-primary-foreground: #FFFFFF;
 
-  --color-secondary: #1C1F2E;
-  --color-secondary-foreground: #CBD5E1;
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-fg);
 
-  --color-muted: #1C1F2E;
-  --color-muted-foreground: #64748B;
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-fg);
 
-  --color-accent: #1E293B;
-  --color-accent-foreground: #F8FAFC;
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-fg);
 
   --color-destructive: #EF4444;
   --color-destructive-foreground: #FFFFFF;
 
-  --color-border: #1E293B;
-  --color-input: #1E293B;
+  --color-border: var(--border);
+  --color-input: var(--input);
   --color-ring: #3B82F6;
 
   --color-score-great: #10B981;
@@ -35,7 +37,13 @@
 
   --color-chart-purple: #A78BFA;
 
-  --color-surface-hover: #1E2233;
+  --color-sidebar: #0F1119;
+  --color-sidebar-foreground: #94A3B8;
+  --color-sidebar-border: #1A1D2B;
+  --color-sidebar-accent: #1A1D2B;
+  --color-sidebar-primary: #3B82F6;
+
+  --color-surface-hover: var(--surface-hover);
   --color-glow-primary: rgba(59, 130, 246, 0.15);
   --color-glow-success: rgba(16, 185, 129, 0.15);
   --color-glow-chart-purple: rgba(167, 139, 250, 0.25);
@@ -48,6 +56,44 @@
   --animate-fade-in: fade-in 0.4s ease-out;
   --animate-slide-up: slide-up 0.4s ease-out;
   --animate-pulse-soft: pulse-soft 2s ease-in-out infinite;
+}
+
+/* Light mode (default) */
+:root {
+  --bg: #F8FAFC;
+  --fg: #0F172A;
+  --card: #FFFFFF;
+  --card-fg: #0F172A;
+  --popover: #FFFFFF;
+  --popover-fg: #0F172A;
+  --secondary: #F1F5F9;
+  --secondary-fg: #475569;
+  --muted: #F1F5F9;
+  --muted-fg: #64748B;
+  --accent: #E2E8F0;
+  --accent-fg: #0F172A;
+  --border: #E2E8F0;
+  --input: #E2E8F0;
+  --surface-hover: #F1F5F9;
+}
+
+/* Dark mode */
+.dark {
+  --bg: #0B0D14;
+  --fg: #F8FAFC;
+  --card: #141720;
+  --card-fg: #F8FAFC;
+  --popover: #141720;
+  --popover-fg: #F8FAFC;
+  --secondary: #1C1F2E;
+  --secondary-fg: #CBD5E1;
+  --muted: #1C1F2E;
+  --muted-fg: #64748B;
+  --accent: #1E293B;
+  --accent-fg: #F8FAFC;
+  --border: #1E293B;
+  --input: #1E293B;
+  --surface-hover: #1E2233;
 }
 
 @keyframes shimmer {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,7 @@ export interface Search {
 }
 
 export interface CreateSearchRequest {
+  name?: string;
   source: string;
   manufacturer: number;
   model: number;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { AuthProvider } from "./contexts/AuthContext";
+import { ThemeProvider } from "./contexts/ThemeContext";
 import { ToastProvider } from "./components/ui/Toast";
 import "./index.css";
 
@@ -20,15 +21,17 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <AuthProvider>
-            <ToastProvider>
-              <App />
-            </ToastProvider>
-          </AuthProvider>
-        </BrowserRouter>
-      </QueryClientProvider>
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <AuthProvider>
+              <ToastProvider>
+                <App />
+              </ToastProvider>
+            </AuthProvider>
+          </BrowserRouter>
+        </QueryClientProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -13,6 +13,7 @@ import { PageHeader } from "@/components/ui/PageHeader";
 import { useToast } from "@/components/ui/Toast";
 
 interface FormData {
+  name: string;
   source: string;
   manufacturer: number;
   model: number;
@@ -40,6 +41,7 @@ export function NewSearchPage() {
   const { toast } = useToast();
   const [error, setError] = useState<string | null>(null);
   const [form, setForm] = useState<FormData>({
+    name: "",
     source: "yad2",
     manufacturer: 0,
     model: 0,
@@ -71,6 +73,7 @@ export function NewSearchPage() {
     setError(null);
     createSearch.mutate(
       {
+        name: form.name || undefined,
         source: form.source,
         manufacturer: form.manufacturer,
         model: form.model,
@@ -110,6 +113,22 @@ export function NewSearchPage() {
           {error}
         </div>
       )}
+
+      {/* Section: Search Name */}
+      <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-5">
+        <FormField
+          label="שם החיפוש"
+          htmlFor="searchName"
+          hint="אופציונלי — ייווצר אוטומטית מהיצרן והדגם"
+        >
+          <Input
+            id="searchName"
+            value={form.name}
+            onChange={(e) => set("name", e.target.value)}
+            placeholder='לדוגמה: "טויוטה קורולה ידנית"'
+          />
+        </FormField>
+      </section>
 
       {/* Section: Source */}
       <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-5">


### PR DESCRIPTION
## Summary

- **Sidebar restyle**: Dedicated `sidebar-*` color tokens, solid background, primary-colored logo box with shadow glow, active dot indicator, notification badge footer
- **Light/dark mode** (#361, #322): Full theme system with `ThemeContext`, CSS variable overrides for light/dark, class-based Tailwind dark mode, localStorage persistence, system preference detection, flash-prevention script
- **Search name field** (#362): Optional custom name input on the new search form — falls back to auto-generated `manufacturer-model` if left empty

## Issues closed

- Closes #361 (light/dark mode toggle)
- Closes #322 (dark-mode only)
- Closes #362 (search name field)

## Test plan

- [x] Go tests pass (`make test`)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Toggle dark/light mode via sidebar button — verify all pages look correct in both modes
- [ ] Verify theme persists across page reloads
- [ ] Create a search with a custom name — verify it appears in the search list
- [ ] Create a search without a name — verify auto-generation still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme switching (dark/light) with persisted preference, meta theme-color updates, and toggles in sidebar and mobile nav.
  * Optional custom search name field when creating a search.

* **Bug Fixes**
  * Prevents creating searches with duplicate names (case-insensitive, trimmed); returns conflict on duplicates and errors if validation fails.

* **Style**
  * Sidebar redesign (icons, active indicator dot, account area, conditional notifications) and mobile nav restyling; theme colors refactored to shared variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->