### PR TITLE
fix: update yad2 item page URL and extract city from enrichment

### DIFF
--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -47,7 +47,8 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 	for i := range listings {
 		needsKm := listings[i].Km <= 0
 		needsImg := listings[i].ImageURL == ""
-		if !needsKm && !needsImg {
+		needsCity := listings[i].City == ""
+		if !needsKm && !needsImg && !needsCity {
 			continue
 		}
 		if attempts >= e.cfg.MaxPerCycle {
@@ -92,11 +93,19 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			listings[i].ImageURL = details.ImageURL
 			changed = true
 		}
+		if needsCity && details.City != "" {
+			listings[i].City = details.City
+			changed = true
+		}
+		if listings[i].Area == "" && details.Area != "" {
+			listings[i].Area = details.Area
+		}
 		if changed {
 			enriched++
 			e.logger.Debug("enriched listing",
 				"token", listings[i].Token,
 				"km", details.Km,
+				"city", details.City,
 				"image", details.ImageURL != "",
 			)
 		}

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -36,7 +36,7 @@ func newTestEnricher(t *testing.T, handler http.Handler, cfg EnricherConfig) *En
 func itemPageHandler(km int) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
-{"props":{"pageProps":{"itemData":{"km":%d}}}}
+{"props":{"pageProps":{"itemData":{"km":%d,"address":{"city":{"text":"תל אביב","textEng":"tel_aviv"},"area":{"text":"מרכז","textEng":"center"}}}}}}
 </script></html>`, km)
 	}
 }
@@ -48,7 +48,7 @@ func TestEnricher_FillsMissingKm(t *testing.T) {
 	})
 
 	listings := []model.RawListing{
-		{Token: "a", Km: 50000},
+		{Token: "a", Km: 50000, City: "Haifa"},
 		{Token: "b", Km: 0},
 		{Token: "c", Km: 0},
 	}
@@ -161,13 +161,13 @@ func TestEnricher_AllHaveKm(t *testing.T) {
 	})
 
 	listings := []model.RawListing{
-		{Token: "a", Km: 10000, ImageURL: "https://img.yad2.co.il/a.jpg"},
-		{Token: "b", Km: 20000, ImageURL: "https://img.yad2.co.il/b.jpg"},
+		{Token: "a", Km: 10000, ImageURL: "https://img.yad2.co.il/a.jpg", City: "Tel Aviv"},
+		{Token: "b", Km: 20000, ImageURL: "https://img.yad2.co.il/b.jpg", City: "Haifa"},
 	}
 
 	count := enricher.Enrich(context.Background(), listings)
 	if count != 0 {
-		t.Errorf("enriched = %d, want 0 (all have km and image)", count)
+		t.Errorf("enriched = %d, want 0 (all have km, image, and city)", count)
 	}
 	if got := requestCount.Load(); got != 0 {
 		t.Errorf("requests = %d, want 0 (no fetches needed)", got)
@@ -177,7 +177,7 @@ func TestEnricher_AllHaveKm(t *testing.T) {
 func TestEnricher_FillsMissingImageOnly(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
-{"props":{"pageProps":{"itemData":{"km":50000,"coverImage":"https://img.yad2.co.il/test.jpg"}}}}
+{"props":{"pageProps":{"itemData":{"km":50000,"coverImage":"https://img.yad2.co.il/test.jpg","address":{"city":{"text":"חיפה","textEng":"haifa"}}}}}}
 </script></html>`)
 	})
 
@@ -187,7 +187,7 @@ func TestEnricher_FillsMissingImageOnly(t *testing.T) {
 	})
 
 	listings := []model.RawListing{
-		{Token: "a", Km: 50000, ImageURL: ""},
+		{Token: "a", Km: 50000, ImageURL: "", City: "Haifa"},
 	}
 
 	count := enricher.Enrich(context.Background(), listings)
