### PR TITLE
fix: reuse listing session for item enrichment to bypass bot protection

### DIFF
--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -2,14 +2,17 @@ package yad2
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
+	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
 )
 
 const (
-	defaultEnrichDelay = 500 * time.Millisecond
+	defaultEnrichDelay     = 500 * time.Millisecond
+	maxConsecutiveFailures = 3
 )
 
 // EnricherConfig controls the enrichment behavior.
@@ -41,6 +44,7 @@ func NewEnricher(fetcher *Yad2Fetcher, logger *slog.Logger, cfg EnricherConfig) 
 func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int {
 	enriched := 0
 	attempts := 0
+	consecutiveFailures := 0
 	for i := range listings {
 		needsKm := listings[i].Km <= 0
 		needsImg := listings[i].ImageURL == ""
@@ -74,13 +78,30 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		attempts++
 		details, err := e.fetcher.FetchItem(ctx, listings[i].Token)
 		if err != nil {
+			if errors.Is(err, fetcher.ErrChallenge) {
+				e.logger.Warn("enrichment blocked by anti-bot protection, skipping remaining items",
+					"attempts", attempts,
+					"remaining", countMissingKm(listings[i:]),
+				)
+				return enriched
+			}
+			consecutiveFailures++
 			e.logger.Warn("enrichment failed",
 				"token", listings[i].Token,
 				"error", err,
 			)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				e.logger.Warn("enrichment aborted after consecutive failures",
+					"consecutive_failures", consecutiveFailures,
+					"attempts", attempts,
+					"remaining", countMissingKm(listings[i:]),
+				)
+				return enriched
+			}
 			continue
 		}
 
+		consecutiveFailures = 0
 		changed := false
 		if needsKm && details.Km > 0 {
 			listings[i].Km = details.Km

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -272,6 +273,105 @@ func TestEnricher_FillsKmAndCity(t *testing.T) {
 	}
 	if listings[0].City != "tel_aviv" {
 		t.Errorf("listing[0].City = %q, want tel_aviv", listings[0].City)
+	}
+}
+
+func TestEnricher_AbortsOnBotChallenge(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if strings.Contains(r.URL.Path, "tok-b") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprint(w, `<html>validate.perfdrive.com - Are you for real?</html>`)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":10000}}}}
+</script></html>`)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+
+	listings := []model.RawListing{
+		{Token: "tok-a", Km: 0},
+		{Token: "tok-b", Km: 0},
+		{Token: "tok-c", Km: 0},
+		{Token: "tok-d", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 1 {
+		t.Errorf("enriched = %d, want 1 (should stop after challenge on tok-b)", count)
+	}
+	if got := requestCount.Load(); got != 2 {
+		t.Errorf("requests = %d, want 2 (tok-a success, tok-b challenge, then abort)", got)
+	}
+	if listings[0].Km != 10000 {
+		t.Errorf("listing[0].Km = %d, want 10000", listings[0].Km)
+	}
+	if listings[2].Km != 0 {
+		t.Errorf("listing[2].Km = %d, want 0 (skipped)", listings[2].Km)
+	}
+}
+
+func TestEnricher_AbortsAfterConsecutiveFailures(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+		{Token: "b", Km: 0},
+		{Token: "c", Km: 0},
+		{Token: "d", Km: 0},
+		{Token: "e", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 0 {
+		t.Errorf("enriched = %d, want 0 (all failed)", count)
+	}
+	if got := requestCount.Load(); got != int32(maxConsecutiveFailures) {
+		t.Errorf("requests = %d, want %d (abort after consecutive failures)", got, maxConsecutiveFailures)
+	}
+}
+
+func TestEnricher_ConsecutiveFailureResets(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		// Fail on requests 2 and 3, succeed on 1 and 4+
+		if n == 2 || n == 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":50000}}}}
+</script></html>`)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+		{Token: "b", Km: 0},
+		{Token: "c", Km: 0},
+		{Token: "d", Km: 0},
+		{Token: "e", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	// Request 1 (tok-a): success, Request 2 (tok-b): fail, Request 3 (tok-c): fail,
+	// Request 4 (tok-d): success (resets counter), Request 5 (tok-e): success
+	if count != 3 {
+		t.Errorf("enriched = %d, want 3 (success resets consecutive failure counter)", count)
+	}
+	if got := requestCount.Load(); got != 5 {
+		t.Errorf("requests = %d, want 5 (all processed, counter reset by success)", got)
 	}
 }
 

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -256,6 +256,123 @@ func TestPlainClient_Get_SetsHeaders(t *testing.T) {
 	}
 }
 
