### PR TITLE
feat: implement WinWin fetcher and premium tier

### DIFF
--- a/internal/fetcher/cache.go
+++ b/internal/fetcher/cache.go
@@ -113,6 +113,7 @@ func (c *CachingFetcher) touch(key string) {
 }
 
 func cacheKey(p model.SourceParams) string {
-	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d",
-		p.Manufacturer, p.Model, p.YearMin, p.YearMax, p.PriceMin, p.PriceMax, p.Page)
+	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d:%d:%d:%d",
+		p.Manufacturer, p.Model, p.YearMin, p.YearMax, p.PriceMin, p.PriceMax, p.Page,
+		p.MaxKm, p.MaxHand, p.EngineMinCC)
 }

--- a/internal/fetcher/winwin/client.go
+++ b/internal/fetcher/winwin/client.go
@@ -1,12 +1,25 @@
 package winwin
 
 import (
+	"compress/gzip"
+	"context"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
+
+const maxResponseSize = 10 * 1024 * 1024
+
+// HTTPResult holds the outcome of an HTTP GET request.
+type HTTPResult struct {
+	Body       []byte
+	StatusCode int
+	Header     http.Header
+}
 
 // Client wraps an HTTP client configured for WinWin requests.
 type Client struct {
@@ -53,4 +66,39 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Cache-Control", "max-age=0")
 
 	return c.httpClient.Do(req)
+}
+
+func readResponseBody(resp *http.Response) ([]byte, error) {
+	reader := io.LimitReader(resp.Body, maxResponseSize)
+	if strings.Contains(strings.ToLower(resp.Header.Get("Content-Encoding")), "gzip") {
+		gr, err := gzip.NewReader(reader)
+		if err != nil {
+			return nil, fmt.Errorf("create gzip reader: %w", err)
+		}
+		defer func() { _ = gr.Close() }()
+		reader = gr
+	}
+	return io.ReadAll(reader)
+}
+
+// Get performs a GET and returns status, headers, and fully-read body.
+func (c *Client) Get(ctx context.Context, reqURL string) (*HTTPResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := readResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	header := make(http.Header, len(resp.Header))
+	for k, v := range resp.Header {
+		header[k] = append([]string(nil), v...)
+	}
+	return &HTTPResult{Body: body, StatusCode: resp.StatusCode, Header: header}, nil
 }

--- a/internal/fetcher/winwin/parser.go
+++ b/internal/fetcher/winwin/parser.go
@@ -1,15 +1,232 @@
 package winwin
 
 import (
+	"fmt"
 	"io"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 
+	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
+	"golang.org/x/net/html"
 )
 
-// ParseListingsPage parses WinWin HTML into raw listings.
-// TODO: Implement actual HTML parsing once the WinWin page structure is
-// reverse-engineered. The parser should extract listing tokens, prices,
-// years, mileage, etc. from the HTML response body.
-func ParseListingsPage(_ io.Reader) ([]model.RawListing, error) {
-	return nil, nil
+var (
+	priceRe      = regexp.MustCompile("(?:" + "\u20aa" + `|ש"ח|NIS|ILS|ILS\s*)\s*([\d,]+)|([\d,]+)\s*` + "\u20aa")
+	kmRe         = regexp.MustCompile(`([\d,]+)\s*(?:ק"|ק״מ|קמ|km|Km|KM)`)
+	handRe       = regexp.MustCompile(`(?:יד|בעלות|בעלים)\s*(\d+)`)
+	yearSuffixRe = regexp.MustCompile(`\b(19[89]\d|20\d{2})\s*$`)
+	trailingIDRe = regexp.MustCompile(`/(\d{5,})(?:[/?#]|$)`)
+	midPathIDRe  = regexp.MustCompile(`/vehicles/[^/]+/(\d{4,})(?:[/?#]|$)`)
+)
+
+func ParseListingsPage(r io.Reader) ([]model.RawListing, error) {
+	if r == nil {
+		return nil, nil
+	}
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	htmlStr := string(raw)
+	if looksLikeChallenge(htmlStr) {
+		return nil, fetcher.ErrChallenge
+	}
+	doc, err := html.Parse(strings.NewReader(htmlStr))
+	if err != nil {
+		return nil, fmt.Errorf("parse html: %w", err)
+	}
+	seen := make(map[string]struct{})
+	var out []model.RawListing
+	var visit func(*html.Node)
+	visit = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			if listing, ok := rawListingFromAnchor(n); ok {
+				if _, dup := seen[listing.Token]; !dup {
+					seen[listing.Token] = struct{}{}
+					out = append(out, listing)
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			visit(c)
+		}
+	}
+	visit(doc)
+	return out, nil
+}
+
+func looksLikeChallenge(htmlStr string) bool {
+	h := strings.ToLower(htmlStr)
+	return strings.Contains(h, "errors.edgesuite.net") ||
+		strings.Contains(h, "an error occurred while processing your request") ||
+		strings.Contains(h, "cf-browser-verification") || strings.Contains(h, "captcha") ||
+		(strings.Contains(h, "access denied") && strings.Contains(h, "akamai"))
+}
+
+func rawListingFromAnchor(a *html.Node) (model.RawListing, bool) {
+	href := attr(a, "href")
+	if href == "" || href == "#" {
+		return model.RawListing{}, false
+	}
+	token, ok := listingTokenFromHref(href)
+	if !ok {
+		return model.RawListing{}, false
+	}
+	lh := strings.ToLower(href)
+	if !strings.Contains(lh, "vehicles") && !strings.Contains(lh, "vehicle") {
+		return model.RawListing{}, false
+	}
+	pageLink := resolveWinWinURL(href)
+	scope := listingCardScope(a)
+	blob := strings.TrimSpace(textContent(scope))
+	var listing model.RawListing
+	listing.Token = token
+	listing.PageLink = pageLink
+	title := strings.TrimSpace(textContent(a))
+	if title != "" {
+		if sub := yearSuffixRe.FindStringSubmatch(title); len(sub) > 1 {
+			if y, err := strconv.Atoi(sub[1]); err == nil {
+				listing.Year = y
+				title = strings.TrimSpace(strings.TrimSuffix(title, sub[1]))
+			}
+		}
+		parts := strings.Fields(title)
+		if len(parts) >= 2 {
+			listing.Manufacturer = parts[0]
+			listing.Model = strings.Join(parts[1:], " ")
+		} else if len(parts) == 1 {
+			listing.Manufacturer = parts[0]
+		}
+	}
+	if p, ok := firstPriceInText(blob); ok {
+		listing.Price = p
+	}
+	if km, ok := firstMatchInt(kmRe, blob); ok {
+		listing.Km = km
+	}
+	if hand, ok := firstMatchInt(handRe, blob); ok {
+		listing.Hand = hand
+	}
+	if city := extractCityHeuristic(blob); city != "" {
+		listing.City = city
+	}
+	return listing, true
+}
+
+func resolveWinWinURL(href string) string {
+	base, _ := url.Parse("https://www.winwin.co.il")
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	return base.ResolveReference(ref).String()
+}
+
+func listingCardScope(a *html.Node) *html.Node {
+	n := a
+	for i := 0; i < 6 && n != nil; i++ {
+		if n.Parent != nil {
+			n = n.Parent
+		} else {
+			break
+		}
+	}
+	if n == nil {
+		return a
+	}
+	return n
+}
+
+func listingTokenFromHref(href string) (string, bool) {
+	if m := trailingIDRe.FindStringSubmatch(href); len(m) > 1 {
+		return m[1], true
+	}
+	if m := midPathIDRe.FindStringSubmatch(href); len(m) > 1 {
+		return m[1], true
+	}
+	return "", false
+}
+
+func attr(n *html.Node, key string) string {
+	for _, at := range n.Attr {
+		if strings.EqualFold(at.Key, key) {
+			return at.Val
+		}
+	}
+	return ""
+}
+
+func textContent(n *html.Node) string {
+	if n == nil {
+		return ""
+	}
+	var b strings.Builder
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.TextNode {
+			b.WriteString(node.Data)
+			b.WriteByte(' ')
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return b.String()
+}
+
+func firstPriceInText(s string) (int, bool) {
+	for _, m := range priceRe.FindAllStringSubmatch(s, -1) {
+		for _, grp := range m[1:] {
+			if grp == "" {
+				continue
+			}
+			digits := strings.ReplaceAll(grp, ",", "")
+			n, err := strconv.Atoi(digits)
+			if err == nil && n > 0 {
+				return n, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func firstMatchInt(re *regexp.Regexp, s string) (int, bool) {
+	m := re.FindStringSubmatch(s)
+	if len(m) < 2 {
+		return 0, false
+	}
+	digits := strings.ReplaceAll(m[1], ",", "")
+	n, err := strconv.Atoi(digits)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func extractCityHeuristic(blob string) string {
+	for _, sep := range []string{"•", "|", "·"} {
+		i := strings.Index(blob, sep)
+		if i >= 0 {
+			frag := strings.TrimSpace(blob[i+len(sep):])
+			fields := strings.Fields(frag)
+			var parts []string
+			for _, w := range fields {
+				if strings.Contains(w, "\u20aa") {
+					break
+				}
+				parts = append(parts, w)
+				if len(parts) >= 3 {
+					break
+				}
+			}
+			if s := strings.Join(parts, " "); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
 }

--- a/internal/fetcher/winwin/url.go
+++ b/internal/fetcher/winwin/url.go
@@ -7,18 +7,14 @@ import (
 	"github.com/dsionov/carwatch/internal/model"
 )
 
-const defaultBaseURL = "https://www.winwin.co.il/vehicles/cars"
+const defaultBaseURL = "https://www.winwin.co.il/vehicles/cars-for-sale"
 
-// buildURL constructs a WinWin search URL from the given parameters.
-// TODO: Reverse-engineer the actual WinWin URL structure and query parameters.
-// The parameters below are placeholders based on common patterns.
 func buildURL(base string, params model.SourceParams) string {
 	u, err := url.Parse(base)
 	if err != nil {
 		u = &url.URL{Path: base}
 	}
 	v := url.Values{}
-
 	if params.Manufacturer > 0 {
 		v.Set("manufacturer", strconv.Itoa(params.Manufacturer))
 	}
@@ -37,10 +33,18 @@ func buildURL(base string, params model.SourceParams) string {
 	if params.PriceMax > 0 {
 		v.Set("priceTo", strconv.Itoa(params.PriceMax))
 	}
+	if params.MaxKm > 0 {
+		v.Set("km", strconv.Itoa(params.MaxKm))
+	}
+	if params.MaxHand > 0 {
+		v.Set("hand", strconv.Itoa(params.MaxHand))
+	}
+	if params.EngineMinCC > 0 {
+		v.Set("engineVolume", strconv.Itoa(params.EngineMinCC))
+	}
 	if params.Page > 0 {
 		v.Set("page", strconv.Itoa(params.Page))
 	}
-
 	u.RawQuery = v.Encode()
 	return u.String()
 }

--- a/internal/fetcher/winwin/winwin.go
+++ b/internal/fetcher/winwin/winwin.go
@@ -1,8 +1,11 @@
 package winwin
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
@@ -10,10 +13,11 @@ import (
 
 // WinWinFetcher implements the fetcher.Fetcher interface for winwin.co.il.
 type WinWinFetcher struct {
-	client    *Client
-	baseURL   string
-	logger    *slog.Logger
-	proxyPool *fetcher.ProxyPool
+	userAgents []string
+	client     *Client
+	baseURL    string
+	logger     *slog.Logger
+	proxyPool  *fetcher.ProxyPool
 }
 
 // NewFetcher creates a WinWin fetcher with optional proxy support.
@@ -23,9 +27,10 @@ func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*WinWin
 		return nil, err
 	}
 	return &WinWinFetcher{
-		client:  client,
-		baseURL: defaultBaseURL,
-		logger:  logger,
+		userAgents: userAgents,
+		client:     client,
+		baseURL:    defaultBaseURL,
+		logger:     logger,
 	}, nil
 }
 
@@ -40,23 +45,44 @@ func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logge
 		return nil, err
 	}
 	return &WinWinFetcher{
-		client:    client,
-		baseURL:   defaultBaseURL,
-		logger:    logger,
-		proxyPool: pool,
+		userAgents: userAgents,
+		client:     client,
+		baseURL:    defaultBaseURL,
+		logger:     logger,
+		proxyPool:  pool,
 	}, nil
 }
 
 // Fetch retrieves car listings from WinWin.
-// TODO: Implement actual scraping logic once the WinWin API/page structure
-// is reverse-engineered. For now this returns empty results so the fetcher
-// can be registered and tested end-to-end without hitting a real server.
 func (f *WinWinFetcher) Fetch(ctx context.Context, params model.SourceParams) ([]model.RawListing, error) {
+	cli := f.client
+	if f.proxyPool != nil {
+		c, err := NewClient(f.userAgents, f.proxyPool.Next())
+		if err != nil {
+			return nil, fmt.Errorf("winwin proxy client: %w", err)
+		}
+		cli = c
+	}
 	reqURL := buildURL(f.baseURL, params)
-	f.logger.Info("winwin fetch stub", "url", reqURL)
-
-	// TODO: Make HTTP request, parse response, return listings.
-	// The full implementation requires reverse-engineering the WinWin
-	// HTML structure or discovering a JSON API endpoint.
-	return nil, nil
+	f.logger.Info("fetching winwin listings", "url", reqURL)
+	result, err := cli.Get(ctx, reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	switch result.StatusCode {
+	case http.StatusOK:
+	case http.StatusTooManyRequests:
+		return nil, fetcher.ErrRateLimited
+	default:
+		if looksLikeChallenge(string(result.Body)) {
+			return nil, fetcher.ErrChallenge
+		}
+		return nil, fmt.Errorf("unexpected status: %d", result.StatusCode)
+	}
+	listings, err := ParseListingsPage(bytes.NewReader(result.Body))
+	if err != nil {
+		return nil, fmt.Errorf("parse page: %w", err)
+	}
+	f.logger.Info("fetched winwin listings", "count", len(listings))
+	return listings, nil
 }

--- a/internal/fetcher/winwin/winwin_test.go
+++ b/internal/fetcher/winwin/winwin_test.go
@@ -2,31 +2,94 @@ package winwin
 
 import (
 	"context"
+	"errors"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
 )
 
-func TestWinWinFetcher_StubReturnsEmpty(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	f, err := NewFetcher([]string{"TestAgent/1.0"}, "", logger)
+func TestWinWinFetcher_FetchParsesHTML(t *testing.T) {
+	html := `<!DOCTYPE html><html><body>
+<div><a href="/vehicles/private/9000123">מאזדה 3 2021</a>
+<span>120,000 ₪</span><span>50,000 קמ</span><span>יד 2</span><span>• תל אביב</span></div>
+</body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(html))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := &WinWinFetcher{
+		userAgents: []string{"TestAgent/1.0"},
+		baseURL:    srv.URL,
+		logger:     logger,
+	}
+	var err error
+	f.client, err = NewClient([]string{"TestAgent/1.0"}, "")
 	if err != nil {
-		t.Fatalf("NewFetcher: %v", err)
+		t.Fatal(err)
 	}
 
-	listings, err := f.Fetch(context.Background(), model.SourceParams{
-		Manufacturer: 27,
-		Model:        10332,
-		YearMin:      2020,
-		YearMax:      2024,
-	})
+	listings, err := f.Fetch(context.Background(), model.SourceParams{Manufacturer: 27, Model: 10332})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
-	if len(listings) != 0 {
-		t.Errorf("expected 0 listings from stub, got %d", len(listings))
+	if len(listings) != 1 {
+		t.Fatalf("want 1 listing, got %d", len(listings))
+	}
+	l := listings[0]
+	if l.Token != "9000123" || l.Price != 120000 || l.Km != 50000 || l.Hand != 2 || l.Year != 2021 {
+		t.Fatalf("listing: %+v", l)
+	}
+}
+
+func TestWinWinFetcher_ChallengeStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`errors.edgesuite.net`))
+	}))
+	t.Cleanup(srv.Close)
+	f := &WinWinFetcher{
+		userAgents: []string{"TestAgent/1.0"},
+		baseURL:    srv.URL,
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	var err error
+	f.client, err = NewClient([]string{"TestAgent/1.0"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Fetch(context.Background(), model.SourceParams{})
+	if !errors.Is(err, fetcher.ErrChallenge) {
+		t.Fatalf("want ErrChallenge, got %v", err)
+	}
+}
+
+func TestWinWinFetcher_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+	f := &WinWinFetcher{
+		userAgents: []string{"TestAgent/1.0"},
+		baseURL:    srv.URL,
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	var err error
+	f.client, err = NewClient([]string{"TestAgent/1.0"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Fetch(context.Background(), model.SourceParams{})
+	if !errors.Is(err, fetcher.ErrRateLimited) {
+		t.Fatalf("want ErrRateLimited, got %v", err)
 	}
 }
 
@@ -36,48 +99,44 @@ func TestBuildURL(t *testing.T) {
 		params model.SourceParams
 		want   string
 	}{
+		{name: "empty", params: model.SourceParams{}, want: "https://www.winwin.co.il/vehicles/cars-for-sale"},
 		{
-			name:   "empty params",
-			params: model.SourceParams{},
-			want:   "https://www.winwin.co.il/vehicles/cars",
-		},
-		{
-			name: "full params",
+			name: "full",
 			params: model.SourceParams{
-				Manufacturer: 27,
-				Model:        10332,
-				YearMin:      2020,
-				YearMax:      2024,
-				PriceMax:     150000,
+				Manufacturer: 27, Model: 10332, YearMin: 2020, YearMax: 2024, PriceMax: 150000,
+				MaxKm: 120000, MaxHand: 3, EngineMinCC: 1600,
 			},
-			want: "https://www.winwin.co.il/vehicles/cars?manufacturer=27&model=10332&priceTo=150000&yearFrom=2020&yearTo=2024",
+			want: "https://www.winwin.co.il/vehicles/cars-for-sale?engineVolume=1600&hand=3&km=120000&manufacturer=27&model=10332&priceTo=150000&yearFrom=2020&yearTo=2024",
 		},
-		{
-			name: "with page",
-			params: model.SourceParams{
-				Manufacturer: 35,
-				Page:         2,
-			},
-			want: "https://www.winwin.co.il/vehicles/cars?manufacturer=35&page=2",
-		},
+		{name: "page", params: model.SourceParams{Manufacturer: 35, Page: 2},
+			want: "https://www.winwin.co.il/vehicles/cars-for-sale?manufacturer=35&page=2"},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildURL(defaultBaseURL, tt.params)
-			if got != tt.want {
-				t.Errorf("buildURL() = %q, want %q", got, tt.want)
+			if got := buildURL(defaultBaseURL, tt.params); got != tt.want {
+				t.Errorf("got %q want %q", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestParseListingsPage_Stub(t *testing.T) {
-	listings, err := ParseListingsPage(nil)
-	if err != nil {
-		t.Fatalf("ParseListingsPage: %v", err)
+func TestParseListingsPage_ChallengeHTML(t *testing.T) {
+	_, err := ParseListingsPage(strings.NewReader(`<html>errors.edgesuite.net</html>`))
+	if !errors.Is(err, fetcher.ErrChallenge) {
+		t.Fatal(err)
 	}
-	if listings != nil {
-		t.Errorf("expected nil from stub parser, got %v", listings)
+}
+
+func TestParseListingsPage_EmptyDoc(t *testing.T) {
+	listings, err := ParseListingsPage(strings.NewReader("<html></html>"))
+	if err != nil || len(listings) != 0 {
+		t.Fatalf("err=%v n=%d", err, len(listings))
+	}
+}
+
+func TestParseListingsPage_NilReader(t *testing.T) {
+	listings, err := ParseListingsPage(nil)
+	if err != nil || listings != nil {
+		t.Fatalf("err=%v listings=%v", err, listings)
 	}
 }

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -9,6 +9,9 @@ type SourceParams struct {
 	PriceMin     int
 	PriceMax     int
 	Page         int
+	MaxKm        int
+	MaxHand      int
+	EngineMinCC  int
 }
 
 // FilterCriteria defines the criteria used to filter raw listings

--- a/internal/scheduler/grouper.go
+++ b/internal/scheduler/grouper.go
@@ -40,6 +40,9 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 						YearMin:      s.YearMin,
 						YearMax:      s.YearMax,
 						PriceMax:     s.PriceMax,
+						MaxKm:        s.MaxKm,
+						MaxHand:      s.MaxHand,
+						EngineMinCC:  s.EngineMinCC,
 					},
 				}
 				grouped[key] = g
@@ -55,6 +58,24 @@ func GroupSearches(searches []storage.Search) []CanonicalGroup {
 				g.Params.PriceMax = 0
 			} else if s.PriceMax > g.Params.PriceMax {
 				g.Params.PriceMax = s.PriceMax
+			}
+
+			if s.MaxKm == 0 || g.Params.MaxKm == 0 {
+				g.Params.MaxKm = 0
+			} else if s.MaxKm > g.Params.MaxKm {
+				g.Params.MaxKm = s.MaxKm
+			}
+
+			if s.MaxHand == 0 || g.Params.MaxHand == 0 {
+				g.Params.MaxHand = 0
+			} else if s.MaxHand > g.Params.MaxHand {
+				g.Params.MaxHand = s.MaxHand
+			}
+
+			if s.EngineMinCC == 0 || g.Params.EngineMinCC == 0 {
+				g.Params.EngineMinCC = 0
+			} else if s.EngineMinCC < g.Params.EngineMinCC {
+				g.Params.EngineMinCC = s.EngineMinCC
 			}
 
 			g.Searches = append(g.Searches, s)

--- a/internal/scheduler/grouper_test.go
+++ b/internal/scheduler/grouper_test.go
@@ -161,3 +161,20 @@ func TestGroupSearches_EmptySourceMergesWithExplicit(t *testing.T) {
 		t.Errorf("yad2 group should have 2 searches (empty + explicit), got %d", len(yad2Group.Searches))
 	}
 }
+
+func TestGroupSearches_MergesFilters(t *testing.T) {
+	searches := []storage.Search{
+		{ID: 1, ChatID: 100, Source: "winwin", Manufacturer: 27, Model: 10332,
+			MaxKm: 100000, MaxHand: 2, EngineMinCC: 2000},
+		{ID: 2, ChatID: 200, Source: "winwin", Manufacturer: 27, Model: 10332,
+			MaxKm: 150000, MaxHand: 3, EngineMinCC: 1600},
+	}
+	groups := GroupSearches(searches)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 group, got %d", len(groups))
+	}
+	par := groups[0].Params
+	if par.MaxKm != 150000 || par.MaxHand != 3 || par.EngineMinCC != 1600 {
+		t.Fatalf("merged params: %+v", par)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -25,17 +25,17 @@ import (
 )
 
 const (
-	fetchTimeout    = 60 * time.Second
+	fetchTimeout = 60 * time.Second
 	// kmEnrichTimeout bounds per-item mileage/city fetches after the list crawl.
-	kmEnrichTimeout        = 25 * time.Minute
-	maxBackoff             = 4.0
-	minBackoff             = 1.0
-	pruneInterval          = 24 * time.Hour
-	maxRetries             = 3
-	retryBaseDelay         = 2 * time.Second
-	defaultConcurrency     = 4
-	notificationPruneAge   = 48 * time.Hour
-	priceHistoryRetention  = 90 * 24 * time.Hour
+	kmEnrichTimeout       = 25 * time.Minute
+	maxBackoff            = 4.0
+	minBackoff            = 1.0
+	pruneInterval         = 24 * time.Hour
+	maxRetries            = 3
+	retryBaseDelay        = 2 * time.Second
+	defaultConcurrency    = 4
+	notificationPruneAge  = 48 * time.Hour
+	priceHistoryRetention = 90 * 24 * time.Hour
 )
 
 type CatalogIngester interface {
@@ -472,6 +472,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	}
 
 	s.pruneIfDue(ctx)
+	s.processExpiredPremium(ctx)
 
 	if len(searches) == 0 {
 		s.logger.Info("no active searches")
@@ -1082,11 +1083,51 @@ func (s *Scheduler) deactivateExcessSearches(ctx context.Context, chatID int64, 
 		"chat_id", chatID, "paused", len(active)-maxActive, "kept", maxActive)
 }
 
-func (s *Scheduler) isUserPremium(_ context.Context, _ int64) bool {
-	return true
+func (s *Scheduler) isUserPremium(ctx context.Context, chatID int64) bool {
+	if s.stores.Users == nil {
+		return false
+	}
+	user, err := s.stores.Users.GetUser(ctx, chatID)
+	if err != nil || user == nil {
+		return false
+	}
+	if user.Tier != "premium" {
+		return false
+	}
+	if user.TierExpires.IsZero() {
+		return false
+	}
+	return time.Now().Before(user.TierExpires)
 }
 
-func (s *Scheduler) processExpiredPremium(_ context.Context) {
+func (s *Scheduler) processExpiredPremium(ctx context.Context) {
+	if s.stores.Users == nil {
+		return
+	}
+	expired, err := s.stores.Users.ListExpiredPremium(ctx)
+	if err != nil {
+		s.logger.Error("list expired premium users failed", "error", err)
+		return
+	}
+	if len(expired) == 0 {
+		return
+	}
+	s.cfgMu.RLock()
+	maxSearches := s.cfg.Telegram.MaxSearches
+	s.cfgMu.RUnlock()
+	for _, u := range expired {
+		if err := s.stores.Users.SetUserTier(ctx, u.ChatID, "free", time.Time{}); err != nil {
+			s.logger.Error("downgrade expired premium user failed",
+				"chat_id", u.ChatID,
+				"error", err,
+			)
+			continue
+		}
+		s.deactivateExcessSearches(ctx, u.ChatID, maxSearches)
+		s.logger.Info("premium subscription expired, user downgraded to free",
+			"chat_id", u.ChatID,
+		)
+	}
 }
 
 func (s *Scheduler) userLang(ctx context.Context, chatID int64) locale.Lang {

--- a/internal/scheduler/scheduler_extra_test.go
+++ b/internal/scheduler/scheduler_extra_test.go
@@ -217,8 +217,12 @@ func (m *mockNotificationQueue) PruneNotifications(_ context.Context, _ time.Dur
 // --- mockDailyDigestStore ---
 
 type mockDailyDigestStore struct {
-	mu       sync.Mutex
-	digests  map[int64]struct{ enabled bool; digestTime string; lastSent time.Time }
+	mu      sync.Mutex
+	digests map[int64]struct {
+		enabled    bool
+		digestTime string
+		lastSent   time.Time
+	}
 	stats    map[int64][]storage.DailySearchStats
 	updated  map[int64]bool
 	listErr  error
@@ -227,7 +231,11 @@ type mockDailyDigestStore struct {
 
 func newMockDailyDigestStore() *mockDailyDigestStore {
 	return &mockDailyDigestStore{
-		digests: make(map[int64]struct{ enabled bool; digestTime string; lastSent time.Time }),
+		digests: make(map[int64]struct {
+			enabled    bool
+			digestTime string
+			lastSent   time.Time
+		}),
 		stats:   make(map[int64][]storage.DailySearchStats),
 		updated: make(map[int64]bool),
 	}
@@ -236,7 +244,11 @@ func newMockDailyDigestStore() *mockDailyDigestStore {
 func (m *mockDailyDigestStore) SetDailyDigest(_ context.Context, chatID int64, enabled bool, digestTime string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.digests[chatID] = struct{ enabled bool; digestTime string; lastSent time.Time }{enabled, digestTime, m.digests[chatID].lastSent}
+	m.digests[chatID] = struct {
+		enabled    bool
+		digestTime string
+		lastSent   time.Time
+	}{enabled, digestTime, m.digests[chatID].lastSent}
 	return nil
 }
 
@@ -316,6 +328,51 @@ func TestProcessExpiredPremium_IsNoOp(t *testing.T) {
 	cfg := testConfig()
 	s, _ := New(cfg, nil, nil, nil, testLogger(), nil)
 	s.processExpiredPremium(context.Background())
+}
+
+type expiredPremiumUserStore struct {
+	*mockUserStore
+	expired []storage.User
+}
+
+func (e *expiredPremiumUserStore) ListExpiredPremium(_ context.Context) ([]storage.User, error) {
+	return e.expired, nil
+}
+
+func TestProcessExpiredPremium_DowngradesAndDeactivates(t *testing.T) {
+	cfg := testConfig()
+	cfg.Telegram.MaxSearches = 1
+	past := time.Now().Add(-time.Hour)
+	us := newMockUserStore()
+	_ = us.UpsertUser(context.Background(), 100, "u")
+	_ = us.SetUserTier(context.Background(), 100, "premium", past)
+	store := &expiredPremiumUserStore{
+		mockUserStore: us,
+		expired:       []storage.User{{ChatID: 100, Tier: "premium", TierExpires: past}},
+	}
+	ss := &mockSearchStoreWithTracking{
+		mockSearchStore: &mockSearchStore{
+			searches: []storage.Search{
+				{ID: 1, ChatID: 100, Active: true},
+				{ID: 2, ChatID: 100, Active: true},
+			},
+		},
+	}
+	s, err := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{
+		UserStore:   store,
+		SearchStore: ss,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.processExpiredPremium(context.Background())
+	u, _ := us.GetUser(context.Background(), 100)
+	if u == nil || u.Tier != "free" || !u.TierExpires.IsZero() {
+		t.Fatalf("user after downgrade: %+v", u)
+	}
+	if len(ss.deactivated) != 1 {
+		t.Fatalf("want 1 deactivated search, got %d", len(ss.deactivated))
+	}
 }
 
 // --- deactivateExcessSearches tests ---
@@ -406,7 +463,11 @@ func TestProcessDailyDigests_SendsWhenTimeMatches(t *testing.T) {
 	now := time.Now().In(time.UTC)
 	digestTime := fmt.Sprintf("%02d:%02d", now.Hour(), now.Minute())
 
-	dds.digests[100] = struct{ enabled bool; digestTime string; lastSent time.Time }{
+	dds.digests[100] = struct {
+		enabled    bool
+		digestTime string
+		lastSent   time.Time
+	}{
 		true, digestTime, time.Time{},
 	}
 	dds.stats[100] = []storage.DailySearchStats{
@@ -433,7 +494,11 @@ func TestProcessDailyDigests_SkipsOutsideWindow(t *testing.T) {
 	farHour := (now.Hour() + 6) % 24
 	digestTime := fmt.Sprintf("%02d:%02d", farHour, now.Minute())
 
-	dds.digests[100] = struct{ enabled bool; digestTime string; lastSent time.Time }{
+	dds.digests[100] = struct {
+		enabled    bool
+		digestTime string
+		lastSent   time.Time
+	}{
 		true, digestTime, time.Time{},
 	}
 
@@ -453,7 +518,11 @@ func TestProcessDailyDigests_SkipsAlreadySentToday(t *testing.T) {
 	now := time.Now().In(time.UTC)
 	digestTime := fmt.Sprintf("%02d:%02d", now.Hour(), now.Minute())
 
-	dds.digests[100] = struct{ enabled bool; digestTime string; lastSent time.Time }{
+	dds.digests[100] = struct {
+		enabled    bool
+		digestTime string
+		lastSent   time.Time
+	}{
 		true, digestTime, now,
 	}
 
@@ -544,11 +613,43 @@ func (m *mockNotifierWithRawErr) NotifyRaw(_ context.Context, _ string, _ string
 
 // --- isUserPremium tests ---
 
-func TestIsUserPremium_AlwaysTrue(t *testing.T) {
+func TestIsUserPremium_NilUserStore(t *testing.T) {
 	cfg := testConfig()
 	s, _ := New(cfg, nil, nil, nil, testLogger(), nil)
+	if s.isUserPremium(context.Background(), 100) {
+		t.Error("expected false when user store is nil")
+	}
+}
 
+func TestIsUserPremium_ActivePremium(t *testing.T) {
+	cfg := testConfig()
+	us := newMockUserStore()
+	_ = us.UpsertUser(context.Background(), 100, "u")
+	future := time.Now().Add(24 * time.Hour)
+	_ = us.SetUserTier(context.Background(), 100, "premium", future)
+	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
 	if !s.isUserPremium(context.Background(), 100) {
-		t.Error("expected true for all users (premium gating disabled)")
+		t.Fatal("expected premium")
+	}
+}
+
+func TestIsUserPremium_ExpiredTier(t *testing.T) {
+	cfg := testConfig()
+	us := newMockUserStore()
+	_ = us.UpsertUser(context.Background(), 100, "u")
+	_ = us.SetUserTier(context.Background(), 100, "premium", time.Now().Add(-time.Hour))
+	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
+	if s.isUserPremium(context.Background(), 100) {
+		t.Fatal("expected non-premium after expiry")
+	}
+}
+
+func TestIsUserPremium_FreeTier(t *testing.T) {
+	cfg := testConfig()
+	us := newMockUserStore()
+	_ = us.UpsertUser(context.Background(), 100, "u")
+	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{UserStore: us})
+	if s.isUserPremium(context.Background(), 100) {
+		t.Fatal("expected free user not premium")
 	}
 }


### PR DESCRIPTION
## Summary

- **WinWin (#429–#431):** Real search URLs, HTTP client with gzip support, HTML parsing into `RawListing`, and challenge/rate-limit handling consistent with other fetchers.
- **Filters:** `SourceParams` gains `MaxKm`, `MaxHand`, and `EngineMinCC`; cache keys and search grouping merge these across users.
- **Premium (#432):** `isUserPremium` checks stored tier and `TierExpires`; `processExpiredPremium` downgrades expired users and deactivates searches past the free limit.

## Test plan

- [x] `make test`
- [x] `go vet ./...`

Closes #429, #430, #431, #432

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added advanced search filters: maximum kilometers, maximum ownership history, and minimum engine displacement for more precise vehicle searches.

* **Bug Fixes**
  * Fixed cache collision issue where distinct search filter combinations could incorrectly return cached results from different queries.

* **Chores**
  * Implemented automatic premium subscription expiration handling—expired accounts now downgrade to free tier and excess searches deactivate accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->