### PR TITLE
refactor: extract helpers, constants, and improve type safety

### DIFF
--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/dsionov/carwatch/internal/model"
 )
@@ -17,6 +18,7 @@ type Fetcher interface {
 }
 
 type Factory struct {
+	mu       sync.RWMutex
 	fetchers map[string]Fetcher
 }
 
@@ -25,10 +27,14 @@ func NewFactory() *Factory {
 }
 
 func (f *Factory) Register(source string, fetcher Fetcher) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.fetchers[source] = fetcher
 }
 
 func (f *Factory) Get(source string) (Fetcher, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	fetcher, ok := f.fetchers[source]
 	return fetcher, ok
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -3,11 +3,13 @@ package health
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/dsionov/carwatch/internal/fetcher"
 )
 
 // UserCounter counts active users (optional dependency).
@@ -52,6 +54,12 @@ type Status struct {
 	searches SearchCounter
 	dbSizer  DBSizer
 }
+
+const (
+	degradedThreshold = 2 * time.Hour
+	startupGracePeriod = 5 * time.Minute
+	snapshotTimeout    = 2 * time.Second
+)
 
 func New() *Status {
 	return &Status{
@@ -112,7 +120,7 @@ func (s *Status) RecordFetch(source string, duration time.Duration, err error) {
 	} else {
 		m.ErrorCount.Add(1)
 		m.LastError.Store(time.Now().UnixNano())
-		if strings.Contains(err.Error(), "challenge") {
+		if errors.Is(err, fetcher.ErrChallenge) {
 			m.ChallengeCount.Add(1)
 		}
 	}
@@ -149,8 +157,8 @@ func (s *Status) Snapshot() map[string]any {
 
 	status := "ok"
 	uptime := time.Since(s.startTime)
-	if cycles > 0 && (lastSuccessNs == 0 || time.Since(lastSuccess) > 2*time.Hour) {
-		if uptime > 5*time.Minute {
+	if cycles > 0 && (lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold) {
+		if uptime > startupGracePeriod {
 			status = "degraded"
 		} else {
 			status = "starting"
@@ -166,7 +174,7 @@ func (s *Status) Snapshot() map[string]any {
 		"listings_found":     s.listingsFound.Load(),
 		"notifications_sent": s.notificationsSent.Load(),
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), snapshotTimeout)
 	defer cancel()
 
 	s.mu.RLock()

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/dsionov/carwatch/internal/fetcher"
 )
 
 func TestStatus_OK(t *testing.T) {
@@ -207,7 +210,7 @@ func TestStatus_RecordFetch(t *testing.T) {
 	s.RecordFetch("yad2", 100*time.Millisecond, nil)
 	s.RecordFetch("yad2", 200*time.Millisecond, nil)
 	s.RecordFetch("yad2", 300*time.Millisecond, errors.New("timeout"))
-	s.RecordFetch("yad2", 150*time.Millisecond, errors.New("anti-bot challenge detected"))
+	s.RecordFetch("yad2", 150*time.Millisecond, fmt.Errorf("yad2: %w", fetcher.ErrChallenge))
 	s.RecordFetch("winwin", 50*time.Millisecond, nil)
 
 	snap := s.Snapshot()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -27,12 +27,15 @@ import (
 const (
 	fetchTimeout    = 60 * time.Second
 	// kmEnrichTimeout bounds per-item mileage/city fetches after the list crawl.
-	kmEnrichTimeout = 25 * time.Minute
-	maxBackoff      = 4.0
-	minBackoff      = 1.0
-	pruneInterval   = 24 * time.Hour
-	maxRetries      = 3
-	retryBaseDelay  = 2 * time.Second
+	kmEnrichTimeout        = 25 * time.Minute
+	maxBackoff             = 4.0
+	minBackoff             = 1.0
+	pruneInterval          = 24 * time.Hour
+	maxRetries             = 3
+	retryBaseDelay         = 2 * time.Second
+	defaultConcurrency     = 4
+	notificationPruneAge   = 48 * time.Hour
+	priceHistoryRetention  = 90 * 24 * time.Hour
 )
 
 type CatalogIngester interface {
@@ -501,7 +504,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	concurrency := s.cfg.Polling.MaxConcurrentFetches
 	s.cfgMu.RUnlock()
 	if concurrency <= 0 {
-		concurrency = 4
+		concurrency = defaultConcurrency
 	}
 
 	sem := make(chan struct{}, concurrency)
@@ -592,7 +595,7 @@ func (s *Scheduler) pruneIfDue(ctx context.Context) {
 		}
 	}
 	if s.stores.Queue != nil {
-		pruned, err := s.stores.Queue.PruneNotifications(ctx, 48*time.Hour)
+		pruned, err := s.stores.Queue.PruneNotifications(ctx, notificationPruneAge)
 		if err != nil {
 			s.logger.Error("prune notifications failed", "error", err)
 		} else if pruned > 0 {
@@ -600,7 +603,7 @@ func (s *Scheduler) pruneIfDue(ctx context.Context) {
 		}
 	}
 	if s.stores.Prices != nil {
-		pruned, err := s.stores.Prices.PrunePrices(ctx, 90*24*time.Hour)
+		pruned, err := s.stores.Prices.PrunePrices(ctx, priceHistoryRetention)
 		if err != nil {
 			s.logger.Error("prune prices failed", "error", err)
 		} else if pruned > 0 {

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/timeutil"
 )
 
 var ErrNotPurgeable = errors.New("table is not purgeable")
@@ -132,22 +133,8 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int) ([]sto
 	return items, total, rows.Err()
 }
 
-var timeFormats = []string{
-	"2006-01-02 15:04:05.999999999",
-	"2006-01-02 15:04:05.999999999-07:00",
-	"2006-01-02 15:04:05",
-	time.RFC3339Nano,
-	time.RFC3339,
-	"2006-01-02T15:04:05",
-}
-
 func parseFlexibleTime(s string) (time.Time, error) {
-	for _, layout := range timeFormats {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t, nil
-		}
-	}
-	return time.Time{}, fmt.Errorf("unrecognized time format: %q", s)
+	return timeutil.ParseFlexible(s)
 }
 
 func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int64) error {

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -10,6 +10,23 @@ import (
 
 const firstSeenAtLayout = "2006-01-02 15:04:05.000000"
 
+type listingScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
+	var l storage.ListingRecord
+	var fs sql.NullFloat64
+	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
+		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt); err != nil {
+		return l, err
+	}
+	if fs.Valid {
+		l.FitnessScore = &fs.Float64
+	}
+	return l, nil
+}
+
 func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO listing_history
@@ -69,24 +86,18 @@ func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecor
 }
 
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {
-	var l storage.ListingRecord
-	var fs sql.NullFloat64
-	err := s.db.QueryRowContext(ctx, `
+	row := s.db.QueryRowContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price,
 			km, hand, city, page_link, image_url, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ? AND token = ?
-		ORDER BY rowid DESC LIMIT 1`, chatID, token).
-		Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
-			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt)
+		ORDER BY rowid DESC LIMIT 1`, chatID, token)
+	l, err := scanListingRow(row)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
 		return nil, err
-	}
-	if fs.Valid {
-		l.FitnessScore = &fs.Float64
 	}
 	return &l, nil
 }
@@ -106,14 +117,9 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 
 	var listings []storage.ListingRecord
 	for rows.Next() {
-		var l storage.ListingRecord
-		var fs sql.NullFloat64
-		if err := rows.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
-			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt); err != nil {
+		l, err := scanListingRow(rows)
+		if err != nil {
 			return nil, err
-		}
-		if fs.Valid {
-			l.FitnessScore = &fs.Float64
 		}
 		listings = append(listings, l)
 	}
@@ -141,14 +147,9 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 
 	var listings []storage.ListingRecord
 	for rows.Next() {
-		var l storage.ListingRecord
-		var fs sql.NullFloat64
-		if err := rows.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
-			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt); err != nil {
+		l, err := scanListingRow(rows)
+		if err != nil {
 			return nil, err
-		}
-		if fs.Valid {
-			l.FitnessScore = &fs.Float64
 		}
 		listings = append(listings, l)
 	}
@@ -186,14 +187,9 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 
 	var listings []storage.ListingRecord
 	for rows.Next() {
-		var l storage.ListingRecord
-		var fs sql.NullFloat64
-		if err := rows.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
-			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt); err != nil {
+		l, err := scanListingRow(rows)
+		if err != nil {
 			return nil, err
-		}
-		if fs.Valid {
-			l.FitnessScore = &fs.Float64
 		}
 		listings = append(listings, l)
 	}
@@ -238,14 +234,9 @@ func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) 
 
 	var listings []storage.ListingRecord
 	for rows.Next() {
-		var l storage.ListingRecord
-		var fs sql.NullFloat64
-		if err := rows.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model,
-			&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL, &fs, &l.FirstSeenAt); err != nil {
+		l, err := scanListingRow(rows)
+		if err != nil {
 			return nil, err
-		}
-		if fs.Valid {
-			l.FitnessScore = &fs.Float64
 		}
 		listings = append(listings, l)
 	}

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -1,0 +1,24 @@
+package timeutil
+
+import (
+	"fmt"
+	"time"
+)
+
+var flexibleFormats = []string{
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02 15:04:05.999999999-07:00",
+	"2006-01-02 15:04:05",
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+}
+
+func ParseFlexible(s string) (time.Time, error) {
+	for _, layout := range flexibleFormats {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized time format: %q", s)
+}


### PR DESCRIPTION
## Summary

Foundational refactoring to extract shared helpers, name magic numbers, and improve type safety across the codebase.

- **Thread-safe fetcher registry** (#475): Added `sync.RWMutex` to `Factory` in `internal/fetcher/fetcher.go`
- **Typed error detection** (#476): Replaced `strings.Contains(err.Error(), "challenge")` with `errors.Is(err, fetcher.ErrChallenge)` in health metrics
- **Shared time parser** (#444): Extracted `parseFlexibleTime` to `internal/timeutil/` package for reuse
- **Listing scan helper** (#441): Extracted `scanListingRow` to eliminate 5 duplicated scan blocks in `listings.go`
- **Named constants** (#443): Replaced magic numbers in scheduler (prune ages, concurrency) and health (degraded thresholds, timeouts)

## Test Plan
- [x] All tests pass (`make test`)
- [x] `go vet` clean

Closes #441, #443, #444, #475, #476

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system health monitoring with better error detection and degradation tracking.
  * Enhanced timeout handling for metrics collection.
  * Increased stability of concurrent operations.

* **Improvements**
  * Refined data retrieval operations with centralized error handling.
  * Better default values for internal scheduling and cleanup intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->