### PR TITLE
feat(web): routing, match score tile, and Base44-style sidebar

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -45,10 +45,10 @@ type runtimeStats struct {
 
 func (s *Server) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		chatID := chatIDFromContext(r.Context())
+		chatID, chatOK := chatIDFromContext(r.Context())
 		email := emailFromContext(r.Context())
 
-		isAdmin := (s.cfg.AdminChatID != 0 && chatID == s.cfg.AdminChatID) ||
+		isAdmin := (chatOK && s.cfg.AdminChatID != 0 && chatID == s.cfg.AdminChatID) ||
 			(s.cfg.AdminEmail != "" && email != "" && email == s.cfg.AdminEmail)
 
 		if !isAdmin {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -235,12 +235,12 @@ func emailFromClaims(tok *fbauth.Token) string {
 	return fmt.Sprint(v)
 }
 
-func chatIDFromContext(ctx context.Context) int64 {
+func chatIDFromContext(ctx context.Context) (int64, bool) {
 	id, ok := ctx.Value(chatIDKey).(int64)
-	if !ok {
-		return 0
+	if !ok || id <= 0 {
+		return 0, false
 	}
-	return id
+	return id, true
 }
 
 func emailFromContext(ctx context.Context) string {
@@ -249,6 +249,15 @@ func emailFromContext(ctx context.Context) string {
 		return ""
 	}
 	return e
+}
+
+func requireChatID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, ok := chatIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "invalid user context")
+		return 0, false
+	}
+	return id, true
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -8,7 +8,10 @@ import (
 )
 
 func (s *Server) saveListing(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	token := r.PathValue("token")
 	if token == "" {
 		writeError(w, http.StatusBadRequest, "missing token")
@@ -24,7 +27,10 @@ func (s *Server) saveListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) unsaveListing(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	token := r.PathValue("token")
 	if token == "" {
 		writeError(w, http.StatusBadRequest, "missing token")
@@ -40,7 +46,10 @@ func (s *Server) unsaveListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	limit, offset := parsePagination(r)
 
 	listings, err := s.saved.ListSaved(r.Context(), chatID, limit, offset)
@@ -71,7 +80,10 @@ func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) hideListing(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	token := r.PathValue("token")
 	if token == "" {
 		writeError(w, http.StatusBadRequest, "missing token")
@@ -87,7 +99,10 @@ func (s *Server) hideListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) unhideListing(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	token := r.PathValue("token")
 	if token == "" {
 		writeError(w, http.StatusBadRequest, "missing token")
@@ -103,7 +118,10 @@ func (s *Server) unhideListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	limit, offset := parsePagination(r)
 
 	listings, err := s.listings.ListUserListings(r.Context(), chatID, limit, offset)

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -29,7 +29,10 @@ type listingsPageResponse struct {
 }
 
 func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	token := r.PathValue("token")
 	if token == "" {
 		writeError(w, http.StatusBadRequest, "missing token")
@@ -75,7 +78,10 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, okChat := requireChatID(w, r)
+	if !okChat {
+		return
+	}
 	id, ok := parsePathID(r)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid search id")

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -7,7 +7,10 @@ type notifCountResponse struct {
 }
 
 func (s *Server) notificationCount(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 
 	since, err := s.notifs.GetLastSeenAt(r.Context(), chatID)
 	if err != nil {
@@ -27,7 +30,10 @@ func (s *Server) notificationCount(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listNotifications(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	limit, offset := parsePagination(r)
 
 	since, err := s.notifs.GetLastSeenAt(r.Context(), chatID)
@@ -62,7 +68,10 @@ func (s *Server) listNotifications(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) markNotificationsSeen(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 
 	if err := s.users.UpdateLastSeenAt(r.Context(), chatID); err != nil {
 		s.logger.Error("update last seen at", "error", err)

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -61,8 +61,8 @@ func (rl *rateLimiter) allow(chatID int64) bool {
 
 func (s *Server) withRateLimit(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		chatID := chatIDFromContext(r.Context())
-		if chatID != 0 && !s.rl.allow(chatID) {
+		chatID, ok := chatIDFromContext(r.Context())
+		if ok && !s.rl.allow(chatID) {
 			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return
 		}

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -119,7 +119,10 @@ func (s *Server) searchResponseWithListingCount(ctx context.Context, chatID int6
 }
 
 func (s *Server) listSearches(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 	searches, err := s.searches.ListSearches(r.Context(), chatID)
 	if err != nil {
 		s.logger.Error("list searches", "error", err)
@@ -135,7 +138,10 @@ func (s *Server) listSearches(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
 
 	var req createSearchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -224,7 +230,10 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getSearch(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, okChat := requireChatID(w, r)
+	if !okChat {
+		return
+	}
 	id, ok := parsePathID(r)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid search id")
@@ -246,7 +255,10 @@ func (s *Server) getSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, okChat := requireChatID(w, r)
+	if !okChat {
+		return
+	}
 	id, ok := parsePathID(r)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid search id")
@@ -294,7 +306,10 @@ func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) deleteSearch(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, okChat := requireChatID(w, r)
+	if !okChat {
+		return
+	}
 	id, ok := parsePathID(r)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid search id")
@@ -323,7 +338,10 @@ func (s *Server) resumeSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) setSearchActive(w http.ResponseWriter, r *http.Request, active bool) {
-	chatID := chatIDFromContext(r.Context())
+	chatID, okChat := requireChatID(w, r)
+	if !okChat {
+		return
+	}
 	id, ok := parsePathID(r)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid search id")

--- a/internal/api/telegram.go
+++ b/internal/api/telegram.go
@@ -22,9 +22,8 @@ func (s *Server) postTelegramLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	chatID := chatIDFromContext(r.Context())
-	if chatID <= 0 {
-		writeError(w, http.StatusUnauthorized, "invalid or missing token")
+	chatID, ok := requireChatID(w, r)
+	if !ok {
 		return
 	}
 	token, err := s.linkTokens.CreateLinkToken(r.Context(), chatID)
@@ -42,9 +41,8 @@ func (s *Server) postTelegramLink(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getTelegramStatus(w http.ResponseWriter, r *http.Request) {
-	chatID := chatIDFromContext(r.Context())
-	if chatID <= 0 {
-		writeError(w, http.StatusUnauthorized, "invalid or missing token")
+	chatID, ok := requireChatID(w, r)
+	if !ok {
 		return
 	}
 	tgUser, err := s.users.GetLinkedTelegramUser(r.Context(), chatID)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,12 +19,12 @@ import { SettingsPage } from "./pages/SettingsPage";
 export default function App() {
   return (
     <Routes>
-      <Route path="/welcome" element={<LandingPage />} />
+      <Route path="/" element={<LandingPage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignupPage />} />
       <Route element={<ProtectedRoute />}>
         <Route element={<Shell />}>
-          <Route path="/" element={<SearchesPage />} />
+          <Route path="/dashboard" element={<SearchesPage />} />
           <Route path="/searches/new" element={<NewSearchPage />} />
           <Route path="/searches/:id/edit" element={<EditSearchPage />} />
           <Route path="/searches/:id/listings" element={<ListingsPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,42 +1,89 @@
+import { lazy, Suspense } from "react";
 import { Routes, Route } from "react-router";
+import { Loader2 } from "lucide-react";
 import { Shell } from "./components/layout/Shell";
 import { ProtectedRoute } from "./components/ProtectedRoute";
-import { SearchesPage } from "./pages/SearchesPage";
-import { NewSearchPage } from "./pages/NewSearchPage";
-import { ListingsPage } from "./pages/ListingsPage";
-import { ListingDetailPage } from "./pages/ListingDetailPage";
-import { AdminPage } from "./pages/AdminPage";
-import { SavedPage } from "./pages/SavedPage";
-import { HistoryPage } from "./pages/HistoryPage";
-import { NotificationsPage } from "./pages/NotificationsPage";
-import { LoginPage } from "./pages/LoginPage";
-import { SignupPage } from "./pages/SignupPage";
-import { EditSearchPage } from "./pages/EditSearchPage";
-import { NotFoundPage } from "./pages/NotFoundPage";
-import { LandingPage } from "./pages/LandingPage";
-import { SettingsPage } from "./pages/SettingsPage";
+
+const LandingPage = lazy(() =>
+  import("./pages/LandingPage").then((m) => ({ default: m.LandingPage })),
+);
+const LoginPage = lazy(() =>
+  import("./pages/LoginPage").then((m) => ({ default: m.LoginPage })),
+);
+const SignupPage = lazy(() =>
+  import("./pages/SignupPage").then((m) => ({ default: m.SignupPage })),
+);
+const SearchesPage = lazy(() =>
+  import("./pages/SearchesPage").then((m) => ({ default: m.SearchesPage })),
+);
+const NewSearchPage = lazy(() =>
+  import("./pages/NewSearchPage").then((m) => ({ default: m.NewSearchPage })),
+);
+const ListingsPage = lazy(() =>
+  import("./pages/ListingsPage").then((m) => ({ default: m.ListingsPage })),
+);
+const ListingDetailPage = lazy(() =>
+  import("./pages/ListingDetailPage").then((m) => ({
+    default: m.ListingDetailPage,
+  })),
+);
+const AdminPage = lazy(() =>
+  import("./pages/AdminPage").then((m) => ({ default: m.AdminPage })),
+);
+const SavedPage = lazy(() =>
+  import("./pages/SavedPage").then((m) => ({ default: m.SavedPage })),
+);
+const HistoryPage = lazy(() =>
+  import("./pages/HistoryPage").then((m) => ({ default: m.HistoryPage })),
+);
+const NotificationsPage = lazy(() =>
+  import("./pages/NotificationsPage").then((m) => ({
+    default: m.NotificationsPage,
+  })),
+);
+const EditSearchPage = lazy(() =>
+  import("./pages/EditSearchPage").then((m) => ({
+    default: m.EditSearchPage,
+  })),
+);
+const NotFoundPage = lazy(() =>
+  import("./pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })),
+);
+const SettingsPage = lazy(() =>
+  import("./pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
+);
+
+function PageFallback() {
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<LandingPage />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/signup" element={<SignupPage />} />
-      <Route element={<ProtectedRoute />}>
-        <Route element={<Shell />}>
-          <Route path="/dashboard" element={<SearchesPage />} />
-          <Route path="/searches/new" element={<NewSearchPage />} />
-          <Route path="/searches/:id/edit" element={<EditSearchPage />} />
-          <Route path="/searches/:id/listings" element={<ListingsPage />} />
-          <Route path="/listings/:token" element={<ListingDetailPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/admin" element={<AdminPage />} />
-          <Route path="/saved" element={<SavedPage />} />
-          <Route path="/history" element={<HistoryPage />} />
-          <Route path="/notifications" element={<NotificationsPage />} />
-          <Route path="*" element={<NotFoundPage />} />
+    <Suspense fallback={<PageFallback />}>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route element={<Shell />}>
+            <Route path="/dashboard" element={<SearchesPage />} />
+            <Route path="/searches/new" element={<NewSearchPage />} />
+            <Route path="/searches/:id/edit" element={<EditSearchPage />} />
+            <Route path="/searches/:id/listings" element={<ListingsPage />} />
+            <Route path="/listings/:token" element={<ListingDetailPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/admin" element={<AdminPage />} />
+            <Route path="/saved" element={<SavedPage />} />
+            <Route path="/history" element={<HistoryPage />} />
+            <Route path="/notifications" element={<NotificationsPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
         </Route>
-      </Route>
-    </Routes>
+      </Routes>
+    </Suspense>
   );
 }

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 import { Bookmark } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
+import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
+import { scoreColor, scoreLabel } from "@/lib/scoringAlgorithm";
 
 /**
  * Shared card body for listing display. When `hoverScale` is true the image
@@ -51,16 +53,27 @@ export function ListingCardBody({
       )}
 
       <div className="p-4">
-        <div className="flex items-start justify-between mb-2">
-          <div>
+        <div className="mb-2 flex items-start gap-3">
+          {listing.fitness_score != null ? (
+            <MatchScoreBox score={listing.fitness_score} size="md" />
+          ) : null}
+          <div className="min-w-0 flex-1">
             <h3 className="font-semibold text-card-foreground">
               {listing.manufacturer} {listing.model}
             </h3>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {listing.year}
-            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">{listing.year}</p>
+            {listing.fitness_score != null ? (
+              <p
+                className={cn(
+                  "mt-0.5 text-xs font-medium",
+                  scoreColor(listing.fitness_score),
+                )}
+              >
+                {scoreLabel(listing.fitness_score)}
+              </p>
+            ) : null}
           </div>
-          <span className="text-lg font-bold text-amber-500 dark:text-amber-400 tabular-nums">
+          <span className="shrink-0 text-lg font-bold tabular-nums text-primary">
             {formatPrice(listing.price)}
           </span>
         </div>
@@ -78,38 +91,12 @@ export function ListingCardBody({
         </div>
 
         <div className="flex items-center gap-2">
-          {listing.fitness_score != null && (
-            <FitnessChip score={listing.fitness_score} />
-          )}
-          <span className="text-xs text-muted-foreground mr-auto">
+          <span className="mr-auto text-xs text-muted-foreground">
             {relativeTime(listing.first_seen_at)}
           </span>
           {actions}
         </div>
       </div>
     </>
-  );
-}
-
-function FitnessChip({ score }: { score: number }) {
-  const tier =
-    score >= 7 ? "great" : score >= 5 ? "good" : "low";
-
-  const styles = {
-    great: "bg-score-great/15 text-score-great",
-    good: "bg-score-good/15 text-score-good",
-    low: "bg-score-low/15 text-score-low",
-  };
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold tabular-nums",
-        styles[tier],
-      )}
-    >
-      {score.toFixed(1)}
-      {tier === "great" && " ⭐"}
-    </span>
   );
 }

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router";
+import { useNavigate, Link } from "react-router";
 import {
   Play,
   Pause,
@@ -44,25 +44,24 @@ export function SearchCard({
     search.max_hand > 0 ? `עד יד ${search.max_hand}` : null,
   ].filter(Boolean) as string[];
 
+  const openCardClassName =
+    "rounded-lg outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary";
+
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <article
       className={cn(
-        "group card-hover cursor-pointer rounded-2xl border bg-card p-5 transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-primary",
+        "group card-hover rounded-2xl border bg-card p-5 transition-all duration-200",
         isActive ? "border-border" : "border-border/50 opacity-75",
       )}
-      onClick={() => navigate(listingsPath)}
-      onKeyDown={(e) => {
-        if (e.currentTarget !== e.target) return;
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          navigate(listingsPath);
-        }
-      }}
     >
-      <div className="mb-3 flex items-start justify-between">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <Link
+          to={listingsPath}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-3",
+            openCardClassName,
+          )}
+        >
           <div
             className={cn(
               "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl",
@@ -92,13 +91,9 @@ export function SearchCard({
               </span>
             </div>
           </div>
-        </div>
+        </Link>
 
-        <div
-          className="flex items-center gap-1"
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
+        <div className="flex shrink-0 items-center gap-1">
           {isActive ? (
             <button
               type="button"
@@ -149,19 +144,30 @@ export function SearchCard({
       </div>
 
       {filterTags.length > 0 ? (
-        <div className="mb-3 flex flex-wrap gap-1.5">
-          {filterTags.map((tag, i) => (
-            <span
-              key={i}
-              className="text-secondary-foreground rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
+        <Link
+          to={listingsPath}
+          className={cn("mb-3 block", openCardClassName)}
+        >
+          <div className="flex flex-wrap gap-1.5">
+            {filterTags.map((tag, i) => (
+              <span
+                key={i}
+                className="text-secondary-foreground rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </Link>
       ) : null}
 
-      <div className="border-border/60 flex items-center justify-between border-t pt-3">
+      <Link
+        to={listingsPath}
+        className={cn(
+          "border-border/60 flex items-center justify-between border-t pt-3",
+          openCardClassName,
+        )}
+      >
         <div className="text-center">
           <div className="text-foreground text-base font-bold tabular-nums">
             {search.listings_count ?? 0}
@@ -176,14 +182,10 @@ export function SearchCard({
             aria-hidden
           />
         </div>
-      </div>
+      </Link>
 
       {isConfirmingDelete ? (
-        <div
-          className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3"
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
+        <div className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3">
           <Button
             type="button"
             variant="destructive"
@@ -203,6 +205,6 @@ export function SearchCard({
           </Button>
         </div>
       ) : null}
-    </div>
+    </article>
   );
 }

--- a/web/src/components/landing/LandingFooter.tsx
+++ b/web/src/components/landing/LandingFooter.tsx
@@ -6,7 +6,7 @@ export function LandingFooter({ version }: { version?: string | null }) {
   return (
     <footer className="border-border border-t px-6 py-10">
       <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 md:flex-row">
-        <Link to="/welcome" className="flex items-center gap-2.5">
+        <Link to="/" className="flex items-center gap-2.5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary shadow shadow-primary/30">
             <Car size={13} className="text-white" />
           </div>

--- a/web/src/components/landing/LandingNav.tsx
+++ b/web/src/components/landing/LandingNav.tsx
@@ -33,7 +33,7 @@ export function LandingNav() {
       )}
     >
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
-        <Link to="/welcome" className="group flex items-center gap-2.5">
+        <Link to="/" className="group flex items-center gap-2.5">
           <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-primary shadow-lg shadow-primary/40 transition-transform group-hover:scale-105">
             <Car size={16} className="text-white" />
           </div>

--- a/web/src/components/landing/SmartScoreSection.tsx
+++ b/web/src/components/landing/SmartScoreSection.tsx
@@ -2,10 +2,10 @@ import type { ReactNode } from "react";
 import { motion } from "motion/react";
 import { Sparkles, TrendingUp, Gauge, Calendar, Users } from "lucide-react";
 import { useInView } from "@/hooks/useInView";
+import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
 import {
   scoreListingAgainstSearch,
   scoreColor,
-  scoreBgColor,
   scoreLabel,
   scoreBarColor,
   type DemoListingInput,
@@ -111,7 +111,6 @@ function DemoCard({
   const { ref, inView } = useInView();
   const { score, breakdown } = scoreListingAgainstSearch(listing, demoSearch);
   const color = scoreColor(score);
-  const bg = scoreBgColor(score);
   const label = scoreLabel(score);
   const bar = scoreBarColor(score);
 
@@ -123,12 +122,7 @@ function DemoCard({
       transition={{ delay, duration: 0.5 }}
       className="flex items-center gap-4 rounded-2xl border border-border bg-card p-4"
     >
-      <div
-        className={`flex h-14 w-14 flex-shrink-0 flex-col items-center justify-center rounded-2xl border-2 font-bold ${bg} ${color}`}
-      >
-        <span className="text-xl leading-none">{score.toFixed(1)}</span>
-        <span className="mt-0.5 text-[9px] opacity-60">/10</span>
-      </div>
+      <MatchScoreBox score={score} size="md" />
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-semibold text-foreground">
@@ -157,7 +151,7 @@ function DemoCard({
         </div>
       </div>
 
-      <div className="flex-shrink-0 text-sm font-bold text-primary">
+      <div className="shrink-0 text-sm font-bold tabular-nums text-primary">
         ₪{listing.price.toLocaleString("he-IL")}
       </div>
     </motion.div>

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -21,7 +21,7 @@ import { ConnectionBanner } from "@/components/ui/ConnectionBanner";
 import { cn } from "@/lib/utils";
 
 const navItems = [
-  { path: "/", label: "לוח בקרה", icon: LayoutDashboard, mobile: true },
+  { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard, mobile: true },
   { path: "/searches/new", label: "חיפוש חדש", icon: Plus, mobile: true },
   { path: "/saved", label: "מועדפים", icon: Bookmark, mobile: true },
   { path: "/history", label: "היסטוריה", icon: History, mobile: true },
@@ -37,7 +37,7 @@ const navItems = [
 ];
 
 function isNavActive(pathname: string, path: string): boolean {
-  if (path === "/") return pathname === "/";
+  if (path === "/dashboard") return pathname === "/dashboard";
   return pathname === path || pathname.startsWith(`${path}/`);
 }
 
@@ -55,17 +55,17 @@ export function Shell() {
   return (
     <div className="min-h-screen bg-background">
       <ConnectionBanner status={connectionStatus} />
-      <aside className="border-sidebar-border bg-sidebar fixed inset-y-0 right-0 z-40 hidden h-full w-64 flex-col border-l md:flex">
-        <div className="border-sidebar-border flex items-center gap-3 border-b px-5 py-5">
-          <div className="bg-sidebar-primary relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl shadow-lg shadow-sidebar-primary/40">
-            <Car className="h-5 w-5 text-white" />
-            <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-white/20 to-transparent" />
+      <aside className="fixed inset-y-0 right-0 z-40 hidden h-full w-64 flex-col border-l border-[color-mix(in_srgb,var(--color-sidebar-border)_100%,transparent)] bg-sidebar md:flex">
+        {/* Base44-style header */}
+        <div className="flex items-center gap-3 border-b border-[color-mix(in_srgb,white_6%,transparent)] px-5 py-5">
+          <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-[#3b82f6] via-[#3b82f6] to-[#2563eb] text-white shadow-[0_8px_28px_-6px_rgba(59,130,246,0.55),inset_0_1px_0_rgba(255,255,255,0.12)]">
+            <Car className="relative z-[1] h-5 w-5 text-white drop-shadow-sm" />
           </div>
           <div className="min-w-0 flex-1">
             <h1 className="text-base leading-none font-bold tracking-tight text-white">
               CarWatch
             </h1>
-            <p className="mt-0.5 text-xs text-sidebar-foreground/60">
+            <p className="mt-0.5 text-xs text-[color-mix(in_srgb,var(--color-sidebar-foreground)_72%,transparent)]">
               מעקב רכבים חכם
             </p>
           </div>
@@ -73,14 +73,14 @@ export function Shell() {
             type="button"
             onClick={toggleTheme}
             aria-label={theme === "dark" ? "הפעל מצב בהיר" : "הפעל מצב כהה"}
-            className="bg-sidebar-accent text-sidebar-foreground/60 hover:bg-sidebar-accent/80 hover:text-sidebar-foreground flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-all"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[color-mix(in_srgb,white_6%,transparent)] text-[color-mix(in_srgb,var(--color-sidebar-foreground)_85%,transparent)] transition-all duration-200 hover:bg-[color-mix(in_srgb,white_10%,transparent)] hover:text-white active:scale-[0.96] motion-reduce:active:scale-100"
             title={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
           >
-            {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
+            {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
           </button>
         </div>
 
-        <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-4">
+        <nav className="flex-1 space-y-1 overflow-y-auto px-2.5 py-4">
           {navItems.map((item) => {
             const Icon = item.icon;
             const active = isNavActive(location.pathname, item.path);
@@ -91,22 +91,33 @@ export function Shell() {
                 key={item.path}
                 to={item.path}
                 className={cn(
-                  "nav-active-pill flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-all duration-150",
+                  "group relative flex items-center gap-3 rounded-xl py-2.5 pe-3 ps-4 text-sm font-medium outline-none transition-[background-color,color,box-shadow] duration-200 ease-out",
+                  "focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--color-sidebar-primary)_38%,transparent)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
                   active
-                    ? "bg-sidebar-primary/15 text-white"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-white",
+                    ? "text-white shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-sidebar-primary)_24%,transparent)] [background-image:linear-gradient(270deg,color-mix(in_oklab,var(--color-sidebar-primary)_20%,transparent)_0%,color-mix(in_oklab,var(--color-sidebar-primary)_6%,transparent)_55%,transparent_100%)]"
+                    : "text-sidebar-foreground hover:bg-[color-mix(in_srgb,white_4.5%,transparent)] hover:text-white",
                 )}
               >
+                {/* Accent rail — Base44-style strip toward main content */}
+                <span
+                  className={cn(
+                    "pointer-events-none absolute left-0 top-1/2 h-7 w-[3px] -translate-y-1/2 rounded-r-full transition-all duration-200 ease-out",
+                    active
+                      ? "bg-sidebar-primary shadow-[0_0_14px_rgba(59,130,246,0.55)]"
+                      : "bg-[color-mix(in_srgb,var(--color-sidebar-primary)_48%,transparent)] opacity-90 group-hover:bg-sidebar-primary group-hover:opacity-100 group-hover:shadow-[0_0_12px_rgba(59,130,246,0.38)]",
+                  )}
+                  aria-hidden
+                />
                 <Icon
                   size={17}
                   className={cn(
-                    "shrink-0 transition-colors",
+                    "relative z-[1] shrink-0 transition-colors duration-200",
                     active
-                      ? "text-sidebar-primary"
-                      : "text-sidebar-foreground/70",
+                      ? "text-sidebar-primary drop-shadow-[0_0_10px_rgba(59,130,246,0.35)]"
+                      : "text-[color-mix(in_srgb,var(--color-sidebar-foreground)_78%,transparent)] group-hover:text-sidebar-primary",
                   )}
                 />
-                <span className="relative">
+                <span className="relative z-[1]">
                   {item.label}
                   {showBadge ? (
                     <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
@@ -115,7 +126,7 @@ export function Shell() {
                   ) : null}
                 </span>
                 {active ? (
-                  <div className="bg-sidebar-primary mr-auto h-1.5 w-1.5 rounded-full shadow-sm shadow-primary/60" />
+                  <div className="relative z-[1] mr-auto h-1.5 w-1.5 rounded-full bg-sidebar-primary shadow-[0_0_12px_2px_rgba(59,130,246,0.65)]" />
                 ) : null}
               </Link>
             );
@@ -123,32 +134,32 @@ export function Shell() {
         </nav>
 
         {unread > 0 ? (
-          <div className="border-sidebar-border border-t px-4 py-4">
+          <div className="border-t border-[color-mix(in_srgb,white_6%,transparent)] px-3 py-4">
             <Link
               to="/notifications"
-              className="border-sidebar-primary/20 bg-sidebar-primary/10 hover:bg-sidebar-primary/15 flex items-center gap-2.5 rounded-xl border px-3 py-2.5 transition-colors"
+              className="flex items-center gap-2.5 rounded-xl border border-[color-mix(in_srgb,var(--color-sidebar-primary)_28%,transparent)] bg-[linear-gradient(270deg,color-mix(in_oklab,var(--color-sidebar-primary)_14%,transparent),color-mix(in_oklab,var(--color-sidebar-primary)_6%,transparent))] px-3 py-2.5 shadow-[inset_0_1px_0_color-mix(in_srgb,white_8%,transparent)] transition-all duration-200 hover:border-[color-mix(in_srgb,var(--color-sidebar-primary)_40%,transparent)] hover:bg-[linear-gradient(270deg,color-mix(in_oklab,var(--color-sidebar-primary)_20%,transparent),color-mix(in_oklab,var(--color-sidebar-primary)_9%,transparent))]"
             >
-              <div className="relative">
-                <Bell className="text-sidebar-primary h-4 w-4" />
-                <span className="bg-sidebar-primary absolute -top-1 -right-1 h-2 w-2 animate-pulse-glow rounded-full" />
+              <div className="relative shrink-0">
+                <Bell className="h-4 w-4 text-sidebar-primary" />
+                <span className="absolute -top-1 -right-1 h-2 w-2 animate-pulse-glow rounded-full bg-sidebar-primary" />
               </div>
-              <span className="text-sidebar-primary text-xs font-medium">
+              <span className="text-xs font-medium text-[#93c5fd]">
                 התראות פעילות
               </span>
-              <span className="bg-sidebar-primary mr-auto flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-xs font-bold text-white shadow shadow-primary/30">
+              <span className="mr-auto flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-sidebar-primary px-1 text-xs font-bold text-white shadow-[0_4px_14px_-4px_rgba(59,130,246,0.65)]">
                 {unread > 99 ? "99+" : unread}
               </span>
             </Link>
           </div>
         ) : null}
 
-        <div className="border-sidebar-border shrink-0 border-t p-4">
+        <div className="shrink-0 border-t border-[color-mix(in_srgb,white_6%,transparent)] p-4">
           <div className="mb-3 flex items-center gap-3">
-            <div className="bg-sidebar-accent text-sidebar-foreground ring-sidebar-border flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-semibold ring-1">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_srgb,white_6%,transparent)] text-sm font-semibold text-[color-mix(in_srgb,var(--color-sidebar-foreground)_92%,transparent)] ring-1 ring-[color-mix(in_srgb,white_10%,transparent)]">
               {emailInitial}
             </div>
             <p
-              className="text-sidebar-foreground/60 min-w-0 flex-1 truncate text-xs"
+              className="min-w-0 flex-1 truncate text-xs text-[color-mix(in_srgb,var(--color-sidebar-foreground)_68%,transparent)]"
               title={user?.email ?? undefined}
             >
               {user?.email ?? ""}
@@ -157,14 +168,14 @@ export function Shell() {
           <button
             type="button"
             onClick={() => void signOut()}
-            className="border-sidebar-border bg-sidebar-accent/50 text-sidebar-foreground hover:bg-sidebar-accent hover:text-white flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors"
+            className="flex w-full items-center justify-center gap-2 rounded-xl border border-[color-mix(in_srgb,white_8%,transparent)] bg-[color-mix(in_srgb,white_3%,transparent)] px-3 py-2.5 text-sm font-medium text-sidebar-foreground transition-all duration-200 hover:border-[color-mix(in_srgb,white_14%,transparent)] hover:bg-[color-mix(in_srgb,white_7%,transparent)] hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
           >
             <LogOut className="h-4 w-4" aria-hidden />
             התנתק
           </button>
           {appVersion ? (
             <p
-              className="mt-3 rounded-lg bg-sidebar-accent/80 px-2 py-1.5 text-center text-sm font-semibold tracking-wide text-sidebar-primary tabular-nums ring-1 ring-sidebar-border"
+              className="mt-3 rounded-xl border border-[color-mix(in_srgb,var(--color-sidebar-primary)_22%,transparent)] bg-[color-mix(in_srgb,var(--color-sidebar-primary)_8%,transparent)] px-2 py-2 text-center text-sm font-semibold tracking-wide text-[#60a5fa] tabular-nums"
               title={`גרסה ${appVersion}`}
             >
               גרסה {appVersion}

--- a/web/src/components/ui/MatchScoreBox.tsx
+++ b/web/src/components/ui/MatchScoreBox.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+import { scoreBgColor, scoreColor } from "@/lib/scoringAlgorithm";
+
+export type MatchScoreBoxProps = {
+  score: number;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+};
+
+const sizeClass: Record<NonNullable<MatchScoreBoxProps["size"]>, string> = {
+  sm: "h-11 w-11 text-lg [&_.denom]:text-[8px]",
+  md: "h-14 w-14 text-xl [&_.denom]:text-[9px]",
+  lg: "h-16 w-16 text-2xl [&_.denom]:text-[10px]",
+};
+
+/**
+ * Rounded score tile matching the landing “Smart Match Score” demo (/10, tier border + fill).
+ */
+export function MatchScoreBox({ score, size = "md", className }: MatchScoreBoxProps) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 flex-col items-center justify-center rounded-2xl border-2 font-bold leading-none",
+        scoreBgColor(score),
+        scoreColor(score),
+        sizeClass[size],
+        className,
+      )}
+      aria-label={`ציון ${score.toFixed(1)} מתוך 10`}
+    >
+      <span className="tabular-nums">{score.toFixed(1)}</span>
+      <span className="denom mt-0.5 font-semibold opacity-65">/10</span>
+    </div>
+  );
+}

--- a/web/src/components/ui/MatchScoreBox.tsx
+++ b/web/src/components/ui/MatchScoreBox.tsx
@@ -17,18 +17,23 @@ const sizeClass: Record<NonNullable<MatchScoreBoxProps["size"]>, string> = {
  * Rounded score tile matching the landing “Smart Match Score” demo (/10, tier border + fill).
  */
 export function MatchScoreBox({ score, size = "md", className }: MatchScoreBoxProps) {
+  const normalized = Number.isFinite(score)
+    ? Math.min(10, Math.max(0, score))
+    : 0;
+  const formatted = normalized.toFixed(1);
+
   return (
     <div
       className={cn(
         "flex shrink-0 flex-col items-center justify-center rounded-2xl border-2 font-bold leading-none",
-        scoreBgColor(score),
-        scoreColor(score),
+        scoreBgColor(normalized),
+        scoreColor(normalized),
         sizeClass[size],
         className,
       )}
-      aria-label={`ציון ${score.toFixed(1)} מתוך 10`}
+      aria-label={`ציון ${formatted} מתוך 10`}
     >
-      <span className="tabular-nums">{score.toFixed(1)}</span>
+      <span className="tabular-nums">{formatted}</span>
       <span className="denom mt-0.5 font-semibold opacity-65">/10</span>
     </div>
   );

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { Badge, badgeVariants, type BadgeProps } from "./Badge";
+export { MatchScoreBox, type MatchScoreBoxProps } from "./MatchScoreBox";
 export { ChipButton, type ChipButtonProps } from "./ChipButton";
 export {
   Button,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -35,9 +35,10 @@
   --color-price: #F59E0B;
   --color-price-foreground: #D97706;
 
-  --color-score-great: #10B981;
-  --color-score-good: #F59E0B;
-  --color-score-low: #64748B;
+  /* Match landing Smart Match tiers: gold / orange / red */
+  --color-score-great: #FBBF24;
+  --color-score-good: #F97316;
+  --color-score-low: #EF4444;
 
   --color-success: #10B981;
   --color-warning: #F59E0B;
@@ -47,11 +48,15 @@
 
   --color-chart-purple: #A78BFA;
 
-  --color-sidebar: #0F1119;
-  --color-sidebar-foreground: #94A3B8;
-  --color-sidebar-border: #1A1D2B;
-  --color-sidebar-accent: #1A1D2B;
-  --color-sidebar-primary: #3B82F6;
+  /* Base44-style app sidebar (dark rail + blue accent) */
+  --color-sidebar: #0b0e14;
+  --color-sidebar-foreground: #94a3b8;
+  --color-sidebar-border: rgba(255, 255, 255, 0.06);
+  --color-sidebar-accent: rgba(255, 255, 255, 0.045);
+  --color-sidebar-accent-hover: rgba(255, 255, 255, 0.07);
+  --color-sidebar-primary: #3b82f6;
+  --color-sidebar-active-fade: rgba(59, 130, 246, 0.16);
+  --color-sidebar-active-edge: rgba(59, 130, 246, 0.22);
 
   --color-surface-hover: var(--surface-hover);
   --color-glow-primary: rgba(59, 130, 246, 0.15);
@@ -185,10 +190,6 @@
     linear-gradient(color-mix(in oklab, var(--fg) 5%, transparent) 1px, transparent 1px),
     linear-gradient(90deg, color-mix(in oklab, var(--fg) 5%, transparent) 1px, transparent 1px);
   background-size: 32px 32px;
-}
-
-@utility nav-active-pill {
-  border-radius: var(--radius-lg);
 }
 
 body {

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -77,18 +77,17 @@ export function scoreListingAgainstSearch(
   };
 }
 
+/** Tier colors aligned with landing Smart Match mock (gold / orange / red). */
 export function scoreColor(score: number): string {
-  if (score >= 8.2) return "text-emerald-500";
-  if (score >= 6.5) return "text-amber-500";
-  if (score >= 4.5) return "text-orange-500";
+  if (score >= 8) return "text-amber-400";
+  if (score >= 5) return "text-orange-500";
   return "text-red-500";
 }
 
 export function scoreBgColor(score: number): string {
-  if (score >= 8.2) return "bg-emerald-500/15 border-emerald-500/40";
-  if (score >= 6.5) return "bg-amber-500/15 border-amber-500/40";
-  if (score >= 4.5) return "bg-orange-500/15 border-orange-500/35";
-  return "bg-red-500/15 border-red-500/35";
+  if (score >= 8) return "bg-amber-400/12 border-amber-400/50";
+  if (score >= 5) return "bg-orange-500/12 border-orange-500/45";
+  return "bg-red-500/12 border-red-500/42";
 }
 
 export function scoreLabel(score: number): string {
@@ -99,8 +98,7 @@ export function scoreLabel(score: number): string {
 }
 
 export function scoreBarColor(score: number): string {
-  if (score >= 8.2) return "bg-emerald-500";
-  if (score >= 6.5) return "bg-amber-500";
-  if (score >= 4.5) return "bg-orange-500";
+  if (score >= 8) return "bg-amber-400";
+  if (score >= 5) return "bg-orange-500";
   return "bg-red-500";
 }

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -41,7 +41,7 @@ export function scoreListingAgainstSearch(
 
   const kmRatio =
     search.mileage_max > 0
-      ? clamp01(listing.mileage / search.mileage_max)
+      ? Math.max(0, listing.mileage/search.mileage_max)
       : 0;
   const mileageFactor = Math.exp(-kmRatio * 2.2);
 

--- a/web/src/pages/EditSearchPage.tsx
+++ b/web/src/pages/EditSearchPage.tsx
@@ -81,7 +81,7 @@ export function EditSearchPage() {
       {
         onSuccess: () => {
           toast("החיפוש עודכן בהצלחה!", "success");
-          navigate("/");
+          navigate("/dashboard");
         },
         onError: () => setError("שגיאה בעדכון החיפוש, נסה שוב"),
       },
@@ -106,7 +106,7 @@ export function EditSearchPage() {
         description="ניתן לחזור לדף הראשי"
         action={
           <Button asChild>
-            <Link to="/">חזרה לחיפושים</Link>
+            <Link to="/dashboard">חזרה לחיפושים</Link>
           </Button>
         }
       />
@@ -118,7 +118,7 @@ export function EditSearchPage() {
       <PageHeader
         title={`עריכת ${search.manufacturer_name} ${search.model_name}`}
         subtitle={`מקור: ${search.source}`}
-        backTo="/"
+        backTo="/dashboard"
         backLabel="חזרה"
       />
 
@@ -274,7 +274,7 @@ export function EditSearchPage() {
             שמור שינויים
           </Button>
           <Button variant="secondary" size="lg" asChild className="md:flex-none">
-            <Link to="/">ביטול</Link>
+            <Link to="/dashboard">ביטול</Link>
           </Button>
         </div>
       </div>

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -37,7 +37,7 @@ export function ListingDetailPage() {
     setListing(stateListingForToken);
     setError(false);
     setLoading(!stateListingForToken && !!token);
-  }, [token]);
+  }, [token, stateListingForToken]);
 
   useEffect(() => {
     if (listing || !token) return;

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -10,11 +10,12 @@ import {
   Clock,
   Car,
 } from "lucide-react";
-import { formatPrice, formatKm, relativeTime, safeHref } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
-import { Badge } from "@/components/ui/Badge";
+import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
+import { scoreColor, scoreLabel } from "@/lib/scoringAlgorithm";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 
@@ -71,7 +72,7 @@ export function ListingDetailPage() {
         description="ניתן לגשת למודעה דרך רשימת התוצאות"
         action={
           <Button asChild>
-            <Link to="/">
+            <Link to="/dashboard">
               <ArrowRight className="h-4 w-4" />
               חזרה לחיפושים
             </Link>
@@ -104,15 +105,28 @@ export function ListingDetailPage() {
         </div>
       )}
 
-      {/* Title + Price */}
-      <div className="flex items-start justify-between">
-        <div>
+      {/* Title + score + Price (aligned with landing Smart Match row) */}
+      <div className="flex items-start gap-4">
+        {listing.fitness_score != null ? (
+          <MatchScoreBox score={listing.fitness_score} size="lg" />
+        ) : null}
+        <div className="min-w-0 flex-1">
           <h1 className="text-2xl font-bold tracking-tight">
             {listing.manufacturer} {listing.model}
           </h1>
-          <p className="text-muted-foreground mt-0.5">{listing.year}</p>
+          <p className="mt-0.5 text-muted-foreground">{listing.year}</p>
+          {listing.fitness_score != null ? (
+            <p
+              className={cn(
+                "mt-1 text-sm font-medium",
+                scoreColor(listing.fitness_score),
+              )}
+            >
+              {scoreLabel(listing.fitness_score)}
+            </p>
+          ) : null}
         </div>
-        <span className="text-2xl font-bold text-amber-500 dark:text-amber-400 tabular-nums">
+        <span className="shrink-0 text-2xl font-bold tabular-nums text-primary">
           {formatPrice(listing.price)}
         </span>
       </div>
@@ -129,28 +143,9 @@ export function ListingDetailPage() {
         />
       </div>
 
-      <div className="flex items-center gap-4">
-        {listing.fitness_score != null && (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">ציון התאמה:</span>
-            <Badge
-              variant={
-                listing.fitness_score >= 7
-                  ? "success"
-                  : listing.fitness_score >= 5
-                    ? "warning"
-                    : "default"
-              }
-              className="text-sm tabular-nums"
-            >
-              {listing.fitness_score.toFixed(1)}
-            </Badge>
-          </div>
-        )}
-        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-          <Clock className="h-4 w-4" />
-          {relativeTime(listing.first_seen_at)}
-        </div>
+      <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <Clock className="h-4 w-4" />
+        {relativeTime(listing.first_seen_at)}
       </div>
 
       {safeHref(listing.page_link) && (

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -28,6 +28,15 @@ const SORT_OPTIONS = [
 
 const PAGE_SIZE = 20;
 
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return (
+    target.closest(
+      "button,a,input,select,textarea,[role='button']",
+    ) != null
+  );
+}
+
 export function ListingsPage() {
   const { id } = useParams();
   const searchId = Number(id);
@@ -173,11 +182,14 @@ function ListingCard({ listing }: { listing: Listing }) {
     <div
       role="button"
       tabIndex={0}
-      onClick={() =>
-        navigate(`/listings/${listing.token}`, { state: { listing } })
-      }
+      onClick={(e) => {
+        if (isInteractiveTarget(e.target)) return;
+        navigate(`/listings/${listing.token}`, { state: { listing } });
+      }}
       onKeyDown={(e) => {
+        if (isInteractiveTarget(e.target)) return;
         if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
           navigate(`/listings/${listing.token}`, { state: { listing } });
         }
       }}

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -8,8 +8,9 @@ import {
 } from "lucide-react";
 import { useListings } from "@/hooks/useListings";
 import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
-import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
+import { safeHref, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
+import { ListingCardBody } from "@/components/ListingCardBody";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -43,7 +44,7 @@ export function ListingsPage() {
   if (!searchId || Number.isNaN(searchId)) {
     return (
       <div className="space-y-4">
-        <PageHeader backTo="/" title="חיפוש לא נמצא" />
+        <PageHeader backTo="/dashboard" title="חיפוש לא נמצא" />
       </div>
     );
   }
@@ -51,7 +52,7 @@ export function ListingsPage() {
   if (isError) {
     return (
       <div className="space-y-4">
-        <PageHeader backTo="/" title="תוצאות" />
+        <PageHeader backTo="/dashboard" title="תוצאות" />
         <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center dir-rtl">
           <p className="text-destructive font-medium">שגיאה בטעינת התוצאות</p>
           <p className="text-sm text-muted-foreground mt-1">נסה לרענן את הדף</p>
@@ -63,7 +64,7 @@ export function ListingsPage() {
   if (isLoading) {
     return (
       <div className="space-y-5 pb-20 md:pb-4">
-        <PageHeader backTo="/" title="תוצאות" />
+        <PageHeader backTo="/dashboard" title="תוצאות" />
         <div className="flex flex-wrap gap-2">
           {[1, 2, 3, 4, 5, 6].map((i) => (
             <Skeleton key={i} className="h-8 w-16 rounded-md" />
@@ -84,7 +85,7 @@ export function ListingsPage() {
   return (
     <div className="space-y-5 pb-20 md:pb-4">
       <PageHeader
-        backTo="/"
+        backTo="/dashboard"
         title="תוצאות"
         subtitle={countSubtitle}
       />
@@ -182,135 +183,58 @@ function ListingCard({ listing }: { listing: Listing }) {
       }}
       className="group block cursor-pointer rounded-2xl border border-border/50 bg-card overflow-hidden transition-all duration-300 hover:border-border hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)] hover:-translate-y-0.5 dir-rtl"
     >
-      {/* Image */}
-      {listing.image_url ? (
-        <div className="relative aspect-video w-full overflow-hidden bg-secondary">
-          {saved ? (
-            <div
-              className="absolute top-2 start-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-background/85 shadow-sm ring-1 ring-border/60 backdrop-blur-[2px]"
-              aria-hidden
+      <ListingCardBody
+        listing={listing}
+        hoverScale
+        showBookmarkOverlay={saved}
+        actions={
+          <>
+            <button
+              type="button"
+              aria-label={saved ? "הסר משמורים" : "שמור מודעה"}
+              aria-pressed={saved}
+              onClick={(e) => {
+                e.stopPropagation();
+                const next = !saved;
+                setSaved(next);
+                const mutation = next ? saveBookmark : removeBookmark;
+                mutation.mutate(listing.token, {
+                  onSuccess: () => {
+                    if (next) {
+                      toast("נשמר בהצלחה", "success");
+                    } else {
+                      toast("הוסר מהשמורים", "info");
+                    }
+                  },
+                  onError: () => setSaved(!next),
+                });
+              }}
+              className={cn(
+                "rounded-lg p-1.5 transition-all duration-200",
+                saved
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:bg-primary/5 hover:text-primary",
+              )}
             >
-              <Bookmark className="h-4 w-4 fill-amber-500 text-amber-600 dark:text-amber-400 dark:fill-amber-400" />
-            </div>
-          ) : null}
-          <img
-            src={listing.image_url}
-            alt={`${listing.manufacturer} ${listing.model}`}
-            referrerPolicy="no-referrer"
-            className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
-            loading="lazy"
-          />
-        </div>
-      ) : (
-        <div className="aspect-video w-full bg-secondary flex items-center justify-center">
-          <span className="text-4xl opacity-20">🚗</span>
-        </div>
-      )}
-
-      <div className="p-4">
-        {/* Title + Price */}
-        <div className="flex items-start justify-between mb-2">
-          <div>
-            <h3 className="font-semibold text-card-foreground">
-              {listing.manufacturer} {listing.model}
-            </h3>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {listing.year}
-            </p>
-          </div>
-          <span className="text-lg font-bold text-amber-500 dark:text-amber-400 tabular-nums">
-            {formatPrice(listing.price)}
-          </span>
-        </div>
-
-        {/* Specs */}
-        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground mb-3">
-          <span className="tabular-nums">{formatKm(listing.km)}</span>
-          <span className="text-border">·</span>
-          <span>יד {listing.hand}</span>
-          {listing.city && (
-            <>
-              <span className="text-border">·</span>
-              <span>{listing.city}</span>
-            </>
-          )}
-        </div>
-
-        {/* Badges + actions */}
-        <div className="flex items-center gap-2">
-          {listing.fitness_score != null && (
-            <ScoreBadge score={listing.fitness_score} />
-          )}
-          <span className="text-xs text-muted-foreground mr-auto">
-            {relativeTime(listing.first_seen_at)}
-          </span>
-          <button
-            type="button"
-            aria-label={saved ? "הסר משמורים" : "שמור מודעה"}
-            aria-pressed={saved}
-            onClick={(e) => {
-              e.stopPropagation();
-              const next = !saved;
-              setSaved(next);
-              const mutation = next ? saveBookmark : removeBookmark;
-              mutation.mutate(listing.token, {
-                onSuccess: () => {
-                  if (next) {
-                    toast("נשמר בהצלחה", "success");
-                  } else {
-                    toast("הוסר מהשמורים", "info");
-                  }
-                },
-                onError: () => setSaved(!next),
-              });
-            }}
-            className={cn(
-              "p-1.5 rounded-lg transition-all duration-200",
-              saved
-                ? "text-primary bg-primary/10"
-                : "text-muted-foreground hover:text-primary hover:bg-primary/5",
-            )}
-          >
-            <Bookmark
-              className={cn("h-3.5 w-3.5", saved && "fill-current")}
-            />
-          </button>
-          {safeHref(listing.page_link) && (
-            <a
-              href={safeHref(listing.page_link)!}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="פתח מודעה באתר חיצוני"
-              onClick={(e) => e.stopPropagation()}
-              className="p-1.5 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/5 transition-all duration-200"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          )}
-        </div>
-      </div>
+              <Bookmark
+                className={cn("h-3.5 w-3.5", saved && "fill-current")}
+              />
+            </button>
+            {safeHref(listing.page_link) ? (
+              <a
+                href={safeHref(listing.page_link)!}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="פתח מודעה באתר חיצוני"
+                onClick={(e) => e.stopPropagation()}
+                className="rounded-lg p-1.5 text-muted-foreground transition-all duration-200 hover:bg-primary/5 hover:text-primary"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            ) : null}
+          </>
+        }
+      />
     </div>
-  );
-}
-
-function ScoreBadge({ score }: { score: number }) {
-  const tier = score >= 7 ? "great" : score >= 5 ? "good" : "low";
-
-  const styles = {
-    great: "bg-score-great/15 text-score-great",
-    good: "bg-score-good/15 text-score-good",
-    low: "bg-score-low/15 text-score-low",
-  };
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold tabular-nums",
-        styles[tier],
-      )}
-    >
-      {score.toFixed(1)}
-      {tier === "great" && " ⭐"}
-    </span>
   );
 }

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -47,7 +47,7 @@ export function LoginPage() {
     redirectTo !== "/login" &&
     redirectTo !== "/signup";
 
-  const from = isSafePath ? redirectTo : "/";
+  const from = isSafePath && redirectTo ? redirectTo : "/dashboard";
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -299,7 +299,7 @@ export function LoginPage() {
             </p>
             <p className="mt-2 text-center text-xs text-muted-foreground/70">
               <Link
-                to="/welcome"
+                to="/"
                 className="underline-offset-4 hover:underline hover:text-muted-foreground"
               >
                 מה זה CarWatch?

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -89,7 +89,7 @@ export function NewSearchPage() {
       {
         onSuccess: () => {
           toast("החיפוש נוצר בהצלחה!", "success");
-          navigate("/");
+          navigate("/dashboard");
         },
         onError: () => setError("שגיאה ביצירת החיפוש, נסה שוב"),
       },
@@ -101,7 +101,7 @@ export function NewSearchPage() {
       <PageHeader
         title="חיפוש חדש"
         subtitle="הגדר פילטרים למעקב אחר מודעות"
-        backTo="/"
+        backTo="/dashboard"
         backLabel="חזרה"
       />
 
@@ -330,7 +330,7 @@ export function NewSearchPage() {
             צור חיפוש
           </Button>
           <Button variant="secondary" size="lg" asChild className="md:flex-none">
-            <Link to="/">ביטול</Link>
+            <Link to="/dashboard">ביטול</Link>
           </Button>
         </div>
       </div>

--- a/web/src/pages/NotFoundPage.tsx
+++ b/web/src/pages/NotFoundPage.tsx
@@ -15,7 +15,7 @@ export function NotFoundPage() {
         action={
           <button
             type="button"
-            onClick={() => void navigate("/")}
+            onClick={() => void navigate("/dashboard")}
             className="mt-4 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             חזרה לדף הבית

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -110,9 +110,9 @@ export function SearchesPage() {
             icon: Car,
             label: "מודעות שנמצאו",
             value: recentListings?.total ?? 0,
-            color: "text-score-great",
-            bg: "bg-score-great/12",
-            glow: "shadow-[0_0_24px_-4px_rgba(16,185,129,0.25)]",
+            color: "text-primary",
+            bg: "bg-primary/12",
+            glow: "shadow-[0_0_24px_-4px_rgba(59,130,246,0.25)]",
           },
           {
             icon: Bell,

--- a/web/src/pages/SignupPage.tsx
+++ b/web/src/pages/SignupPage.tsx
@@ -231,7 +231,7 @@ export function SignupPage() {
                           className={cn(
                             "flex items-center gap-1.5 text-xs transition-colors",
                             pass
-                              ? "text-score-great"
+                              ? "text-success"
                               : "text-muted-foreground",
                           )}
                         >
@@ -298,7 +298,7 @@ export function SignupPage() {
                 {touched.confirm &&
                   confirm.length > 0 &&
                   confirm === password && (
-                    <p className="mt-1.5 flex items-center gap-1 text-xs text-score-great">
+                    <p className="mt-1.5 flex items-center gap-1 text-xs text-success">
                       <Check className="h-3 w-3" />
                       סיסמאות תואמות
                     </p>

--- a/web/src/pages/SignupPage.tsx
+++ b/web/src/pages/SignupPage.tsx
@@ -55,7 +55,7 @@ export function SignupPage() {
   });
 
   useEffect(() => {
-    if (user) navigate("/", { replace: true });
+    if (user) navigate("/dashboard", { replace: true });
   }, [user, navigate]);
 
   const emailErr =
@@ -85,7 +85,7 @@ export function SignupPage() {
     setBusy("email");
     try {
       await createUserWithEmailAndPassword(auth, email.trim(), password);
-      navigate("/", { replace: true });
+      navigate("/dashboard", { replace: true });
     } catch (err) {
       setError(mapAuthError(firebaseAuthErrorCode(err)));
     } finally {
@@ -98,7 +98,7 @@ export function SignupPage() {
     setBusy("google");
     try {
       await signInWithPopup(auth, googleProvider);
-      navigate("/", { replace: true });
+      navigate("/dashboard", { replace: true });
     } catch (err) {
       setError(mapAuthError(firebaseAuthErrorCode(err)));
     } finally {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,4 +18,19 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    chunkSizeWarningLimit: 600,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (id.includes("motion")) return "motion";
+          if (id.includes("firebase")) return "firebase";
+          if (id.includes("@tanstack/react-query")) return "rq";
+          if (id.includes("lucide-react")) return "icons";
+          return "vendor";
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary

This continues the Base44-style web work after the earlier merge: clearer public vs app URLs, one shared match-score presentation, and a darker sidebar with the rail/hover/active treatment from that layout language.

- **Routing:** Marketing lives at `/`; authenticated home is `/dashboard`. Removed the `/welcome` alias so there is a single public entry point.
- **Match score:** Added `MatchScoreBox` (rounded `/10` tile + tier colors) and reused it on the landing demo, listing cards, listing detail, and shared `ListingCardBody`. Listing rows use primary-colored price to mirror the landing demo. Theme tokens for score tiers were updated to gold / orange / red.
- **Sidebar:** Panel uses `#0b0e14`, gradient logo chip, left accent rails with hover glow, active gradient pill + inset ring + dot, and updated notifications/footer/version styling.
- **Other:** SearchCard omits a year chip when both bounds are zero; earlier CodeRabbit fixes remain in history.

## Test plan

- `make test` (passed locally).
- `npm run build` in `web/` (passed locally).

CI should cover `golangci-lint` and web lint/build where applicable.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Match score component added for consistent score display across listings and detail views.
  * Pages now load via code-splitting for improved perceived load behavior.

* **Style**
  * Updated match score palette (gold, orange, red) and refined score/price header layouts.
  * Sidebar and navigation restyled with clearer active indicators and mobile parity.

* **Navigation**
  * Landing routes and many post-action redirects updated to use /dashboard as the primary destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->