### PR TITLE
feat: add listing_history TTL pruning with 90-day retention

### DIFF
--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -98,6 +98,7 @@ func TestRunMultiTenantCycle_PrunesOldListings(t *testing.T) {
 	cfg := testConfig()
 	cfg.Storage.PruneAfter = 1 * time.Hour
 
+	ls := &mockListingStore{}
 	ss := &mockSearchStore{
 		searches: []storage.Search{
 			{ID: 1, ChatID: 100, Name: "test", Source: "yad2", Manufacturer: 27, Model: 10332, Active: true},
@@ -106,8 +107,9 @@ func TestRunMultiTenantCycle_PrunesOldListings(t *testing.T) {
 	h := health.New()
 
 	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
-		SearchStore: ss,
-		Observer:    h,
+		SearchStore:  ss,
+		ListingStore: ls,
+		Observer:     h,
 	})
 	s.lastPruneTime = time.Time{}
 
@@ -117,6 +119,9 @@ func TestRunMultiTenantCycle_PrunesOldListings(t *testing.T) {
 	}
 	if s.lastPruneTime.IsZero() {
 		t.Error("lastPruneTime should be updated after pruning")
+	}
+	if ls.pruneCalls != 1 {
+		t.Errorf("expected PruneListings to be called once, got %d", ls.pruneCalls)
 	}
 }
 
@@ -246,7 +251,8 @@ func TestFlushAndSendDigest_WithHealth(t *testing.T) {
 }
 
 type mockListingStore struct {
-	saved []storage.ListingRecord
+	saved      []storage.ListingRecord
+	pruneCalls int
 }
 
 func (m *mockListingStore) SaveListing(_ context.Context, r storage.ListingRecord) error {
@@ -280,5 +286,6 @@ func (m *mockListingStore) CountSearchListings(_ context.Context, _ int64, _ int
 }
 
 func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (int64, error) {
+	m.pruneCalls++
 	return 0, nil
 }

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -278,3 +278,7 @@ func (m *mockListingStore) ListSearchListings(_ context.Context, _ int64, _ int6
 func (m *mockListingStore) CountSearchListings(_ context.Context, _ int64, _ int64) (int64, error) {
 	return 0, nil
 }
+
+func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -34,8 +34,9 @@ const (
 	maxRetries            = 3
 	retryBaseDelay        = 2 * time.Second
 	defaultConcurrency    = 4
-	notificationPruneAge  = 48 * time.Hour
-	priceHistoryRetention = 90 * 24 * time.Hour
+	notificationPruneAge      = 48 * time.Hour
+	priceHistoryRetention     = 90 * 24 * time.Hour
+	listingHistoryRetention   = 90 * 24 * time.Hour
 )
 
 type CatalogIngester interface {
@@ -530,6 +531,14 @@ func (s *Scheduler) pruneOldData(ctx context.Context) {
 			s.logger.Error("prune prices failed", "error", err)
 		} else if pruned > 0 {
 			s.logger.Info("pruned old price history", "count", pruned)
+		}
+	}
+	if s.stores.Listings != nil {
+		pruned, err := s.stores.Listings.PruneListings(ctx, listingHistoryRetention)
+		if err != nil {
+			s.logger.Error("prune listing history failed", "error", err)
+		} else if pruned > 0 {
+			s.logger.Info("pruned old listing history", "count", pruned)
 		}
 	}
 	s.lastPruneTime = time.Now()

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -155,6 +155,7 @@ type ListingStore interface {
 	CountUserListings(ctx context.Context, chatID int64) (int64, error)
 	ListSearchListings(ctx context.Context, chatID int64, searchID int64, limit, offset int, sort string) ([]ListingRecord, error)
 	CountSearchListings(ctx context.Context, chatID int64, searchID int64) (int64, error)
+	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 }
 
 type SavedListingStore interface {

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -202,6 +203,23 @@ func (s *Store) CountSearchListings(ctx context.Context, chatID int64, searchID 
 		SELECT COUNT(*) FROM listing_history
 		WHERE chat_id = ? AND search_id = ?`, chatID, searchID).Scan(&count)
 	return count, err
+}
+
+func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM listing_history
+		WHERE first_seen_at < ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM saved_listings
+		      WHERE saved_listings.token = listing_history.token
+		        AND saved_listings.chat_id = listing_history.chat_id
+		  )`,
+		cutoff.UTC().Format(firstSeenAtLayout))
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 func (s *Store) SaveBookmark(ctx context.Context, chatID int64, token string) error {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2690,21 +2690,27 @@ func TestPruneListings_RemovesOld(t *testing.T) {
 	old := time.Now().Add(-100 * 24 * time.Hour)
 	recent := time.Now().Add(-10 * 24 * time.Hour)
 
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-1", ChatID: 100, SearchName: "test",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
 		FirstSeenAt: old,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatalf("SaveListing old-1: %v", err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-2", ChatID: 100, SearchName: "test",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000,
 		FirstSeenAt: old,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatalf("SaveListing old-2: %v", err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "recent-1", ChatID: 100, SearchName: "test",
 		Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 95000,
 		FirstSeenAt: recent,
-	})
+	}); err != nil {
+		t.Fatalf("SaveListing recent-1: %v", err)
+	}
 
 	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
 	if err != nil {
@@ -2714,7 +2720,10 @@ func TestPruneListings_RemovesOld(t *testing.T) {
 		t.Errorf("expected 2 pruned, got %d", pruned)
 	}
 
-	count, _ := store.CountUserListings(ctx, 100)
+	count, err := store.CountUserListings(ctx, 100)
+	if err != nil {
+		t.Fatalf("CountUserListings: %v", err)
+	}
 	if count != 1 {
 		t.Errorf("expected 1 remaining listing, got %d", count)
 	}
@@ -2727,18 +2736,24 @@ func TestPruneListings_PreservesSaved(t *testing.T) {
 
 	old := time.Now().Add(-100 * 24 * time.Hour)
 
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-saved", ChatID: 100, SearchName: "test",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
 		FirstSeenAt: old,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatalf("SaveListing old-saved: %v", err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-unsaved", ChatID: 100, SearchName: "test",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000,
 		FirstSeenAt: old,
-	})
+	}); err != nil {
+		t.Fatalf("SaveListing old-unsaved: %v", err)
+	}
 
-	_ = store.SaveBookmark(ctx, 100, "old-saved")
+	if err := store.SaveBookmark(ctx, 100, "old-saved"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
 
 	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
 	if err != nil {
@@ -2748,12 +2763,18 @@ func TestPruneListings_PreservesSaved(t *testing.T) {
 		t.Errorf("expected 1 pruned (unsaved only), got %d", pruned)
 	}
 
-	saved, _ := store.GetListing(ctx, 100, "old-saved")
+	saved, err := store.GetListing(ctx, 100, "old-saved")
+	if err != nil {
+		t.Fatalf("GetListing old-saved: %v", err)
+	}
 	if saved == nil {
 		t.Error("saved listing should survive pruning")
 	}
 
-	unsaved, _ := store.GetListing(ctx, 100, "old-unsaved")
+	unsaved, err := store.GetListing(ctx, 100, "old-unsaved")
+	if err != nil {
+		t.Fatalf("GetListing old-unsaved: %v", err)
+	}
 	if unsaved != nil {
 		t.Error("unsaved old listing should be pruned")
 	}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2682,3 +2682,80 @@ func TestSavedAmong_LargeBatch(t *testing.T) {
 	}
 }
 
+func TestPruneListings_RemovesOld(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	old := time.Now().Add(-100 * 24 * time.Hour)
+	recent := time.Now().Add(-10 * 24 * time.Hour)
+
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-1", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		FirstSeenAt: old,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-2", ChatID: 100, SearchName: "test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000,
+		FirstSeenAt: old,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "recent-1", ChatID: 100, SearchName: "test",
+		Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 95000,
+		FirstSeenAt: recent,
+	})
+
+	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("PruneListings: %v", err)
+	}
+	if pruned != 2 {
+		t.Errorf("expected 2 pruned, got %d", pruned)
+	}
+
+	count, _ := store.CountUserListings(ctx, 100)
+	if count != 1 {
+		t.Errorf("expected 1 remaining listing, got %d", count)
+	}
+}
+
+func TestPruneListings_PreservesSaved(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	old := time.Now().Add(-100 * 24 * time.Hour)
+
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-saved", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		FirstSeenAt: old,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-unsaved", ChatID: 100, SearchName: "test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000,
+		FirstSeenAt: old,
+	})
+
+	_ = store.SaveBookmark(ctx, 100, "old-saved")
+
+	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("PruneListings: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned (unsaved only), got %d", pruned)
+	}
+
+	saved, _ := store.GetListing(ctx, 100, "old-saved")
+	if saved == nil {
+		t.Error("saved listing should survive pruning")
+	}
+
+	unsaved, _ := store.GetListing(ctx, 100, "old-unsaved")
+	if unsaved != nil {
+		t.Error("unsaved old listing should be pruned")
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds `PruneListings(ctx, olderThan)` to the `ListingStore` interface and implements it in the SQLite store
- Wires pruning into the existing `pruneOldData` scheduler loop with 90-day retention (matching `price_history`)
- Saved/bookmarked listings are excluded from pruning via `NOT EXISTS` against `saved_listings`

## Test plan

- [x] `TestPruneListings_RemovesOld` — inserts old + recent listings, verifies only old are deleted
- [x] `TestPruneListings_PreservesSaved` — inserts an old bookmarked listing, verifies it survives pruning
- [x] Full test suite passes (`make test`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic listing history cleanup with a 90-day retention period.
  * Saved/bookmarked listings are preserved and excluded from automatic removal.
* **Tests**
  * Added tests verifying cleanup removes old listings but preserves saved/bookmarked ones.
  * Added test verifying the scheduler invokes the listing-prune path as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->