### PR TITLE
test: complete remaining test coverage

### DIFF
--- a/internal/api/firebase_test.go
+++ b/internal/api/firebase_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewFirebaseVerifier_InvalidJSON(t *testing.T) {
+	_, err := NewFirebaseVerifier("", "{not-json", "test-project")
+	if err == nil {
+		t.Fatal("expected error for invalid credentials JSON")
+	}
+}
+
+func TestNewFirebaseVerifier_MissingCredentialsFile(t *testing.T) {
+	badPath := filepath.Join(t.TempDir(), "nonexistent", "creds.json")
+	_, err := NewFirebaseVerifier(badPath, "", "test-project")
+	if err == nil {
+		t.Fatal("expected error for missing credentials file")
+	}
+}
+
+func TestNewFirebaseVerifier_NoExplicitCredentials(t *testing.T) {
+	// Matches buildAPI when ProjectID is set but credential file/JSON are empty:
+	// Firebase may use application default credentials or return an init error.
+	v, err := NewFirebaseVerifier("", "", "carwatch-firebase-test-project-id")
+	if err != nil {
+		if err.Error() == "" {
+			t.Fatal("error should be non-empty when init fails")
+		}
+		return
+	}
+	if v == nil {
+		t.Fatal("non-nil verifier expected when err is nil")
+	}
+}
+
+func TestNewFirebaseVerifier_InvalidServiceAccountJSON(t *testing.T) {
+	_, err := NewFirebaseVerifier("", `{"foo":true}`, "test-invalid-sa-project")
+	if err == nil {
+		t.Fatal("expected error for non-service-account JSON")
+	}
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -242,14 +242,14 @@ func (b *Bot) lockChat(chatID int64) func() {
 	return entry.mu.Unlock
 }
 
-const (
-	cleanupInterval = 1 * time.Hour
-	staleThreshold  = 1 * time.Hour
-)
+const staleThreshold = 1 * time.Hour
+
+// cleanupTickerInterval is the time between sweeps in StartCleanup (overridable in tests).
+var cleanupTickerInterval = 1 * time.Hour
 
 func (b *Bot) StartCleanup(ctx context.Context) {
 	go func() {
-		ticker := time.NewTicker(cleanupInterval)
+		ticker := time.NewTicker(cleanupTickerInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	tgbot "github.com/go-telegram/bot"
+	tgmodels "github.com/go-telegram/bot/models"
+
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/sqlite"
@@ -33,6 +36,84 @@ func TestIsRateLimited(t *testing.T) {
 	if tb.bot.isRateLimited(chatID + 1) {
 		t.Error("different user should not be rate limited")
 	}
+}
+
+func TestIsRateLimited_RefillsAfterInterval(t *testing.T) {
+	tb := newTestBot(t)
+	const chatID int64 = 901
+	for range rateLimitBurst {
+		if tb.bot.isRateLimited(chatID) {
+			t.Fatal("unexpected limit during burst")
+		}
+	}
+	if !tb.bot.isRateLimited(chatID) {
+		t.Fatal("expected limited after burst")
+	}
+	time.Sleep(rateLimitInterval + 60*time.Millisecond)
+	if tb.bot.isRateLimited(chatID) {
+		t.Error("expected a refilled token after one interval")
+	}
+}
+
+func TestRateLimitedMiddleware_AllowsWhenUnderLimit(t *testing.T) {
+	tb := newTestBot(t)
+	var called bool
+	next := func(context.Context, *tgbot.Bot, *tgmodels.Update) { called = true }
+	h := tb.bot.rateLimited(next)
+	ctx := context.Background()
+	h(ctx, nil, fakeMessage(91001, "/start"))
+	if !called {
+		t.Error("next handler should run when under limit")
+	}
+}
+
+func TestRateLimitedMiddleware_BlocksWhenOverLimit(t *testing.T) {
+	tb := newTestBot(t)
+	const chatID int64 = 91002
+	for range rateLimitBurst {
+		tb.bot.isRateLimited(chatID)
+	}
+	if !tb.bot.isRateLimited(chatID) {
+		t.Fatal("setup: should be rate limited")
+	}
+	var called bool
+	next := func(context.Context, *tgbot.Bot, *tgmodels.Update) { called = true }
+	h := tb.bot.rateLimited(next)
+	ctx := context.Background()
+	h(ctx, nil, fakeMessage(chatID, "/start"))
+	if called {
+		t.Error("next handler should not run when limited")
+	}
+}
+
+func TestStartCleanup_RemovesStaleRateLimitEntries(t *testing.T) {
+	old := cleanupTickerInterval
+	cleanupTickerInterval = 40 * time.Millisecond
+	defer func() { cleanupTickerInterval = old }()
+
+	tb := newTestBot(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tb.bot.StartCleanup(ctx)
+
+	chatID := int64(91003)
+	rl := &userRateLimit{tokens: 5, lastTick: time.Now()}
+	rl.lastSeen.Store(time.Now().Add(-3 * time.Hour).UnixNano())
+	tb.bot.rateLimiter.Store(chatID, rl)
+
+	deadline := time.After(300 * time.Millisecond)
+	for {
+		if _, ok := tb.bot.rateLimiter.Load(chatID); !ok {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("stale rate limiter entry was not swept")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	time.Sleep(30 * time.Millisecond)
 }
 
 func TestWizardData_JSON(t *testing.T) {

--- a/internal/notifier/multi_test.go
+++ b/internal/notifier/multi_test.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -12,13 +13,26 @@ import (
 )
 
 type fakeNotifier struct {
-	name     string
-	calls    []string
-	rawCalls []string
+	name          string
+	calls         []string
+	rawCalls      []string
+	connectErr    error
+	disconnectErr error
 }
 
-func (f *fakeNotifier) Connect(_ context.Context) error { return nil }
-func (f *fakeNotifier) Disconnect() error               { return nil }
+func (f *fakeNotifier) Connect(_ context.Context) error {
+	if f.connectErr != nil {
+		return f.connectErr
+	}
+	return nil
+}
+
+func (f *fakeNotifier) Disconnect() error {
+	if f.disconnectErr != nil {
+		return f.disconnectErr
+	}
+	return nil
+}
 
 func (f *fakeNotifier) Notify(_ context.Context, recipient string, _ []model.Listing, _ locale.Lang) error {
 	f.calls = append(f.calls, recipient)
@@ -167,4 +181,93 @@ func TestMultiNotifier_RegisterValidation(t *testing.T) {
 	if err := mn.Register("telegram", &fakeNotifier{}); err != nil {
 		t.Errorf("valid register: %v", err)
 	}
+}
+
+func TestMultiNotifier_ConnectAllAndDisconnect(t *testing.T) {
+	a := &fakeNotifier{name: "a"}
+	b := &fakeNotifier{name: "b"}
+	users := &fakeUserStore{users: map[int64]*storage.User{}}
+	mn := NewMultiNotifier(users, slog.Default())
+	_ = mn.Register("telegram", a)
+	_ = mn.Register("whatsapp", b)
+
+	ctx := context.Background()
+	if err := mn.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if err := mn.Disconnect(); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+}
+
+func TestMultiNotifier_ConnectStopsOnFirstError(t *testing.T) {
+	boom := errors.New("connect failed")
+	a := &fakeNotifier{name: "bad", connectErr: boom}
+	b := &fakeNotifier{name: "after"}
+	users := &fakeUserStore{users: map[int64]*storage.User{}}
+	mn := NewMultiNotifier(users, slog.Default())
+	_ = mn.Register("a", a)
+	_ = mn.Register("b", b)
+
+	err := mn.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected Connect error")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("expected wrapped boom, got %v", err)
+	}
+}
+
+func TestMultiNotifier_DisconnectJoinsErrors(t *testing.T) {
+	e1 := errors.New("d1")
+	e2 := errors.New("d2")
+	a := &fakeNotifier{name: "a", disconnectErr: e1}
+	b := &fakeNotifier{name: "b", disconnectErr: e2}
+	users := &fakeUserStore{users: map[int64]*storage.User{}}
+	mn := NewMultiNotifier(users, slog.Default())
+	_ = mn.Register("a", a)
+	_ = mn.Register("b", b)
+
+	err := mn.Disconnect()
+	if err == nil {
+		t.Fatal("expected Disconnect errors")
+	}
+	if !errors.Is(err, e1) || !errors.Is(err, e2) {
+		t.Errorf("expected both disconnect errors joined, got %v", err)
+	}
+}
+
+func TestMultiNotifier_NotifyRaw_UserLookupErrorFallsBack(t *testing.T) {
+	tg := &fakeNotifier{name: "telegram"}
+	wa := &fakeNotifier{name: "whatsapp"}
+	base := &fakeUserStore{
+		users: map[int64]*storage.User{
+			55: {ChatID: 55, Channel: "whatsapp"},
+		},
+	}
+	usersBroken := &fakeUserGetErrStore{fakeUserStore: base, err: errors.New("db unavailable")}
+
+	mn := NewMultiNotifier(usersBroken, slog.Default())
+	_ = mn.Register("telegram", tg)
+	_ = mn.Register("whatsapp", wa)
+
+	ctx := context.Background()
+	if err := mn.NotifyRaw(ctx, "55", "hi"); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if len(tg.rawCalls) != 1 {
+		t.Errorf("fallback should use first registered notifier (telegram), calls=%v", tg.rawCalls)
+	}
+	if len(wa.rawCalls) != 0 {
+		t.Errorf("whatsapp should not receive when falling back, got %v", wa.rawCalls)
+	}
+}
+
+type fakeUserGetErrStore struct {
+	*fakeUserStore
+	err error
+}
+
+func (f *fakeUserGetErrStore) GetUser(_ context.Context, _ int64) (*storage.User, error) {
+	return nil, f.err
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/storage/sqlite"
 )
 
 type mockFetcher struct {
@@ -316,5 +317,118 @@ func TestIsActiveHours_WithinWindow(t *testing.T) {
 	s, _ := New(cfg, nil, nil, nil, testLogger(), nil)
 	if !s.isActiveHours() {
 		t.Error("should be active within 00:00-23:59")
+	}
+}
+
+func TestRunMultiTenantCycle_ObserverSuccessPath(t *testing.T) {
+	store, err := sqlite.New(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+	if err := store.UpsertUser(ctx, 1, "alice"); err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	if _, err := store.CreateSearch(ctx, storage.Search{
+		ChatID:       1,
+		Name:         "s1",
+		Source:       "yad2",
+		Manufacturer: 19,
+		Model:        1,
+		YearMin:      2015,
+		YearMax:      2025,
+		PriceMax:     200_000,
+	}); err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	f := &mockFetcher{listings: []model.RawListing{{
+		Token:          "tok-observer-1",
+		ManufacturerID: 19,
+		ModelID:        1,
+		Manufacturer:   "Toyota",
+		Model:          "Corolla",
+		Year:           2018,
+		Price:          90_000,
+	}}}
+
+	cfg := testConfig()
+	obs := &countingObserver{}
+	n := &mockNotifier{}
+	s, err := NewWithOptions(cfg, f, store, n, testLogger(), Options{
+		Observer:     obs,
+		SearchStore:  store,
+		ListingStore: store,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(ctx); err != nil {
+		t.Fatalf("runMultiTenantCycle: %v", err)
+	}
+
+	if obs.fetches != 1 {
+		t.Errorf("RecordFetch calls = %d, want 1", obs.fetches)
+	}
+	if obs.listingsFound != 1 {
+		t.Errorf("listings aggregate = %d, want 1", obs.listingsFound)
+	}
+	if obs.notifications != 1 {
+		t.Errorf("notifications = %d, want 1", obs.notifications)
+	}
+	if obs.successes != 1 {
+		t.Errorf("successes = %d, want 1", obs.successes)
+	}
+	if obs.errors != 0 {
+		t.Errorf("errors = %d, want 0", obs.errors)
+	}
+}
+
+func TestRunMultiTenantCycle_ObserverErrorOnFetchFailure(t *testing.T) {
+	store, err := sqlite.New(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+	if err := store.UpsertUser(ctx, 2, "bob"); err != nil {
+		t.Fatalf("upsert user: %v", err)
+	}
+	if _, err := store.CreateSearch(ctx, storage.Search{
+		ChatID:       2,
+		Name:         "s2",
+		Source:       "yad2",
+		Manufacturer: 27,
+		Model:        1,
+	}); err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	f := &mockFetcher{err: errors.New("fetch failed")}
+	cfg := testConfig()
+	obs := &countingObserver{}
+	s, err := NewWithOptions(cfg, f, store, &mockNotifier{}, testLogger(), Options{
+		Observer:    obs,
+		SearchStore: store,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(ctx); err == nil {
+		t.Fatal("expected error when all fetch groups fail")
+	}
+	if obs.errors != 1 {
+		t.Errorf("errors = %d, want 1", obs.errors)
+	}
+	if obs.fetches != 1 {
+		t.Errorf("fetches = %d, want 1", obs.fetches)
+	}
+	if obs.successes != 0 {
+		t.Errorf("successes = %d, want 0", obs.successes)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `firebase_test.go` for `NewFirebaseVerifier`: invalid JSON, missing credential file, empty explicit credentials (ADC), and invalid service-account JSON.
- Exercise `CycleObserver` during `runMultiTenantCycle` (success path and all-groups fetch failure).
- Expand bot tests: token refill after interval, `rateLimited` middleware allow/block, and `StartCleanup` sweeping stale rate-limit map entries (via `cleanupTickerInterval` in tests).
- Expand `MultiNotifier` tests: `Connect` / `Disconnect`, connect failure propagation, joined disconnect errors, and `NotifyRaw` fallback when user lookup errors.

Closes #457, #458, #459, #461.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Firebase credential validation, rate limiting behavior, multi-notifier error handling, and scheduler observer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->