### PR TITLE
feat: Base44-style landing, sidebar, and dashboard search cards

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -236,12 +236,18 @@ func emailFromClaims(tok *fbauth.Token) string {
 }
 
 func chatIDFromContext(ctx context.Context) int64 {
-	id, _ := ctx.Value(chatIDKey).(int64)
+	id, ok := ctx.Value(chatIDKey).(int64)
+	if !ok {
+		return 0
+	}
 	return id
 }
 
 func emailFromContext(ctx context.Context) string {
-	e, _ := ctx.Value(emailKey).(string)
+	e, ok := ctx.Value(emailKey).(string)
+	if !ok {
+		return ""
+	}
 	return e
 }
 

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -52,6 +52,7 @@ export function SearchCard({
       )}
       onClick={() => navigate(listingsPath)}
       onKeyDown={(e) => {
+        if (e.currentTarget !== e.target) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           navigate(listingsPath);

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -95,6 +95,7 @@ export function SearchCard({
         <div
           className="flex items-center gap-1"
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
         >
           {isActive ? (
             <button
@@ -179,6 +180,7 @@ export function SearchCard({
         <div
           className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3"
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
         >
           <Button
             type="button"

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -36,7 +36,9 @@ export function SearchCard({
 
   const filterTags = [
     `${search.manufacturer_name} ${search.model_name}`.trim(),
-    `${search.year_min}–${search.year_max}`,
+    search.year_min !== 0 || search.year_max !== 0
+      ? `${search.year_min}–${search.year_max}`
+      : null,
     search.price_max > 0 ? `עד ${formatPrice(search.price_max)}` : null,
     search.max_km > 0 ? `עד ${formatKm(search.max_km)}` : null,
     search.max_hand > 0 ? `עד יד ${search.max_hand}` : null,

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -1,0 +1,203 @@
+import { useNavigate } from "react-router";
+import {
+  Play,
+  Pause,
+  Edit2,
+  Trash2,
+  Car,
+  ChevronLeft,
+} from "lucide-react";
+import { cn, formatKm, formatPrice, relativeTime } from "@/lib/utils";
+import type { Search } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+
+export type SearchCardProps = {
+  search: Search;
+  disabled?: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onDelete: () => void;
+  isConfirmingDelete: boolean;
+  onCancelDelete: () => void;
+};
+
+export function SearchCard({
+  search,
+  disabled,
+  onPause,
+  onResume,
+  onDelete,
+  isConfirmingDelete,
+  onCancelDelete,
+}: SearchCardProps) {
+  const navigate = useNavigate();
+  const isActive = search.active;
+  const listingsPath = `/searches/${search.id}/listings`;
+
+  const filterTags = [
+    `${search.manufacturer_name} ${search.model_name}`.trim(),
+    `${search.year_min}–${search.year_max}`,
+    search.price_max > 0 ? `עד ${formatPrice(search.price_max)}` : null,
+    search.max_km > 0 ? `עד ${formatKm(search.max_km)}` : null,
+    search.max_hand > 0 ? `עד יד ${search.max_hand}` : null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={cn(
+        "group card-hover cursor-pointer rounded-2xl border bg-card p-5 transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-primary",
+        isActive ? "border-border" : "border-border/50 opacity-75",
+      )}
+      onClick={() => navigate(listingsPath)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          navigate(listingsPath);
+        }
+      }}
+    >
+      <div className="mb-3 flex items-start justify-between">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div
+            className={cn(
+              "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl",
+              isActive ? "bg-primary/15" : "bg-muted",
+            )}
+          >
+            <Car
+              size={16}
+              className={
+                isActive ? "text-primary" : "text-muted-foreground"
+              }
+            />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-sm leading-tight font-semibold text-foreground">
+              {search.name}
+            </h3>
+            <div className="mt-0.5 flex items-center gap-1.5">
+              <div
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full",
+                  isActive ? "animate-pulse bg-success" : "bg-muted-foreground",
+                )}
+              />
+              <span className="text-xs text-muted-foreground">
+                {isActive ? "פעיל" : "מושהה"}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {isActive ? (
+            <button
+              type="button"
+              onClick={onPause}
+              disabled={disabled}
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+                "bg-warning/15 text-warning hover:bg-warning/25",
+              )}
+              aria-label="השהה חיפוש"
+            >
+              <Pause size={12} />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onResume}
+              disabled={disabled}
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+                "bg-success/15 text-success hover:bg-success/25",
+              )}
+              aria-label="חדש חיפוש"
+            >
+              <Play size={12} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => navigate(`/searches/${search.id}/edit`)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg bg-secondary text-muted-foreground transition-colors hover:bg-secondary/80 hover:text-foreground"
+            aria-label="ערוך חיפוש"
+          >
+            <Edit2 size={12} />
+          </button>
+          {!isConfirmingDelete ? (
+            <button
+              type="button"
+              onClick={onDelete}
+              disabled={disabled}
+              className="flex h-7 w-7 items-center justify-center rounded-lg bg-destructive/10 text-destructive transition-colors hover:bg-destructive/20"
+              aria-label="מחק חיפוש"
+            >
+              <Trash2 size={12} />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {filterTags.length > 0 ? (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {filterTags.map((tag, i) => (
+            <span
+              key={i}
+              className="text-secondary-foreground rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="border-border/60 flex items-center justify-between border-t pt-3">
+        <div className="text-center">
+          <div className="text-foreground text-base font-bold tabular-nums">
+            {search.listings_count ?? 0}
+          </div>
+          <div className="text-[10px] text-muted-foreground">מודעות</div>
+        </div>
+        <div className="flex items-center gap-1 text-xs text-muted-foreground/70">
+          <span>{relativeTime(search.created_at)}</span>
+          <ChevronLeft
+            size={13}
+            className="text-muted-foreground/40 transition-colors group-hover:text-primary/60"
+            aria-hidden
+          />
+        </div>
+      </div>
+
+      {isConfirmingDelete ? (
+        <div
+          className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={onDelete}
+            disabled={disabled}
+          >
+            אישור מחיקה
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onCancelDelete}
+          >
+            ביטול
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/landing/FeaturesSection.tsx
+++ b/web/src/components/landing/FeaturesSection.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react";
+import {
+  Bell,
+  TrendingDown,
+  SlidersHorizontal,
+  Zap,
+  Bookmark,
+  BarChart3,
+  Sparkles,
+} from "lucide-react";
+import { motion } from "motion/react";
+import { useInView } from "@/hooks/useInView";
+
+const features = [
+  {
+    icon: Bell,
+    title: "התראות מיידיות",
+    desc: "קבל התראה בטלגרם או בממשק תוך דקות מרגע שמודעה תואמת לחיפוש שלך.",
+    color: "text-primary",
+    bg: "bg-primary/10",
+    border: "border-primary/20",
+  },
+  {
+    icon: TrendingDown,
+    title: "מעקב מחירים",
+    desc: "CarWatch עוקבת אחר שינויי מחיר — תדע מיד כשמוכר מוריד מחיר.",
+    color: "text-success",
+    bg: "bg-success/10",
+    border: "border-success/20",
+  },
+  {
+    icon: SlidersHorizontal,
+    title: "פילטרים חכמים",
+    desc: "סנן לפי יצרן, דגם, שנה, מחיר, קילומטרז, יד ועוד — מדויק לצרכים שלך.",
+    color: "text-chart-4",
+    bg: "bg-chart-4/10",
+    border: "border-chart-4/20",
+  },
+  {
+    icon: Zap,
+    title: "סריקה אוטומטית",
+    desc: "המערכת סורקת את Yad2 ו-WinWin במקביל — ללא פעולה ידנית מצדך.",
+    color: "text-warning",
+    bg: "bg-warning/10",
+    border: "border-warning/20",
+  },
+  {
+    icon: Bookmark,
+    title: "מועדפים וארכיון",
+    desc: "שמור מודעות מעניינות לבדיקה מאוחרת, ועיין בהיסטוריית כל מה שנמצא.",
+    color: "text-chart-5",
+    bg: "bg-chart-5/10",
+    border: "border-chart-5/20",
+  },
+  {
+    icon: BarChart3,
+    title: "ניתוח שוק",
+    desc: "ראה כמה מודעות קיימות, מה הטווח הממוצע, ואיפה המחיר שאתה רואה ממוקם.",
+    color: "text-chart-2",
+    bg: "bg-chart-2/10",
+    border: "border-chart-2/20",
+  },
+  {
+    icon: Sparkles,
+    title: "Smart Match Score",
+    desc: "אלגוריתם חכם מדרג כל מודעה 0–10 לפי מחיר, ק\"מ, שנה ומצב — כדי שתראה קודם את הכי טוב.",
+    color: "text-primary",
+    bg: "bg-primary/10",
+    border: "border-primary/30",
+    highlight: true,
+  },
+];
+
+function FadeUp({
+  children,
+  delay = 0,
+}: {
+  children: ReactNode;
+  delay?: number;
+}) {
+  const { ref, inView } = useInView();
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 28 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ delay, duration: 0.6 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function FeaturesSection() {
+  return (
+    <section id="features" className="scroll-mt-24 px-6 py-24">
+      <div className="mx-auto max-w-5xl">
+        <FadeUp>
+          <div className="mb-16 text-center">
+            <span className="mb-3 block text-xs font-semibold tracking-widest text-primary uppercase">
+              יכולות
+            </span>
+            <h2 className="mb-4 text-3xl font-bold text-foreground md:text-4xl">
+              כל מה שצריך. כלום מיותר.
+            </h2>
+            <p className="mx-auto max-w-xl text-base text-muted-foreground">
+              כל הכלים שאתה צריך כדי למצוא את הרכב הבא שלך מהר יותר וחכם יותר.
+            </p>
+          </div>
+        </FadeUp>
+
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {features.map((f, i) => {
+            const Icon = f.icon;
+            return (
+              <FadeUp key={f.title} delay={i * 0.07}>
+                <div
+                  className={`card-hover group relative h-full overflow-hidden rounded-2xl border ${f.border} bg-card p-6 ${f.highlight ? "border-primary/40" : ""}`}
+                >
+                  {f.highlight ? (
+                    <div className="pointer-events-none absolute inset-0 bg-primary/3" />
+                  ) : null}
+                  <div
+                    className={`mb-4 flex h-11 w-11 items-center justify-center rounded-2xl ${f.bg} transition-transform group-hover:scale-110`}
+                  >
+                    <Icon size={20} className={f.color} />
+                  </div>
+                  <h3 className="mb-2 font-bold text-foreground">{f.title}</h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {f.desc}
+                  </p>
+                </div>
+              </FadeUp>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/landing/FinalCTA.tsx
+++ b/web/src/components/landing/FinalCTA.tsx
@@ -1,0 +1,55 @@
+import { Link } from "react-router";
+import { ArrowLeft, Zap } from "lucide-react";
+import { motion } from "motion/react";
+import { useInView } from "@/hooks/useInView";
+
+export function FinalCTA() {
+  const { ref, inView } = useInView(0.3);
+
+  return (
+    <section ref={ref} className="px-6 py-24">
+      <div className="mx-auto max-w-3xl">
+        <motion.div
+          initial={{ opacity: 0, y: 32, scale: 0.97 }}
+          animate={inView ? { opacity: 1, y: 0, scale: 1 } : {}}
+          transition={{ duration: 0.7 }}
+          className="relative overflow-hidden rounded-3xl border border-border bg-card p-10 text-center md:p-16"
+        >
+          <div className="pointer-events-none absolute inset-0">
+            <div className="absolute top-0 left-1/2 h-48 w-72 -translate-x-1/2 rounded-full bg-primary/12 blur-[80px]" />
+            <div className="absolute right-1/4 bottom-0 h-32 w-48 rounded-full bg-purple-500/8 blur-[60px]" />
+          </div>
+
+          <div className="landing-grid-bg-sm pointer-events-none absolute inset-0 opacity-[0.025]" />
+
+          <div className="relative z-10">
+            <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/25 bg-primary/15">
+              <Zap size={24} className="text-primary" />
+            </div>
+            <h2 className="mb-4 text-3xl leading-tight font-bold text-foreground md:text-5xl">
+              מוכן למצוא את
+              <br />
+              <span className="gradient-text">הרכב שלך?</span>
+            </h2>
+            <p className="mx-auto mb-10 max-w-md text-base leading-relaxed text-muted-foreground">
+              הצטרף לאלפי קונים שחוסכים זמן וכסף עם CarWatch. הגדרה תוך 2 דקות,
+              בלי כרטיס אשראי.
+            </p>
+            <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+              <Link
+                to="/signup"
+                className="flex items-center gap-2.5 rounded-2xl bg-primary px-8 py-4 text-base font-bold text-white shadow-2xl shadow-primary/30 transition-all hover:bg-primary/90 hover:shadow-primary/50 hover:active:translate-y-0 md:hover:-translate-y-0.5"
+              >
+                התחל לעקוב עכשיו
+                <ArrowLeft size={18} />
+              </Link>
+              <p className="text-sm text-muted-foreground">
+                חינמי לחלוטין · ללא הגבלת חיפושים
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -1,0 +1,213 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { ArrowLeft, Bell, TrendingDown } from "lucide-react";
+import { motion } from "motion/react";
+
+function FloatingCard({
+  className,
+  children,
+  delay = 0,
+}: {
+  className?: string;
+  children: ReactNode;
+  delay?: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay, duration: 0.6, ease: "easeOut" }}
+      className={`glass-card absolute rounded-2xl p-3.5 shadow-xl ${className ?? ""}`}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function HeroSection() {
+  return (
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden pt-16">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute top-1/4 right-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[120px]" />
+        <div className="absolute bottom-1/3 left-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[100px]" />
+        <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[150px]" />
+      </div>
+
+      <div className="landing-grid-bg pointer-events-none absolute inset-0 opacity-[0.03]" />
+
+      <div className="relative z-10 mx-auto max-w-5xl px-6 text-center">
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-8 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary"
+        >
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
+          מעקב רכבים חכם בישראל
+        </motion.div>
+
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1, duration: 0.7 }}
+          className="mb-6 text-5xl leading-tight font-bold text-foreground md:text-7xl"
+        >
+          עקוב אחר רכבים.
+          <br />
+          <span className="gradient-text">קבל התראה ראשון.</span>
+        </motion.h1>
+
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.7 }}
+          className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-muted-foreground md:text-xl"
+        >
+          CarWatch סורקת אלפי מודעות רכב בישראל ומתריאה לך מיד כשמופיע הרכב שחיפשת
+          — במחיר שתוכל להרשות לעצמך.
+        </motion.p>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3, duration: 0.6 }}
+          className="mb-16 flex flex-col items-center justify-center gap-4 sm:flex-row"
+        >
+          <Link
+            to="/signup"
+            className="flex items-center gap-2.5 rounded-2xl bg-primary px-7 py-3.5 text-base font-bold text-white shadow-2xl shadow-primary/25 transition-all hover:bg-primary/90 hover:shadow-primary/40 hover:active:translate-y-0 md:hover:-translate-y-0.5"
+          >
+            התחל לעקוב עכשיו
+            <ArrowLeft size={18} />
+          </Link>
+          <a
+            href="#how"
+            className="flex items-center gap-2 rounded-2xl border border-border px-6 py-3.5 text-sm font-medium text-muted-foreground transition-colors hover:border-border/80 hover:bg-secondary/50 hover:text-foreground"
+          >
+            איך זה עובד?
+          </a>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 40, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
+          className="relative mx-auto max-w-3xl"
+        >
+          <div className="glass-card rounded-3xl border border-border/80 p-6 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="h-2 w-2 animate-pulse rounded-full bg-success" />
+                <span className="text-xs font-medium text-muted-foreground">
+                  3 חיפושים פעילים
+                </span>
+              </div>
+              <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                עדכון אחרון: כרגע
+              </span>
+            </div>
+
+            <div className="space-y-3">
+              {[
+                {
+                  title: "טויוטה קורולה 2020–2022",
+                  count: 47,
+                  new: 3,
+                  price: "עד ₪120,000",
+                },
+                {
+                  title: "קיה ספורטאג׳ יד 2",
+                  count: 31,
+                  new: 1,
+                  price: "עד ₪180,000",
+                },
+                {
+                  title: "מזדה 3 אוטומט",
+                  count: 22,
+                  new: 0,
+                  price: "עד ₪140,000",
+                },
+              ].map((item, i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between rounded-xl bg-secondary/50 px-4 py-3"
+                >
+                  <div className="text-right">
+                    <p className="text-sm font-semibold text-foreground">
+                      {item.title}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {item.price}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">
+                      {item.count} מודעות
+                    </span>
+                    {item.new > 0 ? (
+                      <span className="rounded-full bg-primary px-2.5 py-0.5 text-xs font-bold text-white">
+                        {item.new} חדשות
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <FloatingCard className="-top-5 -left-8 max-w-xs md:-left-14" delay={0.8}>
+            <div className="flex items-start gap-2.5">
+              <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-primary/20">
+                <Bell size={13} className="text-primary" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-foreground">
+                  התראה חדשה!
+                </p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  טויוטה קורולה 2021 — ₪109,000
+                </p>
+                <p className="mt-1 text-[10px] text-primary">
+                  ₪11,000 מתחת לממוצע שוק
+                </p>
+              </div>
+            </div>
+          </FloatingCard>
+
+          <FloatingCard
+            className="-bottom-5 -right-8 md:-right-14"
+            delay={1.0}
+          >
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-success/20">
+                <TrendingDown size={13} className="text-success" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-foreground">ירידת מחיר</p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  מ-₪135,000 → ₪119,000
+                </p>
+              </div>
+            </div>
+          </FloatingCard>
+        </motion.div>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.5 }}
+        className="absolute bottom-8 left-1/2 flex -translate-x-1/2 flex-col items-center gap-1.5"
+      >
+        <span className="text-xs text-muted-foreground/50">גלול למטה</span>
+        <div className="flex h-8 w-5 items-start justify-center rounded-full border-2 border-border/50 p-1">
+          <motion.div
+            animate={{ y: [0, 10, 0] }}
+            transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
+            className="h-1.5 w-1 rounded-full bg-muted-foreground/50"
+          />
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/web/src/components/landing/HowItWorks.tsx
+++ b/web/src/components/landing/HowItWorks.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import { Search, Bell, Car } from "lucide-react";
+import { useInView } from "@/hooks/useInView";
+
+const steps = [
+  {
+    num: "01",
+    icon: Search,
+    title: "הגדר חיפוש",
+    desc: "בחר יצרן, דגם, טווח מחירים, שנה וקילומטרז. קח שתי דקות — פעם אחת.",
+    color: "text-primary",
+    bg: "bg-primary/10",
+    glow: "shadow-primary/20",
+  },
+  {
+    num: "02",
+    icon: Bell,
+    title: "קבל התראות",
+    desc: "כשמופיעה מודעה תואמת — תקבל הודעה מיידית. אתה תמיד ראשון.",
+    color: "text-warning",
+    bg: "bg-warning/10",
+    glow: "shadow-warning/20",
+  },
+  {
+    num: "03",
+    icon: Car,
+    title: "קנה חכם",
+    desc: "ראה את כל הפרטים, השווה למחיר שוק, ועשה עסקה מעמדת כוח.",
+    color: "text-success",
+    bg: "bg-success/10",
+    glow: "shadow-success/20",
+  },
+];
+
+function FadeUp({
+  children,
+  delay = 0,
+}: {
+  children: ReactNode;
+  delay?: number;
+}) {
+  const { ref, inView } = useInView();
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 28 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ delay, duration: 0.6 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function HowItWorks() {
+  return (
+    <section id="how" className="relative scroll-mt-24 overflow-hidden px-6 py-24">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-secondary/15 to-transparent" />
+      <div className="relative mx-auto max-w-5xl">
+        <FadeUp>
+          <div className="mb-16 text-center">
+            <span className="mb-3 block text-xs font-semibold tracking-widest text-primary uppercase">
+              שלושה צעדים
+            </span>
+            <h2 className="text-3xl font-bold text-foreground md:text-4xl">
+              פשוט כמו שנשמע
+            </h2>
+          </div>
+        </FadeUp>
+
+        <div className="relative grid gap-6 md:grid-cols-3">
+          <div className="pointer-events-none absolute top-14 right-[16.5%] left-[16.5%] hidden h-px bg-gradient-to-l from-transparent via-border to-transparent md:block" />
+
+          {steps.map((step, i) => {
+            const Icon = step.icon;
+            return (
+              <FadeUp key={step.num} delay={i * 0.15}>
+                <div className="relative flex flex-col items-center text-center">
+                  <div className="relative mb-6">
+                    <div
+                      className={`relative z-10 flex h-16 w-16 items-center justify-center rounded-2xl border border-border/50 ${step.bg} shadow-xl ${step.glow}`}
+                    >
+                      <Icon size={26} className={step.color} />
+                    </div>
+                    <span className="absolute -top-2 -right-2 z-20 flex h-6 w-6 items-center justify-center rounded-full border border-border bg-background text-[10px] font-bold text-muted-foreground">
+                      {step.num}
+                    </span>
+                  </div>
+                  <h3 className="mb-2 text-lg font-bold text-foreground">
+                    {step.title}
+                  </h3>
+                  <p className="max-w-xs text-sm leading-relaxed text-muted-foreground">
+                    {step.desc}
+                  </p>
+                </div>
+              </FadeUp>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/landing/LandingFooter.tsx
+++ b/web/src/components/landing/LandingFooter.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import { Car } from "lucide-react";
 
 export function LandingFooter({ version }: { version?: string | null }) {
+  const year = new Date().getFullYear();
   return (
     <footer className="border-border border-t px-6 py-10">
       <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 md:flex-row">
@@ -12,7 +13,7 @@ export function LandingFooter({ version }: { version?: string | null }) {
           <span className="text-sm font-bold text-foreground">CarWatch</span>
         </Link>
         <p className="text-center text-xs text-muted-foreground md:text-start">
-          © 2026 CarWatch · מעקב רכבים חכם בישראל
+          © {year} CarWatch · מעקב רכבים חכם בישראל
           {version ? ` · גרסה ${version}` : ""}
         </p>
         <Link

--- a/web/src/components/landing/LandingFooter.tsx
+++ b/web/src/components/landing/LandingFooter.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router";
+import { Car } from "lucide-react";
+
+export function LandingFooter({ version }: { version?: string | null }) {
+  return (
+    <footer className="border-border border-t px-6 py-10">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 md:flex-row">
+        <Link to="/welcome" className="flex items-center gap-2.5">
+          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary shadow shadow-primary/30">
+            <Car size={13} className="text-white" />
+          </div>
+          <span className="text-sm font-bold text-foreground">CarWatch</span>
+        </Link>
+        <p className="text-center text-xs text-muted-foreground md:text-start">
+          © 2026 CarWatch · מעקב רכבים חכם בישראל
+          {version ? ` · גרסה ${version}` : ""}
+        </p>
+        <Link
+          to="/login"
+          className="text-xs font-medium text-primary transition-colors hover:text-primary/80"
+        >
+          כניסה לאפליקציה ←
+        </Link>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/components/landing/LandingNav.tsx
+++ b/web/src/components/landing/LandingNav.tsx
@@ -11,6 +11,7 @@ export function LandingNav() {
 
   useEffect(() => {
     const fn = () => setScrolled(window.scrollY > 20);
+    fn();
     window.addEventListener("scroll", fn);
     return () => window.removeEventListener("scroll", fn);
   }, []);

--- a/web/src/components/landing/LandingNav.tsx
+++ b/web/src/components/landing/LandingNav.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+import { Car, Sun, Moon, Menu, X } from "lucide-react";
+import { useTheme } from "@/contexts/ThemeContext";
+import { cn } from "@/lib/utils";
+
+export function LandingNav() {
+  const { theme, toggle } = useTheme();
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    const fn = () => setScrolled(window.scrollY > 20);
+    window.addEventListener("scroll", fn);
+    return () => window.removeEventListener("scroll", fn);
+  }, []);
+
+  const links = [
+    { label: "תכונות", href: "#features" },
+    { label: "איך זה עובד", href: "#how" },
+    { label: "סטטיסטיקות", href: "#stats" },
+  ];
+
+  return (
+    <header
+      className={cn(
+        "fixed top-0 right-0 left-0 z-50 transition-all duration-300",
+        scrolled
+          ? "border-border/50 border-b bg-background/80 shadow-sm backdrop-blur-xl"
+          : "bg-transparent",
+      )}
+    >
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <Link to="/welcome" className="group flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-primary shadow-lg shadow-primary/40 transition-transform group-hover:scale-105">
+            <Car size={16} className="text-white" />
+          </div>
+          <span className="text-lg font-bold text-foreground">CarWatch</span>
+        </Link>
+
+        <nav className="hidden items-center gap-6 md:flex">
+          {links.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {l.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={toggle}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-all hover:bg-secondary hover:text-foreground"
+            aria-label={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
+          >
+            {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
+          </button>
+          <Link
+            to="/signup"
+            className="hidden items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90 hover:active:translate-y-0 md:flex md:hover:-translate-y-px"
+          >
+            התחל עכשיו
+          </Link>
+          <button
+            type="button"
+            onClick={() => setMobileOpen((o) => !o)}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:hidden"
+            aria-label={mobileOpen ? "סגור תפריט" : "פתח תפריט"}
+          >
+            {mobileOpen ? <X size={18} /> : <Menu size={18} />}
+          </button>
+        </div>
+      </div>
+
+      {mobileOpen ? (
+        <div className="border-border border-b bg-background/95 px-6 py-4 backdrop-blur-xl md:hidden">
+          <div className="space-y-3">
+            {links.map((l) => (
+              <a
+                key={l.href}
+                href={l.href}
+                onClick={() => setMobileOpen(false)}
+                className="block py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {l.label}
+              </a>
+            ))}
+            <Link
+              to="/signup"
+              onClick={() => setMobileOpen(false)}
+              className="mt-2 block w-full rounded-xl bg-primary py-2.5 text-center text-sm font-semibold text-white"
+            >
+              התחל עכשיו
+            </Link>
+          </div>
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/web/src/components/landing/LandingNav.tsx
+++ b/web/src/components/landing/LandingNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Link } from "react-router";
 import { Car, Sun, Moon, Menu, X } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 
 export function LandingNav() {
   const { theme, toggle } = useTheme();
+  const mobileMenuId = useId();
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -71,35 +72,41 @@ export function LandingNav() {
             onClick={() => setMobileOpen((o) => !o)}
             className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground md:hidden"
             aria-label={mobileOpen ? "סגור תפריט" : "פתח תפריט"}
+            aria-expanded={mobileOpen}
+            aria-controls={mobileMenuId}
           >
             {mobileOpen ? <X size={18} /> : <Menu size={18} />}
           </button>
         </div>
       </div>
 
-      {mobileOpen ? (
-        <div className="border-border border-b bg-background/95 px-6 py-4 backdrop-blur-xl md:hidden">
-          <div className="space-y-3">
-            {links.map((l) => (
-              <a
-                key={l.href}
-                href={l.href}
-                onClick={() => setMobileOpen(false)}
-                className="block py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {l.label}
-              </a>
-            ))}
-            <Link
-              to="/signup"
+      <div
+        id={mobileMenuId}
+        role="navigation"
+        aria-label="ניווט ראשי — נייד"
+        hidden={!mobileOpen}
+        className="border-border border-b bg-background/95 px-6 py-4 backdrop-blur-xl md:hidden"
+      >
+        <div className="space-y-3">
+          {links.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
               onClick={() => setMobileOpen(false)}
-              className="mt-2 block w-full rounded-xl bg-primary py-2.5 text-center text-sm font-semibold text-white"
+              className="block py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
-              התחל עכשיו
-            </Link>
-          </div>
+              {l.label}
+            </a>
+          ))}
+          <Link
+            to="/signup"
+            onClick={() => setMobileOpen(false)}
+            className="mt-2 block w-full rounded-xl bg-primary py-2.5 text-center text-sm font-semibold text-white"
+          >
+            התחל עכשיו
+          </Link>
         </div>
-      ) : null}
+      </div>
     </header>
   );
 }

--- a/web/src/components/landing/ProblemSolution.tsx
+++ b/web/src/components/landing/ProblemSolution.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import { X, Check } from "lucide-react";
+import { useInView } from "@/hooks/useInView";
+
+const problems = [
+  "רצת לאתר יד2 כל שעה כדי לא לפספס הזדמנות",
+  "מצאת רכב מצוין — אבל הוא כבר נמכר אתמול",
+  "שילמת יותר כי לא ידעת שהמחיר ירד",
+  "בזבזת שעות על מיון ידני של מאות מודעות",
+];
+
+const solutions = [
+  "CarWatch סורקת אוטומטית — אתה ישן בשקט",
+  "קבל התראה תוך דקות מרגע פרסום המודעה",
+  "מעקב מחירים חכם — תדע כשמחיר יורד",
+  "פילטרים מדויקים — רק מה שרלוונטי אליך",
+];
+
+function FadeUp({
+  children,
+  delay = 0,
+}: {
+  children: ReactNode;
+  delay?: number;
+}) {
+  const { ref, inView } = useInView();
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 24 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ delay, duration: 0.6 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function ProblemSolution() {
+  return (
+    <section className="relative overflow-hidden px-6 py-24">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-secondary/20 to-transparent" />
+      <div className="mx-auto max-w-5xl">
+        <FadeUp>
+          <div className="mb-16 text-center">
+            <span className="mb-3 block text-xs font-semibold tracking-widest text-primary uppercase">
+              הבעיה שפתרנו
+            </span>
+            <h2 className="text-3xl font-bold text-foreground md:text-4xl">
+              חיפוש רכב זה ניהול משרה נוספת
+            </h2>
+          </div>
+        </FadeUp>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <FadeUp delay={0.1}>
+            <div className="rounded-3xl border border-destructive/15 bg-destructive/5 p-7">
+              <div className="mb-6 flex items-center gap-2.5">
+                <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-destructive/15">
+                  <X size={16} className="text-destructive" />
+                </div>
+                <h3 className="text-base font-bold text-foreground">בלי CarWatch</h3>
+              </div>
+              <ul className="space-y-3.5">
+                {problems.map((p, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-3 text-sm text-muted-foreground"
+                  >
+                    <X
+                      size={14}
+                      className="mt-0.5 flex-shrink-0 text-destructive/70"
+                    />
+                    {p}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </FadeUp>
+
+          <FadeUp delay={0.2}>
+            <div className="relative overflow-hidden rounded-3xl border border-success/20 bg-success/5 p-7">
+              <div className="absolute top-0 right-0 h-32 w-32 translate-x-1/2 -translate-y-1/2 rounded-full bg-success/5" />
+              <div className="mb-6 flex items-center gap-2.5">
+                <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-success/15">
+                  <Check size={16} className="text-success" />
+                </div>
+                <h3 className="text-base font-bold text-foreground">עם CarWatch</h3>
+              </div>
+              <ul className="space-y-3.5">
+                {solutions.map((s, i) => (
+                  <li key={i} className="flex items-start gap-3 text-sm text-foreground">
+                    <Check size={14} className="mt-0.5 flex-shrink-0 text-success" />
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </FadeUp>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/landing/SmartScoreSection.tsx
+++ b/web/src/components/landing/SmartScoreSection.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { motion } from "motion/react";
-import { Sparkles, TrendingUp, Gauge, Calendar, Users, BadgeCheck } from "lucide-react";
+import { Sparkles, TrendingUp, Gauge, Calendar, Users } from "lucide-react";
 import { useInView } from "@/hooks/useInView";
 import {
   scoreListingAgainstSearch,
@@ -65,7 +65,7 @@ const factors = [
     icon: Gauge,
     label: "קילומטרז",
     desc: "פחות ק\"מ = עייפות פחותה = ציון גבוה יותר",
-    weight: "25%",
+    weight: "30%",
   },
   {
     icon: Calendar,
@@ -77,13 +77,7 @@ const factors = [
     icon: Users,
     label: "מספר ידיים",
     desc: "בעלים ראשון שווה ציון גבוה משמעותית",
-    weight: "15%",
-  },
-  {
-    icon: BadgeCheck,
-    label: "מצב כללי",
-    desc: "שקלול סינרגטי של גיל, שימוש, ובלאי כולל",
-    weight: "10%",
+    weight: "20%",
   },
 ];
 

--- a/web/src/components/landing/SmartScoreSection.tsx
+++ b/web/src/components/landing/SmartScoreSection.tsx
@@ -1,0 +1,259 @@
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import { Sparkles, TrendingUp, Gauge, Calendar, Users, BadgeCheck } from "lucide-react";
+import { useInView } from "@/hooks/useInView";
+import {
+  scoreListingAgainstSearch,
+  scoreColor,
+  scoreBgColor,
+  scoreLabel,
+  scoreBarColor,
+  type DemoListingInput,
+} from "@/lib/scoringAlgorithm";
+
+const demoSearch = {
+  year_min: 2018,
+  year_max: 2022,
+  price_max: 130000,
+  mileage_max: 120000,
+  hand_max: 2,
+};
+
+const demoListings: DemoListingInput[] = [
+  {
+    title: "טויוטה קורולה 2021",
+    year: 2021,
+    price: 119000,
+    mileage: 38000,
+    hand: 1,
+    city: "תל אביב",
+  },
+  {
+    title: "יונדאי i35 2020",
+    year: 2020,
+    price: 108000,
+    mileage: 72000,
+    hand: 2,
+    city: "חיפה",
+  },
+  {
+    title: "קיה ספורטאג׳ 2019",
+    year: 2019,
+    price: 143000,
+    mileage: 55000,
+    hand: 1,
+    city: "ירושלים",
+  },
+  {
+    title: "מזדה 3 2018",
+    year: 2018,
+    price: 91000,
+    mileage: 148000,
+    hand: 3,
+    city: 'ראשל"צ',
+  },
+];
+
+const factors = [
+  {
+    icon: TrendingUp,
+    label: "מחיר מול תקציב",
+    desc: "ציון גבוה לרכבים שנמצאים מתחת לתקציב שהגדרת",
+    weight: "30%",
+  },
+  {
+    icon: Gauge,
+    label: "קילומטרז",
+    desc: "פחות ק\"מ = עייפות פחותה = ציון גבוה יותר",
+    weight: "25%",
+  },
+  {
+    icon: Calendar,
+    label: "שנת ייצור",
+    desc: "רכבים חדשים יותר בטווח המבוקש מקבלים עדיפות",
+    weight: "20%",
+  },
+  {
+    icon: Users,
+    label: "מספר ידיים",
+    desc: "בעלים ראשון שווה ציון גבוה משמעותית",
+    weight: "15%",
+  },
+  {
+    icon: BadgeCheck,
+    label: "מצב כללי",
+    desc: "שקלול סינרגטי של גיל, שימוש, ובלאי כולל",
+    weight: "10%",
+  },
+];
+
+function FadeUp({
+  children,
+  delay = 0,
+}: {
+  children: ReactNode;
+  delay?: number;
+}) {
+  const { ref, inView } = useInView();
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 28 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ delay, duration: 0.6 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+function DemoCard({
+  listing,
+  delay,
+}: {
+  listing: DemoListingInput;
+  delay: number;
+}) {
+  const { ref, inView } = useInView();
+  const { score, breakdown } = scoreListingAgainstSearch(listing, demoSearch);
+  const color = scoreColor(score);
+  const bg = scoreBgColor(score);
+  const label = scoreLabel(score);
+  const bar = scoreBarColor(score);
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, x: 20 }}
+      animate={inView ? { opacity: 1, x: 0 } : {}}
+      transition={{ delay, duration: 0.5 }}
+      className="flex items-center gap-4 rounded-2xl border border-border bg-card p-4"
+    >
+      <div
+        className={`flex h-14 w-14 flex-shrink-0 flex-col items-center justify-center rounded-2xl border-2 font-bold ${bg} ${color}`}
+      >
+        <span className="text-xl leading-none">{score.toFixed(1)}</span>
+        <span className="mt-0.5 text-[9px] opacity-60">/10</span>
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {listing.title}
+        </p>
+        <p className={`mt-0.5 text-xs font-medium ${color}`}>{label}</p>
+        <div className="mt-2 flex gap-2">
+          {(
+            [
+              { key: "price" as const, label: "מחיר" },
+              { key: "mileage" as const, label: "ק״מ" },
+              { key: "year" as const, label: "שנה" },
+              { key: "hand" as const, label: "יד" },
+            ] as const
+          ).map((f) => (
+            <div key={f.key} className="flex flex-1 flex-col items-center gap-0.5">
+              <div className="h-1 w-full overflow-hidden rounded-full bg-secondary">
+                <div
+                  className={`h-full rounded-full ${bar}`}
+                  style={{ width: `${breakdown[f.key]}%` }}
+                />
+              </div>
+              <span className="text-[9px] text-muted-foreground">{f.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-shrink-0 text-sm font-bold text-primary">
+        ₪{listing.price.toLocaleString("he-IL")}
+      </div>
+    </motion.div>
+  );
+}
+
+export function SmartScoreSection() {
+  return (
+    <section className="relative overflow-hidden px-6 py-24">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute top-1/2 left-1/2 h-[300px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/6 blur-[100px]" />
+      </div>
+
+      <div className="relative mx-auto max-w-5xl">
+        <FadeUp>
+          <div className="mb-16 text-center">
+            <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-1.5 text-xs font-semibold tracking-widest text-primary uppercase">
+              <Sparkles size={12} />
+              חדש · Smart Match Score
+            </span>
+            <h2 className="mb-4 text-3xl font-bold text-foreground md:text-4xl">
+              לא רק לסנן —
+              <span className="gradient-text"> לדרג חכם.</span>
+            </h2>
+            <p className="mx-auto max-w-xl text-base leading-relaxed text-muted-foreground">
+              CarWatch מחשבת ציון 0–10 לכל מודעה על בסיס האלגוריתם שלנו — כך שתמיד תראה קודם את העסקאות הכי טובות עבורך.
+            </p>
+          </div>
+        </FadeUp>
+
+        <div className="grid items-start gap-10 md:grid-cols-2">
+          <div>
+            <FadeUp>
+              <div className="mb-4 flex items-center gap-2">
+                <span className="text-xs font-medium text-muted-foreground">
+                  דוגמה חיה — חיפוש: 2018–2022, עד ₪130K
+                </span>
+              </div>
+            </FadeUp>
+            <div className="space-y-3">
+              {demoListings.map((l, i) => (
+                <DemoCard key={l.title} listing={l} delay={i * 0.1} />
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <FadeUp>
+              <h3 className="mb-5 text-base font-bold text-foreground">
+                מה נכנס לחישוב?
+              </h3>
+            </FadeUp>
+            {factors.map((f, i) => {
+              const Icon = f.icon;
+              return (
+                <FadeUp key={f.label} delay={0.05 + i * 0.07}>
+                  <div className="flex items-start gap-3 rounded-xl border border-border bg-card p-4">
+                    <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-primary/10">
+                      <Icon size={16} className="text-primary" />
+                    </div>
+                    <div className="flex-1">
+                      <div className="mb-0.5 flex items-center justify-between">
+                        <span className="text-sm font-semibold text-foreground">
+                          {f.label}
+                        </span>
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary">
+                          {f.weight}
+                        </span>
+                      </div>
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        {f.desc}
+                      </p>
+                    </div>
+                  </div>
+                </FadeUp>
+              );
+            })}
+
+            <FadeUp delay={0.4}>
+              <div className="mt-2 rounded-xl border border-primary/15 bg-primary/5 p-4">
+                <p className="text-xs leading-relaxed text-primary/90">
+                  <span className="font-bold">ללא סף חריף.</span> כל הגורמים
+                  משתמשים בחישוב רציף עם דעיכה חלקה — כך שהציון תמיד מרגיש הגיוני
+                  ומוסבר.
+                </p>
+              </div>
+            </FadeUp>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/landing/StatsSection.tsx
+++ b/web/src/components/landing/StatsSection.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { useInView } from "@/hooks/useInView";
+
+/** Illustrative counters for marketing; replace when real metrics exist. */
+const stats = [
+  { value: 12000, suffix: "+", label: "מודעות נסרקות מדי יום", decimals: 0 },
+  {
+    value: 98,
+    suffix: "%",
+    label: "מהמשתמשים מוצאים רכב תוך שבועיים",
+    decimals: 0,
+  },
+  {
+    value: 3.5,
+    suffix: "K",
+    label: "חיפושים שמורים פעילים",
+    decimals: 1,
+  },
+  {
+    value: 4,
+    suffix: " דק׳",
+    label: "זמן ממוצע מפרסום לקבלת התראה",
+    decimals: 0,
+  },
+];
+
+function Counter({
+  target,
+  suffix,
+  decimals,
+  active,
+}: {
+  target: number;
+  suffix: string;
+  decimals: number;
+  active: boolean;
+}) {
+  const [val, setVal] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const duration = 1800;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setVal(eased * target);
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [active, target]);
+
+  const display =
+    decimals > 0
+      ? val.toFixed(decimals)
+      : Math.floor(val).toLocaleString("he-IL");
+  return (
+    <span>
+      {display}
+      {suffix}
+    </span>
+  );
+}
+
+function FadeUp({
+  children,
+  delay = 0,
+}: {
+  children: ReactNode;
+  delay?: number;
+}) {
+  const { ref, inView } = useInView();
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 20 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ delay, duration: 0.5 }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function StatsSection() {
+  const { ref, inView } = useInView(0.3);
+
+  return (
+    <section id="stats" ref={ref} className="scroll-mt-24 px-6 py-24">
+      <div className="mx-auto max-w-5xl">
+        <FadeUp>
+          <div className="mb-14 text-center">
+            <span className="mb-3 block text-xs font-semibold tracking-widest text-primary uppercase">
+              במספרים
+            </span>
+            <h2 className="text-3xl font-bold text-foreground md:text-4xl">
+              פלטפורמה שעובדת
+            </h2>
+          </div>
+        </FadeUp>
+
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {stats.map((s, i) => (
+            <FadeUp key={s.label} delay={i * 0.1}>
+              <div className="card-hover rounded-2xl border border-border bg-card p-6 text-center">
+                <div className="gradient-text mb-2 text-3xl font-bold tabular-nums md:text-4xl">
+                  <Counter
+                    target={s.value}
+                    suffix={s.suffix}
+                    decimals={s.decimals}
+                    active={inView}
+                  />
+                </div>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  {s.label}
+                </p>
+              </div>
+            </FadeUp>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/landing/index.ts
+++ b/web/src/components/landing/index.ts
@@ -1,0 +1,9 @@
+export { LandingNav } from "./LandingNav";
+export { HeroSection } from "./HeroSection";
+export { ProblemSolution } from "./ProblemSolution";
+export { FeaturesSection } from "./FeaturesSection";
+export { SmartScoreSection } from "./SmartScoreSection";
+export { HowItWorks } from "./HowItWorks";
+export { StatsSection } from "./StatsSection";
+export { FinalCTA } from "./FinalCTA";
+export { LandingFooter } from "./LandingFooter";

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -1,12 +1,12 @@
 import { Outlet, Link, useLocation } from "react-router";
 import {
-  Search,
+  LayoutDashboard,
   Plus,
   Car,
   Settings,
   Wrench,
   Bookmark,
-  Clock,
+  History,
   Bell,
   LogOut,
   Sun,
@@ -21,14 +21,25 @@ import { ConnectionBanner } from "@/components/ui/ConnectionBanner";
 import { cn } from "@/lib/utils";
 
 const navItems = [
-  { path: "/", label: "חיפושים", icon: Search, mobile: true },
-  { path: "/searches/new", label: "חיפוש חדש", icon: Plus, mobile: false },
-  { path: "/saved", label: "שמורים", icon: Bookmark, mobile: true },
-  { path: "/history", label: "היסטוריה", icon: Clock, mobile: true },
-  { path: "/notifications", label: "התראות", icon: Bell, badge: true, mobile: true },
+  { path: "/", label: "לוח בקרה", icon: LayoutDashboard, mobile: true },
+  { path: "/searches/new", label: "חיפוש חדש", icon: Plus, mobile: true },
+  { path: "/saved", label: "מועדפים", icon: Bookmark, mobile: true },
+  { path: "/history", label: "היסטוריה", icon: History, mobile: true },
+  {
+    path: "/notifications",
+    label: "התראות",
+    icon: Bell,
+    badge: true,
+    mobile: true,
+  },
   { path: "/settings", label: "הגדרות", icon: Settings, mobile: true },
   { path: "/admin", label: "ניהול", icon: Wrench, mobile: false },
 ];
+
+function isNavActive(pathname: string, path: string): boolean {
+  if (path === "/") return pathname === "/";
+  return pathname === path || pathname.startsWith(`${path}/`);
+}
 
 export function Shell() {
   const location = useLocation();
@@ -44,17 +55,17 @@ export function Shell() {
   return (
     <div className="min-h-screen bg-background">
       <ConnectionBanner status={connectionStatus} />
-      <aside className="fixed inset-y-0 right-0 z-50 hidden w-64 flex-col border-l border-sidebar-border bg-sidebar md:flex">
-        <div className="flex items-center gap-3 px-5 py-5 border-b border-sidebar-border">
-          <div className="relative w-10 h-10 shrink-0 rounded-xl bg-sidebar-primary flex items-center justify-center shadow-lg shadow-sidebar-primary/40">
-            <Car className="w-5 h-5 text-white" />
+      <aside className="border-sidebar-border bg-sidebar fixed inset-y-0 right-0 z-40 hidden h-full w-64 flex-col border-l md:flex">
+        <div className="border-sidebar-border flex items-center gap-3 border-b px-5 py-5">
+          <div className="bg-sidebar-primary relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl shadow-lg shadow-sidebar-primary/40">
+            <Car className="h-5 w-5 text-white" />
             <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-white/20 to-transparent" />
           </div>
-          <div className="flex-1 min-w-0">
-            <h1 className="font-bold text-base text-white leading-none tracking-tight">
+          <div className="min-w-0 flex-1">
+            <h1 className="text-base leading-none font-bold tracking-tight text-white">
               CarWatch
             </h1>
-            <p className="text-xs text-sidebar-foreground/60 mt-0.5">
+            <p className="mt-0.5 text-xs text-sidebar-foreground/60">
               מעקב רכבים חכם
             </p>
           </div>
@@ -62,20 +73,17 @@ export function Shell() {
             type="button"
             onClick={toggleTheme}
             aria-label={theme === "dark" ? "הפעל מצב בהיר" : "הפעל מצב כהה"}
-            className="w-7 h-7 shrink-0 rounded-lg bg-sidebar-accent flex items-center justify-center text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent/80 transition-all"
+            className="bg-sidebar-accent text-sidebar-foreground/60 hover:bg-sidebar-accent/80 hover:text-sidebar-foreground flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-all"
             title={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
           >
             {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
           </button>
         </div>
 
-        <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
+        <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-4">
           {navItems.map((item) => {
             const Icon = item.icon;
-            const isActive =
-              item.path === "/"
-                ? location.pathname === "/"
-                : location.pathname.startsWith(item.path);
+            const active = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;
 
             return (
@@ -83,64 +91,64 @@ export function Shell() {
                 key={item.path}
                 to={item.path}
                 className={cn(
-                  "flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-150",
-                  isActive
+                  "nav-active-pill flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-all duration-150",
+                  active
                     ? "bg-sidebar-primary/15 text-white"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-white hover:translate-x-[-2px]",
+                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-white",
                 )}
               >
                 <Icon
                   size={17}
                   className={cn(
                     "shrink-0 transition-colors",
-                    isActive
+                    active
                       ? "text-sidebar-primary"
                       : "text-sidebar-foreground/70",
                   )}
                 />
                 <span className="relative">
                   {item.label}
-                  {showBadge && (
+                  {showBadge ? (
                     <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
                       {unread > 99 ? "99+" : unread}
                     </span>
-                  )}
+                  ) : null}
                 </span>
-                {isActive && (
-                  <div className="mr-auto w-1.5 h-1.5 rounded-full bg-sidebar-primary shadow-sm shadow-sidebar-primary/60" />
-                )}
+                {active ? (
+                  <div className="bg-sidebar-primary mr-auto h-1.5 w-1.5 rounded-full shadow-sm shadow-primary/60" />
+                ) : null}
               </Link>
             );
           })}
         </nav>
 
-        {unread > 0 && (
-          <div className="px-4 py-4 border-t border-sidebar-border">
+        {unread > 0 ? (
+          <div className="border-sidebar-border border-t px-4 py-4">
             <Link
               to="/notifications"
-              className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl bg-sidebar-primary/10 border border-sidebar-primary/20 transition-colors hover:bg-sidebar-primary/15"
+              className="border-sidebar-primary/20 bg-sidebar-primary/10 hover:bg-sidebar-primary/15 flex items-center gap-2.5 rounded-xl border px-3 py-2.5 transition-colors"
             >
               <div className="relative">
-                <Bell className="w-4 h-4 text-sidebar-primary" />
-                <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-sidebar-primary animate-pulse-soft" />
+                <Bell className="text-sidebar-primary h-4 w-4" />
+                <span className="bg-sidebar-primary absolute -top-1 -right-1 h-2 w-2 animate-pulse-glow rounded-full" />
               </div>
-              <span className="text-xs text-sidebar-primary font-medium">
+              <span className="text-sidebar-primary text-xs font-medium">
                 התראות פעילות
               </span>
-              <span className="mr-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-sidebar-primary px-1 text-xs font-bold text-white shadow shadow-sidebar-primary/30">
+              <span className="bg-sidebar-primary mr-auto flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-xs font-bold text-white shadow shadow-primary/30">
                 {unread > 99 ? "99+" : unread}
               </span>
             </Link>
           </div>
-        )}
+        ) : null}
 
-        <div className="shrink-0 border-t border-sidebar-border p-4">
+        <div className="border-sidebar-border shrink-0 border-t p-4">
           <div className="mb-3 flex items-center gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-sm font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
+            <div className="bg-sidebar-accent text-sidebar-foreground ring-sidebar-border flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-semibold ring-1">
               {emailInitial}
             </div>
             <p
-              className="min-w-0 flex-1 truncate text-xs text-sidebar-foreground/60"
+              className="text-sidebar-foreground/60 min-w-0 flex-1 truncate text-xs"
               title={user?.email ?? undefined}
             >
               {user?.email ?? ""}
@@ -149,16 +157,19 @@ export function Shell() {
           <button
             type="button"
             onClick={() => void signOut()}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent/50 px-3 py-2.5 text-sm font-medium text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-white"
+            className="border-sidebar-border bg-sidebar-accent/50 text-sidebar-foreground hover:bg-sidebar-accent hover:text-white flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors"
           >
             <LogOut className="h-4 w-4" aria-hidden />
             התנתק
           </button>
-          {appVersion && (
-            <p className="mt-2 text-center text-[10px] text-sidebar-foreground/30 tabular-nums">
-              v{appVersion}
+          {appVersion ? (
+            <p
+              className="mt-3 rounded-lg bg-sidebar-accent/80 px-2 py-1.5 text-center text-sm font-semibold tracking-wide text-sidebar-primary tabular-nums ring-1 ring-sidebar-border"
+              title={`גרסה ${appVersion}`}
+            >
+              גרסה {appVersion}
             </p>
-          )}
+          ) : null}
         </div>
       </aside>
 
@@ -174,10 +185,7 @@ export function Shell() {
         <div className="flex justify-around px-1 py-3 landscape:py-1.5">
           {navItems.filter((item) => item.mobile).map((item) => {
             const Icon = item.icon;
-            const isActive =
-              item.path === "/"
-                ? location.pathname === "/"
-                : location.pathname.startsWith(item.path);
+            const isActive = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;
 
             return (

--- a/web/src/hooks/useInView.ts
+++ b/web/src/hooks/useInView.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Intersection observer for scroll-triggered animations (marketing sections).
+ */
+export function useInView(threshold = 0.15) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const hit = entries.some((e) => e.isIntersecting);
+        if (hit) setInView(true);
+      },
+      { threshold },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [threshold]);
+
+  return { ref, inView };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -39,6 +39,12 @@
   --color-score-good: #F59E0B;
   --color-score-low: #64748B;
 
+  --color-success: #10B981;
+  --color-warning: #F59E0B;
+  --color-chart-2: #22C55E;
+  --color-chart-4: #A855F7;
+  --color-chart-5: #EC4899;
+
   --color-chart-purple: #A78BFA;
 
   --color-sidebar: #0F1119;
@@ -60,6 +66,7 @@
   --animate-fade-in: fade-in 0.4s ease-out;
   --animate-slide-up: slide-up 0.4s ease-out;
   --animate-pulse-soft: pulse-soft 2s ease-in-out infinite;
+  --animate-pulse-glow: pulse-glow 2s ease-in-out infinite;
 }
 
 /* Light mode (default) */
@@ -120,6 +127,17 @@
   50% { opacity: 0.6; }
 }
 
+@keyframes pulse-glow {
+  0%, 100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-sidebar-primary) 45%, transparent);
+  }
+  50% {
+    opacity: 0.85;
+    box-shadow: 0 0 10px 2px color-mix(in oklab, var(--color-sidebar-primary) 35%, transparent);
+  }
+}
+
 @utility shimmer-skeleton {
   background: linear-gradient(
     90deg,
@@ -129,6 +147,48 @@
   );
   background-size: 200% 100%;
   animation: shimmer 2s infinite;
+}
+
+@utility gradient-text {
+  background-image: linear-gradient(to left, var(--color-primary), #a855f7);
+  background-clip: text;
+  color: transparent;
+}
+
+@utility glass-card {
+  background-color: color-mix(in oklab, var(--color-card) 82%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+@utility card-hover {
+  transition-property: transform, box-shadow, border-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 200ms;
+
+  &:hover {
+    border-color: color-mix(in oklab, var(--color-primary) 28%, var(--color-border));
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px -18px color-mix(in oklab, var(--color-primary) 35%, transparent);
+  }
+}
+
+@utility landing-grid-bg {
+  background-image:
+    linear-gradient(color-mix(in oklab, var(--fg) 5%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklab, var(--fg) 5%, transparent) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+@utility landing-grid-bg-sm {
+  background-image:
+    linear-gradient(color-mix(in oklab, var(--fg) 5%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklab, var(--fg) 5%, transparent) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+@utility nav-active-pill {
+  border-radius: var(--radius-lg);
 }
 
 body {

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -57,15 +57,12 @@ export function scoreListingAgainstSearch(
         ? 1
         : 0.55;
 
-  const conditionFactor =
-    mileageFactor * 0.45 + yearFactor * 0.35 + handFactor * 0.2;
-
+  /* Weights match the “מה נכנס לחישוב?” copy on the landing page (30/30/20/20). */
   const combined =
     0.3 * priceFactor +
-    0.25 * mileageFactor +
+    0.3 * mileageFactor +
     0.2 * yearFactor +
-    0.15 * handFactor +
-    0.1 * conditionFactor;
+    0.2 * handFactor;
 
   const score = clamp01(combined) * 10;
 

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -1,0 +1,109 @@
+/**
+ * Demo scoring for landing-page Smart Match section only.
+ * Production listing scores may use different weights / inputs.
+ */
+
+export type DemoSearchCriteria = {
+  year_min: number;
+  year_max: number;
+  price_max: number;
+  mileage_max: number;
+  hand_max: number;
+};
+
+export type DemoListingInput = {
+  title: string;
+  year: number;
+  price: number;
+  mileage: number;
+  hand: number;
+  city: string;
+};
+
+export type ScoreBreakdownPct = {
+  price: number;
+  mileage: number;
+  year: number;
+  hand: number;
+};
+
+function clamp01(x: number): number {
+  return Math.max(0, Math.min(1, x));
+}
+
+export function scoreListingAgainstSearch(
+  listing: DemoListingInput,
+  search: DemoSearchCriteria,
+): { score: number; breakdown: ScoreBreakdownPct } {
+  const priceRatio =
+    search.price_max > 0 ? listing.price / search.price_max : 1;
+  const priceFactor = priceRatio <= 1 ? 1 : Math.exp(-(priceRatio - 1) * 3);
+
+  const kmRatio =
+    search.mileage_max > 0
+      ? clamp01(listing.mileage / search.mileage_max)
+      : 0;
+  const mileageFactor = Math.exp(-kmRatio * 2.2);
+
+  const span = Math.max(1, search.year_max - search.year_min);
+  const yearFactor = clamp01((listing.year - search.year_min) / span);
+
+  const handFactor =
+    search.hand_max > 0
+      ? Math.exp(
+          -Math.max(0, listing.hand - 1) / Math.max(1, search.hand_max),
+        )
+      : listing.hand <= 1
+        ? 1
+        : 0.55;
+
+  const conditionFactor =
+    mileageFactor * 0.45 + yearFactor * 0.35 + handFactor * 0.2;
+
+  const combined =
+    0.3 * priceFactor +
+    0.25 * mileageFactor +
+    0.2 * yearFactor +
+    0.15 * handFactor +
+    0.1 * conditionFactor;
+
+  const score = clamp01(combined) * 10;
+
+  return {
+    score,
+    breakdown: {
+      price: Math.round(priceFactor * 100),
+      mileage: Math.round(mileageFactor * 100),
+      year: Math.round(yearFactor * 100),
+      hand: Math.round(handFactor * 100),
+    },
+  };
+}
+
+export function scoreColor(score: number): string {
+  if (score >= 8.2) return "text-emerald-500";
+  if (score >= 6.5) return "text-amber-500";
+  if (score >= 4.5) return "text-orange-500";
+  return "text-red-500";
+}
+
+export function scoreBgColor(score: number): string {
+  if (score >= 8.2) return "bg-emerald-500/15 border-emerald-500/40";
+  if (score >= 6.5) return "bg-amber-500/15 border-amber-500/40";
+  if (score >= 4.5) return "bg-orange-500/15 border-orange-500/35";
+  return "bg-red-500/15 border-red-500/35";
+}
+
+export function scoreLabel(score: number): string {
+  if (score >= 8.5) return "מצוין";
+  if (score >= 7) return "טוב מאוד";
+  if (score >= 5.5) return "טוב";
+  return "חלש";
+}
+
+export function scoreBarColor(score: number): string {
+  if (score >= 8.2) return "bg-emerald-500";
+  if (score >= 6.5) return "bg-amber-500";
+  if (score >= 4.5) return "bg-orange-500";
+  return "bg-red-500";
+}

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
 import {
-  Car,
-  Bell,
-  TrendingDown,
-  Search,
-  Zap,
-  Shield,
-  ChevronLeft,
-  Globe,
-} from "lucide-react";
+  LandingNav,
+  HeroSection,
+  ProblemSolution,
+  FeaturesSection,
+  SmartScoreSection,
+  HowItWorks,
+  StatsSection,
+  FinalCTA,
+  LandingFooter,
+} from "@/components/landing";
 
 function useAppVersion() {
   const [version, setVersion] = useState<string | null>(null);
@@ -24,200 +24,23 @@ function useAppVersion() {
   return version;
 }
 
-const features = [
-  {
-    icon: Bell,
-    title: "התראות בזמן אמת",
-    desc: "קבל התראה מיידית בטלגרם ברגע שרכב חדש מתאים לחיפוש שלך מופיע.",
-  },
-  {
-    icon: TrendingDown,
-    title: "מעקב ירידת מחירים",
-    desc: "נעקוב אחרי שינויי מחיר ונודיע לך כשרכב שמעניין אותך יורד במחיר.",
-  },
-  {
-    icon: Search,
-    title: "סינון חכם",
-    desc: "הגדר חיפוש מדויק — יצרן, דגם, שנה, מחיר, קילומטראז׳, יד ועוד.",
-  },
-  {
-    icon: Globe,
-    title: "ריבוי מקורות",
-    desc: "סורקים את Yad2 ו-WinWin במקביל כדי שלא תפספס אף מודעה.",
-  },
-  {
-    icon: Zap,
-    title: "ציון התאמה",
-    desc: "כל מודעה מקבלת ציון התאמה לקריטריונים שלך — כדי שתראה קודם את הטובות ביותר.",
-  },
-  {
-    icon: Shield,
-    title: "ממשק מאובטח",
-    desc: "כניסה מאובטחת עם Google ו-Firebase. הנתונים שלך פרטיים ומוגנים.",
-  },
-];
-
-const steps = [
-  {
-    num: "1",
-    title: "הירשם",
-    desc: "צור חשבון בשניות עם Google או אימייל.",
-  },
-  {
-    num: "2",
-    title: "הגדר חיפוש",
-    desc: "בחר יצרן, דגם, טווח שנים ומחיר — ותן לנו לעבוד.",
-  },
-  {
-    num: "3",
-    title: "קבל התראות",
-    desc: "נשלח לך הודעה בטלגרם או בדאשבורד ברגע שמשהו חדש צץ.",
-  },
-];
-
 export function LandingPage() {
   const version = useAppVersion();
 
   return (
-    <div dir="rtl" className="min-h-screen bg-background text-foreground">
-      <div
-        className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(59,130,246,0.12),transparent)]"
-        aria-hidden
-      />
-
-      {/* Header */}
-      <header className="relative z-10 flex items-center justify-between px-6 py-5 sm:px-10">
-        <div className="flex items-center gap-3">
-          <div className="relative flex h-10 w-10 items-center justify-center rounded-xl bg-primary shadow-lg shadow-primary/30">
-            <Car className="h-5 w-5 text-white" />
-            <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-white/20 to-transparent" />
-          </div>
-          <div>
-            <span className="text-lg font-bold tracking-tight">CarWatch</span>
-            <span className="mr-1 text-xs text-muted-foreground">
-              מעקב רכבים חכם
-            </span>
-          </div>
-        </div>
-        <Link
-          to="/login"
-          className="rounded-xl bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
-        >
-          התחבר
-        </Link>
-      </header>
-
-      {/* Hero */}
-      <section className="relative z-10 mx-auto max-w-4xl px-6 pb-20 pt-16 text-center sm:px-10 sm:pt-24">
-        <h1 className="text-4xl font-extrabold leading-tight tracking-tight sm:text-5xl lg:text-6xl">
-          <span className="bg-gradient-to-l from-primary to-blue-400 bg-clip-text text-transparent">
-            מוצא לך רכב
-          </span>
-          <br />
-          <span>לפני כולם</span>
-        </h1>
-        <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
-          CarWatch סורק את לוחות הרכב המובילים בישראל, מסנן לפי הקריטריונים
-          שלך, ומתריע לך ברגע שעסקה טובה מופיעה — אוטומטית, 24/7.
-        </p>
-
-        <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-          <Link
-            to="/signup"
-            className="group inline-flex items-center gap-2 rounded-xl bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/25 transition-all hover:shadow-primary/40 hover:opacity-95"
-          >
-            התחל בחינם
-            <ChevronLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
-          </Link>
-          <Link
-            to="/login"
-            className="inline-flex items-center gap-2 rounded-xl border border-border bg-card px-7 py-3.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-          >
-            יש לי חשבון
-          </Link>
-        </div>
-      </section>
-
-      {/* Features */}
-      <section className="relative z-10 mx-auto max-w-6xl px-6 py-20 sm:px-10">
-        <h2 className="mb-4 text-center text-2xl font-bold sm:text-3xl">
-          למה CarWatch?
-        </h2>
-        <p className="mx-auto mb-14 max-w-xl text-center text-muted-foreground">
-          כל הכלים שאתה צריך כדי למצוא את הרכב הבא שלך — במקום אחד.
-        </p>
-
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {features.map((f) => {
-            const Icon = f.icon;
-            return (
-              <div
-                key={f.title}
-                className="group rounded-2xl border border-border/60 bg-card/80 p-6 backdrop-blur-sm transition-colors hover:border-primary/30 hover:bg-card"
-              >
-                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-                  <Icon className="h-5 w-5" />
-                </div>
-                <h3 className="mb-2 text-base font-semibold">{f.title}</h3>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  {f.desc}
-                </p>
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* How it works */}
-      <section className="relative z-10 mx-auto max-w-4xl px-6 py-20 sm:px-10">
-        <h2 className="mb-14 text-center text-2xl font-bold sm:text-3xl">
-          איך זה עובד?
-        </h2>
-        <div className="grid gap-8 sm:grid-cols-3">
-          {steps.map((s) => (
-            <div key={s.num} className="text-center">
-              <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-xl font-bold text-primary">
-                {s.num}
-              </div>
-              <h3 className="mb-2 text-lg font-semibold">{s.title}</h3>
-              <p className="text-sm leading-relaxed text-muted-foreground">
-                {s.desc}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="relative z-10 mx-auto max-w-3xl px-6 py-20 text-center sm:px-10">
-        <h2 className="mb-4 text-2xl font-bold sm:text-3xl">
-          מוכן לחסוך זמן בחיפוש?
-        </h2>
-        <p className="mx-auto mb-8 max-w-lg text-muted-foreground">
-          הצטרף עכשיו וקבל התראות על עסקאות טובות — לפני כולם.
-        </p>
-        <Link
-          to="/signup"
-          className="inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-3.5 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/25 transition-all hover:shadow-primary/40 hover:opacity-95"
-        >
-          התחל בחינם
-        </Link>
-      </section>
-
-      {/* Footer */}
-      <footer className="relative z-10 border-t border-border/40 px-6 py-8 text-center sm:px-10">
-        <div className="flex flex-col items-center gap-2">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Car className="h-4 w-4" />
-            <span>CarWatch — מעקב רכבים חכם</span>
-          </div>
-          {version && (
-            <span className="text-xs text-muted-foreground/60">
-              גרסה {version}
-            </span>
-          )}
-        </div>
-      </footer>
+    <div
+      dir="rtl"
+      className="min-h-screen overflow-x-hidden bg-background text-foreground"
+    >
+      <LandingNav />
+      <HeroSection />
+      <ProblemSolution />
+      <FeaturesSection />
+      <SmartScoreSection />
+      <HowItWorks />
+      <StatsSection />
+      <FinalCTA />
+      <LandingFooter version={version} />
     </div>
   );
 }

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -1,17 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router";
-import {
-  Plus,
-  Play,
-  Pause,
-  Trash2,
-  List,
-  Pencil,
-  Search as SearchIcon,
-  Activity,
-  Bell,
-  Car,
-} from "lucide-react";
+import { Plus, Search as SearchIcon, Activity, Bell, Car } from "lucide-react";
 import { motion } from "motion/react";
 import {
   useSearches,
@@ -23,11 +12,11 @@ import {
   useNotificationCount,
   useNotifications,
 } from "@/hooks/useNotifications";
-import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
-import type { Search, Listing } from "@/lib/api";
+import { formatPrice, relativeTime, cn } from "@/lib/utils";
+import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
-import { Badge } from "@/components/ui/Badge";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { SearchCard } from "@/components/SearchCard";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { SectionHeader } from "@/components/ui/SectionHeader";
 import { useToast } from "@/components/ui/Toast";
@@ -298,150 +287,6 @@ function StatCard({
         </div>
       </div>
       <p className="text-2xl sm:text-3xl font-bold tabular-nums text-foreground">{value}</p>
-    </div>
-  );
-}
-
-function SearchCard({
-  search,
-  disabled,
-  onPause,
-  onResume,
-  onDelete,
-  isConfirmingDelete,
-  onCancelDelete,
-}: {
-  search: Search;
-  disabled: boolean;
-  onPause: () => void;
-  onResume: () => void;
-  onDelete: () => void;
-  isConfirmingDelete: boolean;
-  onCancelDelete: () => void;
-}) {
-  return (
-    <div className="group rounded-2xl border border-border/50 bg-card p-5 transition-all duration-200 hover:border-border hover:shadow-[0_4px_24px_rgba(0,0,0,0.3)]">
-      <div className="flex items-start justify-between mb-3 gap-2">
-        <div className="min-w-0">
-          <h3 className="text-lg font-semibold">
-            {search.manufacturer_name} {search.model_name}
-          </h3>
-          <span className="text-xs text-muted-foreground">{search.source}</span>
-        </div>
-        <div className="flex shrink-0 items-start gap-2">
-          {(search.listings_count ?? 0) > 0 && (
-            <span
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-bold tabular-nums text-primary ring-1 ring-primary/20"
-              title="מספר מודעות שנמצאו בחיפוש"
-              aria-label={`מספר מודעות: ${search.listings_count!.toLocaleString("he-IL")}`}
-            >
-              <Car className="h-3 w-3" aria-hidden />
-              {search.listings_count!.toLocaleString("he-IL")}
-            </span>
-          )}
-          <Badge variant={search.active ? "success" : "warning"}>
-            {search.active ? "פעיל" : "מושהה"}
-          </Badge>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-2 text-sm text-muted-foreground mb-4">
-        <div>
-          שנים: {search.year_min}–{search.year_max}
-        </div>
-        {search.price_max > 0 && (
-          <div className="tabular-nums">עד {formatPrice(search.price_max)}</div>
-        )}
-        {search.max_km > 0 && (
-          <div className="tabular-nums">עד {formatKm(search.max_km)}</div>
-        )}
-        {search.max_hand > 0 && <div>עד יד {search.max_hand}</div>}
-      </div>
-
-      <div className="flex items-center gap-1.5 border-t border-border/50 pt-3">
-        <Button
-          as={Link}
-          to={`/searches/${search.id}/listings`}
-          variant="primary"
-          size="sm"
-          className="flex-1 sm:flex-none"
-        >
-          <List className="h-3.5 w-3.5" />
-          תוצאות
-        </Button>
-
-        <Button
-          as={Link}
-          to={`/searches/${search.id}/edit`}
-          variant="secondary"
-          size="icon"
-          className="h-8 w-8"
-          aria-label="ערוך חיפוש"
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </Button>
-
-        {search.active ? (
-          <Button
-            type="button"
-            variant="secondary"
-            size="icon"
-            className="h-8 w-8"
-            onClick={onPause}
-            disabled={disabled}
-            aria-label="השהה חיפוש"
-          >
-            <Pause className="h-3.5 w-3.5" />
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="secondary"
-            size="icon"
-            className="h-8 w-8"
-            onClick={onResume}
-            disabled={disabled}
-            aria-label="חדש חיפוש"
-          >
-            <Play className="h-3.5 w-3.5" />
-          </Button>
-        )}
-
-        <div className="mr-auto">
-          {isConfirmingDelete ? (
-            <div className="flex items-center gap-1">
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                onClick={onDelete}
-              >
-                אישור
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={onCancelDelete}
-              >
-                ביטול
-              </Button>
-            </div>
-          ) : (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-destructive hover:bg-destructive/10"
-              onClick={onDelete}
-              disabled={disabled}
-              aria-label="מחק חיפוש"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          )}
-        </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Ports the marketing experience and app chrome closer to the Base44 CarWatch reference: a sectioned **`/welcome`** page, an updated **desktop sidebar**, and a **dashboard search card** that matches the reference layout while staying on CarWatch routes and APIs.

## What changed

- **Landing (`/welcome`)**: New composable sections — sticky nav with anchors + theme toggle, hero with mock dashboard + floating alerts, problem/solution, feature grid (Yad2 + WinWin copy), Smart Match **demo** (client-side scoring only), how-it-works, illustrative stats counters, final CTA, footer with optional version from `/healthz`.
- **Design tokens / CSS**: `success`, `warning`, `chart-*`, `gradient-text`, `glass-card`, `card-hover`, landing grid backgrounds, `nav-active-pill`, `animate-pulse-glow`.
- **Hooks / lib**: `useInView` for scroll animations; `scoringAlgorithm.ts` for landing demo only (documented).
- **Dashboard**: New shared **`SearchCard`** — tag chips, stats row, toolbar (pause/resume/edit/delete with existing confirm flow); card opens listings; avoids nested links.
- **Shell sidebar**: Base44-style labels/icons (**לוח בקרה** + `LayoutDashboard`, **מועדפים**, `History`), shared **`isNavActive`**, notification strip uses **`animate-pulse-glow`**, **version** line is larger and higher-contrast.

## Verification

- `npm run build` (web)
- `make test`

## Related

- Tracks UI scope discussed in #401.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New landing sections (hero, features, how-it-works, stats, smart-match demo, CTA, footer) and a shared Search card with keyboard navigation, pause/resume, edit, and delete-confirm flows
  * Demo Smart-Match scoring shown in the SmartScore section
  * Added an in-view hook for scroll-triggered animations

* **Refactor**
  * Landing page composed from new landing components; searches page now uses the shared Search card

* **Design**
  * Extended color tokens, new utilities and a pulse-glow animation; updated navigation and sidebar layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->