### PR TITLE
feat: display app version in sidebar and health endpoint

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -113,6 +113,7 @@ func run(configPath string, logger *slog.Logger) error {
 	fetcherFactory.Register("winwin", winwinCB)
 
 	h := health.New()
+	h.SetVersion(version)
 	h.SetUserCounter(store)
 	h.SetSearchCounter(store)
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -32,6 +32,7 @@ type SourceMetrics struct {
 
 type Status struct {
 	startTime         time.Time
+	version           string
 	cycleCount        atomic.Int64
 	errorCount        atomic.Int64
 	lastSuccessUnixNs atomic.Int64
@@ -51,6 +52,12 @@ func New() *Status {
 		startTime: time.Now(),
 		sources:   make(map[string]*SourceMetrics),
 	}
+}
+
+func (s *Status) SetVersion(v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.version = v
 }
 
 func (s *Status) SetUserCounter(u UserCounter) {
@@ -152,8 +159,13 @@ func (s *Status) Snapshot() map[string]any {
 	defer cancel()
 
 	s.mu.RLock()
+	version := s.version
 	users, searches := s.users, s.searches
 	s.mu.RUnlock()
+
+	if version != "" {
+		resp["version"] = version
+	}
 
 	if users != nil {
 		if n, err := users.CountUsers(ctx); err == nil {

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -12,6 +12,7 @@ import {
   Moon,
 } from "lucide-react";
 import { useNotificationCount } from "@/hooks/useNotifications";
+import { useAppVersion } from "@/hooks/useAppVersion";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { cn } from "@/lib/utils";
@@ -31,6 +32,7 @@ export function Shell() {
   const unread = notifCount?.count ?? 0;
   const { user, signOut } = useAuth();
   const { theme, toggle: toggleTheme } = useTheme();
+  const appVersion = useAppVersion();
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
 
@@ -146,6 +148,11 @@ export function Shell() {
             <LogOut className="h-4 w-4" aria-hidden />
             התנתק
           </button>
+          {appVersion && (
+            <p className="mt-2 text-center text-[10px] text-sidebar-foreground/30 tabular-nums">
+              v{appVersion}
+            </p>
+          )}
         </div>
       </aside>
 

--- a/web/src/hooks/useAppVersion.ts
+++ b/web/src/hooks/useAppVersion.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export function useAppVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+  useEffect(() => {
+    fetch("/healthz")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d?.version) setVersion(d.version);
+      })
+      .catch(() => {});
+  }, []);
+  return version;
+}


### PR DESCRIPTION
## Summary
- Expose build version through `/healthz` JSON response so the frontend knows which release is running
- Add `useAppVersion` shared hook that fetches the version once on mount
- Display version as a subtle `v{version}` label at the bottom of the sidebar, visible to all logged-in users

This gives a quick way to verify which version is deployed in production without SSH-ing into the VM.

## Test plan
- [ ] `make test` passes (82.9% coverage)
- [ ] `npx tsc --noEmit` passes
- [ ] `/healthz` returns `"version": "..."` when built with `-ldflags`
- [ ] Sidebar shows version below logout button
- [ ] Dev builds show `vdev` (default value)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application version is now displayed in the sidebar, allowing users to quickly check the current build version installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->