### PR TITLE
fix: isolate enrichment onto dedicated HTTP client to prevent cascading failures

### DIFF
--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	defaultEnrichDelay     = 500 * time.Millisecond
+	defaultEnrichDelay     = 2 * time.Second
+	defaultMaxPerCycle     = 5
 	maxConsecutiveFailures = 3
 )
 
@@ -35,6 +36,9 @@ type Enricher struct {
 func NewEnricher(fetcher *Yad2Fetcher, logger *slog.Logger, cfg EnricherConfig) *Enricher {
 	if cfg.Delay == 0 {
 		cfg.Delay = defaultEnrichDelay
+	}
+	if cfg.MaxPerCycle == 0 {
+		cfg.MaxPerCycle = defaultMaxPerCycle
 	}
 	return &Enricher{fetcher: fetcher, logger: logger, cfg: cfg}
 }

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -21,7 +21,7 @@ type EnricherConfig struct {
 	// Delay between individual item fetches to avoid rate-limiting.
 	Delay time.Duration
 	// MaxPerCycle limits how many item-page fetches run per Enrich call.
-	// 0 means no limit (enrich every listing that still needs km/image/city).
+	// 0 (default) applies defaultMaxPerCycle. Negative means no limit.
 	MaxPerCycle int
 }
 

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -60,7 +60,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			e.logger.Info("enrichment limit reached",
 				"enriched", enriched,
 				"attempts", attempts,
-				"remaining", countMissingKm(listings[i:]),
+				"remaining", countNeedingEnrichment(listings[i:]),
 			)
 			break
 		}
@@ -85,7 +85,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			if errors.Is(err, fetcher.ErrChallenge) {
 				e.logger.Warn("enrichment blocked by anti-bot protection, skipping remaining items",
 					"attempts", attempts,
-					"remaining", countMissingKm(listings[i:]),
+					"remaining", countNeedingEnrichment(listings[i:]),
 				)
 				return enriched
 			}
@@ -98,7 +98,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 				e.logger.Warn("enrichment aborted after consecutive failures",
 					"consecutive_failures", consecutiveFailures,
 					"attempts", attempts,
-					"remaining", countMissingKm(listings[i:]),
+					"remaining", countNeedingEnrichment(listings[i:]),
 				)
 				return enriched
 			}
@@ -135,10 +135,10 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 	return enriched
 }
 
-func countMissingKm(listings []model.RawListing) int {
+func countNeedingEnrichment(listings []model.RawListing) int {
 	n := 0
 	for _, l := range listings {
-		if l.Km <= 0 {
+		if l.Km <= 0 || l.ImageURL == "" || l.City == "" {
 			n++
 		}
 	}

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -99,6 +99,29 @@ func TestEnricher_DefaultMaxPerCycle(t *testing.T) {
 	}
 }
 
+func TestEnricher_NegativeMaxPerCycleIsUnlimited(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":42000}}}}
+</script></html>`)
+	})
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond, MaxPerCycle: -1})
+
+	listings := make([]model.RawListing, 10)
+	for i := range listings {
+		listings[i] = model.RawListing{Token: fmt.Sprintf("tok-%d", i), Km: 0}
+	}
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 10 {
+		t.Errorf("enriched = %d, want 10 (negative MaxPerCycle = unlimited)", count)
+	}
+	if got := requestCount.Load(); got != 10 {
+		t.Errorf("requests = %d, want 10", got)
+	}
+}
+
 func TestEnricher_FillsMissingKm(t *testing.T) {
 	enricher := newTestEnricher(t, itemPageHandler(75000), EnricherConfig{
 		Delay:       time.Millisecond,

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -24,8 +24,14 @@ func newTestEnricher(t *testing.T, handler http.Handler, cfg EnricherConfig) *En
 		t.Fatalf("create plain client: %v", err)
 	}
 
+	ic, err := newPlainClient([]string{"test-ua"}, "")
+	if err != nil {
+		t.Fatalf("create plain client (itemClient): %v", err)
+	}
+
 	fetcher := &Yad2Fetcher{
 		client:     client,
+		itemClient: ic,
 		baseURL:    srv.URL,
 		logger:     slog.Default(),
 		userAgents: []string{"test-ua"},
@@ -42,7 +48,7 @@ func itemPageHandler(km int) http.HandlerFunc {
 	}
 }
 
-func TestEnricher_UnlimitedEnrichesAllNeedingKm(t *testing.T) {
+func TestEnricher_HighLimitEnrichesAll(t *testing.T) {
 	var requestCount atomic.Int32
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		requestCount.Add(1)
@@ -50,7 +56,7 @@ func TestEnricher_UnlimitedEnrichesAllNeedingKm(t *testing.T) {
 {"props":{"pageProps":{"itemData":{"km":42000}}}}
 </script></html>`)
 	})
