### PR TITLE
fix: system stabilization — stale listings, scheduler reliability, admin security

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage/sqlite"
@@ -46,15 +47,27 @@ type runtimeStats struct {
 	Uptime     string `json:"uptime"`
 }
 
+func (s *Server) isAdmin(chatID int64, email string) bool {
+	return (chatID > 0 && s.cfg.AdminChatID != 0 && chatID == s.cfg.AdminChatID) ||
+		(s.cfg.AdminEmail != "" && email != "" && strings.EqualFold(email, s.cfg.AdminEmail))
+}
+
+func (s *Server) getMe(w http.ResponseWriter, r *http.Request) {
+	chatID, _ := chatIDFromContext(r.Context())
+	email := emailFromContext(r.Context())
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"email":    email,
+		"is_admin": s.isAdmin(chatID, email),
+	})
+}
+
 func (s *Server) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		chatID, chatOK := chatIDFromContext(r.Context())
+		chatID, _ := chatIDFromContext(r.Context())
 		email := emailFromContext(r.Context())
 
-		isAdmin := (chatOK && s.cfg.AdminChatID != 0 && chatID == s.cfg.AdminChatID) ||
-			(s.cfg.AdminEmail != "" && email != "" && email == s.cfg.AdminEmail)
-
-		if !isAdmin {
+		if !s.isAdmin(chatID, email) {
 			writeError(w, http.StatusForbidden, "admin access required")
 			return
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -98,6 +98,8 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /api/v1/catalog/manufacturers", s.listManufacturers)
 	mux.HandleFunc("GET /api/v1/catalog/manufacturers/{id}/models", s.listModels)
 
+	mux.HandleFunc("GET /api/v1/me", s.getMe)
+
 	mux.HandleFunc("GET /api/v1/searches", s.listSearches)
 	mux.HandleFunc("POST /api/v1/searches", s.createSearch)
 	mux.HandleFunc("GET /api/v1/searches/{id}", s.getSearch)

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+
+	"github.com/dsionov/carwatch/internal/storage"
 )
 
 type listingResponse struct {
@@ -77,6 +79,16 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func listingFilterFromSearch(sr *storage.Search) storage.ListingFilter {
+	return storage.ListingFilter{
+		PriceMax: sr.PriceMax,
+		YearMin:  sr.YearMin,
+		YearMax:  sr.YearMax,
+		MaxKm:    sr.MaxKm,
+		MaxHand:  sr.MaxHand,
+	}
+}
+
 func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {
 	chatID, okChat := requireChatID(w, r)
 	if !okChat {
@@ -100,20 +112,23 @@ func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	limit := parseIntParam(r, "limit", 20)
-	if limit > 100 {
+	if limit <= 0 {
+		limit = 20
+	} else if limit > 100 {
 		limit = 100
 	}
 	offset := parseIntParam(r, "offset", 0)
 	sort := parseSortParam(r)
+	f := listingFilterFromSearch(sr)
 
-	listings, err := s.listings.ListSearchListings(r.Context(), chatID, sr.ID, limit, offset, sort)
+	listings, err := s.listings.ListSearchListings(r.Context(), chatID, sr.ID, f, limit, offset, sort)
 	if err != nil {
 		s.logger.Error("list search listings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list listings")
 		return
 	}
 
-	total, err := s.listings.CountSearchListings(r.Context(), chatID, sr.ID)
+	total, err := s.listings.CountSearchListings(r.Context(), chatID, sr.ID, f)
 	if err != nil {
 		s.logger.Error("count search listings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to count listings")

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -108,7 +108,7 @@ func (s *Server) toSearchResponse(sr storage.Search) searchResponse {
 func (s *Server) searchResponseWithListingCount(ctx context.Context, chatID int64, sr storage.Search) searchResponse {
 	item := s.toSearchResponse(sr)
 	if s.listings != nil {
-		n, err := s.listings.CountSearchListings(ctx, chatID, sr.ID)
+		n, err := s.listings.CountSearchListings(ctx, chatID, sr.ID, listingFilterFromSearch(&sr))
 		if err != nil {
 			s.logger.Error("count search listings", "error", err, "search_id", sr.ID)
 		} else {

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -277,11 +277,11 @@ func (m *mockListingStore) CountUserListings(_ context.Context, _ int64) (int64,
 	return 0, nil
 }
 
-func (m *mockListingStore) ListSearchListings(_ context.Context, _ int64, _ int64, _, _ int, _ string) ([]storage.ListingRecord, error) {
+func (m *mockListingStore) ListSearchListings(_ context.Context, _ int64, _ int64, _ storage.ListingFilter, _, _ int, _ string) ([]storage.ListingRecord, error) {
 	return nil, nil
 }
 
-func (m *mockListingStore) CountSearchListings(_ context.Context, _ int64, _ int64) (int64, error) {
+func (m *mockListingStore) CountSearchListings(_ context.Context, _ int64, _ int64, _ storage.ListingFilter) (int64, error) {
 	return 0, nil
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -260,7 +260,9 @@ func (s *Scheduler) deliveryFor(ctx context.Context, chatID int64, lang locale.L
 	if s.stores.Digests != nil {
 		var mode string
 		if v, ok := s.digestCache.Load(chatID); ok {
-			mode = v.(digestMeta).mode
+			if dm, ok := v.(digestMeta); ok {
+				mode = dm.mode
+			}
 		} else {
 			m, interval, err := s.stores.Digests.GetDigestMode(ctx, chatID)
 			if err != nil {
@@ -684,10 +686,18 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		filtered := filter.Apply(buildFilterCriteria(search), raw)
 		lang := s.userLang(ctx, search.ChatID)
 		sr := s.processSearchListings(ctx, search, filtered, marketCache, lang)
+		persistOK := true
 		if s.stores.Listings != nil && len(sr.listingRecords) > 0 {
 			if err := s.persistListings(ctx, sr.listingRecords); err != nil {
-				continue
+				persistOK = false
 			}
+		}
+		if !persistOK {
+			// Persist failed: still deliver price-drop messages (already saved
+			// individually in tryPriceDropListing), but drop new-listing
+			// notifications since they weren't persisted.
+			sr.newListings = nil
+			sr.listingRecords = nil
 		}
 		gs.newListings += len(sr.newListings)
 		delivered := s.deliverResults(ctx, search, lang, sr)
@@ -1241,7 +1251,9 @@ func (s *Scheduler) processExpiredPremium(ctx context.Context) {
 
 func (s *Scheduler) userLang(ctx context.Context, chatID int64) locale.Lang {
 	if v, ok := s.langCache.Load(chatID); ok {
-		return v.(locale.Lang)
+		if l, ok := v.(locale.Lang); ok {
+			return l
+		}
 	}
 	lang := locale.Hebrew
 	if s.stores.Users != nil {

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -147,14 +147,24 @@ type PricePoint struct {
 	ObservedAt time.Time
 }
 
+// ListingFilter restricts which listing_history rows are returned.
+// Zero values are ignored (no constraint applied for that field).
+type ListingFilter struct {
+	PriceMax int
+	YearMin  int
+	YearMax  int
+	MaxKm    int
+	MaxHand  int
+}
+
 type ListingStore interface {
 	SaveListing(ctx context.Context, r ListingRecord) error
 	SaveListings(ctx context.Context, records []ListingRecord) error
 	GetListing(ctx context.Context, chatID int64, token string) (*ListingRecord, error)
 	ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]ListingRecord, error)
 	CountUserListings(ctx context.Context, chatID int64) (int64, error)
-	ListSearchListings(ctx context.Context, chatID int64, searchID int64, limit, offset int, sort string) ([]ListingRecord, error)
-	CountSearchListings(ctx context.Context, chatID int64, searchID int64) (int64, error)
+	ListSearchListings(ctx context.Context, chatID int64, searchID int64, f ListingFilter, limit, offset int, sort string) ([]ListingRecord, error)
+	CountSearchListings(ctx context.Context, chatID int64, searchID int64, f ListingFilter) (int64, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 }
 

--- a/internal/storage/sqlite/coverage_test.go
+++ b/internal/storage/sqlite/coverage_test.go
@@ -261,7 +261,7 @@ func TestDeleteSearch_CascadeCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	listings, err := store.ListSearchListings(ctx, 100, id, 100, 0, "newest")
+	listings, err := store.ListSearchListings(ctx, 100, id, storage.ListingFilter{}, 100, 0, "newest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,7 +322,7 @@ func TestDeleteSearch_DuplicateNameDoesNotAffectOther(t *testing.T) {
 	}
 
 	// Deleting id1 cascades only rows tied to that search_id; id2's listing remains.
-	listings, err := store.ListSearchListings(ctx, 100, id2, 100, 0, "newest")
+	listings, err := store.ListSearchListings(ctx, 100, id2, storage.ListingFilter{}, 100, 0, "newest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -4,12 +4,31 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
 const firstSeenAtLayout = "2006-01-02 15:04:05.000000"
+
+const upsertListingSQL = `
+	INSERT INTO listing_history
+	(token, chat_id, search_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, image_url, fitness_score, first_seen_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(token, chat_id) DO UPDATE SET
+		search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
+		search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
+		manufacturer = CASE WHEN excluded.manufacturer != '' THEN excluded.manufacturer ELSE listing_history.manufacturer END,
+		model = CASE WHEN excluded.model != '' THEN excluded.model ELSE listing_history.model END,
+		year = CASE WHEN excluded.year > 0 THEN excluded.year ELSE listing_history.year END,
+		price = excluded.price,
+		km = CASE WHEN excluded.km > 0 THEN excluded.km ELSE listing_history.km END,
+		hand = excluded.hand,
+		city = CASE WHEN excluded.city != '' THEN excluded.city ELSE listing_history.city END,
+		page_link = CASE WHEN excluded.page_link != '' THEN excluded.page_link ELSE listing_history.page_link END,
+		image_url = CASE WHEN excluded.image_url != '' THEN excluded.image_url ELSE listing_history.image_url END,
+		fitness_score = excluded.fitness_score`
 
 type listingScanner interface {
 	Scan(dest ...any) error
@@ -28,22 +47,15 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	return l, nil
 }
 
-func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error {
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO listing_history
-		(token, chat_id, search_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, image_url, fitness_score, first_seen_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(token, chat_id) DO UPDATE SET
-			search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
-			search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
-			price = excluded.price,
-			km = CASE WHEN excluded.km > 0 THEN excluded.km ELSE listing_history.km END,
-			hand = excluded.hand,
-			city = CASE WHEN excluded.city != '' THEN excluded.city ELSE listing_history.city END,
-			image_url = CASE WHEN excluded.image_url != '' THEN excluded.image_url ELSE listing_history.image_url END,
-			fitness_score = excluded.fitness_score`,
+func upsertListingArgs(r storage.ListingRecord) []any {
+	return []any{
 		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.Year, r.Price,
-		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL, r.FitnessScore, r.FirstSeenAt.UTC().Format(firstSeenAtLayout))
+		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL, r.FitnessScore, r.FirstSeenAt.UTC().Format(firstSeenAtLayout),
+	}
+}
+
+func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error {
+	_, err := s.db.ExecContext(ctx, upsertListingSQL, upsertListingArgs(r)...)
 	return err
 }
 
@@ -58,28 +70,14 @@ func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecor
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	listingStmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO listing_history
-		(token, chat_id, search_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, image_url, fitness_score, first_seen_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(token, chat_id) DO UPDATE SET
-			search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
-			search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
-			price = excluded.price,
-			km = CASE WHEN excluded.km > 0 THEN excluded.km ELSE listing_history.km END,
-			hand = excluded.hand,
-			city = CASE WHEN excluded.city != '' THEN excluded.city ELSE listing_history.city END,
-			image_url = CASE WHEN excluded.image_url != '' THEN excluded.image_url ELSE listing_history.image_url END,
-			fitness_score = excluded.fitness_score`)
+	stmt, err := tx.PrepareContext(ctx, upsertListingSQL)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = listingStmt.Close() }()
+	defer func() { _ = stmt.Close() }()
 
 	for _, r := range records {
-		if _, err := listingStmt.ExecContext(ctx,
-			r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.Year, r.Price,
-			r.Km, r.Hand, r.City, r.PageLink, r.ImageURL, r.FitnessScore, r.FirstSeenAt.UTC().Format(firstSeenAtLayout)); err != nil {
+		if _, err := stmt.ExecContext(ctx, upsertListingArgs(r)...); err != nil {
 			return err
 		}
 	}
@@ -157,7 +155,36 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	return listings, rows.Err()
 }
 
-func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID int64, limit, offset int, sort string) ([]storage.ListingRecord, error) {
+func buildFilterClauses(f storage.ListingFilter) (string, []any) {
+	var clauses []string
+	var args []any
+	if f.PriceMax > 0 {
+		clauses = append(clauses, "price <= ?")
+		args = append(args, f.PriceMax)
+	}
+	if f.YearMin > 0 {
+		clauses = append(clauses, "year >= ?")
+		args = append(args, f.YearMin)
+	}
+	if f.YearMax > 0 {
+		clauses = append(clauses, "year <= ?")
+		args = append(args, f.YearMax)
+	}
+	if f.MaxKm > 0 {
+		clauses = append(clauses, "(km <= ? OR km = 0)")
+		args = append(args, f.MaxKm)
+	}
+	if f.MaxHand > 0 {
+		clauses = append(clauses, "hand <= ?")
+		args = append(args, f.MaxHand)
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " AND " + strings.Join(clauses, " AND "), args
+}
+
+func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID int64, f storage.ListingFilter, limit, offset int, sort string) ([]storage.ListingRecord, error) {
 	orderBy := "first_seen_at DESC, token DESC"
 	switch sort {
 	case "newest":
@@ -174,13 +201,18 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 		orderBy = "year DESC, token DESC"
 	}
 
+	filterSQL, filterArgs := buildFilterClauses(f)
+	args := []any{chatID, searchID}
+	args = append(args, filterArgs...)
+	args = append(args, limit, offset)
+
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT token, search_name, manufacturer, model, year, price,
 			km, hand, city, page_link, image_url, fitness_score, first_seen_at
 		FROM listing_history
-		WHERE chat_id = ? AND search_id = ?
+		WHERE chat_id = ? AND search_id = ?%s
 		ORDER BY %s
-		LIMIT ? OFFSET ?`, orderBy), chatID, searchID, limit, offset)
+		LIMIT ? OFFSET ?`, filterSQL, orderBy), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -197,11 +229,15 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 	return listings, rows.Err()
 }
 
-func (s *Store) CountSearchListings(ctx context.Context, chatID int64, searchID int64) (int64, error) {
+func (s *Store) CountSearchListings(ctx context.Context, chatID int64, searchID int64, f storage.ListingFilter) (int64, error) {
+	filterSQL, filterArgs := buildFilterClauses(f)
+	args := []any{chatID, searchID}
+	args = append(args, filterArgs...)
+
 	var count int64
-	err := s.db.QueryRowContext(ctx, `
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT COUNT(*) FROM listing_history
-		WHERE chat_id = ? AND search_id = ?`, chatID, searchID).Scan(&count)
+		WHERE chat_id = ? AND search_id = ?%s`, filterSQL), args...).Scan(&count)
 	return count, err
 }
 

--- a/internal/storage/sqlite/migrate.go
+++ b/internal/storage/sqlite/migrate.go
@@ -40,6 +40,7 @@ func migrate(db *sql.DB) error {
 		migrateUserLinkedWebID,
 		migrateUserLinkedWebIndex,
 		migrateUsersActiveIndex,
+		migrateMissingIndexes,
 	}
 	for _, step := range steps {
 		if err := step(db); err != nil {

--- a/internal/storage/sqlite/migrate_steps.go
+++ b/internal/storage/sqlite/migrate_steps.go
@@ -627,3 +627,15 @@ func migrateUsersActiveIndex(db *sql.DB) error {
 
 	return nil
 }
+
+func migrateMissingIndexes(db *sql.DB) error {
+	if _, err := db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_seen_listings_search_chat
+			ON seen_listings(search_id, chat_id);
+		CREATE INDEX IF NOT EXISTS idx_pending_notifications_name_recipient
+			ON pending_notifications(search_name, recipient)
+	`); err != nil {
+		return fmt.Errorf("create missing indexes: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2313,6 +2313,83 @@ func TestListSearchListings(t *testing.T) {
 	if listings[0].Token != "lsl-1" {
 		t.Fatalf("pagination offset=1 returned %q, want lsl-1", listings[0].Token)
 	}
+
+	// Test data reminder:
+	//   lsl-1: Year=2021, Price=120000, Km=50000, Hand=2
+	//   lsl-2: Year=2022, Price=90000,  Km=30000, Hand=1
+	t.Run("applies listing filters", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			filter storage.ListingFilter
+			want   []string
+		}{
+			{
+				name:   "price_max excludes expensive",
+				filter: storage.ListingFilter{PriceMax: 100000},
+				want:   []string{"lsl-2"},
+			},
+			{
+				name:   "price_max includes all",
+				filter: storage.ListingFilter{PriceMax: 200000},
+				want:   []string{"lsl-2", "lsl-1"},
+			},
+			{
+				name:   "year_min",
+				filter: storage.ListingFilter{YearMin: 2022},
+				want:   []string{"lsl-2"},
+			},
+			{
+				name:   "year_max",
+				filter: storage.ListingFilter{YearMax: 2021},
+				want:   []string{"lsl-1"},
+			},
+			{
+				name:   "max_km",
+				filter: storage.ListingFilter{MaxKm: 40000},
+				want:   []string{"lsl-2"},
+			},
+			{
+				name:   "max_hand",
+				filter: storage.ListingFilter{MaxHand: 1},
+				want:   []string{"lsl-2"},
+			},
+			{
+				name:   "combined filters",
+				filter: storage.ListingFilter{PriceMax: 100000, YearMin: 2022, MaxKm: 40000, MaxHand: 1},
+				want:   []string{"lsl-2"},
+			},
+			{
+				name:   "all filtered out",
+				filter: storage.ListingFilter{PriceMax: 50000},
+				want:   nil,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := store.ListSearchListings(ctx, 100, idMazda3, tc.filter, 20, 0, "newest")
+				if err != nil {
+					t.Fatalf("ListSearchListings(%s): %v", tc.name, err)
+				}
+				if len(got) != len(tc.want) {
+					t.Fatalf("%s: got %d rows, want %d", tc.name, len(got), len(tc.want))
+				}
+				for i := range tc.want {
+					if got[i].Token != tc.want[i] {
+						t.Errorf("%s: got token %q at %d, want %q", tc.name, got[i].Token, i, tc.want[i])
+					}
+				}
+
+				count, err := store.CountSearchListings(ctx, 100, idMazda3, tc.filter)
+				if err != nil {
+					t.Fatalf("CountSearchListings(%s): %v", tc.name, err)
+				}
+				if int(count) != len(tc.want) {
+					t.Errorf("CountSearchListings(%s): got %d, want %d", tc.name, count, len(tc.want))
+				}
+			})
+		}
+	})
 }
 
 // --- New() edge cases ---

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -455,7 +455,7 @@ func TestDeleteSearch_CascadesRelatedRecords(t *testing.T) {
 	}
 
 	// listing_history for user 100 should be cleaned up.
-	count100, err := store.CountSearchListings(ctx, 100, id1)
+	count100, err := store.CountSearchListings(ctx, 100, id1, storage.ListingFilter{})
 	if err != nil {
 		t.Fatalf("count listings user 100: %v", err)
 	}
@@ -464,7 +464,7 @@ func TestDeleteSearch_CascadesRelatedRecords(t *testing.T) {
 	}
 
 	// User 200's listing_history should be untouched.
-	count200, err := store.CountSearchListings(ctx, 200, id2)
+	count200, err := store.CountSearchListings(ctx, 200, id2, storage.ListingFilter{})
 	if err != nil {
 		t.Fatalf("count listings user 200: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestDeleteSearch_CascadeNotFound(t *testing.T) {
 	}
 
 	// Verify dependent rows for the real search are still intact.
-	count, err := store.CountSearchListings(ctx, 100, id)
+	count, err := store.CountSearchListings(ctx, 100, id, storage.ListingFilter{})
 	if err != nil {
 		t.Fatalf("count listings: %v", err)
 	}
@@ -2249,7 +2249,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	listings, err := store.ListSearchListings(ctx, 100, idMazda3, 20, 0, "newest")
+	listings, err := store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 20, 0, "newest")
 	if err != nil {
 		t.Fatalf("ListSearchListings: %v", err)
 	}
@@ -2260,7 +2260,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Fatalf("newest sort order = [%s, %s], want [lsl-2, lsl-1]", listings[0].Token, listings[1].Token)
 	}
 
-	listings, err = store.ListSearchListings(ctx, 100, idMazda3, 20, 0, "price_asc")
+	listings, err = store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 20, 0, "price_asc")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2268,7 +2268,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Errorf("price_asc: expected 90000 first, got %d", listings[0].Price)
 	}
 
-	listings, err = store.ListSearchListings(ctx, 100, idMazda3, 20, 0, "price_desc")
+	listings, err = store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 20, 0, "price_desc")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2276,7 +2276,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Errorf("price_desc: expected 120000 first, got %d", listings[0].Price)
 	}
 
-	listings, err = store.ListSearchListings(ctx, 100, idMazda3, 20, 0, "km")
+	listings, err = store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 20, 0, "km")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2284,7 +2284,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Errorf("km sort: expected 30000 first, got %d", listings[0].Km)
 	}
 
-	listings, err = store.ListSearchListings(ctx, 100, idMazda3, 20, 0, "year")
+	listings, err = store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 20, 0, "year")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2292,7 +2292,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Errorf("year sort: expected 2022 first, got %d", listings[0].Year)
 	}
 
-	listings, err = store.ListSearchListings(ctx, 100, idMazda3, 1, 0, "newest")
+	listings, err = store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 1, 0, "newest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2303,7 +2303,7 @@ func TestListSearchListings(t *testing.T) {
 		t.Fatalf("pagination offset=0 returned %q, want lsl-2", listings[0].Token)
 	}
 
-	listings, err = store.ListSearchListings(ctx, 100, idMazda3, 1, 1, "newest")
+	listings, err = store.ListSearchListings(ctx, 100, idMazda3, storage.ListingFilter{}, 1, 1, "newest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,9 @@
 import { lazy, Suspense } from "react";
-import { Routes, Route } from "react-router";
+import { Routes, Route, Navigate } from "react-router";
 import { Loader2 } from "lucide-react";
 import { Shell } from "./components/layout/Shell";
 import { ProtectedRoute } from "./components/ProtectedRoute";
+import { useMe } from "./hooks/useMe";
 
 const LandingPage = lazy(() =>
   import("./pages/LandingPage").then((m) => ({ default: m.LandingPage })),
@@ -53,6 +54,13 @@ const SettingsPage = lazy(() =>
   import("./pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );
 
+function AdminGuard({ children }: { children: React.ReactNode }) {
+  const { data: me, isLoading } = useMe();
+  if (isLoading) return <PageFallback />;
+  if (!me?.is_admin) return <Navigate to="/dashboard" replace />;
+  return <>{children}</>;
+}
+
 function PageFallback() {
   return (
     <div className="flex min-h-[40vh] items-center justify-center">
@@ -76,7 +84,7 @@ export default function App() {
             <Route path="/searches/:id/listings" element={<ListingsPage />} />
             <Route path="/listings/:token" element={<ListingDetailPage />} />
             <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/admin" element={<AdminPage />} />
+            <Route path="/admin" element={<AdminGuard><AdminPage /></AdminGuard>} />
             <Route path="/saved" element={<SavedPage />} />
             <Route path="/history" element={<HistoryPage />} />
             <Route path="/notifications" element={<NotificationsPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -55,8 +55,15 @@ const SettingsPage = lazy(() =>
 );
 
 function AdminGuard({ children }: { children: React.ReactNode }) {
-  const { data: me, isLoading } = useMe();
+  const { data: me, isLoading, isError } = useMe();
   if (isLoading) return <PageFallback />;
+  if (isError) {
+    return (
+      <div className="flex min-h-[40vh] flex-col items-center justify-center gap-2 text-muted-foreground">
+        <span>שגיאה בבדיקת הרשאות</span>
+      </div>
+    );
+  }
   if (!me?.is_admin) return <Navigate to="/dashboard" replace />;
   return <>{children}</>;
 }

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -17,10 +17,20 @@ import { useAppVersion } from "@/hooks/useAppVersion";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useHealthCheck } from "@/hooks/useHealthCheck";
+import { useMe } from "@/hooks/useMe";
 import { ConnectionBanner } from "@/components/ui/ConnectionBanner";
 import { cn } from "@/lib/utils";
 
-const navItems = [
+interface NavItem {
+  path: string;
+  label: string;
+  icon: typeof LayoutDashboard;
+  mobile: boolean;
+  badge?: boolean;
+  adminOnly?: boolean;
+}
+
+const navItems: NavItem[] = [
   { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard, mobile: true },
   { path: "/searches/new", label: "חיפוש חדש", icon: Plus, mobile: true },
   { path: "/saved", label: "מועדפים", icon: Bookmark, mobile: true },
@@ -33,7 +43,7 @@ const navItems = [
     mobile: true,
   },
   { path: "/settings", label: "הגדרות", icon: Settings, mobile: true },
-  { path: "/admin", label: "ניהול", icon: Wrench, mobile: false },
+  { path: "/admin", label: "ניהול", icon: Wrench, mobile: false, adminOnly: true },
 ];
 
 function isNavActive(pathname: string, path: string): boolean {
@@ -49,6 +59,11 @@ export function Shell() {
   const { theme, toggle: toggleTheme } = useTheme();
   const appVersion = useAppVersion();
   const connectionStatus = useHealthCheck();
+  const { data: me } = useMe();
+  const isAdmin = me?.is_admin ?? false;
+  const visibleNavItems = navItems.filter(
+    (item) => !item.adminOnly || isAdmin,
+  );
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
 
@@ -81,7 +96,7 @@ export function Shell() {
         </div>
 
         <nav className="flex-1 space-y-1 overflow-y-auto px-2.5 py-4">
-          {navItems.map((item) => {
+          {visibleNavItems.map((item) => {
             const Icon = item.icon;
             const active = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;
@@ -194,7 +209,7 @@ export function Shell() {
 
       <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/40 bg-card/80 shadow-[0_-4px_24px_-8px_rgba(0,0,0,0.15)] dark:shadow-[0_-12px_40px_-12px_rgba(0,0,0,0.55)] backdrop-blur-2xl backdrop-saturate-150 md:hidden">
         <div className="flex justify-around px-1 py-3 landscape:py-1.5">
-          {navItems.filter((item) => item.mobile).map((item) => {
+          {visibleNavItems.filter((item) => item.mobile).map((item) => {
             const Icon = item.icon;
             const isActive = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;

--- a/web/src/hooks/useMe.ts
+++ b/web/src/hooks/useMe.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { userApi } from "@/lib/api";
+
+export function useMe() {
+  return useQuery({
+    queryKey: ["me"],
+    queryFn: userApi.me,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/web/src/hooks/useSearches.ts
+++ b/web/src/hooks/useSearches.ts
@@ -14,7 +14,10 @@ export function useUpdateSearch() {
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: Partial<CreateSearchRequest> }) =>
       api.searches.update(id, data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["searches"] }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["searches"] });
+      queryClient.invalidateQueries({ queryKey: ["listings", variables.id] });
+    },
   });
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -271,6 +271,15 @@ export const adminApi = {
     fetchAPI<VacuumResult>("/admin/vacuum", { method: "POST" }),
 };
 
+export interface UserProfile {
+  email: string;
+  is_admin: boolean;
+}
+
+export const userApi = {
+  me: () => fetchAPI<UserProfile>("/me"),
+};
+
 export interface TelegramLinkResponse {
   link: string;
   expires_in_seconds: number;


### PR DESCRIPTION
## Summary

Comprehensive fix for data integrity, scheduler reliability, and admin security issues identified in the [system stabilization epic (#495)](https://github.com/Danielsio/carwatch/issues/495).

**The core bug:** Cars priced above the user's `price_max` were showing in the dashboard because `listing_history` was queried by `search_id` only — tightening search criteria (e.g., lowering price from 100K to 70K) left old expensive listings visible. This PR adds real-time re-filtering against current search criteria at query time.

### Changes across 17 files:

**Data integrity (closes #496, #498):**
- `ListSearchListings` and `CountSearchListings` now accept a `ListingFilter` and apply `price_max`, `year_min`, `year_max`, `max_km`, `max_hand` as WHERE clauses
- `ON CONFLICT` upsert updates all mutable fields (manufacturer, model, year, page_link) — previously left stale
- `limit=0` on listings endpoint normalized to default (20)
- Deduplicated `SaveListing`/`SaveListings` SQL into shared constant

**Scheduler reliability:**
- `persistListings` failure no longer silently drops price-drop notifications — only new-listing delivery is skipped
- `sync.Map` type assertions use comma-ok pattern to prevent panics

**Admin security (closes #499):**
- New `GET /api/v1/me` endpoint returns `{ email, is_admin }` with case-insensitive email comparison
- Frontend admin nav only rendered for admin users (via `/me` check)
- `/admin` route guarded with `AdminGuard` — non-admins redirected to dashboard
- Non-admin users have zero indication an admin area exists

**Performance:**
- Added missing indexes on `seen_listings(search_id, chat_id)` and `pending_notifications(search_name, recipient)` for `DeleteSearch` cascade performance

**Frontend:**
- `useUpdateSearch` now invalidates `["listings", searchId]` cache, preventing stale data after criteria changes

## Test plan

- [x] `make test` — all tests pass (82.0% coverage, no decrease)
- [x] `golangci-lint run ./...` — clean
- [x] `npx tsc --noEmit` — TypeScript clean
- [ ] Verify in production: set a search with 70K max, confirm no cars above 70K appear
- [ ] Verify admin nav is hidden for non-admin users
- [ ] Verify admin route redirects to dashboard for non-admins


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user profile endpoint to retrieve email and admin status
  * Implemented admin-guarded routing and conditional nav items for admins
  * Added per-search listing filters applied to listing results and totals; tightened listing limit handling

* **Bug Fixes**
  * Scheduler made more robust with safer cache handling and preserved notifications on partial persistence
  * Improved client cache invalidation after search updates

* **Performance**
  * Added database indexes to improve query performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->