### PR TITLE
feat: full Yad2 km enrichment and structured observability logs

### DIFF
--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -10,14 +10,14 @@ import (
 
 const (
 	defaultEnrichDelay = 500 * time.Millisecond
-	defaultMaxEnrich   = 15
 )
 
 // EnricherConfig controls the enrichment behavior.
 type EnricherConfig struct {
 	// Delay between individual item fetches to avoid rate-limiting.
 	Delay time.Duration
-	// MaxPerCycle limits how many listings are enriched per poll cycle.
+	// MaxPerCycle limits how many item-page fetches run per Enrich call.
+	// 0 means no limit (enrich every listing that still needs km/image/city).
 	MaxPerCycle int
 }
 
@@ -32,9 +32,6 @@ type Enricher struct {
 func NewEnricher(fetcher *Yad2Fetcher, logger *slog.Logger, cfg EnricherConfig) *Enricher {
 	if cfg.Delay == 0 {
 		cfg.Delay = defaultEnrichDelay
-	}
-	if cfg.MaxPerCycle <= 0 {
-		cfg.MaxPerCycle = defaultMaxEnrich
 	}
 	return &Enricher{fetcher: fetcher, logger: logger, cfg: cfg}
 }
@@ -51,7 +48,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		if !needsKm && !needsImg && !needsCity {
 			continue
 		}
-		if attempts >= e.cfg.MaxPerCycle {
+		if e.cfg.MaxPerCycle > 0 && attempts >= e.cfg.MaxPerCycle {
 			e.logger.Info("enrichment limit reached",
 				"enriched", enriched,
 				"attempts", attempts,

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -41,6 +41,34 @@ func itemPageHandler(km int) http.HandlerFunc {
 	}
 }
 
+func TestEnricher_UnlimitedEnrichesAllNeedingKm(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":42000}}}}
+</script></html>`)
+	})
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0}, {Token: "b", Km: 0}, {Token: "c", Km: 0},
+		{Token: "d", Km: 0}, {Token: "e", Km: 0},
+	}
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 5 {
+		t.Errorf("enriched = %d, want 5", count)
+	}
+	if got := requestCount.Load(); got != 5 {
+		t.Errorf("requests = %d, want 5 (no per-cycle cap)", got)
+	}
+	for i, l := range listings {
+		if l.Km != 42000 {
+			t.Errorf("listing[%d].Km = %d, want 42000", i, l.Km)
+		}
+	}
+}
+
 func TestEnricher_FillsMissingKm(t *testing.T) {
 	enricher := newTestEnricher(t, itemPageHandler(75000), EnricherConfig{
 		Delay:       time.Millisecond,

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -52,6 +52,16 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 	}
 
 	if logger != nil && len(items) > 0 {
+		var probe feedItem
+		if err := json.Unmarshal(items[0], &probe); err == nil {
+			logger.Info("yad2 feed item summary",
+				"token", probe.Token,
+				"km", probe.Km,
+				"has_city", strings.TrimSpace(textFromField(probe.Address.City)) != "",
+				"has_area", strings.TrimSpace(textFromField(probe.Address.Area)) != "",
+				"price", probe.Price,
+			)
+		}
 		logger.Info("raw feed item sample", "json", string(items[0]))
 	}
 

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -111,6 +111,14 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 		return ItemDetails{}, fmt.Errorf("parse item %s: %w", token, err)
 	}
 
+	f.logger.Info("yad2 item page parsed",
+		"token", token,
+		"km", details.Km,
+		"city", details.City,
+		"area", details.Area,
+		"has_cover_image", details.ImageURL != "",
+	)
+
 	return details, nil
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -25,12 +25,14 @@ import (
 )
 
 const (
-	fetchTimeout   = 60 * time.Second
-	maxBackoff     = 4.0
-	minBackoff     = 1.0
-	pruneInterval  = 24 * time.Hour
-	maxRetries     = 3
-	retryBaseDelay = 2 * time.Second
+	fetchTimeout    = 60 * time.Second
+	// kmEnrichTimeout bounds per-item mileage/city fetches after the list crawl.
+	kmEnrichTimeout = 25 * time.Minute
+	maxBackoff      = 4.0
+	minBackoff      = 1.0
+	pruneInterval   = 24 * time.Hour
+	maxRetries      = 3
+	retryBaseDelay  = 2 * time.Second
 )
 
 type CatalogIngester interface {
@@ -637,8 +639,8 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 }
 
 func (s *Scheduler) fetchAndEnrich(ctx context.Context, group CanonicalGroup) ([]model.RawListing, string, error) {
-	fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
-	defer cancel()
+	listCtx, cancelList := context.WithTimeout(ctx, fetchTimeout)
+	defer cancelList()
 
 	source := group.Source
 	if source == "" {
@@ -646,7 +648,7 @@ func (s *Scheduler) fetchAndEnrich(ctx context.Context, group CanonicalGroup) ([
 	}
 	activeFetcher := s.fetcherForSource(source)
 	fetchStart := time.Now()
-	raw, err := s.fetchWithRetryUsing(fetchCtx, activeFetcher, group.Params)
+	raw, err := s.fetchWithRetryUsing(listCtx, activeFetcher, group.Params)
 	s.observer.RecordFetch(source, time.Since(fetchStart), err)
 	if err != nil {
 		return nil, source, err
@@ -659,7 +661,9 @@ func (s *Scheduler) fetchAndEnrich(ctx context.Context, group CanonicalGroup) ([
 	}
 
 	if source == "yad2" && s.kmEnricher != nil {
-		enriched := s.kmEnricher.Enrich(fetchCtx, raw)
+		enrichCtx, cancelEnrich := context.WithTimeout(ctx, kmEnrichTimeout)
+		defer cancelEnrich()
+		enriched := s.kmEnricher.Enrich(enrichCtx, raw)
 		if enriched > 0 {
 			s.logger.Info("km enrichment complete", "enriched", enriched)
 		}


### PR DESCRIPTION
## Summary

Mileage is required for fitness scoring, but the search-results feed often omits `km` and city. This PR ensures we attempt enrichment for **every** listing that still needs data (unless `MaxPerCycle` is set to a positive limit), and keeps enrichment from being aborted by the short list-fetch timeout.

## Changes

- **Enricher**: `MaxPerCycle == 0` (default) means **no cap**. Optional caps apply only when `MaxPerCycle > 0` (tests / tuning).
- **Scheduler**: List crawl stays on **60s**; item-page enrichment runs under a separate **25 minute** context so large groups can finish.
- **Logs**: `yad2 feed item summary` (structured snapshot of first card on each results page) plus existing raw JSON sample; `yad2 item page parsed` after each successful item HTML parse (km, city, area, cover image).

## Testing

`make test`

## Ops note

INFO volume increases with enrichment frequency (one `yad2 item page parsed` per successful item fetch). Adjust log filtering or ask for DEBUG-only item logs if needed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Enrichment now continues without per-cycle limits when the maximum-per-cycle setting is unset or zero.
  * Enrichment timeout is now managed independently from the initial fetch timeout for improved reliability and resource control.

* **Improvements**
  * Enhanced logging visibility into parsed listing details during the enrichment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->