### PR TITLE
fix: vacuum now truncates WAL and rejects concurrent requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ firebase-service-account*.json
 web/.env
 web/.env.local
 web/.env.*.local
+
+# Cursor IDE (may contain sensitive project-local rules)
+.cursor/

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,5 +41,6 @@ api:
   cors_origins:
     - "http://localhost:5173"              # dev (Vite)
     - "https://${CARWATCH_DOMAIN}"         # production
+  admin_email: ""             # Firebase email granted admin access in the web UI
   # dev_chat_id: 0       # chat_id to use in dev mode (no auth)
   # auth_token: ""       # bearer token for API auth (optional)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -201,6 +201,12 @@ func (s *Server) adminDeleteListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) adminVacuum(w http.ResponseWriter, r *http.Request) {
+	if !s.vacuumMu.TryLock() {
+		writeError(w, http.StatusConflict, "vacuum already in progress")
+		return
+	}
+	defer s.vacuumMu.Unlock()
+
 	if err := s.admin.VacuumDB(r.Context()); err != nil {
 		s.logger.Error("admin: vacuum", "error", err)
 		writeError(w, http.StatusInternalServerError, "vacuum failed")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	fbauth "firebase.google.com/go/v4/auth"
@@ -39,6 +40,7 @@ type Server struct {
 	cfg       config.APIConfig
 	startTime time.Time
 	rl        *rateLimiter
+	vacuumMu  sync.Mutex
 }
 
 type Config struct {

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -139,6 +139,14 @@ func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int
 }
 
 func (s *Store) VacuumDB(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, "VACUUM")
-	return err
+	if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return fmt.Errorf("wal checkpoint: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, "VACUUM"); err != nil {
+		return fmt.Errorf("vacuum: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return fmt.Errorf("post-vacuum wal checkpoint: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- **WAL checkpoint:** `VACUUM` alone doesn't shrink the WAL file — after purging all tables, the DB showed 4.2 MB (140 KB data + 4 MB WAL). Now runs `PRAGMA wal_checkpoint(TRUNCATE)` before and after `VACUUM` to actually reclaim disk space.
- **Concurrent request guard:** Added `sync.Mutex` with `TryLock` on the vacuum endpoint — rapid clicks now return `409 Conflict` instead of spawning parallel VACUUMs that spike memory.
- **Config:** Document `admin_email` field in `config.example.yaml`.
- **Gitignore:** Add `.cursor/` to prevent committing sensitive local rules.

## Test plan

- [x] `make test` passes
- [ ] Click vacuum on admin dashboard — DB size should drop to ~100-200 KB
- [ ] Rapid-click vacuum — only first request succeeds, rest get 409


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `api.admin_email` configuration field for REST API settings.

* **Bug Fixes**
  * Improved database vacuum operation to prevent concurrent executions and ensure proper cleanup.

* **Chores**
  * Updated project gitignore to exclude IDE-specific files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->