### PR TITLE
fix: correct KM, city, and fitness score data pipeline

### DIFF
--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -174,12 +174,8 @@ func itemToListing(raw json.RawMessage) (model.RawListing, error) {
 		PageLink:     fmt.Sprintf("https://www.yad2.co.il/item/%s", item.Token),
 	}
 
-	if item.Address.City.Text != "" {
-		listing.City = item.Address.City.Text
-	}
-	if item.Address.Area.Text != "" {
-		listing.Area = item.Address.Area.Text
-	}
+	listing.City = textFromField(item.Address.City)
+	listing.Area = textFromField(item.Address.Area)
 
 	createdAt := item.Dates.CreatedAt
 	if createdAt == "" {

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -245,6 +245,56 @@ func TestTextFromField_PrefersEnglish(t *testing.T) {
 	}
 }
 
+func TestParseNextData_CityEnglishTextFallback(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "eng-city", "manufacturer": {"text": "Honda"}, "model": {"text": "Civic"}, "price": 50000, "hand": 1,
+				 "address": {"city": {"text": "", "english_text": "Tel Aviv", "id": 5000}, "area": {"text": "", "english_text": "Center", "id": 2}}}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].City != "Tel Aviv" {
+		t.Errorf("city = %q, want 'Tel Aviv' (english_text fallback)", listings[0].City)
+	}
+	if listings[0].Area != "Center" {
+		t.Errorf("area = %q, want 'Center' (english_text fallback)", listings[0].Area)
+	}
+}
+
+func TestParseNextData_CityTextEngFallback(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "eng2-city", "manufacturer": {"text": "Honda"}, "model": {"text": "Civic"}, "price": 50000, "hand": 1,
+				 "address": {"city": {"text": "", "textEng": "Haifa", "id": 4000}, "area": {"text": "", "textEng": "North", "id": 4}}}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].City != "Haifa" {
+		t.Errorf("city = %q, want 'Haifa' (textEng fallback)", listings[0].City)
+	}
+	if listings[0].Area != "North" {
+		t.Errorf("area = %q, want 'North' (textEng fallback)", listings[0].Area)
+	}
+}
+
 func TestParseNextData_DeduplicatesAcrossBuckets(t *testing.T) {
 	data := []byte(`{
 		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -165,7 +165,7 @@ func priceScore(price, priceMax int) float64 {
 
 func kmScore(km, maxKm int) float64 {
 	if km <= 0 {
-		return 1.0
+		return 0.5
 	}
 	ref := maxKm
 	if ref <= 0 {

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -341,13 +341,12 @@ func TestKmScore(t *testing.T) {
 	}{
 		{"zero km is neutral", 0, 150000, 0.5},
 		{"negative km is neutral", -1, 150000, 0.5},
-		{"low km scores high", 10000, 150000, -1},
-		{"at max km scores zero", 150000, 150000, -1},
+		{"at max km scores zero", 150000, 150000, 0.0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := kmScore(tt.km, tt.maxKm)
-			if tt.want >= 0 && got != tt.want {
+			if got != tt.want {
 				t.Errorf("kmScore(%d, %d) = %.2f, want %.2f", tt.km, tt.maxKm, got, tt.want)
 			}
 		})

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -332,26 +332,34 @@ func TestFitnessScoreDetailed_NoPriceDim(t *testing.T) {
 	}
 }
 
-func TestKmScore_UnknownIsNeutral(t *testing.T) {
-	got := kmScore(0, 150000)
-	if got != 0.5 {
-		t.Errorf("kmScore(0, 150000) = %.2f, want 0.5 (neutral for unknown)", got)
+func TestKmScore(t *testing.T) {
+	tests := []struct {
+		name  string
+		km    int
+		maxKm int
+		want  float64
+	}{
+		{"zero km is neutral", 0, 150000, 0.5},
+		{"negative km is neutral", -1, 150000, 0.5},
+		{"low km scores high", 10000, 150000, -1},
+		{"at max km scores zero", 150000, 150000, -1},
 	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kmScore(tt.km, tt.maxKm)
+			if tt.want >= 0 && got != tt.want {
+				t.Errorf("kmScore(%d, %d) = %.2f, want %.2f", tt.km, tt.maxKm, got, tt.want)
+			}
+		})
+	}
 
-func TestKmScore_NegativeIsNeutral(t *testing.T) {
-	got := kmScore(-1, 150000)
-	if got != 0.5 {
-		t.Errorf("kmScore(-1, 150000) = %.2f, want 0.5 (neutral for unknown)", got)
-	}
-}
-
-func TestKmScore_KnownLowBeatsUnknown(t *testing.T) {
-	low := kmScore(10000, 150000)
-	unknown := kmScore(0, 150000)
-	if low <= unknown {
-		t.Errorf("low-km listing (%.3f) should score higher than unknown-km (%.3f)", low, unknown)
-	}
+	t.Run("known low beats unknown", func(t *testing.T) {
+		low := kmScore(10000, 150000)
+		unknown := kmScore(0, 150000)
+		if low <= unknown {
+			t.Errorf("low-km (%.3f) should score higher than unknown-km (%.3f)", low, unknown)
+		}
+	})
 }
 
 func TestFitnessScore_NonLinearKm(t *testing.T) {

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -169,7 +169,7 @@ func TestFitnessScore(t *testing.T) {
 		{
 			name: "perfect listing",
 			p: FitnessParams{
-				Price: 50000, Km: 0, Hand: 1, Year: 2024, EngineVolume: 3000,
+				Price: 50000, Km: 1000, Hand: 1, Year: 2024, EngineVolume: 3000,
 				PriceMax: 200000, MaxKm: 150000, MaxHand: 4, YearMin: 2018, YearMax: 2024, EngineMinCC: 1500,
 			},
 			min: 9.0, max: 10.0,
@@ -247,12 +247,12 @@ func TestFitnessScore(t *testing.T) {
 			min: 6.0, max: 9.0,
 		},
 		{
-			name: "brand new car with zero km",
+			name: "unknown km gets neutral score",
 			p: FitnessParams{
 				Price: 150000, Km: 0, Hand: 1, Year: 2024, EngineVolume: 2000,
 				PriceMax: 200000, MaxKm: 100000, MaxHand: 3, YearMin: 2020, YearMax: 2024, EngineMinCC: 1500,
 			},
-			min: 6.5, max: 9.5,
+			min: 5.0, max: 8.0,
 		},
 		{
 			name: "price exactly at max",
@@ -260,7 +260,7 @@ func TestFitnessScore(t *testing.T) {
 				Price: 200000, Km: 0, Hand: 1, Year: 2024, EngineVolume: 2000,
 				PriceMax: 200000, MaxKm: 100000, MaxHand: 3, YearMin: 2020, YearMax: 2024, EngineMinCC: 1500,
 			},
-			min: 5.5, max: 7.5,
+			min: 4.0, max: 6.5,
 		},
 	}
 
@@ -329,6 +329,21 @@ func TestFitnessScoreDetailed_NoPriceDim(t *testing.T) {
 	}
 	if len(result.Dims) != 4 {
 		t.Errorf("expected 4 dimensions without price, got %d", len(result.Dims))
+	}
+}
+
+func TestKmScore_UnknownIsNeutral(t *testing.T) {
+	got := kmScore(0, 150000)
+	if got != 0.5 {
+		t.Errorf("kmScore(0, 150000) = %.2f, want 0.5 (neutral for unknown)", got)
+	}
+}
+
+func TestKmScore_KnownLowBeatsUnknown(t *testing.T) {
+	low := kmScore(10000, 150000)
+	unknown := kmScore(0, 150000)
+	if low <= unknown {
+		t.Errorf("low-km listing (%.3f) should score higher than unknown-km (%.3f)", low, unknown)
 	}
 }
 

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -339,6 +339,13 @@ func TestKmScore_UnknownIsNeutral(t *testing.T) {
 	}
 }
 
+func TestKmScore_NegativeIsNeutral(t *testing.T) {
+	got := kmScore(-1, 150000)
+	if got != 0.5 {
+		t.Errorf("kmScore(-1, 150000) = %.2f, want 0.5 (neutral for unknown)", got)
+	}
+}
+
 func TestKmScore_KnownLowBeatsUnknown(t *testing.T) {
 	low := kmScore(10000, 150000)
 	unknown := kmScore(0, 150000)

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -17,8 +17,9 @@ func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error 
 			search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
 			search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
 			price = excluded.price,
-			km = excluded.km,
+			km = CASE WHEN excluded.km > 0 THEN excluded.km ELSE listing_history.km END,
 			hand = excluded.hand,
+			city = CASE WHEN excluded.city != '' THEN excluded.city ELSE listing_history.city END,
 			image_url = CASE WHEN excluded.image_url != '' THEN excluded.image_url ELSE listing_history.image_url END,
 			fitness_score = excluded.fitness_score`,
 		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.Year, r.Price,
@@ -62,8 +63,9 @@ func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecor
 			search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
 			search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
 			price = excluded.price,
-			km = excluded.km,
+			km = CASE WHEN excluded.km > 0 THEN excluded.km ELSE listing_history.km END,
 			hand = excluded.hand,
+			city = CASE WHEN excluded.city != '' THEN excluded.city ELSE listing_history.city END,
 			image_url = CASE WHEN excluded.image_url != '' THEN excluded.image_url ELSE listing_history.image_url END,
 			fitness_score = excluded.fitness_score`)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **City parsing**: Changed from raw `.Text` to `textFromField()` to pick up cities provided via `english_text` or `textEng` fields — consistent with how manufacturer/model/engine are parsed.
- **UPSERT preservation**: Added `city` to the `ON CONFLICT` update clause (only overwrite if non-empty), and changed `km` to only overwrite if the new value is > 0 — so enriched data isn't lost on subsequent saves.
- **Fitness score accuracy**: `kmScore()` returned `1.0` (best possible) for unknown KM (`km=0`), artificially inflating scores. Changed to `0.5` (neutral) so unknown mileage neither rewards nor penalizes.

Closes #352

## Test plan

- [x] All scoring tests pass with updated expectations
- [x] New `TestKmScore_UnknownIsNeutral` and `TestKmScore_KnownLowBeatsUnknown` tests verify the neutral behavior
- [x] Parser test still validates city extraction from Hebrew `text` field
- [x] Storage tests pass with updated UPSERT logic

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address parsing to reliably extract city and area using fallback text fields when primary values are empty.

* **Updates**
  * Adjusted scoring so unknown or negative mileage yields a neutral score.
  * Enhanced historical-data handling to avoid overwriting existing kilometers and city unless new valid values are provided.

* **Tests**
  * Added and updated tests for address fallback parsing and mileage-scoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->