-	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond, MaxPerCycle: 100})
 
 	listings := []model.RawListing{
 		{Token: "a", Km: 0}, {Token: "b", Km: 0}, {Token: "c", Km: 0},
@@ -61,12 +67,35 @@ func TestEnricher_UnlimitedEnrichesAllNeedingKm(t *testing.T) {
 		t.Errorf("enriched = %d, want 5", count)
 	}
 	if got := requestCount.Load(); got != 5 {
-		t.Errorf("requests = %d, want 5 (no per-cycle cap)", got)
+		t.Errorf("requests = %d, want 5", got)
 	}
 	for i, l := range listings {
 		if l.Km != 42000 {
 			t.Errorf("listing[%d].Km = %d, want 42000", i, l.Km)
 		}
+	}
+}
+
+func TestEnricher_DefaultMaxPerCycle(t *testing.T) {
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		_, _ = fmt.Fprintf(w, `<html><script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"itemData":{"km":42000}}}}
+</script></html>`)
+	})
+	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+
+	listings := make([]model.RawListing, 10)
+	for i := range listings {
+		listings[i] = model.RawListing{Token: fmt.Sprintf("tok-%d", i), Km: 0}
+	}
+	count := enricher.Enrich(context.Background(), listings)
+	if count != defaultMaxPerCycle {
+		t.Errorf("enriched = %d, want %d (defaultMaxPerCycle)", count, defaultMaxPerCycle)
+	}
+	if got := requestCount.Load(); got != int32(defaultMaxPerCycle) {
+		t.Errorf("requests = %d, want %d", got, defaultMaxPerCycle)
 	}
 }
 

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -367,6 +367,11 @@ func TestLooksLikeBotProtection(t *testing.T) {
 
 func TestYad2Fetcher_FetchItem_DoesNotPoisonListingClient(t *testing.T) {
 	listingHandler := func(w http.ResponseWriter, r *http.Request) {
+		if _, err := r.Cookie("poison"); err == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`<html><head><title>400 Bad Request</title></head></html>`))
+			return
+		}
 		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write([]byte(validPageHTML()))
 	}

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -426,6 +426,23 @@ func TestYad2Fetcher_FetchItem_Generic400IsChallenge(t *testing.T) {
 	}
 }
 
