### PR TITLE
feat: enrich missing km by fetching individual listing pages

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -203,6 +203,8 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
+	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger, yad2.EnricherConfig{})
+
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, multi, logger, scheduler.Options{
 		Observer:         h,
 		Queue:            store,
@@ -215,6 +217,7 @@ func run(configPath string, logger *slog.Logger) error {
 		DigestStore:      store,
 		HiddenStore:      store,
 		CatalogIngester:  dynCatalog,
+		KmEnricher:       kmEnricher,
 		MarketStore:      store,
 		DailyDigestStore: store,
 	})

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -203,7 +203,11 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
-	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger, yad2.EnricherConfig{})
+	var kmEnricher *yad2.Enricher
+	if cfg.Polling.EnableKmEnrichment {
+		kmEnricher = yad2.NewEnricher(yad2Fetcher, logger, yad2.EnricherConfig{})
+		logger.Info("km enrichment enabled")
+	}
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, multi, logger, scheduler.Options{
 		Observer:         h,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type PollingConfig struct {
 	ActiveHours          *ActiveHours  `yaml:"active_hours"`
 	Timezone             string        `yaml:"timezone"`
 	MaxConcurrentFetches int           `yaml:"max_concurrent_fetches"`
+	EnableKmEnrichment   bool          `yaml:"enable_km_enrichment"`
 }
 
 type ActiveHours struct {

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -43,16 +43,27 @@ func NewEnricher(fetcher *Yad2Fetcher, logger *slog.Logger, cfg EnricherConfig) 
 // It modifies the slice in place and returns the number of successfully enriched listings.
 func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int {
 	enriched := 0
+	attempts := 0
 	for i := range listings {
 		if listings[i].Km > 0 {
 			continue
 		}
-		if enriched >= e.cfg.MaxPerCycle {
-			e.logger.Info("km enrichment limit reached", "enriched", enriched, "remaining", countMissingKm(listings[i:]))
+		if attempts >= e.cfg.MaxPerCycle {
+			e.logger.Info("km enrichment limit reached",
+				"enriched", enriched,
+				"attempts", attempts,
+				"remaining", countMissingKm(listings[i:]),
+			)
 			break
 		}
 
-		if enriched > 0 {
+		select {
+		case <-ctx.Done():
+			return enriched
+		default:
+		}
+
+		if attempts > 0 {
 			select {
 			case <-ctx.Done():
 				return enriched
@@ -60,6 +71,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			}
 		}
 
+		attempts++
 		details, err := e.fetcher.FetchItem(ctx, listings[i].Token)
 		if err != nil {
 			e.logger.Warn("km enrichment failed",

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -1,0 +1,92 @@
+package yad2
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+const (
+	defaultEnrichDelay = 500 * time.Millisecond
+	defaultMaxEnrich   = 5
+)
+
+// EnricherConfig controls the enrichment behavior.
+type EnricherConfig struct {
+	// Delay between individual item fetches to avoid rate-limiting.
+	Delay time.Duration
+	// MaxPerCycle limits how many listings are enriched per poll cycle.
+	MaxPerCycle int
+}
+
+// Enricher fills in missing km data by fetching individual listing pages.
+type Enricher struct {
+	fetcher *Yad2Fetcher
+	logger  *slog.Logger
+	cfg     EnricherConfig
+}
+
+// NewEnricher creates an Enricher backed by the given Yad2Fetcher.
+func NewEnricher(fetcher *Yad2Fetcher, logger *slog.Logger, cfg EnricherConfig) *Enricher {
+	if cfg.Delay == 0 {
+		cfg.Delay = defaultEnrichDelay
+	}
+	if cfg.MaxPerCycle <= 0 {
+		cfg.MaxPerCycle = defaultMaxEnrich
+	}
+	return &Enricher{fetcher: fetcher, logger: logger, cfg: cfg}
+}
+
+// Enrich fills in Km for listings where it is zero.
+// It modifies the slice in place and returns the number of successfully enriched listings.
+func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int {
+	enriched := 0
+	for i := range listings {
+		if listings[i].Km > 0 {
+			continue
+		}
+		if enriched >= e.cfg.MaxPerCycle {
+			e.logger.Info("km enrichment limit reached", "enriched", enriched, "remaining", countMissingKm(listings[i:]))
+			break
+		}
+
+		if enriched > 0 {
+			select {
+			case <-ctx.Done():
+				return enriched
+			case <-time.After(e.cfg.Delay):
+			}
+		}
+
+		details, err := e.fetcher.FetchItem(ctx, listings[i].Token)
+		if err != nil {
+			e.logger.Warn("km enrichment failed",
+				"token", listings[i].Token,
+				"error", err,
+			)
+			continue
+		}
+
+		if details.Km > 0 {
+			listings[i].Km = details.Km
+			enriched++
+			e.logger.Debug("enriched km",
+				"token", listings[i].Token,
+				"km", details.Km,
+			)
+		}
+	}
+	return enriched
+}
+
+func countMissingKm(listings []model.RawListing) int {
+	n := 0
+	for _, l := range listings {
+		if l.Km <= 0 {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -1,0 +1,169 @@
+package yad2
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+func TestEnricher_FillsMissingKm(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":75000}}}}
+</script></html>`)
+	}))
+	defer srv.Close()
+
+	fetcher := &Yad2Fetcher{
+		client:  mustPlainClient(t),
+		baseURL: srv.URL,
+		logger:  slog.Default(),
+	}
+	// Override the item URL by wrapping the fetcher's FetchItem via a test enricher.
+	// Instead, we'll just test the Enricher directly with a custom server.
+	enricher := &testEnricher{details: ItemDetails{Km: 75000}}
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 50000},
+		{Token: "b", Km: 0},
+		{Token: "c", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 2 {
+		t.Errorf("enriched = %d, want 2", count)
+	}
+	if listings[0].Km != 50000 {
+		t.Errorf("listing[0].Km = %d, want 50000 (unchanged)", listings[0].Km)
+	}
+	if listings[1].Km != 75000 {
+		t.Errorf("listing[1].Km = %d, want 75000", listings[1].Km)
+	}
+	if listings[2].Km != 75000 {
+		t.Errorf("listing[2].Km = %d, want 75000", listings[2].Km)
+	}
+
+	_ = fetcher
+}
+
+func TestEnricher_RespectsMaxPerCycle(t *testing.T) {
+	enricher := &testEnricher{details: ItemDetails{Km: 10000}, maxPerCycle: 1}
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+		{Token: "b", Km: 0},
+		{Token: "c", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 1 {
+		t.Errorf("enriched = %d, want 1 (max per cycle)", count)
+	}
+	if listings[0].Km != 10000 {
+		t.Errorf("listing[0].Km = %d, want 10000", listings[0].Km)
+	}
+	if listings[1].Km != 0 {
+		t.Errorf("listing[1].Km = %d, want 0 (not enriched)", listings[1].Km)
+	}
+}
+
+func TestEnricher_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	enricher := &testEnricher{details: ItemDetails{Km: 10000}}
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+		{Token: "b", Km: 0},
+	}
+
+	// First item gets enriched (no delay before first), second should be skipped.
+	count := enricher.Enrich(ctx, listings)
+	if count > 1 {
+		t.Errorf("enriched = %d, want <= 1 (ctx canceled)", count)
+	}
+}
+
+func TestEnricher_SkipsOnError(t *testing.T) {
+	enricher := &testEnricher{err: fmt.Errorf("network error")}
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 0 {
+		t.Errorf("enriched = %d, want 0 (error)", count)
+	}
+	if listings[0].Km != 0 {
+		t.Errorf("listing[0].Km = %d, want 0 (unchanged on error)", listings[0].Km)
+	}
+}
+
+func TestEnricher_AllHaveKm(t *testing.T) {
+	enricher := &testEnricher{details: ItemDetails{Km: 50000}}
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 10000},
+		{Token: "b", Km: 20000},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 0 {
+		t.Errorf("enriched = %d, want 0 (all have km)", count)
+	}
+}
+
+// testEnricher is a mock that simulates the real Enricher's logic.
+type testEnricher struct {
+	details     ItemDetails
+	err         error
+	maxPerCycle int
+}
+
+func (e *testEnricher) Enrich(ctx context.Context, listings []model.RawListing) int {
+	max := e.maxPerCycle
+	if max <= 0 {
+		max = 100
+	}
+	enriched := 0
+	for i := range listings {
+		if listings[i].Km > 0 {
+			continue
+		}
+		if enriched >= max {
+			break
+		}
+		if enriched > 0 {
+			select {
+			case <-ctx.Done():
+				return enriched
+			case <-time.After(time.Millisecond):
+			}
+		}
+		if e.err != nil {
+			continue
+		}
+		if e.details.Km > 0 {
+			listings[i].Km = e.details.Km
+			enriched++
+		}
+	}
+	return enriched
+}
+
+func mustPlainClient(t *testing.T) HTTPDoer {
+	t.Helper()
+	c, err := newPlainClient([]string{"test-ua"}, "")
+	if err != nil {
+		t.Fatalf("create plain client: %v", err)
+	}
+	return c
+}

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestEnricher_FillsMissingKm(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
 {"props":{"pageProps":{"itemData":{"km":75000}}}}
 </script></html>`)
 	}))

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -6,28 +6,46 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/model"
 )
 
-func TestEnricher_FillsMissingKm(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
-{"props":{"pageProps":{"itemData":{"km":75000}}}}
-</script></html>`)
-	}))
-	defer srv.Close()
+func newTestEnricher(t *testing.T, handler http.Handler, cfg EnricherConfig) *Enricher {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client, err := newPlainClient([]string{"test-ua"}, "")
+	if err != nil {
+		t.Fatalf("create plain client: %v", err)
+	}
 
 	fetcher := &Yad2Fetcher{
-		client:  mustPlainClient(t),
-		baseURL: srv.URL,
-		logger:  slog.Default(),
+		client:     client,
+		baseURL:    srv.URL,
+		logger:     slog.Default(),
+		userAgents: []string{"test-ua"},
 	}
-	// Override the item URL by wrapping the fetcher's FetchItem via a test enricher.
-	// Instead, we'll just test the Enricher directly with a custom server.
-	enricher := &testEnricher{details: ItemDetails{Km: 75000}}
+
+	return NewEnricher(fetcher, slog.Default(), cfg)
+}
+
+func itemPageHandler(km int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":%d}}}}
+</script></html>`, km)
+	}
+}
+
+func TestEnricher_FillsMissingKm(t *testing.T) {
+	enricher := newTestEnricher(t, itemPageHandler(75000), EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 10,
+	})
 
 	listings := []model.RawListing{
 		{Token: "a", Km: 50000},
@@ -48,12 +66,21 @@ func TestEnricher_FillsMissingKm(t *testing.T) {
 	if listings[2].Km != 75000 {
 		t.Errorf("listing[2].Km = %d, want 75000", listings[2].Km)
 	}
-
-	_ = fetcher
 }
 
 func TestEnricher_RespectsMaxPerCycle(t *testing.T) {
-	enricher := &testEnricher{details: ItemDetails{Km: 10000}, maxPerCycle: 1}
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":10000}}}}
+</script></html>`)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 1,
+	})
 
 	listings := []model.RawListing{
 		{Token: "a", Km: 0},
@@ -71,28 +98,40 @@ func TestEnricher_RespectsMaxPerCycle(t *testing.T) {
 	if listings[1].Km != 0 {
 		t.Errorf("listing[1].Km = %d, want 0 (not enriched)", listings[1].Km)
 	}
+	if got := requestCount.Load(); got != 1 {
+		t.Errorf("requests = %d, want 1 (budget limits attempts)", got)
+	}
 }
 
 func TestEnricher_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	enricher := &testEnricher{details: ItemDetails{Km: 10000}}
+	enricher := newTestEnricher(t, itemPageHandler(10000), EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 10,
+	})
 
 	listings := []model.RawListing{
 		{Token: "a", Km: 0},
 		{Token: "b", Km: 0},
 	}
 
-	// First item gets enriched (no delay before first), second should be skipped.
 	count := enricher.Enrich(ctx, listings)
-	if count > 1 {
-		t.Errorf("enriched = %d, want <= 1 (ctx canceled)", count)
+	if count > 0 {
+		t.Errorf("enriched = %d, want 0 (ctx canceled before first attempt)", count)
 	}
 }
 
 func TestEnricher_SkipsOnError(t *testing.T) {
-	enricher := &testEnricher{err: fmt.Errorf("network error")}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 10,
+	})
 
 	listings := []model.RawListing{
 		{Token: "a", Km: 0},
@@ -108,7 +147,18 @@ func TestEnricher_SkipsOnError(t *testing.T) {
 }
 
 func TestEnricher_AllHaveKm(t *testing.T) {
-	enricher := &testEnricher{details: ItemDetails{Km: 50000}}
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":50000}}}}
+</script></html>`)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 10,
+	})
 
 	listings := []model.RawListing{
 		{Token: "a", Km: 10000},
@@ -119,51 +169,34 @@ func TestEnricher_AllHaveKm(t *testing.T) {
 	if count != 0 {
 		t.Errorf("enriched = %d, want 0 (all have km)", count)
 	}
+	if got := requestCount.Load(); got != 0 {
+		t.Errorf("requests = %d, want 0 (no fetches needed)", got)
+	}
 }
 
-// testEnricher is a mock that simulates the real Enricher's logic.
-type testEnricher struct {
-	details     ItemDetails
-	err         error
-	maxPerCycle int
-}
+func TestEnricher_FailedAttemptsConsumeBudget(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
 
-func (e *testEnricher) Enrich(ctx context.Context, listings []model.RawListing) int {
-	max := e.maxPerCycle
-	if max <= 0 {
-		max = 100
-	}
-	enriched := 0
-	for i := range listings {
-		if listings[i].Km > 0 {
-			continue
-		}
-		if enriched >= max {
-			break
-		}
-		if enriched > 0 {
-			select {
-			case <-ctx.Done():
-				return enriched
-			case <-time.After(time.Millisecond):
-			}
-		}
-		if e.err != nil {
-			continue
-		}
-		if e.details.Km > 0 {
-			listings[i].Km = e.details.Km
-			enriched++
-		}
-	}
-	return enriched
-}
+	enricher := newTestEnricher(t, handler, EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 2,
+	})
 
-func mustPlainClient(t *testing.T) HTTPDoer {
-	t.Helper()
-	c, err := newPlainClient([]string{"test-ua"}, "")
-	if err != nil {
-		t.Fatalf("create plain client: %v", err)
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+		{Token: "b", Km: 0},
+		{Token: "c", Km: 0},
 	}
-	return c
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 0 {
+		t.Errorf("enriched = %d, want 0 (all failed)", count)
+	}
+	if got := requestCount.Load(); got != 2 {
+		t.Errorf("requests = %d, want 2 (budget=2, failures count)", got)
+	}
 }

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -1,0 +1,100 @@
+package yad2
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+var itemNextDataRe = regexp.MustCompile(`(?s)<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>`)
+
+// ItemDetails holds enrichment data parsed from an individual listing page.
+type ItemDetails struct {
+	Km int
+}
+
+// ParseItemPage extracts listing details (primarily km) from a Yad2 item page.
+func ParseItemPage(body io.Reader) (ItemDetails, error) {
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return ItemDetails{}, fmt.Errorf("read item page body: %w", err)
+	}
+	html := string(raw)
+
+	if strings.Contains(html, challengeMarker) {
+		return ItemDetails{}, fmt.Errorf("yad2 item: challenge page")
+	}
+
+	matches := itemNextDataRe.FindStringSubmatch(html)
+	if len(matches) < 2 || matches[1] == "" {
+		return ItemDetails{}, fmt.Errorf("item page: __NEXT_DATA__ not found")
+	}
+
+	return parseItemNextData([]byte(matches[1]))
+}
+
+func parseItemNextData(data []byte) (ItemDetails, error) {
+	// Try pageProps.itemData first (common item page structure).
+	var envelope struct {
+		Props struct {
+			PageProps struct {
+				ItemData *itemPageData `json:"itemData"`
+			} `json:"pageProps"`
+		} `json:"props"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return ItemDetails{}, fmt.Errorf("unmarshal item __NEXT_DATA__: %w", err)
+	}
+
+	if envelope.Props.PageProps.ItemData != nil {
+		d := envelope.Props.PageProps.ItemData
+		if d.Km > 0 {
+			return ItemDetails{Km: d.Km}, nil
+		}
+	}
+
+	// Fallback: search dehydratedState queries for km field.
+	var dehydrated struct {
+		Props struct {
+			PageProps struct {
+				DehydratedState struct {
+					Queries []struct {
+						State struct {
+							Data json.RawMessage `json:"data"`
+						} `json:"state"`
+					} `json:"queries"`
+				} `json:"dehydratedState"`
+			} `json:"pageProps"`
+		} `json:"props"`
+	}
+	if err := json.Unmarshal(data, &dehydrated); err == nil {
+		for _, q := range dehydrated.Props.PageProps.DehydratedState.Queries {
+			if q.State.Data == nil {
+				continue
+			}
+			var item itemPageData
+			if json.Unmarshal(q.State.Data, &item) == nil && item.Km > 0 {
+				return ItemDetails{Km: item.Km}, nil
+			}
+			// Try nested under a wrapper key.
+			var wrapper map[string]json.RawMessage
+			if json.Unmarshal(q.State.Data, &wrapper) == nil {
+				for _, v := range wrapper {
+					var nested itemPageData
+					if json.Unmarshal(v, &nested) == nil && nested.Km > 0 {
+						return ItemDetails{Km: nested.Km}, nil
+					}
+				}
+			}
+		}
+	}
+
+	return ItemDetails{}, fmt.Errorf("km not found in item page data")
+}
+
+type itemPageData struct {
+	Km       int `json:"km"`
+	Kilometer int `json:"kilometer"`
+}

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var itemNextDataRe = regexp.MustCompile(`(?s)<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>`)
+var itemNextDataRe = regexp.MustCompile(`(?is)<script[^>]*\bid=["']__NEXT_DATA__["'][^>]*>(.*?)</script>`)
 
 // ItemDetails holds enrichment data parsed from an individual listing page.
 type ItemDetails struct {
@@ -49,9 +49,8 @@ func parseItemNextData(data []byte) (ItemDetails, error) {
 	}
 
 	if envelope.Props.PageProps.ItemData != nil {
-		d := envelope.Props.PageProps.ItemData
-		if d.Km > 0 {
-			return ItemDetails{Km: d.Km}, nil
+		if km := effectiveKm(*envelope.Props.PageProps.ItemData); km > 0 {
+			return ItemDetails{Km: km}, nil
 		}
 	}
 
@@ -75,16 +74,19 @@ func parseItemNextData(data []byte) (ItemDetails, error) {
 				continue
 			}
 			var item itemPageData
-			if json.Unmarshal(q.State.Data, &item) == nil && item.Km > 0 {
-				return ItemDetails{Km: item.Km}, nil
+			if json.Unmarshal(q.State.Data, &item) == nil {
+				if km := effectiveKm(item); km > 0 {
+					return ItemDetails{Km: km}, nil
+				}
 			}
-			// Try nested under a wrapper key.
 			var wrapper map[string]json.RawMessage
 			if json.Unmarshal(q.State.Data, &wrapper) == nil {
 				for _, v := range wrapper {
 					var nested itemPageData
-					if json.Unmarshal(v, &nested) == nil && nested.Km > 0 {
-						return ItemDetails{Km: nested.Km}, nil
+					if json.Unmarshal(v, &nested) == nil {
+						if km := effectiveKm(nested); km > 0 {
+							return ItemDetails{Km: km}, nil
+						}
 					}
 				}
 			}
@@ -95,6 +97,13 @@ func parseItemNextData(data []byte) (ItemDetails, error) {
 }
 
 type itemPageData struct {
-	Km       int `json:"km"`
+	Km        int `json:"km"`
 	Kilometer int `json:"kilometer"`
+}
+
+func effectiveKm(d itemPageData) int {
+	if d.Km > 0 {
+		return d.Km
+	}
+	return d.Kilometer
 }

--- a/internal/fetcher/yad2/item_parser_test.go
+++ b/internal/fetcher/yad2/item_parser_test.go
@@ -1,0 +1,72 @@
+package yad2
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseItemPage_ItemData(t *testing.T) {
+	f, err := os.Open("../../../testdata/yad2_item_page.html")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	details, err := ParseItemPage(f)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if details.Km != 62000 {
+		t.Errorf("km = %d, want 62000", details.Km)
+	}
+}
+
+func TestParseItemPage_DehydratedState(t *testing.T) {
+	f, err := os.Open("../../../testdata/yad2_item_dehydrated.html")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	details, err := ParseItemPage(f)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if details.Km != 120000 {
+		t.Errorf("km = %d, want 120000", details.Km)
+	}
+}
+
+func TestParseItemPage_Challenge(t *testing.T) {
+	html := `<html><body>Are you for real</body></html>`
+	_, err := ParseItemPage(strings.NewReader(html))
+	if err == nil {
+		t.Fatal("expected error for challenge page")
+	}
+	if !strings.Contains(err.Error(), "challenge") {
+		t.Errorf("error should mention challenge, got: %v", err)
+	}
+}
+
+func TestParseItemPage_NoScript(t *testing.T) {
+	html := `<html><body><p>No script here</p></body></html>`
+	_, err := ParseItemPage(strings.NewReader(html))
+	if err == nil {
+		t.Fatal("expected error for missing __NEXT_DATA__")
+	}
+}
+
+func TestParseItemPage_NoKm(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"token":"abc","km":0}}}}
+</script>
+</body></html>`
+	_, err := ParseItemPage(strings.NewReader(html))
+	if err == nil {
+		t.Fatal("expected error when km is 0")
+	}
+}

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -70,6 +70,44 @@ func (f *Yad2Fetcher) Close() {
 	}
 }
 
+// FetchItem fetches an individual listing page and returns enrichment details.
+func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails, error) {
+	itemURL := fmt.Sprintf("https://www.yad2.co.il/item/%s", token)
+
+	client := f.client
+	var usedProxy string
+	if f.proxyPool != nil {
+		usedProxy = f.proxyPool.Next()
+		if f.clientPool != nil {
+			c, err := f.clientPool.Get(usedProxy)
+			if err != nil {
+				f.logger.Warn("failed to get pooled client for item fetch", "proxy", redactProxy(usedProxy), "error", err)
+			} else {
+				client = c
+			}
+		}
+	}
+
+	result, err := client.Get(ctx, itemURL)
+	if err != nil {
+		if f.clientPool != nil && usedProxy != "" {
+			f.clientPool.Evict(usedProxy)
+		}
+		return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, err)
+	}
+
+	if result.StatusCode != http.StatusOK {
+		return ItemDetails{}, fmt.Errorf("fetch item %s: status %d", token, result.StatusCode)
+	}
+
+	details, err := ParseItemPage(bytes.NewReader(result.Body))
+	if err != nil {
+		return ItemDetails{}, fmt.Errorf("parse item %s: %w", token, err)
+	}
+
+	return details, nil
+}
+
 func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]model.RawListing, error) {
 	client := f.client
 	var usedProxy string

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -72,7 +72,13 @@ func (f *Yad2Fetcher) Close() {
 
 // FetchItem fetches an individual listing page and returns enrichment details.
 func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails, error) {
-	itemURL := fmt.Sprintf("https://www.yad2.co.il/item/%s", token)
+	base, err := url.Parse(f.baseURL)
+	if err != nil {
+		return ItemDetails{}, fmt.Errorf("parse base URL: %w", err)
+	}
+	base.Path = "/item/" + url.PathEscape(token)
+	base.RawQuery = ""
+	itemURL := base.String()
 
 	client := f.client
 	var usedProxy string

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -37,6 +37,11 @@ type CatalogIngester interface {
 	Flush(ctx context.Context)
 }
 
+// KmEnricher fills in missing km data by fetching individual listing pages.
+type KmEnricher interface {
+	Enrich(ctx context.Context, listings []model.RawListing) int
+}
+
 type Scheduler struct {
 	cfgMu             sync.RWMutex
 	cfg               *config.Config
@@ -59,6 +64,7 @@ type Scheduler struct {
 	digestStore       storage.DigestStore
 	hiddenStore       storage.HiddenListingStore
 	catalogIngester   CatalogIngester
+	kmEnricher        KmEnricher
 	marketStore       storage.MarketStore
 	dailyDigestStore  storage.DailyDigestStore
 	triggerCh         chan struct{}
@@ -84,6 +90,7 @@ type Options struct {
 	DigestStore     storage.DigestStore
 	HiddenStore      storage.HiddenListingStore
 	CatalogIngester  CatalogIngester
+	KmEnricher       KmEnricher
 	MarketStore      storage.MarketStore
 	DailyDigestStore storage.DailyDigestStore
 }
@@ -134,6 +141,7 @@ func NewWithOptions(
 		digestStore:       opts.DigestStore,
 		hiddenStore:       opts.HiddenStore,
 		catalogIngester:   opts.CatalogIngester,
+		kmEnricher:        opts.KmEnricher,
 		marketStore:       opts.MarketStore,
 		dailyDigestStore:  opts.DailyDigestStore,
 		triggerCh:         make(chan struct{}, 1),
@@ -604,6 +612,13 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 	if s.catalogIngester != nil {
 		for _, l := range raw {
 			s.catalogIngester.Ingest(ctx, l.ManufacturerID, l.Manufacturer, l.ModelID, l.Model)
+		}
+	}
+
+	if s.kmEnricher != nil {
+		enriched := s.kmEnricher.Enrich(ctx, raw)
+		if enriched > 0 {
+			s.logger.Info("km enrichment complete", "enriched", enriched)
 		}
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -615,8 +615,8 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		}
 	}
 
-	if s.kmEnricher != nil {
-		enriched := s.kmEnricher.Enrich(ctx, raw)
+	if source == "yad2" && s.kmEnricher != nil {
+		enriched := s.kmEnricher.Enrich(fetchCtx, raw)
 		if enriched > 0 {
 			s.logger.Info("km enrichment complete", "enriched", enriched)
 		}

--- a/testdata/yad2_item_dehydrated.html
+++ b/testdata/yad2_item_dehydrated.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head><title>Yad2 - Item</title></head>
+<body>
+<div id="__next">
+  <div>Individual listing page content</div>
+</div>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "dehydratedState": {
+        "queries": [
+          {
+            "state": {
+              "data": {
+                "item": {
+                  "token": "item-token-456",
+                  "km": 120000,
+                  "price": 55000
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>

--- a/testdata/yad2_item_page.html
+++ b/testdata/yad2_item_page.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head><title>Yad2 - Item</title></head>
+<body>
+<div id="__next">
+  <div>Individual listing page content</div>
+</div>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "itemData": {
+        "token": "item-token-123",
+        "km": 62000,
+        "price": 85000,
+        "year_of_production": 2020,
+        "manufacturer": {"text": "טויוטה", "english_text": "Toyota"},
+        "model": {"text": "קורולה", "english_text": "Corolla"}
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -36,6 +36,7 @@ export function ListingCardBody({
           <img
             src={listing.image_url}
             alt={`${listing.manufacturer} ${listing.model}`}
+            referrerPolicy="no-referrer"
             className={cn(
               "h-full w-full object-cover transition-transform duration-500 ease-out",
               hoverScale && "group-hover:scale-105",

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -94,6 +94,7 @@ export function ListingDetailPage() {
           <img
             src={listing.image_url}
             alt={`${listing.manufacturer} ${listing.model}`}
+            referrerPolicy="no-referrer"
             className="h-full w-full object-cover"
           />
         </div>

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -196,6 +196,7 @@ function ListingCard({ listing }: { listing: Listing }) {
           <img
             src={listing.image_url}
             alt={`${listing.manufacturer} ${listing.model}`}
+            referrerPolicy="no-referrer"
             className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
             loading="lazy"
           />

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -451,6 +451,7 @@ function RecentListingRow({ listing }: { listing: Listing }) {
           <img
             src={listing.image_url}
             alt={`${listing.manufacturer} ${listing.model}`}
+            referrerPolicy="no-referrer"
             className="h-full w-full object-cover"
             loading="lazy"
           />


### PR DESCRIPTION
## Summary

- Yad2's search feed often returns `km: 0` for listings. This adds a post-fetch enrichment step that fetches individual item pages (`/item/{token}`) and extracts the real km from `__NEXT_DATA__` JSON.
- Enrichment is rate-limited (500ms between requests, max 5 per cycle) to avoid triggering anti-bot measures.
- The enricher is optional — if not configured, behavior is unchanged.

## Implementation

| File | Change |
|------|--------|
| `internal/fetcher/yad2/item_parser.go` | Parse km from individual listing page (itemData + dehydratedState fallback) |
| `internal/fetcher/yad2/yad2.go` | Add `FetchItem` method |
| `internal/fetcher/yad2/enricher.go` | `Enricher` with delay/max-per-cycle controls |
| `internal/scheduler/scheduler.go` | `KmEnricher` interface + wire into `processGroup` |
| `cmd/bot/main.go` | Instantiate and pass enricher |

## Test plan

- [x] Item page parser tests (itemData, dehydratedState, challenge, no-script, zero-km)
- [x] Enricher tests (fills missing, respects max, context cancel, skips errors, all-have-km)
- [x] Existing scheduler and fetcher tests still pass
- [ ] Deploy and verify km shows up for listings that previously showed "—"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic listing enrichment to fetch and populate missing distance (Km) for Yad2 listings, with configurable per-cycle limits and request throttling; enrichment can be toggled via config and runs only for Yad2 sources.
* **Tests**
  * Added unit tests covering enrichment behavior, parsing, request limits, and failure modes.
* **Chores**
  * Listing images now load with referrerPolicy set to no-referrer (suppresses referrer header).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->