### PR TITLE
feat: trigger immediate poll when a search is created via web UI

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -227,6 +227,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 
 	botHandler.SetPollTrigger(sched)
+	apiServer.SetPollTrigger(sched)
 	botHandler.StartCleanup(ctx)
 
 	go tgNotif.Bot().Start(ctx)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,6 +25,10 @@ const (
 	emailKey  contextKey = "email"
 )
 
+type PollTrigger interface {
+	TriggerPoll()
+}
+
 type Server struct {
 	catalog       catalog.Catalog
 	searches      storage.SearchStore
@@ -36,11 +40,16 @@ type Server struct {
 	saved     storage.SavedListingStore
 	hidden    storage.HiddenListingStore
 	notifs    storage.NotificationStore
+	poller    PollTrigger
 	logger    *slog.Logger
 	cfg       config.APIConfig
 	startTime time.Time
 	rl        *rateLimiter
 	vacuumMu  sync.Mutex
+}
+
+func (s *Server) SetPollTrigger(p PollTrigger) {
+	s.poller = p
 }
 
 type Config struct {

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -217,6 +217,10 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, s.searchResponseWithListingCount(r.Context(), chatID, *created))
+
+	if s.poller != nil {
+		s.poller.TriggerPoll()
+	}
 }
 
 func (s *Server) getSearch(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Creating a search from the web UI stored it in the DB but didn't trigger any fetch — users had to wait 15+ minutes for the next scheduler cycle to see results.

Now the API calls `scheduler.TriggerPoll()` after creating a search, so the scheduler immediately picks up the new search and fetches listings.

Uses the same `PollTrigger` interface pattern already used by the Telegram bot handler.

## Test plan

- [x] `make test` passes
- [ ] Create a new search in the web UI — listings should appear within seconds


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Search creation now triggers immediate polling to fetch results faster, reducing latency for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->