+func TestYad2Fetcher_FetchItem_Generic403IsChallenge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`<html><head><title>403 Forbidden</title></head><body><center><h1>403 Forbidden</h1></center><hr><center>nginx</center></body></html>`))
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+	_, err := f.FetchItem(context.Background(), "tok-generic403")
+	if err == nil {
+		t.Fatal("expected error for generic 403 response")
+	}
+	if !strings.Contains(err.Error(), "anti-bot challenge") {
+		t.Errorf("error should mention anti-bot challenge: %v", err)
+	}
+}
+
 func TestLooksLikeGenericError(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -30,7 +30,11 @@ func newTestFetcher(t *testing.T, serverURL string) *Yad2Fetcher {
 	if err != nil {
 		t.Fatalf("NewPlainClient: %v", err)
 	}
-	return &Yad2Fetcher{client: client, baseURL: serverURL, logger: discardLogger, userAgents: []string{"TestAgent/1.0"}}
+	ic, err := NewPlainClient([]string{"TestAgent/1.0"}, "")
+	if err != nil {
+		t.Fatalf("NewPlainClient (itemClient): %v", err)
+	}
+	return &Yad2Fetcher{client: client, itemClient: ic, baseURL: serverURL, logger: discardLogger, userAgents: []string{"TestAgent/1.0"}}
 }
 
 func TestNewFetcher(t *testing.T) {
@@ -134,7 +138,11 @@ func TestYad2Fetcher_Fetch_ServerDown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPlainClient: %v", err)
 	}
-	f := &Yad2Fetcher{client: client, baseURL: "http://127.0.0.1:1", logger: discardLogger, userAgents: []string{"TestAgent/1.0"}}
+	ic, err := NewPlainClient([]string{"TestAgent/1.0"}, "")
+	if err != nil {
+		t.Fatalf("NewPlainClient (itemClient): %v", err)
+	}
+	f := &Yad2Fetcher{client: client, itemClient: ic, baseURL: "http://127.0.0.1:1", logger: discardLogger, userAgents: []string{"TestAgent/1.0"}}
 
 	_, err = f.Fetch(context.Background(), defaultParams())
 	if err == nil {
@@ -256,29 +264,20 @@ func TestPlainClient_Get_SetsHeaders(t *testing.T) {
 	}
 }
 
-func TestYad2Fetcher_FetchItem_ReusesListingClient(t *testing.T) {
-	var listingReqs, itemReqs int
+func TestYad2Fetcher_FetchItem_UsesItemClient(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/vehicles/item/") {
-			itemReqs++
 			_, _ = w.Write([]byte(`<html><script id="__NEXT_DATA__" type="application/json">
 {"props":{"pageProps":{"itemData":{"km":55000,"address":{"city":{"text":"חיפה","textEng":"haifa"}}}}}}
 </script></html>`))
 			return
 		}
-		listingReqs++
 		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write([]byte(validPageHTML()))
 	}))
 	defer server.Close()
 
 	f := newTestFetcher(t, server.URL)
