### PR TITLE
fix: enable km enrichment by default without config flag

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -203,11 +203,7 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
-	var kmEnricher *yad2.Enricher
-	if cfg.Polling.EnableKmEnrichment {
-		kmEnricher = yad2.NewEnricher(yad2Fetcher, logger, yad2.EnricherConfig{})
-		logger.Info("km enrichment enabled")
-	}
+	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger, yad2.EnricherConfig{})
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, multi, logger, scheduler.Options{
 		Observer:         h,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,6 @@ type PollingConfig struct {
 	ActiveHours          *ActiveHours  `yaml:"active_hours"`
 	Timezone             string        `yaml:"timezone"`
 	MaxConcurrentFetches int           `yaml:"max_concurrent_fetches"`
-	EnableKmEnrichment   bool          `yaml:"enable_km_enrichment"`
 }
 
 type ActiveHours struct {


### PR DESCRIPTION
## Summary

- Removes the `enable_km_enrichment` config flag — enrichment now always runs.
- The feature gate was added per CodeRabbit suggestion but is unnecessary for this project. The enricher is already safely bounded (rate-limited, scoped to yad2, respects fetch timeout).

## Changes

- `cmd/bot/main.go`: Always create `kmEnricher` (no conditional)
- `internal/config/config.go`: Remove `EnableKmEnrichment` field from `PollingConfig`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the configuration option to disable KM enrichment. This feature is now always active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->