### PR TITLE
fix: hero section clipping and continuous score color gradient

### DIFF
--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -3,7 +3,7 @@ import { Bookmark } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
-import { scoreColor, scoreLabel } from "@/lib/scoringAlgorithm";
+import { scoreHsl, scoreLabel } from "@/lib/scoringAlgorithm";
 
 /**
  * Shared card body for listing display. When `hoverScale` is true the image
@@ -64,10 +64,8 @@ export function ListingCardBody({
             <p className="mt-0.5 text-xs text-muted-foreground">{listing.year}</p>
             {listing.fitness_score != null ? (
               <p
-                className={cn(
-                  "mt-0.5 text-xs font-medium",
-                  scoreColor(listing.fitness_score),
-                )}
+                className="mt-0.5 text-xs font-medium"
+                style={{ color: scoreHsl(listing.fitness_score) }}
               >
                 {scoreLabel(listing.fitness_score)}
               </p>

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -32,8 +32,8 @@ function FloatingCard({
 export function HeroSection() {
   const reduceMotion = useReducedMotion();
   return (
-    <section className="relative flex min-h-screen items-center justify-center overflow-hidden pt-16">
-      <div className="pointer-events-none absolute inset-0">
+    <section className="relative flex min-h-screen items-center justify-center pt-16">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute top-1/4 end-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[120px]" />
         <div className="absolute bottom-1/3 start-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[100px]" />
         <div className="absolute top-1/2 start-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[150px]" />
@@ -111,7 +111,7 @@ export function HeroSection() {
           initial={{ opacity: 0, y: 40, scale: 0.95 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
-          className="relative mx-auto max-w-3xl"
+          className="relative mx-auto max-w-3xl pb-10"
         >
           <div className="glass-card rounded-3xl border border-border/80 p-5 shadow-2xl sm:p-6">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-2">

--- a/web/src/components/landing/SmartScoreSection.tsx
+++ b/web/src/components/landing/SmartScoreSection.tsx
@@ -5,9 +5,8 @@ import { useInView } from "@/hooks/useInView";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
 import {
   scoreListingAgainstSearch,
-  scoreColor,
+  scoreHsl,
   scoreLabel,
-  scoreBarColor,
   type DemoListingInput,
 } from "@/lib/scoringAlgorithm";
 
@@ -110,9 +109,8 @@ function DemoCard({
 }) {
   const { ref, inView } = useInView();
   const { score, breakdown } = scoreListingAgainstSearch(listing, demoSearch);
-  const color = scoreColor(score);
+  const hsl = scoreHsl(score);
   const label = scoreLabel(score);
-  const bar = scoreBarColor(score);
 
   return (
     <motion.div
@@ -128,7 +126,7 @@ function DemoCard({
         <p className="truncate text-sm font-semibold text-foreground">
           {listing.title}
         </p>
-        <p className={`mt-0.5 text-xs font-medium ${color}`}>{label}</p>
+        <p className="mt-0.5 text-xs font-medium" style={{ color: hsl }}>{label}</p>
         <div className="mt-2 flex gap-2">
           {(
             [
@@ -141,8 +139,8 @@ function DemoCard({
             <div key={f.key} className="flex flex-1 flex-col items-center gap-0.5">
               <div className="h-1 w-full overflow-hidden rounded-full bg-secondary">
                 <div
-                  className={`h-full rounded-full ${bar}`}
-                  style={{ width: `${breakdown[f.key]}%` }}
+                  className="h-full rounded-full"
+                  style={{ width: `${breakdown[f.key]}%`, backgroundColor: hsl }}
                 />
               </div>
               <span className="text-[9px] text-muted-foreground">{f.label}</span>

--- a/web/src/components/ui/MatchScoreBox.tsx
+++ b/web/src/components/ui/MatchScoreBox.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { scoreBgColor, scoreColor } from "@/lib/scoringAlgorithm";
+import { scoreHsl, scoreHslAlpha } from "@/lib/scoringAlgorithm";
 
 export type MatchScoreBoxProps = {
   score: number;
@@ -13,9 +13,6 @@ const sizeClass: Record<NonNullable<MatchScoreBoxProps["size"]>, string> = {
   lg: "h-16 w-16 text-2xl [&_.denom]:text-[10px]",
 };
 
-/**
- * Rounded score tile matching the landing “Smart Match Score” demo (/10, tier border + fill).
- */
 export function MatchScoreBox({ score, size = "md", className }: MatchScoreBoxProps) {
   const normalized = Number.isFinite(score)
     ? Math.min(10, Math.max(0, score))
@@ -26,11 +23,14 @@ export function MatchScoreBox({ score, size = "md", className }: MatchScoreBoxPr
     <div
       className={cn(
         "flex shrink-0 flex-col items-center justify-center rounded-2xl border-2 font-bold leading-none",
-        scoreBgColor(normalized),
-        scoreColor(normalized),
         sizeClass[size],
         className,
       )}
+      style={{
+        color: scoreHsl(normalized),
+        backgroundColor: scoreHslAlpha(normalized, 0.12),
+        borderColor: scoreHslAlpha(normalized, 0.5),
+      }}
       aria-label={`ציון ${formatted} מתוך 10`}
     >
       <span className="tabular-nums">{formatted}</span>

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -57,7 +57,7 @@ export function scoreListingAgainstSearch(
         ? 1
         : 0.55;
 
-  /* Weights match the “מה נכנס לחישוב?” copy on the landing page (30/30/20/20). */
+  /* Weights match the "מה נכנס לחישוב?" copy on the landing page (30/30/20/20). */
   const combined =
     0.3 * priceFactor +
     0.3 * mileageFactor +
@@ -77,17 +77,25 @@ export function scoreListingAgainstSearch(
   };
 }
 
-/** Tier colors: green (great) → amber (good) → red (low). */
-export function scoreColor(score: number): string {
-  if (score >= 8) return "text-emerald-400";
-  if (score >= 5) return "text-amber-400";
-  return "text-red-500";
+/**
+ * Continuous HSL gradient: red (0) → amber (5) → emerald-green (10).
+ * Returns raw HSL components so consumers can build color / bg / border.
+ */
+function scoreHue(score: number): number {
+  if (!Number.isFinite(score)) return 0;
+  const t = Math.max(0, Math.min(10, score)) / 10;
+  return Math.round(t * 160);
 }
 
-export function scoreBgColor(score: number): string {
-  if (score >= 8) return "bg-emerald-400/12 border-emerald-400/50";
-  if (score >= 5) return "bg-amber-400/12 border-amber-400/45";
-  return "bg-red-500/12 border-red-500/42";
+export function scoreHsl(score: number): string {
+  const hue = scoreHue(score);
+  return `hsl(${hue} 72% 55%)`;
+}
+
+export function scoreHslAlpha(score: number, alpha: number): string {
+  const hue = scoreHue(score);
+  const a = Math.max(0, Math.min(1, alpha));
+  return `hsl(${hue} 72% 55% / ${a})`;
 }
 
 export function scoreLabel(score: number): string {
@@ -95,10 +103,4 @@ export function scoreLabel(score: number): string {
   if (score >= 7) return "טוב מאוד";
   if (score >= 5.5) return "טוב";
   return "חלש";
-}
-
-export function scoreBarColor(score: number): string {
-  if (score >= 8) return "bg-emerald-400";
-  if (score >= 5) return "bg-amber-400";
-  return "bg-red-500";
 }

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -10,12 +10,12 @@ import {
   Clock,
   Car,
 } from "lucide-react";
-import { formatPrice, formatKm, relativeTime, safeHref, cn } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, safeHref } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
-import { scoreColor, scoreLabel } from "@/lib/scoringAlgorithm";
+import { scoreHsl, scoreLabel } from "@/lib/scoringAlgorithm";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 
@@ -117,10 +117,8 @@ export function ListingDetailPage() {
           <p className="mt-0.5 text-muted-foreground">{listing.year}</p>
           {listing.fitness_score != null ? (
             <p
-              className={cn(
-                "mt-1 text-sm font-medium",
-                scoreColor(listing.fitness_score),
-              )}
+              className="mt-1 text-sm font-medium"
+              style={{ color: scoreHsl(listing.fitness_score) }}
             >
               {scoreLabel(listing.fitness_score)}
             </p>


### PR DESCRIPTION
## Summary

- **Hero section clipping** — moved `overflow-hidden` from the `<section>` onto the background blur wrapper, so the decorative blobs are still contained but the "ירידת מחיר" FloatingCard (positioned at `-bottom-5`) is no longer clipped on mobile. Added `pb-10` to the mock container for breathing room.
- **Continuous score colors** — replaced the 3-tier Tailwind class approach (green ≥8 / amber ≥5 / red <5) with a smooth **HSL hue interpolation** from red (score 0, hue 0°) through amber (score 5, hue ~80°) to emerald-green (score 10, hue 160°). Every score now gets a unique color proportional to its value — no abrupt jumps at thresholds. All consumers (`MatchScoreBox`, `ListingCardBody`, `ListingDetailPage`, `SmartScoreSection`) use inline styles via `scoreHsl()` / `scoreHslAlpha()`.

## Test plan

- [x] TypeScript compiles (`tsc --noEmit`)
- [ ] Verify "ירידת מחיר" FloatingCard is fully visible on mobile viewports
- [ ] Verify score color smoothly transitions: red at low → amber at mid → green at high

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Score colors throughout the application now use a continuous gradient instead of discrete color tiers, providing more nuanced and consistent visual feedback. This refinement affects all score displays, including listing fitness scores, match score components, and detailed scoring breakdowns, creating a more cohesive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->