### PR TITLE
fix: restore listing click navigation, polish mobile landing and score colors

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,8 +2,8 @@
 <html lang="he" dir="rtl" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" href="/logo-login.png" />
+    <link rel="apple-touch-icon" href="/logo-login.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0B0D14" />

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -7,9 +7,10 @@
   "theme_color": "#0B0D14",
   "icons": [
     {
-      "src": "/favicon-32.png",
-      "sizes": "32x32",
-      "type": "image/png"
+      "src": "/logo-login.png",
+      "sizes": "any",
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/logo-192.png",

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -232,7 +232,7 @@ export function HeroSection() {
             </div>
           </FloatingCard>
 
-          <FloatingCard className="-bottom-5 sm:-end-8 md:-end-14" delay={1.0}>
+          <FloatingCard className="-bottom-5 max-w-[min(18rem,calc(100vw-3rem))] sm:-end-8 md:-end-14" delay={1.0}>
             <div className="flex items-center gap-2.5">
               <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-success/20">
                 <TrendingDown size={13} className="text-success" />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -35,9 +35,9 @@
   --color-price: #F59E0B;
   --color-price-foreground: #D97706;
 
-  /* Match landing Smart Match tiers: gold / orange / red */
-  --color-score-great: #FBBF24;
-  --color-score-good: #F97316;
+  /* Match Smart Match tiers: green / amber / red */
+  --color-score-great: #34D399;
+  --color-score-good: #FBBF24;
   --color-score-low: #EF4444;
 
   --color-success: #10B981;

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -77,16 +77,16 @@ export function scoreListingAgainstSearch(
   };
 }
 
-/** Tier colors aligned with landing Smart Match mock (gold / orange / red). */
+/** Tier colors: green (great) → amber (good) → red (low). */
 export function scoreColor(score: number): string {
-  if (score >= 8) return "text-amber-400";
-  if (score >= 5) return "text-orange-500";
+  if (score >= 8) return "text-emerald-400";
+  if (score >= 5) return "text-amber-400";
   return "text-red-500";
 }
 
 export function scoreBgColor(score: number): string {
-  if (score >= 8) return "bg-amber-400/12 border-amber-400/50";
-  if (score >= 5) return "bg-orange-500/12 border-orange-500/45";
+  if (score >= 8) return "bg-emerald-400/12 border-emerald-400/50";
+  if (score >= 5) return "bg-amber-400/12 border-amber-400/45";
   return "bg-red-500/12 border-red-500/42";
 }
 
@@ -98,7 +98,7 @@ export function scoreLabel(score: number): string {
 }
 
 export function scoreBarColor(score: number): string {
-  if (score >= 8) return "bg-amber-400";
-  if (score >= 5) return "bg-orange-500";
+  if (score >= 8) return "bg-emerald-400";
+  if (score >= 5) return "bg-amber-400";
   return "bg-red-500";
 }

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -30,11 +30,7 @@ const PAGE_SIZE = 20;
 
 function isInteractiveTarget(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
-  return (
-    target.closest(
-      "button,a,input,select,textarea,[role='button']",
-    ) != null
-  );
+  return target.closest("button,a,input,select,textarea") != null;
 }
 
 export function ListingsPage() {


### PR DESCRIPTION
## Summary

- **Listing click broken** — `isInteractiveTarget` included `[role='button']` in its selector, but the card wrapper itself carries `role="button"`, so `closest()` always matched and navigation was silently swallowed. Removed it from the selector.
- **Landing page mobile** — the bottom "ירידת מחיר" FloatingCard lacked the viewport-safe `max-w-[min(18rem,calc(100vw-3rem))]` that the top notification card already had, causing it to clip on narrow screens.
- **Score colors** — changed tier palette from gold/orange/red → **green/amber/red** so higher scores visually read as green (`emerald-400` ≥ 8, `amber-400` ≥ 5, `red-500` < 5). Updated scoring functions, CSS tokens, and all downstream components.
- **Favicon** — swapped the plain `favicon-32.png` and `apple-touch-icon.png` references for `logo-login.png` (the CarWatch logo used on the auth page), updating both `index.html` and `manifest.json`.

## Test plan

- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Go tests pass (`make test` — 82.1% coverage)
- [x] `go vet ./...` clean
- [ ] Verify listing cards navigate to `/listings/:token` on click
- [ ] Verify "ירידת מחיר" FloatingCard is fully visible on mobile viewports
- [ ] Verify score boxes show green for ≥8, amber for ≥5, red for <5
- [ ] Verify favicon shows the CarWatch logo in the browser tab

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed Smart Match tier color palette from gold/orange to green/amber scheme for clearer visual feedback.

* **UI Improvements**
  * Improved responsive layout for floating cards on smaller screens.

* **Bug Fixes**
  * Fixed listing card navigation to properly handle clicks on interactive elements.

* **Chores**
  * Updated favicon and PWA manifest icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->