@@ -199,6 +199,51 @@ func TestEnricher_FillsMissingImageOnly(t *testing.T) {
 	}
 	if listings[0].Km != 50000 {
 		t.Errorf("listing[0].Km = %d, want 50000 (unchanged)", listings[0].Km)
+	}
+}
+
+func TestEnricher_FillsMissingCity(t *testing.T) {
+	enricher := newTestEnricher(t, itemPageHandler(75000), EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 10,
+	})
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 50000, ImageURL: "https://img.yad2.co.il/a.jpg", City: ""},
+		{Token: "b", Km: 50000, ImageURL: "https://img.yad2.co.il/b.jpg", City: "Haifa"},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 1 {
+		t.Errorf("enriched = %d, want 1 (only first needs city)", count)
+	}
+	if listings[0].City != "tel_aviv" {
+		t.Errorf("listing[0].City = %q, want tel_aviv", listings[0].City)
+	}
+	if listings[1].City != "Haifa" {
+		t.Errorf("listing[1].City = %q, want Haifa (unchanged)", listings[1].City)
+	}
+}
+
+func TestEnricher_FillsKmAndCity(t *testing.T) {
+	enricher := newTestEnricher(t, itemPageHandler(90000), EnricherConfig{
+		Delay:       time.Millisecond,
+		MaxPerCycle: 10,
+	})
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0, City: ""},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 1 {
+		t.Errorf("enriched = %d, want 1", count)
+	}
+	if listings[0].Km != 90000 {
+		t.Errorf("listing[0].Km = %d, want 90000", listings[0].Km)
+	}
+	if listings[0].City != "tel_aviv" {
+		t.Errorf("listing[0].City = %q, want tel_aviv", listings[0].City)
 	}
 }
 

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -128,7 +128,7 @@ func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
-		if v != "" {
+		if strings.TrimSpace(v) != "" {
 			return v
 		}
 	}

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -14,6 +14,8 @@ var itemNextDataRe = regexp.MustCompile(`(?is)<script[^>]*\bid=["']__NEXT_DATA__
 type ItemDetails struct {
 	Km       int
 	ImageURL string
+	City     string
+	Area     string
 }
 
 // ParseItemPage extracts listing details (primarily km) from a Yad2 item page.
@@ -102,14 +104,35 @@ type itemPageData struct {
 	Km         int    `json:"km"`
 	Kilometer  int    `json:"kilometer"`
 	CoverImage string `json:"coverImage"`
+	Address    struct {
+		City struct {
+			Text    string `json:"text"`
+			TextEng string `json:"textEng"`
+		} `json:"city"`
+		Area struct {
+			Text    string `json:"text"`
+			TextEng string `json:"textEng"`
+		} `json:"area"`
+	} `json:"address"`
 }
 
 func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 	details := ItemDetails{
 		Km:       effectiveKm(d),
 		ImageURL: d.CoverImage,
+		City:     firstNonEmpty(d.Address.City.TextEng, d.Address.City.Text),
+		Area:     firstNonEmpty(d.Address.Area.TextEng, d.Address.Area.Text),
 	}
-	return details, details.Km > 0 || details.ImageURL != ""
+	return details, details.Km > 0 || details.ImageURL != "" || details.City != ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func effectiveKm(d itemPageData) int {

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -123,7 +123,7 @@ func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 		City:     firstNonEmpty(d.Address.City.TextEng, d.Address.City.Text),
 		Area:     firstNonEmpty(d.Address.Area.TextEng, d.Address.Area.Text),
 	}
-	return details, details.Km > 0 || details.ImageURL != "" || details.City != ""
+	return details, details.Km > 0 || details.ImageURL != "" || details.City != "" || details.Area != ""
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/fetcher/yad2/item_parser_test.go
+++ b/internal/fetcher/yad2/item_parser_test.go
@@ -59,6 +59,58 @@ func TestParseItemPage_NoScript(t *testing.T) {
 	}
 }
 
+func TestParseItemPage_WithAddress(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 237000,
+  "coverImage": "https://img.yad2.co.il/test.jpg",
+  "address": {
+    "city": {"id": "1724", "text": "נצרת", "textEng": "nazareth"},
+    "area": {"id": 91, "text": "אזור נצרת", "textEng": "nazareth_area"}
+  }
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.Km != 237000 {
+		t.Errorf("km = %d, want 237000", details.Km)
+	}
+	if details.City != "nazareth" {
+		t.Errorf("city = %q, want nazareth (textEng preferred)", details.City)
+	}
+	if details.Area != "nazareth_area" {
+		t.Errorf("area = %q, want nazareth_area", details.Area)
+	}
+}
+
+func TestParseItemPage_AddressHebrewFallback(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 100000,
+  "address": {
+    "city": {"id": "5000", "text": "תל אביב"},
+    "area": {"id": 2, "text": "מרכז"}
+  }
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.City != "תל אביב" {
+		t.Errorf("city = %q, want Hebrew fallback", details.City)
+	}
+	if details.Area != "מרכז" {
+		t.Errorf("area = %q, want Hebrew fallback", details.Area)
+	}
+}
+
 func TestParseItemPage_NoKm(t *testing.T) {
 	html := `<html><body>
 <script id="__NEXT_DATA__" type="application/json">

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -171,7 +171,7 @@ func itemToListing(raw json.RawMessage) (model.RawListing, error) {
 		Price:        item.Price,
 		Description:  item.MetaData.Description,
 		ImageURL:     item.MetaData.CoverImage,
-		PageLink:     fmt.Sprintf("https://www.yad2.co.il/item/%s", item.Token),
+		PageLink:     fmt.Sprintf("https://www.yad2.co.il/vehicles/item/%s", item.Token),
 	}
 
 	listing.City = textFromField(item.Address.City)

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -63,7 +63,7 @@ func TestParseListingsPage_ValidHTML(t *testing.T) {
 	if l.Price != 95000 {
 		t.Errorf("price = %d, want 95000", l.Price)
 	}
-	if l.PageLink != "https://www.yad2.co.il/item/test-token-1" {
+	if l.PageLink != "https://www.yad2.co.il/vehicles/item/test-token-1" {
 		t.Errorf("link = %q", l.PageLink)
 	}
 }
@@ -292,6 +292,60 @@ func TestParseNextData_CityTextEngFallback(t *testing.T) {
 	}
 	if listings[0].Area != "North" {
 		t.Errorf("area = %q, want 'North' (textEng fallback)", listings[0].Area)
+	}
+}
+
+func TestParseNextData_NewFeedFormat(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "new-fmt-1",
+				 "manufacturer": {"id": 17, "text": "הונדה"},
+				 "model": {"id": 10182, "text": "סיוויק"},
+				 "subModel": {"id": 103617, "text": "Sport אוט׳ 1.8"},
+				 "vehicleDates": {"yearOfProduction": 2010},
+				 "engineType": {"id": 1101, "text": "בנזין"},
+				 "engineVolume": 1799,
+				 "hand": {"id": 2, "text": "יד שניה"},
+				 "price": 16200,
+				 "address": {"area": {"id": 91, "text": "אזור נצרת"}},
+				 "metaData": {"coverImage": "https://img.yad2.co.il/test.jpg"}}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+
+	l := listings[0]
+	if l.Manufacturer != "הונדה" {
+		t.Errorf("manufacturer = %q, want Hebrew fallback", l.Manufacturer)
+	}
+	if l.ManufacturerID != 17 {
+		t.Errorf("manufacturer_id = %d, want 17", l.ManufacturerID)
+	}
+	if l.Year != 2010 {
+		t.Errorf("year = %d, want 2010 (from vehicleDates)", l.Year)
+	}
+	if l.EngineVolume != 1799 {
+		t.Errorf("engine = %f, want 1799 (from engineVolume)", l.EngineVolume)
+	}
+	if l.Km != 0 {
+		t.Errorf("km = %d, want 0 (not in new feed format)", l.Km)
+	}
+	if l.Hand != 2 {
+		t.Errorf("hand = %d, want 2 (from field object)", l.Hand)
+	}
+	if l.City != "" {
+		t.Errorf("city = %q, want empty (not in feed)", l.City)
+	}
+	if l.Area != "אזור נצרת" {
+		t.Errorf("area = %q, want Hebrew area text", l.Area)
 	}
 }
 

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -76,7 +76,7 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 	if err != nil {
 		return ItemDetails{}, fmt.Errorf("parse base URL: %w", err)
 	}
