### PR TITLE
refactor: codebase audit — error wrapping, GetSearch ownership, source validation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -54,6 +54,12 @@ func (s *Server) SetPollTrigger(p PollTrigger) {
 	s.poller = p
 }
 
+func (s *Server) Shutdown() {
+	if s.rl != nil {
+		s.rl.stop()
+	}
+}
+
 type Config struct {
 	Catalog  catalog.Catalog
 	Searches storage.SearchStore
@@ -88,7 +94,7 @@ func New(c Config) *Server {
 		cfg:       c.API,
 		botUsername: c.BotUsername,
 		startTime: time.Now(),
-		rl:        newRateLimiter(context.Background(), 60, time.Second/60),
+		rl:        newRateLimiter(60, time.Second/60),
 	}
 }
 

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -100,13 +100,13 @@ func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sr, err := s.searches.GetSearch(r.Context(), id)
+	sr, err := s.searches.GetSearch(r.Context(), id, chatID)
 	if err != nil {
 		s.logger.Error("get search for listings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get search")
 		return
 	}
-	if sr == nil || sr.ChatID != chatID {
+	if sr == nil {
 		writeError(w, http.StatusNotFound, "search not found")
 		return
 	}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -8,11 +8,12 @@ import (
 )
 
 type rateLimiter struct {
-	mu    sync.Mutex
-	users map[int64]*bucket
-	burst int
-	every time.Duration
-	done  chan struct{}
+	mu     sync.Mutex
+	users  map[int64]*bucket
+	burst  int
+	every  time.Duration
+	done   chan struct{}
+	cancel context.CancelFunc
 }
 
 type bucket struct {
@@ -21,15 +22,22 @@ type bucket struct {
 	lastUsed time.Time
 }
 
-func newRateLimiter(ctx context.Context, burst int, every time.Duration) *rateLimiter {
+func newRateLimiter(burst int, every time.Duration) *rateLimiter {
+	ctx, cancel := context.WithCancel(context.Background())
 	rl := &rateLimiter{
-		users: make(map[int64]*bucket),
-		burst: burst,
-		every: every,
-		done:  make(chan struct{}),
+		users:  make(map[int64]*bucket),
+		burst:  burst,
+		every:  every,
+		done:   make(chan struct{}),
+		cancel: cancel,
 	}
 	go rl.cleanup(ctx)
 	return rl
+}
+
+func (rl *rateLimiter) stop() {
+	rl.cancel()
+	<-rl.done
 }
 
 func (rl *rateLimiter) allow(chatID int64) bool {

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -58,15 +58,13 @@ type searchResponse struct {
 	ListingsCount    int64  `json:"listings_count"`
 }
 
-var validSources = map[string]bool{
-	"yad2":         true,
-	"winwin":       true,
-	"yad2,winwin":  true,
-	"winwin,yad2":  true,
-}
-
 func isValidSource(source string) bool {
-	return validSources[source]
+	switch source {
+	case "yad2", "winwin", "yad2,winwin", "winwin,yad2":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateSearchRanges(yearMin, yearMax, priceMax, maxKm, maxHand, engineMinCC int) string {
@@ -159,7 +157,7 @@ func (s *Server) validateCreateSearchInput(ctx context.Context, chatID int64, re
 		req.Source = "yad2"
 	}
 	if !isValidSource(req.Source) {
-		return "", http.StatusBadRequest, "invalid source: must be yad2, winwin, or yad2,winwin"
+		return "", http.StatusBadRequest, "invalid source: must be yad2, winwin, yad2,winwin, or winwin,yad2"
 	}
 
 	if msg := validateSearchRanges(req.YearMin, req.YearMax, req.PriceMax, req.MaxKm, req.MaxHand, req.EngineMinCC); msg != "" {

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -58,6 +58,17 @@ type searchResponse struct {
 	ListingsCount    int64  `json:"listings_count"`
 }
 
+var validSources = map[string]bool{
+	"yad2":         true,
+	"winwin":       true,
+	"yad2,winwin":  true,
+	"winwin,yad2":  true,
+}
+
+func isValidSource(source string) bool {
+	return validSources[source]
+}
+
 func validateSearchRanges(yearMin, yearMax, priceMax, maxKm, maxHand, engineMinCC int) string {
 	if yearMin < 0 {
 		return "year_min must not be negative"
@@ -147,6 +158,9 @@ func (s *Server) validateCreateSearchInput(ctx context.Context, chatID int64, re
 	if req.Source == "" {
 		req.Source = "yad2"
 	}
+	if !isValidSource(req.Source) {
+		return "", http.StatusBadRequest, "invalid source: must be yad2, winwin, or yad2,winwin"
+	}
 
 	if msg := validateSearchRanges(req.YearMin, req.YearMax, req.PriceMax, req.MaxKm, req.MaxHand, req.EngineMinCC); msg != "" {
 		return "", http.StatusBadRequest, msg
@@ -198,7 +212,7 @@ func createSearchRecord(chatID int64, name string, req createSearchRequest) stor
 }
 
 func (s *Server) writeCreatedSearch(w http.ResponseWriter, r *http.Request, chatID, id int64) {
-	created, err := s.searches.GetSearch(r.Context(), id)
+	created, err := s.searches.GetSearch(r.Context(), id, chatID)
 	if err != nil || created == nil {
 		s.logger.Error("get created search", "error", err)
 		writeError(w, http.StatusInternalServerError, "search created but failed to retrieve")
@@ -251,13 +265,13 @@ func (s *Server) getSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sr, err := s.searches.GetSearch(r.Context(), id)
+	sr, err := s.searches.GetSearch(r.Context(), id, chatID)
 	if err != nil {
 		s.logger.Error("get search", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get search")
 		return
 	}
-	if sr == nil || sr.ChatID != chatID {
+	if sr == nil {
 		writeError(w, http.StatusNotFound, "search not found")
 		return
 	}
@@ -276,13 +290,13 @@ func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	existing, err := s.searches.GetSearch(r.Context(), id)
+	existing, err := s.searches.GetSearch(r.Context(), id, chatID)
 	if err != nil {
 		s.logger.Error("get search for update", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get search")
 		return
 	}
-	if existing == nil || existing.ChatID != chatID {
+	if existing == nil {
 		writeError(w, http.StatusNotFound, "search not found")
 		return
 	}
@@ -359,18 +373,11 @@ func (s *Server) setSearchActive(w http.ResponseWriter, r *http.Request, active 
 		return
 	}
 
-	sr, err := s.searches.GetSearch(r.Context(), id)
-	if err != nil {
-		s.logger.Error("get search for active toggle", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to get search")
-		return
-	}
-	if sr == nil || sr.ChatID != chatID {
-		writeError(w, http.StatusNotFound, "search not found")
-		return
-	}
-
 	if err := s.searches.SetSearchActive(r.Context(), id, chatID, active); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "search not found")
+			return
+		}
 		s.logger.Error("set search active", "error", err, "active", active)
 		writeError(w, http.StatusInternalServerError, "failed to update search")
 		return

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -322,6 +322,10 @@ func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
 	existing.ExcludeKeys = splitKeywords(req.ExcludeKeys)
 
 	if err := s.searches.UpdateSearch(r.Context(), *existing); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "search not found")
+			return
+		}
 		s.logger.Error("update search", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update search")
 		return

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -73,8 +73,8 @@ func (b *Bot) handleShare(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 		return
 	}
 
-	search, err := b.searches.GetSearch(ctx, id)
-	if err != nil || search == nil || search.ChatID != chatID {
+	search, err := b.searches.GetSearch(ctx, id, chatID)
+	if err != nil || search == nil {
 		b.send(ctx, chatID, locale.T(lang, "share_not_found"))
 		return
 	}
@@ -268,8 +268,8 @@ func (b *Bot) handlePause(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 		return
 	}
 
-	search, err := b.searches.GetSearch(ctx, id)
-	if err != nil || search == nil || search.ChatID != chatID {
+	search, err := b.searches.GetSearch(ctx, id, chatID)
+	if err != nil || search == nil {
 		b.send(ctx, chatID, locale.T(lang, "pause_not_found"))
 		return
 	}
@@ -302,8 +302,8 @@ func (b *Bot) handleResume(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 		return
 	}
 
-	search, err := b.searches.GetSearch(ctx, id)
-	if err != nil || search == nil || search.ChatID != chatID {
+	search, err := b.searches.GetSearch(ctx, id, chatID)
+	if err != nil || search == nil {
 		b.send(ctx, chatID, locale.T(lang, "resume_not_found"))
 		return
 	}
@@ -479,8 +479,8 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 		return
 	}
 
-	search, err := b.searches.GetSearch(ctx, id)
-	if err != nil || search == nil || search.ChatID != chatID {
+	search, err := b.searches.GetSearch(ctx, id, chatID)
+	if err != nil || search == nil {
 		b.send(ctx, chatID, locale.T(lang, "edit_not_found"))
 		return
 	}

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -105,7 +105,7 @@ func (m *errSearchStore) ListSearches(_ context.Context, _ int64) ([]storage.Sea
 	return m.searches, nil
 }
 
-func (m *errSearchStore) GetSearch(_ context.Context, _ int64) (*storage.Search, error) {
+func (m *errSearchStore) GetSearch(_ context.Context, _ int64, _ int64) (*storage.Search, error) {
 	if m.getErr != nil {
 		return nil, m.getErr
 	}

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -105,12 +105,14 @@ func (m *errSearchStore) ListSearches(_ context.Context, _ int64) ([]storage.Sea
 	return m.searches, nil
 }
 
-func (m *errSearchStore) GetSearch(_ context.Context, _ int64, _ int64) (*storage.Search, error) {
+func (m *errSearchStore) GetSearch(_ context.Context, id int64, chatID int64) (*storage.Search, error) {
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
-	if len(m.searches) > 0 {
-		return &m.searches[0], nil
+	for i := range m.searches {
+		if m.searches[i].ID == id && m.searches[i].ChatID == chatID {
+			return &m.searches[i], nil
+		}
 	}
 	return nil, nil
 }

--- a/internal/bot/handler_test.go
+++ b/internal/bot/handler_test.go
@@ -860,7 +860,7 @@ func TestHandlePause(t *testing.T) {
 	var nilBot *tgbot.Bot
 	tb.bot.handlePause(ctx, nilBot, update)
 
-	s, _ := tb.store.GetSearch(ctx, id)
+	s, _ := tb.store.GetSearch(ctx, id, chatID)
 	if s.Active {
 		t.Error("search should be paused")
 	}
@@ -887,7 +887,7 @@ func TestHandleResume(t *testing.T) {
 	var nilBot *tgbot.Bot
 	tb.bot.handleResume(ctx, nilBot, update)
 
-	s, _ := tb.store.GetSearch(ctx, id)
+	s, _ := tb.store.GetSearch(ctx, id, chatID)
 	if !s.Active {
 		t.Error("search should be active after resume")
 	}

--- a/internal/bot/pause_resume_test.go
+++ b/internal/bot/pause_resume_test.go
@@ -22,7 +22,7 @@ func TestPauseSearch(t *testing.T) {
 	}
 
 	// Search starts active
-	s, err := store.GetSearch(ctx, id)
+	s, err := store.GetSearch(ctx, id, 200)
 	if err != nil {
 		t.Fatalf("get search: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestPauseSearch(t *testing.T) {
 		t.Fatalf("pause search: %v", err)
 	}
 
-	s, err = store.GetSearch(ctx, id)
+	s, err = store.GetSearch(ctx, id, 200)
 	if err != nil {
 		t.Fatalf("get search after pause: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestResumeSearch(t *testing.T) {
 		t.Fatalf("resume: %v", err)
 	}
 
-	s, err := store.GetSearch(ctx, id)
+	s, err := store.GetSearch(ctx, id, 300)
 	if err != nil {
 		t.Fatalf("get search after resume: %v", err)
 	}
@@ -109,18 +109,22 @@ func TestPauseSearchOwnership(t *testing.T) {
 		t.Fatalf("create search: %v", err)
 	}
 
-	// Verify ownership check: GetSearch returns the search but chatID won't match
-	s, err := store.GetSearch(ctx, id)
+	// Verify ownership: GetSearch with correct owner succeeds
+	s, err := store.GetSearch(ctx, id, 400)
 	if err != nil {
 		t.Fatalf("get search: %v", err)
 	}
-	if s.ChatID != 400 {
-		t.Errorf("search owner = %d, want 400", s.ChatID)
+	if s == nil || s.ChatID != 400 {
+		t.Errorf("search owner = %v, want 400", s)
 	}
 
-	// Eve's chatID (401) doesn't match - the handler would reject this
-	if s.ChatID == 401 {
-		t.Error("search should not belong to eve")
+	// Eve's chatID (401) doesn't match - GetSearch returns nil
+	sEve, err := store.GetSearch(ctx, id, 401)
+	if err != nil {
+		t.Fatalf("get search as eve: %v", err)
+	}
+	if sEve != nil {
+		t.Error("search should not be visible to eve")
 	}
 }
 
@@ -147,7 +151,7 @@ func TestPauseAlreadyPausedSearch(t *testing.T) {
 		t.Fatalf("second pause: %v", err)
 	}
 
-	s, _ := store.GetSearch(ctx, id)
+	s, _ := store.GetSearch(ctx, id, 500)
 	if s.Active {
 		t.Error("search should still be paused")
 	}
@@ -171,7 +175,7 @@ func TestResumeAlreadyActiveSearch(t *testing.T) {
 		t.Fatalf("resume active search: %v", err)
 	}
 
-	s, _ := store.GetSearch(ctx, id)
+	s, _ := store.GetSearch(ctx, id, 600)
 	if !s.Active {
 		t.Error("search should still be active")
 	}
@@ -221,7 +225,7 @@ func TestGetSearchNonExistent(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	s, err := store.GetSearch(ctx, 99999)
+	s, err := store.GetSearch(ctx, 99999, 0)
 	if err != nil {
 		t.Fatalf("get non-existent search: %v", err)
 	}

--- a/internal/bot/share_handler_test.go
+++ b/internal/bot/share_handler_test.go
@@ -121,7 +121,7 @@ func TestHandleShareStart_ValidLink(t *testing.T) {
 		ChatID: 100, Name: "mazda-3", Manufacturer: 27, Model: 10332,
 		YearMin: 2020, YearMax: 2024, PriceMax: 100000, EngineMinCC: 2000,
 	})
-	search, _ := tb.store.GetSearch(ctx, id)
+	search, _ := tb.store.GetSearch(ctx, id, 100)
 	tb.msg.reset()
 
 	tb.simulateCommand(ctx, 200, fmt.Sprintf("/start share_%s", search.ShareToken))
@@ -145,7 +145,7 @@ func TestHandleShareStart_DeletedSearch(t *testing.T) {
 	id, _ := tb.store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "temp", Manufacturer: 27, Model: 10332,
 	})
-	search, _ := tb.store.GetSearch(ctx, id)
+	search, _ := tb.store.GetSearch(ctx, id, 100)
 	shareToken := search.ShareToken
 	_ = tb.store.DeleteSearch(ctx, id, 100)
 	tb.msg.reset()
@@ -185,7 +185,7 @@ func TestOnShareCopy_Success(t *testing.T) {
 		ChatID: 100, Name: "mazda-3", Source: "yad2", Manufacturer: 27, Model: 10332,
 		YearMin: 2020, YearMax: 2024, PriceMax: 100000, EngineMinCC: 2000,
 	})
-	search, _ := tb.store.GetSearch(ctx, srcID)
+	search, _ := tb.store.GetSearch(ctx, srcID, 100)
 	tb.msg.reset()
 
 	tb.simulateCallback(ctx, 200, cbPrefixShareCopy+search.ShareToken)
@@ -214,7 +214,7 @@ func TestOnShareCopy_AtMaxSearches(t *testing.T) {
 	srcID, _ := tb.store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "shared", Manufacturer: 27, Model: 10332,
 	})
-	search, _ := tb.store.GetSearch(ctx, srcID)
+	search, _ := tb.store.GetSearch(ctx, srcID, 100)
 
 	for i := range 10 {
 		_, _ = tb.store.CreateSearch(ctx, storage.Search{
@@ -241,7 +241,7 @@ func TestOnShareCopy_DeletedSource(t *testing.T) {
 	srcID, _ := tb.store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "temp", Manufacturer: 27, Model: 10332,
 	})
-	search, _ := tb.store.GetSearch(ctx, srcID)
+	search, _ := tb.store.GetSearch(ctx, srcID, 100)
 	shareToken := search.ShareToken
 	_ = tb.store.DeleteSearch(ctx, srcID, 100)
 	tb.msg.reset()

--- a/internal/bot/share_test.go
+++ b/internal/bot/share_test.go
@@ -52,7 +52,7 @@ func TestCloneSearch(t *testing.T) {
 	}
 
 	// Retrieve the source search.
-	src, err := store.GetSearch(ctx, srcID)
+	src, err := store.GetSearch(ctx, srcID, 100)
 	if err != nil || src == nil {
 		t.Fatalf("get source search: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestCloneSearch(t *testing.T) {
 		t.Fatalf("clone search: %v", err)
 	}
 
-	clone, err := store.GetSearch(ctx, cloneID)
+	clone, err := store.GetSearch(ctx, cloneID, 200)
 	if err != nil || clone == nil {
 		t.Fatalf("get cloned search: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestCloneSearchRespectsLimit(t *testing.T) {
 	}
 
 	// Verify that source search exists (the handler would check this).
-	src, _ := store.GetSearch(ctx, srcID)
+	src, _ := store.GetSearch(ctx, srcID, 100)
 	if src == nil {
 		t.Fatal("source search not found")
 	}
@@ -177,7 +177,7 @@ func TestCloneSearchFromDeletedSource(t *testing.T) {
 	_ = store.DeleteSearch(ctx, srcID, 100)
 
 	// The search should no longer exist.
-	src, err := store.GetSearch(ctx, srcID)
+	src, err := store.GetSearch(ctx, srcID, 100)
 	if err != nil {
 		t.Fatalf("get deleted search: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestCreateSearch_GeneratesShareToken(t *testing.T) {
 		t.Fatalf("create search: %v", err)
 	}
 
-	s, err := store.GetSearch(ctx, id)
+	s, err := store.GetSearch(ctx, id, 100)
 	if err != nil || s == nil {
 		t.Fatalf("get search: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestGetSearchByShareToken(t *testing.T) {
 		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
 	})
 
-	original, _ := store.GetSearch(ctx, id)
+	original, _ := store.GetSearch(ctx, id, 100)
 	if original == nil {
 		t.Fatal("original search not found")
 	}
@@ -289,8 +289,8 @@ func TestShareTokensAreUnique(t *testing.T) {
 		ChatID: 100, Name: "second", Manufacturer: 2, Model: 2,
 	})
 
-	s1, _ := store.GetSearch(ctx, id1)
-	s2, _ := store.GetSearch(ctx, id2)
+	s1, _ := store.GetSearch(ctx, id1, 100)
+	s2, _ := store.GetSearch(ctx, id2, 100)
 
 	if s1.ShareToken == s2.ShareToken {
 		t.Error("two searches should have different share tokens")

--- a/internal/bot/share_test.go
+++ b/internal/bot/share_test.go
@@ -299,9 +299,15 @@ func TestShareTokensAreUnique(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get search 1: %v", err)
 	}
+	if s1 == nil {
+		t.Fatal("search 1 not found")
+	}
 	s2, err := store.GetSearch(ctx, id2, 100)
 	if err != nil {
 		t.Fatalf("get search 2: %v", err)
+	}
+	if s2 == nil {
+		t.Fatal("search 2 not found")
 	}
 
 	if s1.ShareToken == s2.ShareToken {

--- a/internal/bot/share_test.go
+++ b/internal/bot/share_test.go
@@ -152,7 +152,10 @@ func TestCloneSearchRespectsLimit(t *testing.T) {
 	}
 
 	// Verify that source search exists (the handler would check this).
-	src, _ := store.GetSearch(ctx, srcID, 100)
+	src, err := store.GetSearch(ctx, srcID, 100)
+	if err != nil {
+		t.Fatalf("get source search: %v", err)
+	}
 	if src == nil {
 		t.Fatal("source search not found")
 	}
@@ -251,7 +254,10 @@ func TestGetSearchByShareToken(t *testing.T) {
 		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
 	})
 
-	original, _ := store.GetSearch(ctx, id, 100)
+	original, err := store.GetSearch(ctx, id, 100)
+	if err != nil {
+		t.Fatalf("get search: %v", err)
+	}
 	if original == nil {
 		t.Fatal("original search not found")
 	}
@@ -289,8 +295,14 @@ func TestShareTokensAreUnique(t *testing.T) {
 		ChatID: 100, Name: "second", Manufacturer: 2, Model: 2,
 	})
 
-	s1, _ := store.GetSearch(ctx, id1, 100)
-	s2, _ := store.GetSearch(ctx, id2, 100)
+	s1, err := store.GetSearch(ctx, id1, 100)
+	if err != nil {
+		t.Fatalf("get search 1: %v", err)
+	}
+	s2, err := store.GetSearch(ctx, id2, 100)
+	if err != nil {
+		t.Fatalf("get search 2: %v", err)
+	}
 
 	if s1.ShareToken == s2.ShareToken {
 		t.Error("two searches should have different share tokens")

--- a/internal/bot/wizard_test.go
+++ b/internal/bot/wizard_test.go
@@ -519,7 +519,7 @@ func TestHandleEdit_KeywordsRoundTrip(t *testing.T) {
 	// Confirm
 	tb.simulateCallback(ctx, chatID, cbConfirm)
 
-	s, err := tb.store.GetSearch(ctx, id)
+	s, err := tb.store.GetSearch(ctx, id, chatID)
 	if err != nil {
 		t.Fatalf("get search: %v", err)
 	}

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -32,9 +32,9 @@ func (m *mockSearchStore) ListSearches(_ context.Context, chatID int64) ([]stora
 	return result, nil
 }
 
-func (m *mockSearchStore) GetSearch(_ context.Context, id int64) (*storage.Search, error) {
+func (m *mockSearchStore) GetSearch(_ context.Context, id int64, chatID int64) (*storage.Search, error) {
 	for i := range m.searches {
-		if m.searches[i].ID == id {
+		if m.searches[i].ID == id && m.searches[i].ChatID == chatID {
 			return &m.searches[i], nil
 		}
 	}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -77,7 +77,7 @@ type SearchStore interface {
 	CreateSearch(ctx context.Context, s Search) (int64, error)
 	UpdateSearch(ctx context.Context, s Search) error
 	ListSearches(ctx context.Context, chatID int64) ([]Search, error)
-	GetSearch(ctx context.Context, id int64) (*Search, error)
+	GetSearch(ctx context.Context, id int64, chatID int64) (*Search, error)
 	GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*Search, error)
 	GetSearchByShareToken(ctx context.Context, token string) (*Search, error)
 	DeleteSearch(ctx context.Context, id int64, chatID int64) error

--- a/internal/storage/sqlite/coverage_test.go
+++ b/internal/storage/sqlite/coverage_test.go
@@ -495,7 +495,7 @@ func TestGetSearchByShareToken_Coverage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	search, err := store.GetSearch(ctx, id)
+	search, err := store.GetSearch(ctx, id, 100)
 	if err != nil || search == nil {
 		t.Fatal("search should exist")
 	}

--- a/internal/storage/sqlite/dedup.go
+++ b/internal/storage/sqlite/dedup.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -10,23 +11,29 @@ func (s *Store) ClaimNew(ctx context.Context, token string, chatID int64, search
 		"INSERT OR IGNORE INTO seen_listings (token, chat_id, search_id) VALUES (?, ?, ?)",
 		token, chatID, searchID)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("claim new: %w", err)
 	}
 	rows, err := result.RowsAffected()
-	return rows > 0, err
+	if err != nil {
+		return false, fmt.Errorf("claim new rows affected: %w", err)
+	}
+	return rows > 0, nil
 }
 
 func (s *Store) ReleaseClaim(ctx context.Context, token string, chatID int64) error {
 	_, err := s.db.ExecContext(ctx,
 		"DELETE FROM seen_listings WHERE token = ? AND chat_id = ?", token, chatID)
-	return err
+	if err != nil {
+		return fmt.Errorf("release claim: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) Prune(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, "DELETE FROM seen_listings WHERE first_seen_at < ?", cutoff)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("prune seen listings: %w", err)
 	}
 	return result.RowsAffected()
 }

--- a/internal/storage/sqlite/dedup.go
+++ b/internal/storage/sqlite/dedup.go
@@ -35,5 +35,9 @@ func (s *Store) Prune(ctx context.Context, olderThan time.Duration) (int64, erro
 	if err != nil {
 		return 0, fmt.Errorf("prune seen listings: %w", err)
 	}
-	return result.RowsAffected()
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune seen listings rows affected: %w", err)
+	}
+	return rows, nil
 }

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -56,7 +56,10 @@ func upsertListingArgs(r storage.ListingRecord) []any {
 
 func (s *Store) SaveListing(ctx context.Context, r storage.ListingRecord) error {
 	_, err := s.db.ExecContext(ctx, upsertListingSQL, upsertListingArgs(r)...)
-	return err
+	if err != nil {
+		return fmt.Errorf("save listing: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecord) error {
@@ -66,22 +69,25 @@ func (s *Store) SaveListings(ctx context.Context, records []storage.ListingRecor
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("save listings begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	stmt, err := tx.PrepareContext(ctx, upsertListingSQL)
 	if err != nil {
-		return err
+		return fmt.Errorf("save listings prepare: %w", err)
 	}
 	defer func() { _ = stmt.Close() }()
 
 	for _, r := range records {
 		if _, err := stmt.ExecContext(ctx, upsertListingArgs(r)...); err != nil {
-			return err
+			return fmt.Errorf("save listings exec: %w", err)
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("save listings commit: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {

--- a/internal/storage/sqlite/prices.go
+++ b/internal/storage/sqlite/prices.go
@@ -63,7 +63,10 @@ func (s *Store) GetPriceHistory(ctx context.Context, token string) ([]storage.Pr
 		}
 		points = append(points, p)
 	}
-	return points, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get price history rows: %w", err)
+	}
+	return points, nil
 }
 
 func (s *Store) PrunePrices(ctx context.Context, olderThan time.Duration) (int64, error) {
@@ -72,5 +75,9 @@ func (s *Store) PrunePrices(ctx context.Context, olderThan time.Duration) (int64
 	if err != nil {
 		return 0, fmt.Errorf("prune prices: %w", err)
 	}
-	return result.RowsAffected()
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune prices rows affected: %w", err)
+	}
+	return n, nil
 }

--- a/internal/storage/sqlite/prices.go
+++ b/internal/storage/sqlite/prices.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
@@ -11,7 +12,7 @@ import (
 func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, false, err
+		return 0, false, fmt.Errorf("record price begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -24,18 +25,21 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 		"INSERT INTO price_history (token, price) VALUES (?, ?)",
 		token, price)
 	if err != nil {
-		return 0, false, err
+		return 0, false, fmt.Errorf("record price insert: %w", err)
 	}
 
 	if scanErr == sql.ErrNoRows {
-		return 0, false, tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return 0, false, fmt.Errorf("record price commit: %w", err)
+		}
+		return 0, false, nil
 	}
 	if scanErr != nil {
-		return 0, false, scanErr
+		return 0, false, fmt.Errorf("record price scan prev: %w", scanErr)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, false, err
+		return 0, false, fmt.Errorf("record price commit: %w", err)
 	}
 	if price != prev {
 		return prev, true, nil
@@ -47,7 +51,7 @@ func (s *Store) GetPriceHistory(ctx context.Context, token string) ([]storage.Pr
 	rows, err := s.db.QueryContext(ctx,
 		"SELECT price, observed_at FROM price_history WHERE token = ? ORDER BY observed_at DESC, rowid DESC", token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get price history: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -55,7 +59,7 @@ func (s *Store) GetPriceHistory(ctx context.Context, token string) ([]storage.Pr
 	for rows.Next() {
 		var p storage.PricePoint
 		if err := rows.Scan(&p.Price, &p.ObservedAt); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan price point: %w", err)
 		}
 		points = append(points, p)
 	}
@@ -66,7 +70,7 @@ func (s *Store) PrunePrices(ctx context.Context, olderThan time.Duration) (int64
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, "DELETE FROM price_history WHERE observed_at < ?", cutoff)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("prune prices: %w", err)
 	}
 	return result.RowsAffected()
 }

--- a/internal/storage/sqlite/searches.go
+++ b/internal/storage/sqlite/searches.go
@@ -60,16 +60,16 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = ? ORDER BY created_at DESC`, chatID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list searches: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	return scanSearches(rows)
 }
 
-func (s *Store) GetSearch(ctx context.Context, id int64) (*storage.Search, error) {
+func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
-		FROM searches WHERE id = ?`, id)
+		FROM searches WHERE id = ? AND chat_id = ?`, id, chatID)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
@@ -81,7 +81,7 @@ func (s *Store) GetSearch(ctx context.Context, id int64) (*storage.Search, error
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get search: %w", err)
 	}
 	return &search, nil
 }
@@ -101,7 +101,7 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get search by seq: %w", err)
 	}
 	return &search, nil
 }
@@ -121,7 +121,7 @@ func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*stora
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get search by share token: %w", err)
 	}
 	return &search, nil
 }
@@ -141,11 +141,11 @@ func (s *Store) UpdateSearch(ctx context.Context, search storage.Search) error {
 		search.MaxKm, search.MaxHand, search.Keywords, search.ExcludeKeys,
 		search.ID, search.ChatID)
 	if err != nil {
-		return err
+		return fmt.Errorf("update search: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return err
+		return fmt.Errorf("update search rows affected: %w", err)
 	}
 	if rows == 0 {
 		return storage.ErrNotFound
@@ -199,9 +199,19 @@ func (s *Store) DeleteSearch(ctx context.Context, id int64, chatID int64) error 
 }
 
 func (s *Store) SetSearchActive(ctx context.Context, id int64, chatID int64, active bool) error {
-	_, err := s.db.ExecContext(ctx,
+	result, err := s.db.ExecContext(ctx,
 		"UPDATE searches SET active = ? WHERE id = ? AND chat_id = ?", active, id, chatID)
-	return err
+	if err != nil {
+		return fmt.Errorf("set search active: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set search active rows affected: %w", err)
+	}
+	if rows == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
 }
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
@@ -212,7 +222,7 @@ func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, er
 		WHERE s.active = true AND u.active = true
 		ORDER BY s.source, s.manufacturer, s.model`)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list active searches: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	return scanSearches(rows)
@@ -223,14 +233,20 @@ func (s *Store) CountSearches(ctx context.Context, chatID int64) (int64, error) 
 	err := s.db.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM searches WHERE chat_id = ? AND active = true",
 		chatID).Scan(&count)
-	return count, err
+	if err != nil {
+		return 0, fmt.Errorf("count searches: %w", err)
+	}
+	return count, nil
 }
 
 func (s *Store) CountAllSearches(ctx context.Context) (int64, error) {
 	var count int64
 	err := s.db.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM searches WHERE active = true").Scan(&count)
-	return count, err
+	if err != nil {
+		return 0, fmt.Errorf("count all searches: %w", err)
+	}
+	return count, nil
 }
 
 func scanSearches(rows *sql.Rows) ([]storage.Search, error) {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -364,7 +364,10 @@ func TestDeleteSearch_WrongOwner(t *testing.T) {
 
 	_ = store.DeleteSearch(ctx, id, 200)
 
-	s, _ := store.GetSearch(ctx, id, 100)
+	s, err := store.GetSearch(ctx, id, 100)
+	if err != nil {
+		t.Fatalf("get search after wrong-owner delete: %v", err)
+	}
 	if s == nil {
 		t.Error("search should NOT be deleted by wrong owner")
 	}
@@ -552,24 +555,33 @@ func TestSetSearchActive(t *testing.T) {
 	if err := store.SetSearchActive(ctx, id, 100, false); err != nil {
 		t.Fatalf("set inactive: %v", err)
 	}
-	s, _ := store.GetSearch(ctx, id, 100)
+	s, err := store.GetSearch(ctx, id, 100)
+	if err != nil {
+		t.Fatalf("get search after set inactive: %v", err)
+	}
 	if s.Active {
 		t.Error("search should be inactive")
 	}
 
-	if err := store.SetSearchActive(ctx, id, 100, true); err != nil {
+	if err = store.SetSearchActive(ctx, id, 100, true); err != nil {
 		t.Fatalf("set active: %v", err)
 	}
-	s, _ = store.GetSearch(ctx, id, 100)
+	s, err = store.GetSearch(ctx, id, 100)
+	if err != nil {
+		t.Fatalf("get search after set active: %v", err)
+	}
 	if !s.Active {
 		t.Error("search should be active again")
 	}
 
 	// Wrong owner should return ErrNotFound.
-	if err := store.SetSearchActive(ctx, id, 999, false); !errors.Is(err, storage.ErrNotFound) {
+	if err = store.SetSearchActive(ctx, id, 999, false); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for wrong owner, got: %v", err)
 	}
-	s, _ = store.GetSearch(ctx, id, 100)
+	s, err = store.GetSearch(ctx, id, 100)
+	if err != nil {
+		t.Fatalf("get search after wrong-owner toggle: %v", err)
+	}
 	if !s.Active {
 		t.Error("wrong owner should not be able to deactivate search")
 	}
@@ -627,9 +639,18 @@ func TestCreateSearch_AssignsUserSeq(t *testing.T) {
 	id2, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "second", Manufacturer: 2, Model: 2})
 	id3, _ := store.CreateSearch(ctx, storage.Search{ChatID: 200, Name: "other-user", Manufacturer: 1, Model: 1})
 
-	s1, _ := store.GetSearch(ctx, id1, 100)
-	s2, _ := store.GetSearch(ctx, id2, 100)
-	s3, _ := store.GetSearch(ctx, id3, 200)
+	s1, err := store.GetSearch(ctx, id1, 100)
+	if err != nil {
+		t.Fatalf("get search 1: %v", err)
+	}
+	s2, err := store.GetSearch(ctx, id2, 100)
+	if err != nil {
+		t.Fatalf("get search 2: %v", err)
+	}
+	s3, err := store.GetSearch(ctx, id3, 200)
+	if err != nil {
+		t.Fatalf("get search 3: %v", err)
+	}
 
 	if s1.UserSeq != 1 {
 		t.Errorf("first search UserSeq = %d, want 1", s1.UserSeq)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -362,7 +362,9 @@ func TestDeleteSearch_WrongOwner(t *testing.T) {
 		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
 	})
 
-	_ = store.DeleteSearch(ctx, id, 200)
+	if err := store.DeleteSearch(ctx, id, 200); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for wrong-owner delete, got: %v", err)
+	}
 
 	s, err := store.GetSearch(ctx, id, 100)
 	if err != nil {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -307,7 +308,7 @@ func TestGetSearch(t *testing.T) {
 		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
 	})
 
-	s, err := store.GetSearch(ctx, id)
+	s, err := store.GetSearch(ctx, id, 100)
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -315,12 +316,20 @@ func TestGetSearch(t *testing.T) {
 		t.Errorf("search = %+v", s)
 	}
 
-	s, err = store.GetSearch(ctx, 999)
+	s, err = store.GetSearch(ctx, 999, 100)
 	if err != nil {
 		t.Fatalf("get nonexistent: %v", err)
 	}
 	if s != nil {
 		t.Error("expected nil for nonexistent search")
+	}
+
+	s, err = store.GetSearch(ctx, id, 999)
+	if err != nil {
+		t.Fatalf("get wrong chatID: %v", err)
+	}
+	if s != nil {
+		t.Error("expected nil when chatID does not match")
 	}
 }
 
@@ -355,7 +364,7 @@ func TestDeleteSearch_WrongOwner(t *testing.T) {
 
 	_ = store.DeleteSearch(ctx, id, 200)
 
-	s, _ := store.GetSearch(ctx, id)
+	s, _ := store.GetSearch(ctx, id, 100)
 	if s == nil {
 		t.Error("search should NOT be deleted by wrong owner")
 	}
@@ -428,7 +437,7 @@ func TestDeleteSearch_CascadesRelatedRecords(t *testing.T) {
 	}
 
 	// Search itself should be gone.
-	s, err := store.GetSearch(ctx, id1)
+	s, err := store.GetSearch(ctx, id1, 100)
 	if err != nil {
 		t.Fatalf("get deleted search: %v", err)
 	}
@@ -543,7 +552,7 @@ func TestSetSearchActive(t *testing.T) {
 	if err := store.SetSearchActive(ctx, id, 100, false); err != nil {
 		t.Fatalf("set inactive: %v", err)
 	}
-	s, _ := store.GetSearch(ctx, id)
+	s, _ := store.GetSearch(ctx, id, 100)
 	if s.Active {
 		t.Error("search should be inactive")
 	}
@@ -551,16 +560,16 @@ func TestSetSearchActive(t *testing.T) {
 	if err := store.SetSearchActive(ctx, id, 100, true); err != nil {
 		t.Fatalf("set active: %v", err)
 	}
-	s, _ = store.GetSearch(ctx, id)
+	s, _ = store.GetSearch(ctx, id, 100)
 	if !s.Active {
 		t.Error("search should be active again")
 	}
 
-	// Wrong owner should have no effect.
-	if err := store.SetSearchActive(ctx, id, 999, false); err != nil {
-		t.Fatalf("set active with wrong owner: %v", err)
+	// Wrong owner should return ErrNotFound.
+	if err := store.SetSearchActive(ctx, id, 999, false); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for wrong owner, got: %v", err)
 	}
-	s, _ = store.GetSearch(ctx, id)
+	s, _ = store.GetSearch(ctx, id, 100)
 	if !s.Active {
 		t.Error("wrong owner should not be able to deactivate search")
 	}
@@ -618,9 +627,9 @@ func TestCreateSearch_AssignsUserSeq(t *testing.T) {
 	id2, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "second", Manufacturer: 2, Model: 2})
 	id3, _ := store.CreateSearch(ctx, storage.Search{ChatID: 200, Name: "other-user", Manufacturer: 1, Model: 1})
 
-	s1, _ := store.GetSearch(ctx, id1)
-	s2, _ := store.GetSearch(ctx, id2)
-	s3, _ := store.GetSearch(ctx, id3)
+	s1, _ := store.GetSearch(ctx, id1, 100)
+	s2, _ := store.GetSearch(ctx, id2, 100)
+	s3, _ := store.GetSearch(ctx, id3, 200)
 
 	if s1.UserSeq != 1 {
 		t.Errorf("first search UserSeq = %d, want 1", s1.UserSeq)
@@ -1905,7 +1914,7 @@ func TestUpdateSearch(t *testing.T) {
 		t.Fatalf("UpdateSearch: %v", err)
 	}
 
-	s, err := store.GetSearch(ctx, id)
+	s, err := store.GetSearch(ctx, id, 100)
 	if err != nil {
 		t.Fatalf("GetSearch: %v", err)
 	}
@@ -2151,7 +2160,7 @@ func TestGetSearchByShareToken(t *testing.T) {
 		t.Fatalf("CreateSearch: %v", err)
 	}
 
-	search, err := store.GetSearch(ctx, id)
+	search, err := store.GetSearch(ctx, id, 100)
 	if err != nil {
 		t.Fatalf("GetSearch: %v", err)
 	}

--- a/web/src/pages/EditSearchPage.tsx
+++ b/web/src/pages/EditSearchPage.tsx
@@ -149,7 +149,7 @@ export function EditSearchPage() {
               type="number"
               value={form.yearMin}
               onChange={(e) => set("yearMin", Number(e.target.value))}
-              min={2000}
+              min={1990}
               max={2030}
               error={form.yearMin > form.yearMax}
               className="tabular-nums"
@@ -162,7 +162,7 @@ export function EditSearchPage() {
               type="number"
               value={form.yearMax}
               onChange={(e) => set("yearMax", Number(e.target.value))}
-              min={2000}
+              min={1990}
               max={2030}
               className="tabular-nums"
             />

--- a/web/src/pages/EditSearchPage.tsx
+++ b/web/src/pages/EditSearchPage.tsx
@@ -56,10 +56,11 @@ export function EditSearchPage() {
   const set = <K extends keyof typeof form>(key: K, val: (typeof form)[K]) =>
     setForm((prev) => ({ ...prev, [key]: val }));
 
+  const validYear = (y: number) => y === 0 || y >= 1990;
   const canSubmit =
-    form.yearMin >= 2000 &&
-    form.yearMax >= 2000 &&
-    form.yearMin <= form.yearMax &&
+    validYear(form.yearMin) &&
+    validYear(form.yearMax) &&
+    (form.yearMin === 0 || form.yearMax === 0 || form.yearMin <= form.yearMax) &&
     !updateSearch.isPending;
 
   function handleSubmit() {

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -61,12 +61,13 @@ export function NewSearchPage() {
   const set = <K extends keyof FormData>(key: K, val: FormData[K]) =>
     setForm((prev) => ({ ...prev, [key]: val }));
 
+  const validYear = (y: number) => y === 0 || y >= 1990;
   const canSubmit =
     form.manufacturer > 0 &&
     form.model > 0 &&
-    form.yearMin >= 2000 &&
-    form.yearMax >= 2000 &&
-    form.yearMin <= form.yearMax &&
+    validYear(form.yearMin) &&
+    validYear(form.yearMax) &&
+    (form.yearMin === 0 || form.yearMax === 0 || form.yearMin <= form.yearMax) &&
     !createSearch.isPending;
 
   function handleSubmit() {

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -202,7 +202,7 @@ export function NewSearchPage() {
               type="number"
               value={form.yearMin}
               onChange={(e) => set("yearMin", Number(e.target.value))}
-              min={2000}
+              min={1990}
               max={2030}
               error={form.yearMin > form.yearMax}
               className="tabular-nums"
@@ -215,7 +215,7 @@ export function NewSearchPage() {
               type="number"
               value={form.yearMax}
               onChange={(e) => set("yearMax", Number(e.target.value))}
-              min={2000}
+              min={1990}
               max={2030}
               className="tabular-nums"
             />


### PR DESCRIPTION
## Summary

Addresses the remaining items from [#500](https://github.com/Danielsio/carwatch/issues/500) (Codebase Audit & Refactoring Opportunities) and a leftover from [#498](https://github.com/Danielsio/carwatch/issues/498) (SetSearchActive not returning ErrNotFound).

### Changes

- **Consistent error wrapping** (#3): All storage methods in `searches.go`, `listings.go`, `dedup.go`, and `prices.go` now wrap errors with `fmt.Errorf("context: %w", err)` at the store boundary, making debugging and error tracing consistent across the codebase.

- **GetSearch ownership enforcement** (#5): Changed `GetSearch(ctx, id)` to `GetSearch(ctx, id, chatID)` — the SQL query now includes `AND chat_id = ?`, enforcing ownership at the database level. All callers (API handlers, bot commands, tests) updated to pass `chatID`, eliminating the error-prone pattern of separate `sr.ChatID != chatID` checks after every call.

- **SetSearchActive returns ErrNotFound** (#498): `SetSearchActive` now checks `RowsAffected()` and returns `storage.ErrNotFound` when the search doesn't exist or doesn't belong to the caller. This removes the need for a pre-check `GetSearch` call in `setSearchActive` API handler.

- **Source validation** (#6): `validateCreateSearchInput` now rejects unknown `source` values with a clear error. Valid sources: `yad2`, `winwin`, `yad2,winwin`, `winwin,yad2`.

- **Rate limiter lifecycle** (#7): The cleanup goroutine now uses a cancellable context created internally, with a `Server.Shutdown()` method for clean teardown. Removes the leaked `context.Background()` goroutine.

- **Frontend year validation alignment** (#9): Both `EditSearchPage` and `NewSearchPage` now allow `0` (no constraint) or years `>= 1990`, matching the backend which only requires non-negative values. Previously the frontend required `>= 2000`, blocking valid searches.

### Test plan

- [x] `make test` — all 19 packages pass (82.0% coverage)
- [x] `golangci-lint run ./...` — clean
- [x] `npx tsc --noEmit` — clean
- [x] New test case in `TestGetSearch` verifying wrong chatID returns nil
- [x] Updated `TestSetSearchActive` to verify `ErrNotFound` for wrong owner
- [x] Updated `TestPauseSearchOwnership` to test new GetSearch contract

Closes #500

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful shutdown: server stops background rate-limiting work on shutdown
  * Year range inputs accept 0 as unlimited/unset and lower min year to 1990

* **Bug Fixes**
  * Stronger search access control by scoping lookups to the requesting chat
  * Validation added for permitted search sources
  * Improved error reporting with contextual messages across storage and DB operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->