+func TestYad2Fetcher_FetchItem_ReusesListingClient(t *testing.T) {
+	var listingReqs, itemReqs int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/vehicles/item/") {
+			itemReqs++
+			_, _ = w.Write([]byte(`<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":55000,"address":{"city":{"text":"חיפה","textEng":"haifa"}}}}}}
+</script></html>`))
+			return
+		}
+		listingReqs++
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(validPageHTML()))
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+	_, err := f.Fetch(context.Background(), defaultParams())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// After Fetch, lastFetchClient should be set. FetchItem should reuse it.
+	details, err := f.FetchItem(context.Background(), "tok-1")
+	if err != nil {
+		t.Fatalf("FetchItem: %v", err)
+	}
+	if details.Km != 55000 {
+		t.Errorf("Km = %d, want 55000", details.Km)
+	}
+	if listingReqs != 1 {
+		t.Errorf("listing requests = %d, want 1", listingReqs)
+	}
+	if itemReqs != 1 {
+		t.Errorf("item requests = %d, want 1", itemReqs)
+	}
+}
+
+func TestYad2Fetcher_FetchItem_FallsBackWithoutPriorFetch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":30000,"address":{"city":{"text":"באר שבע","textEng":"beer_sheva"}}}}}}
+</script></html>`))
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+	// No prior Fetch call — should fall back to f.client
+	details, err := f.FetchItem(context.Background(), "tok-2")
+	if err != nil {
+		t.Fatalf("FetchItem without prior Fetch: %v", err)
+	}
+	if details.Km != 30000 {
+		t.Errorf("Km = %d, want 30000", details.Km)
+	}
+	if details.City != "beer_sheva" {
+		t.Errorf("City = %q, want beer_sheva", details.City)
+	}
+}
+
+func TestYad2Fetcher_FetchItem_BotProtection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`<html>validate.perfdrive.com challenge</html>`))
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+	_, err := f.FetchItem(context.Background(), "tok-blocked")
+	if err == nil {
+		t.Fatal("expected error for bot protection response")
+	}
+	if !strings.Contains(err.Error(), "anti-bot challenge") {
+		t.Errorf("error should mention anti-bot challenge: %v", err)
+	}
+}
+
+func TestYad2Fetcher_Fetch_BotProtection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`<html>ShieldSquare captcha page</html>`))
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+	_, err := f.Fetch(context.Background(), defaultParams())
+	if err == nil {
+		t.Fatal("expected error for bot protection response")
+	}
+	if !strings.Contains(err.Error(), "anti-bot challenge") {
+		t.Errorf("error should mention anti-bot challenge: %v", err)
+	}
+}
+
+func TestLooksLikeBotProtection(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"perfdrive", "<html>validate.perfdrive.com</html>", true},
+		{"shieldsquare", "<html>ShieldSquare captcha</html>", true},
+		{"are you for real", "<html>Are you for real?</html>", true},
+		{"cf-browser", "<html>cf-browser-verification</html>", true},
+		{"captcha", "<html>Please complete the CAPTCHA</html>", true},
+		{"normal page", "<html><body>Normal content</body></html>", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeBotProtection([]byte(tc.body)); got != tc.want {
+				t.Errorf("looksLikeBotProtection(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestYad2Fetcher_Close_Idempotent(t *testing.T) {
 	f, err := NewFetcher([]string{"TestAgent/1.0"}, "", discardLogger)
 	if err != nil {

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
@@ -28,6 +29,9 @@ type Yad2Fetcher struct {
 	userAgents []string
 	proxyPool  *fetcher.ProxyPool
 	clientPool *ClientPool
+
+	lastFetchMu     sync.Mutex
+	lastFetchClient HTTPDoer
 }
 
 func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*Yad2Fetcher, error) {
@@ -80,29 +84,33 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 	base.RawQuery = ""
 	itemURL := base.String()
 
-	client := f.client
-	var usedProxy string
-	if f.proxyPool != nil {
-		usedProxy = f.proxyPool.Next()
-		if f.clientPool != nil {
-			c, err := f.clientPool.Get(usedProxy)
-			if err != nil {
-				f.logger.Warn("failed to get pooled client for item fetch", "proxy", redactProxy(usedProxy), "error", err)
-			} else {
-				client = c
-			}
-		}
+	// Prefer the client that last fetched a listing page; its session
+	// carries the perfdrive validation cookies for yad2.co.il.
+	f.lastFetchMu.Lock()
+	client := f.lastFetchClient
+	f.lastFetchMu.Unlock()
+	if client == nil {
+		client = f.client
 	}
 
 	result, err := client.Get(ctx, itemURL)
 	if err != nil {
-		if f.clientPool != nil && usedProxy != "" {
-			f.clientPool.Evict(usedProxy)
-		}
 		return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, err)
 	}
 
 	if result.StatusCode != http.StatusOK {
+		if looksLikeBotProtection(result.Body) {
+			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
+		}
+		snippet := string(result.Body)
+		if len(snippet) > 200 {
+			snippet = snippet[:200]
+		}
+		f.logger.Debug("item fetch non-200 response",
+			"token", token,
+			"status", result.StatusCode,
+			"body_preview", snippet,
+		)
 		return ItemDetails{}, fmt.Errorf("fetch item %s: status %d", token, result.StatusCode)
 	}
 
@@ -149,6 +157,9 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 	}
 
 	if result.StatusCode != http.StatusOK {
+		if looksLikeBotProtection(result.Body) {
+			return nil, fmt.Errorf("yad2: %w", fetcher.ErrChallenge)
+		}
 		return nil, fmt.Errorf("unexpected status: %d", result.StatusCode)
 	}
 
@@ -156,6 +167,11 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 	if err != nil {
 		return nil, fmt.Errorf("parse page: %w", err)
 	}
+
+	// Remember this client so FetchItem reuses its session cookies.
+	f.lastFetchMu.Lock()
+	f.lastFetchClient = client
+	f.lastFetchMu.Unlock()
 
 	f.logger.Info("fetched listings", "count", len(listings))
 	return listings, nil
@@ -213,4 +229,14 @@ func buildURL(base string, params model.SourceParams) string {
 
 	u.RawQuery = v.Encode()
 	return u.String()
+}
+
+func looksLikeBotProtection(body []byte) bool {
+	h := strings.ToLower(string(body))
+	return strings.Contains(h, "perfdrive") ||
+		strings.Contains(h, "shieldsquare") ||
+		strings.Contains(h, "validate.perfdrive.com") ||
+		strings.Contains(h, "are you for real") ||
+		strings.Contains(h, "cf-browser-verification") ||
+		strings.Contains(h, "captcha")
 }


### PR DESCRIPTION
## Summary

- **Session reuse**: After a successful listing page fetch, the `Yad2Fetcher` now saves the HTTP client and reuses it for subsequent item page fetches. This preserves the PerimeterX/ShieldSquare validation cookies that yad2.co.il requires, eliminating the `status 400` errors during enrichment.
- **Bot detection at HTTP level**: Added `looksLikeBotProtection()` to detect anti-bot challenge pages (perfdrive, ShieldSquare, captcha markers) in non-200 response bodies, returning `ErrChallenge` so callers can react appropriately.
- **Early abort logic**: The enricher now stops immediately on bot challenge detection and aborts after 3 consecutive non-challenge failures, preventing log spam and wasted requests.

## Test plan

- [x] `TestYad2Fetcher_FetchItem_ReusesListingClient` — verifies item fetches reuse the client from a successful listing fetch
- [x] `TestYad2Fetcher_FetchItem_FallsBackWithoutPriorFetch` — verifies fallback to default client when no listing fetch occurred
- [x] `TestYad2Fetcher_FetchItem_BotProtection` — verifies `ErrChallenge` on bot-protected item responses
- [x] `TestYad2Fetcher_Fetch_BotProtection` — verifies `ErrChallenge` on bot-protected listing responses
- [x] `TestLooksLikeBotProtection` — table-driven tests for all detection markers and negative cases
- [x] `TestEnricher_AbortsOnBotChallenge` — verifies immediate abort when bot challenge is hit mid-enrichment
- [x] `TestEnricher_AbortsAfterConsecutiveFailures` — verifies abort after 3 consecutive non-challenge failures
- [x] `TestEnricher_ConsecutiveFailureResets` — verifies a successful fetch resets the consecutive failure counter
- [x] Full `go test ./...` passes (all packages), `go vet ./...` clean


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot-protection detection: the system now immediately stops processing when a bot challenge is encountered, preventing wasted requests.
  * Enhanced error handling: enrichment operations now gracefully abort after encountering three consecutive failures, improving reliability and resource efficiency.
  * Better session management: HTTP client state is now preserved across related requests, improving consistency and reducing potential authentication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->