### PR TITLE
fix(ui): improve search card button layout

### DIFF
--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -358,12 +358,13 @@ function SearchCard({
         {search.max_hand > 0 && <div>עד יד {search.max_hand}</div>}
       </div>
 
-      <div className="flex items-center gap-2 border-t border-border/50 pt-3">
+      <div className="flex items-center gap-1.5 border-t border-border/50 pt-3">
         <Button
           as={Link}
           to={`/searches/${search.id}/listings`}
-          variant="secondary"
+          variant="primary"
           size="sm"
+          className="flex-1 sm:flex-none"
         >
           <List className="h-3.5 w-3.5" />
           תוצאות
@@ -373,33 +374,36 @@ function SearchCard({
           as={Link}
           to={`/searches/${search.id}/edit`}
           variant="secondary"
-          size="sm"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="ערוך חיפוש"
         >
           <Pencil className="h-3.5 w-3.5" />
-          ערוך
         </Button>
 
         {search.active ? (
           <Button
             type="button"
             variant="secondary"
-            size="sm"
+            size="icon"
+            className="h-8 w-8"
             onClick={onPause}
             disabled={disabled}
+            aria-label="השהה חיפוש"
           >
             <Pause className="h-3.5 w-3.5" />
-            השהה
           </Button>
         ) : (
           <Button
             type="button"
             variant="secondary"
-            size="sm"
+            size="icon"
+            className="h-8 w-8"
             onClick={onResume}
             disabled={disabled}
+            aria-label="חדש חיפוש"
           >
             <Play className="h-3.5 w-3.5" />
-            חדש
           </Button>
         )}
 
@@ -427,12 +431,12 @@ function SearchCard({
             <Button
               type="button"
               variant="ghost"
-              size="sm"
+              size="icon"
+              className="h-8 w-8 text-destructive hover:bg-destructive/10"
               onClick={onDelete}
-              className="text-destructive hover:bg-destructive/10"
+              aria-label="מחק חיפוש"
             >
               <Trash2 className="h-3.5 w-3.5" />
-              מחק
             </Button>
           )}
         </div>

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -434,6 +434,7 @@ function SearchCard({
               size="icon"
               className="h-8 w-8 text-destructive hover:bg-destructive/10"
               onClick={onDelete}
+              disabled={disabled}
               aria-label="מחק חיפוש"
             >
               <Trash2 className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

- Promoted "תוצאות" (Results) to primary button — it's the main action and now stands out with `variant="primary"` and fills available width on mobile (`flex-1 sm:flex-none`)
- Converted "ערוך" (Edit), "השהה/חדש" (Pause/Resume), and "מחק" (Delete) to icon-only buttons (`size="icon"`) — reduces horizontal cramming on half-width cards
- Added `aria-label` to all icon-only buttons for accessibility
- Tightened gap from `gap-2` to `gap-1.5` for better visual balance

## Before/After

**Before:** 4 labeled buttons + delete in a single row — cramped on half-width cards  
**After:** 1 labeled primary button + 3 icon buttons — clean, readable, and touch-friendly

## Test plan

- [x] TypeScript compiles clean
- [ ] Visual check: dashboard with 1 and 2+ searches
- [ ] Verify icon buttons have proper hover/active states
- [ ] Verify confirm-delete flow still works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned search-card action buttons from text-based to icon-only controls for a cleaner, more streamlined interface.
  * Updated results control to a primary-styled button and aligned button sizing/layout for visual consistency.
  * Made delete, edit, pause/resume controls respect disabled state and improved hover/destructive styling.

* **Accessibility**
  * Added explicit accessibility labels to all action buttons, improving screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->