-	base.Path = "/item/" + url.PathEscape(token)
+	base.Path = "/vehicles/item/" + url.PathEscape(token)
 	base.RawQuery = ""
 	itemURL := base.String()
 


### PR DESCRIPTION
## Summary

- **Root cause**: Yad2 changed their item page URL from `/item/{token}` to `/vehicles/item/{token}`, causing all enrichment requests to fail with HTTP 400. Since the listing feed no longer includes `km` or `city` data, enrichment is the only way to get these values — and it was silently broken.
- Fix the `FetchItem` URL path so enrichment works again, extracting KM from individual item pages
- Also extract `city` and `area` from the item page `address` object during enrichment (the feed only provides `area` in Hebrew)
- Update `PageLink` to use the correct `/vehicles/item/{token}` URL format

## What changed

| File | Change |
|------|--------|
| `yad2.go` | Fix `FetchItem` URL: `/item/` → `/vehicles/item/` |
| `item_parser.go` | Add `City`/`Area` to `ItemDetails`, parse from item page address |
| `enricher.go` | Enrich missing city alongside km/image |
| `parser.go` | Update `PageLink` format to new URL |
| `*_test.go` | Tests for new feed format, city enrichment, address parsing |

## How I debugged this

Scraped yad2 live for Honda 2010-2015 (40 listings). Key findings:
- Feed JSON has **no `km` field** at all (0/40 listings had KM)
- Feed JSON has **no `city`** in address (only `area`)
- Old item URL `/item/{token}` → **HTTP 400**
- New item URL `/vehicles/item/{token}` → **HTTP 200** with `km`, `city`, `area` data

## Test plan

- [x] All existing tests pass (54 tests in yad2 package)
- [x] New test: `TestParseNextData_NewFeedFormat` — verifies parsing of feed items without `km`/`city`
- [x] New test: `TestParseItemPage_WithAddress` — verifies city extraction with `textEng` preference
- [x] New test: `TestParseItemPage_AddressHebrewFallback` — verifies Hebrew fallback when no English
- [x] New test: `TestEnricher_FillsMissingCity` — verifies city-only enrichment
- [x] New test: `TestEnricher_FillsKmAndCity` — verifies combined km+city enrichment
- [x] Full suite: 81.3% coverage, golangci-lint clean

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listings now automatically populate city and area when missing; enrichment will fetch details if city, mileage, or images are absent.
  * Page links for vehicle items updated to the new site path so item pages are resolved consistently.

* **Tests**
  * Expanded coverage for address parsing and enrichment, including English/Hebrew fallbacks and combinations of missing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->