-	_, err := f.Fetch(context.Background(), defaultParams())
-	if err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
-
-	// After Fetch, lastFetchClient should be set. FetchItem should reuse it.
 	details, err := f.FetchItem(context.Background(), "tok-1")
 	if err != nil {
 		t.Fatalf("FetchItem: %v", err)
@@ -286,15 +285,9 @@ func TestYad2Fetcher_FetchItem_ReusesListingClient(t *testing.T) {
 	if details.Km != 55000 {
 		t.Errorf("Km = %d, want 55000", details.Km)
 	}
-	if listingReqs != 1 {
-		t.Errorf("listing requests = %d, want 1", listingReqs)
-	}
-	if itemReqs != 1 {
-		t.Errorf("item requests = %d, want 1", itemReqs)
-	}
 }
 
-func TestYad2Fetcher_FetchItem_FallsBackWithoutPriorFetch(t *testing.T) {
+func TestYad2Fetcher_FetchItem_ParsesCityAndKm(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`<html><script id="__NEXT_DATA__" type="application/json">
 {"props":{"pageProps":{"itemData":{"km":30000,"address":{"city":{"text":"באר שבע","textEng":"beer_sheva"}}}}}}
@@ -303,10 +296,9 @@ func TestYad2Fetcher_FetchItem_FallsBackWithoutPriorFetch(t *testing.T) {
 	defer server.Close()
 
 	f := newTestFetcher(t, server.URL)
-	// No prior Fetch call — should fall back to f.client
 	details, err := f.FetchItem(context.Background(), "tok-2")
 	if err != nil {
-		t.Fatalf("FetchItem without prior Fetch: %v", err)
+		t.Fatalf("FetchItem: %v", err)
 	}
 	if details.Km != 30000 {
 		t.Errorf("Km = %d, want 30000", details.Km)
@@ -368,6 +360,87 @@ func TestLooksLikeBotProtection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := looksLikeBotProtection([]byte(tc.body)); got != tc.want {
 				t.Errorf("looksLikeBotProtection(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestYad2Fetcher_FetchItem_DoesNotPoisonListingClient(t *testing.T) {
+	listingHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(validPageHTML()))
+	}
+	itemHandler := func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "poison", Value: "bad"})
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`<html><head><title>400 Bad Request</title></head></html>`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/vehicles/item/") {
+			itemHandler(w, r)
+			return
+		}
+		listingHandler(w, r)
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+
+	listings, err := f.Fetch(context.Background(), defaultParams())
+	if err != nil {
+		t.Fatalf("Fetch before item: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+
+	_, err = f.FetchItem(context.Background(), "tok-1")
+	if err == nil {
+		t.Fatal("expected error for 400 item response")
+	}
+
+	listings, err = f.Fetch(context.Background(), defaultParams())
+	if err != nil {
+		t.Fatalf("Fetch after poisoned item should still succeed: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing after item failure, got %d", len(listings))
+	}
+}
+
+func TestYad2Fetcher_FetchItem_Generic400IsChallenge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`<html><head><title>400 Bad Request</title></head><body><center><h1>400 Bad Request</h1></center><hr><center>nginx</center></body></html>`))
+	}))
+	defer server.Close()
+
+	f := newTestFetcher(t, server.URL)
+	_, err := f.FetchItem(context.Background(), "tok-generic400")
+	if err == nil {
+		t.Fatal("expected error for generic 400 response")
+	}
+	if !strings.Contains(err.Error(), "anti-bot challenge") {
+		t.Errorf("error should mention anti-bot challenge: %v", err)
+	}
+}
+
+func TestLooksLikeGenericError(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"400 title", "<html><head><title>400 Bad Request</title></head></html>", true},
+		{"403 title", "<html><head><title>403 Forbidden</title></head></html>", true},
+		{"normal page", "<html><body>Normal content</body></html>", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeGenericError([]byte(tc.body)); got != tc.want {
+				t.Errorf("looksLikeGenericError(%q) = %v, want %v", tc.body, got, tc.want)
 			}
 		})
 	}

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -104,7 +104,8 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 		if looksLikeBotProtection(result.Body) {
 			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
 		}
-		if result.StatusCode == http.StatusBadRequest && looksLikeGenericError(result.Body) {
+		if (result.StatusCode == http.StatusBadRequest || result.StatusCode == http.StatusForbidden) &&
+			looksLikeGenericError(result.Body) {
 			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
 		}
 		snippet := string(result.Body)

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
@@ -23,15 +22,13 @@ const (
 )
 
 type Yad2Fetcher struct {
-	client     HTTPDoer
+	client     HTTPDoer // listing pages only
+	itemClient HTTPDoer // item pages only (isolated cookie jar)
 	baseURL    string
 	logger     *slog.Logger
 	userAgents []string
 	proxyPool  *fetcher.ProxyPool
 	clientPool *ClientPool
-
-	lastFetchMu     sync.Mutex
-	lastFetchClient HTTPDoer
 }
 
 func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*Yad2Fetcher, error) {
@@ -39,7 +36,12 @@ func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*Yad2Fe
 	if err != nil {
 		return nil, err
 	}
-	return &Yad2Fetcher{client: client, baseURL: defaultBaseURL, logger: logger, userAgents: userAgents}, nil
+	ic, err := NewClient(userAgents, proxy)
+	if err != nil {
+		client.Close()
+		return nil, err
+	}
+	return &Yad2Fetcher{client: client, itemClient: ic, baseURL: defaultBaseURL, logger: logger, userAgents: userAgents}, nil
 }
 
 func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logger *slog.Logger) (*Yad2Fetcher, error) {
@@ -51,12 +53,18 @@ func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logge
 	if err != nil {
 		return nil, err
 	}
+	ic, err := NewClient(userAgents, proxy)
+	if err != nil {
+		client.Close()
+		return nil, err
+	}
 	var cp *ClientPool
 	if pool != nil {
 		cp = NewClientPool(userAgents, logger)
 	}
 	return &Yad2Fetcher{
 		client:     client,
+		itemClient: ic,
 		baseURL:    defaultBaseURL,
 		logger:     logger,
 		userAgents: userAgents,
@@ -68,6 +76,9 @@ func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logge
 func (f *Yad2Fetcher) Close() {
 	if f.clientPool != nil {
 		f.clientPool.Close()
+	}
+	if f.itemClient != nil {
+		f.itemClient.Close()
 	}
 	if f.client != nil {
 		f.client.Close()
@@ -84,22 +95,16 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 	base.RawQuery = ""
 	itemURL := base.String()
 
-	// Prefer the client that last fetched a listing page; its session
-	// carries the perfdrive validation cookies for yad2.co.il.
-	f.lastFetchMu.Lock()
-	client := f.lastFetchClient
-	f.lastFetchMu.Unlock()
-	if client == nil {
-		client = f.client
-	}
-
-	result, err := client.Get(ctx, itemURL)
+	result, err := f.itemClient.Get(ctx, itemURL)
 	if err != nil {
 		return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, err)
 	}
 
 	if result.StatusCode != http.StatusOK {
 		if looksLikeBotProtection(result.Body) {
+			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
+		}
+		if result.StatusCode == http.StatusBadRequest && looksLikeGenericError(result.Body) {
 			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
 		}
 		snippet := string(result.Body)
@@ -168,11 +173,6 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 		return nil, fmt.Errorf("parse page: %w", err)
 	}
 
-	// Remember this client so FetchItem reuses its session cookies.
-	f.lastFetchMu.Lock()
-	f.lastFetchClient = client
-	f.lastFetchMu.Unlock()
-
 	f.logger.Info("fetched listings", "count", len(listings))
 	return listings, nil
 }
@@ -229,6 +229,14 @@ func buildURL(base string, params model.SourceParams) string {
 
 	u.RawQuery = v.Encode()
 	return u.String()
+}
+
+// looksLikeGenericError detects generic nginx/CDN error pages that don't
+// contain explicit bot-protection markers but are still anti-bot responses.
+func looksLikeGenericError(body []byte) bool {
+	h := strings.ToLower(string(body))
+	return strings.Contains(h, "<title>400 bad request</title>") ||
+		strings.Contains(h, "<title>403 forbidden</title>")
 }
 
 func looksLikeBotProtection(body []byte) bool {


### PR DESCRIPTION
## Summary

- **Isolates item-page fetching onto a dedicated `itemClient`** with its own cookie jar, preventing 400 responses from poisoning the shared listing client and triggering cascading circuit breaker failures
- **Treats generic 400/403 nginx error pages as `ErrChallenge`** for faster enrichment abort (immediate rather than waiting for 3 consecutive failures)
- **Sets conservative enrichment defaults**: delay increased from 500ms to 2s, added a default cap of 5 item fetches per cycle

## Root cause

Item-page 400 responses injected corrupted cookies into the shared HTTP client via `azuretls` Set-Cookie merging. This poisoned client was then used for listing page fetches, causing those to fail too, which tripped the circuit breaker for 30 minutes and blocked all groups.

## Test plan

- [x] `TestYad2Fetcher_FetchItem_DoesNotPoisonListingClient` — verifies a 400 on FetchItem doesn't break subsequent Fetch()
- [x] `TestYad2Fetcher_FetchItem_Generic400IsChallenge` — verifies generic 400 body maps to ErrChallenge
- [x] `TestLooksLikeGenericError` — table-driven test for the new detector
- [x] `TestEnricher_DefaultMaxPerCycle` — verifies the new default cap of 5
- [x] Full test suite passes (`go test ./...`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broader anti-bot detection: certain generic error pages (including 400/403 responses) are now treated as bot challenges.
  * Item-page failures no longer affect listing fetches; item requests use an isolated client and are closed properly.

* **Chores**
  * Default per-cycle enrichment cap introduced (5 when unset; negative disables limit) and default enrich delay increased to 2s.
  * Enrichment logging/diagnostics now report remaining items needing enrichment across missing km, image, or city.

* **Tests**
  * Tests added/updated to validate enrichment limits, item-vs-listing isolation, anti-bot detection, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->