### PR TITLE
feat: redesign admin dashboard with live log streaming

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/fetcher/winwin"
 	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/health"
@@ -67,7 +68,10 @@ func run(configPath string, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("parse log_level %q: %w", cfg.LogLevel, err)
 	}
-	logger = slog.New(newLogHandler(cfg.LogFormat, logLevel))
+	logHub := logstream.NewHub(500)
+	baseHandler := newLogHandler(cfg.LogFormat, logLevel)
+	teeHandler := logstream.NewTeeHandler(baseHandler, logHub, "yad2", "winwin", "scheduler", "enricher")
+	logger = slog.New(teeHandler)
 	slog.SetDefault(logger)
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
@@ -105,7 +109,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = multi.Disconnect() }()
 
-	apiServer, err := buildAPI(cfg, store, dynCatalog, logger)
+	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, logger)
 	if err != nil {
 		return err
 	}
@@ -238,7 +242,7 @@ func buildBot(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 	return botHandler, tgNotif, multi, nil
 }
 
-func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logger *slog.Logger) (*api.Server, error) {
+func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logger *slog.Logger) (*api.Server, error) {
 	var firebaseAuth api.TokenVerifier
 	if cfg.Firebase.ProjectID != "" {
 		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)
@@ -264,6 +268,7 @@ func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 		API:          cfg.API,
 		FirebaseAuth: firebaseAuth,
 		BotUsername:  cfg.Telegram.BotUsername,
+		LogHub:       logHub,
 	})
 
 	return apiServer, nil

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -369,9 +369,12 @@ func (s *Server) adminLogStream(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				continue
 			}
-			// Extend write deadline for this long-lived connection.
-			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
-			fmt.Fprintf(w, "data: %s\n\n", data)
+			if err := rc.SetWriteDeadline(time.Now().Add(30 * time.Second)); err != nil && !errors.Is(err, http.ErrNotSupported) {
+				return
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+				return
+			}
 			flusher.Flush()
 		}
 	}

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -325,4 +326,53 @@ func (s *Server) adminVacuum(w http.ResponseWriter, r *http.Request) {
 		"size_after": humanBytes(fileSize),
 		"size_bytes": fileSize,
 	})
+}
+
+func (s *Server) adminLogs(w http.ResponseWriter, r *http.Request) {
+	n := parseIntParam(r, "limit", 200)
+	if n > 500 {
+		n = 500
+	}
+
+	entries := s.logHub.Recent(n)
+	if entries == nil {
+		entries = []logstream.LogEntry{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": entries})
+}
+
+func (s *Server) adminLogStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	flusher.Flush()
+
+	rc := http.NewResponseController(w)
+
+	ch, unsub := s.logHub.Subscribe()
+	defer unsub()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry := <-ch:
+			data, err := json.Marshal(entry)
+			if err != nil {
+				continue
+			}
+			// Extend write deadline for this long-lived connection.
+			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
 }

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -220,6 +220,86 @@ func (s *Server) adminDeleteListing(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (s *Server) adminListSearches(w http.ResponseWriter, r *http.Request) {
+	searches, err := s.admin.AdminListSearches(r.Context())
+	if err != nil {
+		s.logger.Error("admin: list searches", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list searches")
+		return
+	}
+
+	type searchResp struct {
+		ID           int64  `json:"id"`
+		ChatID       int64  `json:"chat_id"`
+		Name         string `json:"name"`
+		Source       string `json:"source"`
+		Manufacturer int    `json:"manufacturer"`
+		Model        int    `json:"model"`
+		YearMin      int    `json:"year_min"`
+		YearMax      int    `json:"year_max"`
+		PriceMax     int    `json:"price_max"`
+		MaxKm        int    `json:"max_km"`
+		MaxHand      int    `json:"max_hand"`
+		Active       bool   `json:"active"`
+		CreatedAt    string `json:"created_at"`
+	}
+
+	resp := make([]searchResp, 0, len(searches))
+	for _, s := range searches {
+		resp = append(resp, searchResp{
+			ID:           s.ID,
+			ChatID:       s.ChatID,
+			Name:         s.Name,
+			Source:       s.Source,
+			Manufacturer: s.Manufacturer,
+			Model:        s.Model,
+			YearMin:      s.YearMin,
+			YearMax:      s.YearMax,
+			PriceMax:     s.PriceMax,
+			MaxKm:        s.MaxKm,
+			MaxHand:      s.MaxHand,
+			Active:       s.Active,
+			CreatedAt:    s.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": resp, "total": len(resp)})
+}
+
+func (s *Server) adminListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := s.admin.AdminListUsers(r.Context())
+	if err != nil {
+		s.logger.Error("admin: list users", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list users")
+		return
+	}
+
+	type userResp struct {
+		ChatID    int64  `json:"chat_id"`
+		Username  string `json:"username"`
+		Channel   string `json:"channel"`
+		ChannelID string `json:"channel_id"`
+		Active    bool   `json:"active"`
+		Tier      string `json:"tier"`
+		Language  string `json:"language"`
+		CreatedAt string `json:"created_at"`
+	}
+
+	resp := make([]userResp, 0, len(users))
+	for _, u := range users {
+		resp = append(resp, userResp{
+			ChatID:    u.ChatID,
+			Username:  u.Username,
+			Channel:   u.Channel,
+			ChannelID: u.ChannelID,
+			Active:    u.Active,
+			Tier:      u.Tier,
+			Language:  u.Language,
+			CreatedAt: u.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": resp, "total": len(resp)})
+}
+
 func (s *Server) adminVacuum(w http.ResponseWriter, r *http.Request) {
 	if !s.vacuumMu.TryLock() {
 		writeError(w, http.StatusConflict, "vacuum already in progress")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -188,8 +188,8 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		authHdr := r.Header.Get("Authorization")
 		bearer := bearerFromAuthHeader(authHdr)
 
-		// Allow token via query param for SSE (EventSource can't set headers).
-		if bearer == "" {
+		// Allow token via query param for SSE only (EventSource can't set headers).
+		if bearer == "" && strings.HasPrefix(r.URL.Path, "/api/v1/admin/logs/") {
 			if qt := r.URL.Query().Get("token"); qt != "" {
 				bearer = qt
 			}
@@ -217,7 +217,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		} else if s.firebaseAuth == nil {
 			if s.cfg.AuthToken != "" {
-				if authHdr != "Bearer "+s.cfg.AuthToken {
+				if bearer != s.cfg.AuthToken {
 					writeError(w, http.StatusUnauthorized, "invalid or missing token")
 					return
 				}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -41,6 +42,7 @@ type Server struct {
 	saved     storage.SavedListingStore
 	hidden    storage.HiddenListingStore
 	notifs    storage.NotificationStore
+	logHub    *logstream.Hub
 	poller    PollTrigger
 	logger    *slog.Logger
 	cfg       config.APIConfig
@@ -71,6 +73,7 @@ type Config struct {
 	Saved    storage.SavedListingStore
 	Hidden       storage.HiddenListingStore
 	Notifs       storage.NotificationStore
+	LogHub       *logstream.Hub
 	Logger       *slog.Logger
 	API          config.APIConfig
 	FirebaseAuth TokenVerifier
@@ -90,6 +93,7 @@ func New(c Config) *Server {
 		saved:     c.Saved,
 		hidden:    c.Hidden,
 		notifs:    c.Notifs,
+		logHub:    c.LogHub,
 		logger:    c.Logger,
 		cfg:       c.API,
 		botUsername: c.BotUsername,
@@ -125,6 +129,10 @@ func (s *Server) Routes() http.Handler {
 		mux.HandleFunc("GET /api/v1/admin/users", s.requireAdmin(s.adminListUsers))
 		mux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
 		mux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))
+		if s.logHub != nil {
+			mux.HandleFunc("GET /api/v1/admin/logs", s.requireAdmin(s.adminLogs))
+			mux.HandleFunc("GET /api/v1/admin/logs/stream", s.requireAdmin(s.adminLogStream))
+		}
 	}
 
 	if s.notifs != nil {
@@ -179,6 +187,13 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHdr := r.Header.Get("Authorization")
 		bearer := bearerFromAuthHeader(authHdr)
+
+		// Allow token via query param for SSE (EventSource can't set headers).
+		if bearer == "" {
+			if qt := r.URL.Query().Get("token"); qt != "" {
+				bearer = qt
+			}
+		}
 
 		var chatID int64
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -121,6 +121,8 @@ func (s *Server) Routes() http.Handler {
 		mux.HandleFunc("GET /api/v1/admin/stats", s.requireAdmin(s.adminStats))
 		mux.HandleFunc("GET /api/v1/admin/listings", s.requireAdmin(s.adminListListings))
 		mux.HandleFunc("DELETE /api/v1/admin/listings/{token}", s.requireAdmin(s.adminDeleteListing))
+		mux.HandleFunc("GET /api/v1/admin/searches", s.requireAdmin(s.adminListSearches))
+		mux.HandleFunc("GET /api/v1/admin/users", s.requireAdmin(s.adminListUsers))
 		mux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
 		mux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -712,6 +712,14 @@ func (f *failingAdminStore) AdminDeleteListing(_ context.Context, _ string, _ in
 	return nil
 }
 
+func (f *failingAdminStore) AdminListSearches(_ context.Context) ([]storage.Search, error) {
+	return nil, nil
+}
+
+func (f *failingAdminStore) AdminListUsers(_ context.Context) ([]storage.User, error) {
+	return nil, nil
+}
+
 func (f *failingAdminStore) VacuumDB(_ context.Context) error {
 	return nil
 }

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -769,6 +769,9 @@ func TestAdminListSearches(t *testing.T) {
 	if resp.Total != 1 {
 		t.Fatalf("expected total=1, got %d", resp.Total)
 	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
 	if resp.Items[0].Name != "test-search" {
 		t.Fatalf("expected name=test-search, got %s", resp.Items[0].Name)
 	}

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -736,6 +736,75 @@ func TestAdminDeleteListing(t *testing.T) {
 	}
 }
 
+func TestAdminListSearches(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.UpsertUser(ctx, 999, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 999, Name: "test-search", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/searches", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Items []struct {
+			ID     int64  `json:"id"`
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Fatalf("expected total=1, got %d", resp.Total)
+	}
+	if resp.Items[0].Name != "test-search" {
+		t.Fatalf("expected name=test-search, got %s", resp.Items[0].Name)
+	}
+}
+
+func TestAdminListUsers(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.UpsertUser(ctx, 999, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertUser(ctx, 100, "user1"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/users", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Items []struct {
+			ChatID   int64  `json:"chat_id"`
+			Username string `json:"username"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2, got %d", resp.Total)
+	}
+}
+
 func TestAdminVacuum(t *testing.T) {
 	srv, _ := setupTestServer(t)
 

--- a/internal/logstream/buffer.go
+++ b/internal/logstream/buffer.go
@@ -1,0 +1,69 @@
+package logstream
+
+import "sync"
+
+// Buffer is a thread-safe circular buffer of log entries.
+type Buffer struct {
+	mu    sync.RWMutex
+	items []LogEntry
+	pos   int
+	full  bool
+	cap   int
+}
+
+// NewBuffer creates a ring buffer that holds the last cap entries.
+func NewBuffer(cap int) *Buffer {
+	return &Buffer{
+		items: make([]LogEntry, cap),
+		cap:   cap,
+	}
+}
+
+// Write appends an entry, overwriting the oldest if full.
+func (b *Buffer) Write(e LogEntry) {
+	b.mu.Lock()
+	b.items[b.pos] = e
+	b.pos = (b.pos + 1) % b.cap
+	if !b.full && b.pos == 0 {
+		b.full = true
+	}
+	b.mu.Unlock()
+}
+
+// Recent returns the last n entries in chronological order.
+// If n <= 0 or exceeds the stored count, all stored entries are returned.
+func (b *Buffer) Recent(n int) []LogEntry {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	count := b.pos
+	if b.full {
+		count = b.cap
+	}
+	if n <= 0 || n > count {
+		n = count
+	}
+	if n == 0 {
+		return nil
+	}
+
+	out := make([]LogEntry, n)
+	start := b.pos - n
+	if start < 0 {
+		start += b.cap
+	}
+	for i := range n {
+		out[i] = b.items[(start+i)%b.cap]
+	}
+	return out
+}
+
+// Len returns the number of entries currently stored.
+func (b *Buffer) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.full {
+		return b.cap
+	}
+	return b.pos
+}

--- a/internal/logstream/buffer.go
+++ b/internal/logstream/buffer.go
@@ -12,7 +12,11 @@ type Buffer struct {
 }
 
 // NewBuffer creates a ring buffer that holds the last cap entries.
+// Panics if cap is not positive.
 func NewBuffer(cap int) *Buffer {
+	if cap <= 0 {
+		panic("logstream: buffer capacity must be positive")
+	}
 	return &Buffer{
 		items: make([]LogEntry, cap),
 		cap:   cap,

--- a/internal/logstream/buffer_test.go
+++ b/internal/logstream/buffer_test.go
@@ -1,0 +1,112 @@
+package logstream
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func makeEntry(msg string) LogEntry {
+	return LogEntry{Time: time.Now(), Level: "INFO", Message: msg, Component: "test"}
+}
+
+func TestBuffer_EmptyRecent(t *testing.T) {
+	b := NewBuffer(10)
+	if got := b.Recent(5); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("expected len 0, got %d", b.Len())
+	}
+}
+
+func TestBuffer_WriteThenRecent(t *testing.T) {
+	b := NewBuffer(5)
+	for i := range 3 {
+		b.Write(makeEntry(fmt.Sprintf("m%d", i)))
+	}
+
+	if b.Len() != 3 {
+		t.Fatalf("expected len 3, got %d", b.Len())
+	}
+
+	got := b.Recent(2)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[0].Message != "m1" || got[1].Message != "m2" {
+		t.Fatalf("unexpected entries: %v", got)
+	}
+}
+
+func TestBuffer_RecentAll(t *testing.T) {
+	b := NewBuffer(5)
+	for i := range 3 {
+		b.Write(makeEntry(fmt.Sprintf("m%d", i)))
+	}
+
+	got := b.Recent(0)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries for Recent(0), got %d", len(got))
+	}
+}
+
+func TestBuffer_Wrap(t *testing.T) {
+	b := NewBuffer(3)
+	for i := range 5 {
+		b.Write(makeEntry(fmt.Sprintf("m%d", i)))
+	}
+
+	if b.Len() != 3 {
+		t.Fatalf("expected len 3 after wrap, got %d", b.Len())
+	}
+
+	got := b.Recent(0)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(got))
+	}
+	// Should have m2, m3, m4 (oldest two overwritten)
+	for i, want := range []string{"m2", "m3", "m4"} {
+		if got[i].Message != want {
+			t.Errorf("entry[%d]: got %q, want %q", i, got[i].Message, want)
+		}
+	}
+}
+
+func TestBuffer_RecentExceedsStored(t *testing.T) {
+	b := NewBuffer(10)
+	b.Write(makeEntry("only"))
+	got := b.Recent(100)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+}
+
+func TestBuffer_Concurrent(t *testing.T) {
+	b := NewBuffer(100)
+	var wg sync.WaitGroup
+	for g := range 10 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range 50 {
+				b.Write(makeEntry(fmt.Sprintf("g%d-m%d", id, i)))
+			}
+		}(g)
+	}
+
+	// Read while writes are happening
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 20 {
+			_ = b.Recent(10)
+		}
+	}()
+
+	wg.Wait()
+	if b.Len() != 100 {
+		t.Fatalf("expected len 100, got %d", b.Len())
+	}
+}

--- a/internal/logstream/buffer_test.go
+++ b/internal/logstream/buffer_test.go
@@ -11,6 +11,24 @@ func makeEntry(msg string) LogEntry {
 	return LogEntry{Time: time.Now(), Level: "INFO", Message: msg, Component: "test"}
 }
 
+func TestNewBuffer_PanicsOnZero(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero capacity")
+		}
+	}()
+	NewBuffer(0)
+}
+
+func TestNewBuffer_PanicsOnNegative(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative capacity")
+		}
+	}()
+	NewBuffer(-1)
+}
+
 func TestBuffer_EmptyRecent(t *testing.T) {
 	b := NewBuffer(10)
 	if got := b.Recent(5); got != nil {

--- a/internal/logstream/entry.go
+++ b/internal/logstream/entry.go
@@ -1,0 +1,12 @@
+package logstream
+
+import "time"
+
+// LogEntry is a single captured log record.
+type LogEntry struct {
+	Time      time.Time         `json:"time"`
+	Level     string            `json:"level"`
+	Message   string            `json:"message"`
+	Component string            `json:"component"`
+	Attrs     map[string]string `json:"attrs,omitempty"`
+}

--- a/internal/logstream/handler.go
+++ b/internal/logstream/handler.go
@@ -1,0 +1,122 @@
+package logstream
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// TeeHandler wraps an slog.Handler, forwarding all records to it while also
+// capturing records whose "component" attribute matches the allow-list and
+// publishing them to a Hub.
+type TeeHandler struct {
+	inner      slog.Handler
+	hub        *Hub
+	components map[string]bool
+	// preAttrs are attributes added via WithAttrs
+	preAttrs []slog.Attr
+	// group prefix from WithGroup
+	groups []string
+}
+
+// NewTeeHandler wraps inner and publishes matching records to hub.
+// Only records with a "component" attr matching one of the given components
+// are captured; all records are forwarded to inner regardless.
+func NewTeeHandler(inner slog.Handler, hub *Hub, components ...string) *TeeHandler {
+	m := make(map[string]bool, len(components))
+	for _, c := range components {
+		m[c] = true
+	}
+	return &TeeHandler{
+		inner:      inner,
+		hub:        hub,
+		components: m,
+	}
+}
+
+func (h *TeeHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *TeeHandler) Handle(ctx context.Context, r slog.Record) error {
+	component := h.componentFromPre()
+	attrs := make(map[string]string)
+
+	// Collect pre-set attrs (from WithAttrs)
+	for _, a := range h.preAttrs {
+		if a.Key == "component" {
+			component = a.Value.String()
+		} else {
+			attrs[a.Key] = attrValueString(a.Value)
+		}
+	}
+
+	// Collect record-level attrs
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "component" {
+			component = a.Value.String()
+		} else {
+			attrs[a.Key] = attrValueString(a.Value)
+		}
+		return true
+	})
+
+	if h.components[component] {
+		ts := r.Time
+		if ts.IsZero() {
+			ts = time.Now()
+		}
+		h.hub.Publish(LogEntry{
+			Time:      ts,
+			Level:     r.Level.String(),
+			Message:   r.Message,
+			Component: component,
+			Attrs:     attrs,
+		})
+	}
+
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *TeeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newPre := make([]slog.Attr, len(h.preAttrs), len(h.preAttrs)+len(attrs))
+	copy(newPre, h.preAttrs)
+	newPre = append(newPre, attrs...)
+	return &TeeHandler{
+		inner:      h.inner.WithAttrs(attrs),
+		hub:        h.hub,
+		components: h.components,
+		preAttrs:   newPre,
+		groups:     h.groups,
+	}
+}
+
+func (h *TeeHandler) WithGroup(name string) slog.Handler {
+	newGroups := make([]string, len(h.groups), len(h.groups)+1)
+	copy(newGroups, h.groups)
+	newGroups = append(newGroups, name)
+	return &TeeHandler{
+		inner:      h.inner.WithGroup(name),
+		hub:        h.hub,
+		components: h.components,
+		preAttrs:   h.preAttrs,
+		groups:     newGroups,
+	}
+}
+
+func (h *TeeHandler) componentFromPre() string {
+	for _, a := range h.preAttrs {
+		if a.Key == "component" {
+			return a.Value.String()
+		}
+	}
+	return ""
+}
+
+func attrValueString(v slog.Value) string {
+	if v.Kind() == slog.KindTime {
+		return v.Time().Format(time.RFC3339)
+	}
+	return fmt.Sprint(v.Any())
+}

--- a/internal/logstream/handler.go
+++ b/internal/logstream/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -43,12 +44,22 @@ func (h *TeeHandler) Handle(ctx context.Context, r slog.Record) error {
 	component := h.componentFromPre()
 	attrs := make(map[string]string)
 
-	// Collect pre-set attrs (from WithAttrs)
+	groupPrefix := ""
+	if len(h.groups) > 0 {
+		groupPrefix = strings.Join(h.groups, ".") + "."
+	}
+
+	// Collect pre-set attrs (from WithAttrs).
+	// "component" is a well-known key used for filtering, never prefixed.
 	for _, a := range h.preAttrs {
 		if a.Key == "component" {
 			component = a.Value.String()
 		} else {
-			attrs[a.Key] = attrValueString(a.Value)
+			key := a.Key
+			if groupPrefix != "" {
+				key = groupPrefix + key
+			}
+			attrs[key] = attrValueString(a.Value)
 		}
 	}
 

--- a/internal/logstream/handler_test.go
+++ b/internal/logstream/handler_test.go
@@ -106,6 +106,26 @@ func TestTeeHandler_LevelCaptured(t *testing.T) {
 	}
 }
 
+func TestTeeHandler_WithGroup(t *testing.T) {
+	hub := NewHub(100)
+	inner := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	handler := NewTeeHandler(inner, hub, "yad2")
+
+	logger := slog.New(handler).WithGroup("grp").With("component", "yad2")
+	logger.Info("msg", "count", 42)
+
+	entries := hub.Recent(0)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Component != "yad2" {
+		t.Errorf("expected component=yad2, got %q", entries[0].Component)
+	}
+	if entries[0].Attrs["count"] != "42" {
+		t.Errorf("expected count=42, got attrs: %v", entries[0].Attrs)
+	}
+}
+
 func TestTeeHandler_SubscriberReceivesLive(t *testing.T) {
 	hub := NewHub(100)
 	inner := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})

--- a/internal/logstream/handler_test.go
+++ b/internal/logstream/handler_test.go
@@ -1,0 +1,128 @@
+package logstream
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestTeeHandler_FiltersByComponent(t *testing.T) {
+	hub := NewHub(100)
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	handler := NewTeeHandler(inner, hub, "yad2", "scheduler")
+
+	logger := slog.New(handler)
+
+	// This should be captured (component=yad2)
+	logger.With("component", "yad2").Info("fetching")
+
+	// This should NOT be captured (component=bot)
+	logger.With("component", "bot").Info("handling")
+
+	// This should be captured (component=scheduler)
+	logger.With("component", "scheduler").Warn("retry")
+
+	entries := hub.Recent(0)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 captured entries, got %d", len(entries))
+	}
+	if entries[0].Message != "fetching" || entries[0].Component != "yad2" {
+		t.Errorf("entry 0: got %+v", entries[0])
+	}
+	if entries[1].Message != "retry" || entries[1].Component != "scheduler" {
+		t.Errorf("entry 1: got %+v", entries[1])
+	}
+}
+
+func TestTeeHandler_ForwardsAllToInner(t *testing.T) {
+	hub := NewHub(100)
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	handler := NewTeeHandler(inner, hub, "yad2")
+
+	logger := slog.New(handler)
+	logger.With("component", "bot").Info("should forward")
+
+	// Inner should have received it even though it's not captured
+	if !bytes.Contains(buf.Bytes(), []byte("should forward")) {
+		t.Fatalf("inner handler did not receive the record: %s", buf.String())
+	}
+	// Hub should not have captured it
+	if len(hub.Recent(0)) != 0 {
+		t.Fatal("hub should not have captured non-matching component")
+	}
+}
+
+func TestTeeHandler_RecordAttrs(t *testing.T) {
+	hub := NewHub(100)
+	inner := slog.NewTextHandler(&bytes.Buffer{}, nil)
+	handler := NewTeeHandler(inner, hub, "yad2")
+
+	logger := slog.New(handler).With("component", "yad2")
+	logger.Info("fetched listings", "count", 42, "page", 1)
+
+	entries := hub.Recent(0)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Attrs["count"] != "42" {
+		t.Errorf("expected count=42, got %q", entries[0].Attrs["count"])
+	}
+	if entries[0].Attrs["page"] != "1" {
+		t.Errorf("expected page=1, got %q", entries[0].Attrs["page"])
+	}
+}
+
+func TestTeeHandler_Enabled(t *testing.T) {
+	hub := NewHub(100)
+	inner := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelWarn})
+	handler := NewTeeHandler(inner, hub, "yad2")
+
+	if handler.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("should not be enabled for debug when inner is warn")
+	}
+	if !handler.Enabled(context.Background(), slog.LevelWarn) {
+		t.Fatal("should be enabled for warn")
+	}
+}
+
+func TestTeeHandler_LevelCaptured(t *testing.T) {
+	hub := NewHub(100)
+	inner := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	handler := NewTeeHandler(inner, hub, "yad2")
+
+	logger := slog.New(handler).With("component", "yad2")
+	logger.Warn("something bad")
+
+	entries := hub.Recent(0)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1, got %d", len(entries))
+	}
+	if entries[0].Level != "WARN" {
+		t.Errorf("expected WARN, got %q", entries[0].Level)
+	}
+}
+
+func TestTeeHandler_SubscriberReceivesLive(t *testing.T) {
+	hub := NewHub(100)
+	inner := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	handler := NewTeeHandler(inner, hub, "scheduler")
+
+	ch, unsub := hub.Subscribe()
+	defer unsub()
+
+	logger := slog.New(handler).With("component", "scheduler")
+	logger.Info("cycle start")
+
+	select {
+	case e := <-ch:
+		if e.Message != "cycle start" {
+			t.Fatalf("unexpected message %q", e.Message)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live entry")
+	}
+}

--- a/internal/logstream/hub.go
+++ b/internal/logstream/hub.go
@@ -1,0 +1,58 @@
+package logstream
+
+import "sync"
+
+// Hub fans out log entries to SSE subscribers and stores them in a ring buffer.
+type Hub struct {
+	buf  *Buffer
+	mu   sync.RWMutex
+	subs map[*subscriber]struct{}
+}
+
+type subscriber struct {
+	ch chan LogEntry
+}
+
+// NewHub creates a hub with a ring buffer of the given capacity.
+func NewHub(bufCap int) *Hub {
+	return &Hub{
+		buf:  NewBuffer(bufCap),
+		subs: make(map[*subscriber]struct{}),
+	}
+}
+
+// Publish writes an entry to the buffer and broadcasts it to all subscribers.
+func (h *Hub) Publish(e LogEntry) {
+	h.buf.Write(e)
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for s := range h.subs {
+		select {
+		case s.ch <- e:
+		default:
+			// subscriber too slow, drop
+		}
+	}
+}
+
+// Subscribe returns a channel that receives new entries and an unsubscribe function.
+// The caller must call unsubscribe when done.
+func (h *Hub) Subscribe() (<-chan LogEntry, func()) {
+	s := &subscriber{ch: make(chan LogEntry, 64)}
+	h.mu.Lock()
+	h.subs[s] = struct{}{}
+	h.mu.Unlock()
+
+	unsub := func() {
+		h.mu.Lock()
+		delete(h.subs, s)
+		h.mu.Unlock()
+	}
+	return s.ch, unsub
+}
+
+// Recent returns the last n entries from the ring buffer.
+func (h *Hub) Recent(n int) []LogEntry {
+	return h.buf.Recent(n)
+}

--- a/internal/logstream/hub_test.go
+++ b/internal/logstream/hub_test.go
@@ -1,0 +1,102 @@
+package logstream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHub_PublishAndSubscribe(t *testing.T) {
+	h := NewHub(100)
+	ch, unsub := h.Subscribe()
+	defer unsub()
+
+	e := LogEntry{
+		Time:      time.Now(),
+		Level:     "INFO",
+		Message:   "hello",
+		Component: "yad2",
+	}
+	h.Publish(e)
+
+	select {
+	case got := <-ch:
+		if got.Message != "hello" {
+			t.Fatalf("got message %q, want %q", got.Message, "hello")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for published entry")
+	}
+}
+
+func TestHub_Unsubscribe(t *testing.T) {
+	h := NewHub(100)
+	ch, unsub := h.Subscribe()
+	unsub()
+
+	h.Publish(makeEntry("after-unsub"))
+
+	select {
+	case <-ch:
+		t.Fatal("should not receive after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestHub_MultipleSubscribers(t *testing.T) {
+	h := NewHub(100)
+	ch1, unsub1 := h.Subscribe()
+	defer unsub1()
+	ch2, unsub2 := h.Subscribe()
+	defer unsub2()
+
+	h.Publish(makeEntry("multi"))
+
+	for i, ch := range []<-chan LogEntry{ch1, ch2} {
+		select {
+		case got := <-ch:
+			if got.Message != "multi" {
+				t.Errorf("subscriber %d: got %q, want %q", i, got.Message, "multi")
+			}
+		case <-time.After(time.Second):
+			t.Errorf("subscriber %d: timed out", i)
+		}
+	}
+}
+
+func TestHub_Recent(t *testing.T) {
+	h := NewHub(10)
+	h.Publish(makeEntry("a"))
+	h.Publish(makeEntry("b"))
+
+	got := h.Recent(5)
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+}
+
+func TestHub_SlowSubscriberDrops(t *testing.T) {
+	h := NewHub(100)
+	ch, unsub := h.Subscribe()
+	defer unsub()
+
+	// Fill the subscriber channel buffer (capacity 64)
+	for i := range 100 {
+		h.Publish(makeEntry(time.Now().String() + string(rune(i))))
+	}
+
+	// Should have received up to buffer cap, rest dropped
+	count := 0
+	for {
+		select {
+		case <-ch:
+			count++
+		default:
+			goto done
+		}
+	}
+done:
+	if count != 64 {
+		t.Fatalf("expected 64 buffered entries, got %d", count)
+	}
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -232,6 +232,8 @@ type AdminStore interface {
 	PurgeTable(ctx context.Context, table string) (int64, error)
 	AdminListListings(ctx context.Context, limit, offset int) ([]ListingRecord, int64, error)
 	AdminDeleteListing(ctx context.Context, token string, chatID int64) error
+	AdminListSearches(ctx context.Context) ([]Search, error)
+	AdminListUsers(ctx context.Context) ([]User, error)
 	VacuumDB(ctx context.Context) error
 }
 

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -127,6 +127,33 @@ func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int
 	return err
 }
 
+func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
+			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at,
+			COALESCE(share_token, '')
+		FROM searches
+		ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("admin list searches: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanSearches(rows)
+}
+
+func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT chat_id, username, state, state_data, created_at, active, language, tier,
+			tier_expires_at, trial_used
+		FROM users
+		ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("admin list users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanUsers(rows)
+}
+
 func (s *Store) VacuumDB(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, `VACUUM`); err != nil {
 		return fmt.Errorf("vacuum: %w", err)

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -144,14 +144,27 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error)
 func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT chat_id, username, state, state_data, created_at, active, language, tier,
-			tier_expires_at, trial_used
+			tier_expires_at, trial_used, channel, channel_id
 		FROM users
 		ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("admin list users: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	return scanUsers(rows)
+	return scanAdminUsers(rows)
+}
+
+func scanAdminUsers(rows *sql.Rows) ([]storage.User, error) {
+	var users []storage.User
+	for rows.Next() {
+		var u storage.User
+		if err := rows.Scan(&u.ChatID, &u.Username, &u.State, &u.StateData, &u.CreatedAt, &u.Active, &u.Language,
+			&u.Tier, &u.TierExpires, &u.TrialUsed, &u.Channel, &u.ChannelID); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
 }
 
 func (s *Store) VacuumDB(ctx context.Context) error {

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -139,6 +139,33 @@ func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int
 	return err
 }
 
+func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
+			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at,
+			COALESCE(share_token, '')
+		FROM searches
+		ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("admin list searches: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanSearches(rows)
+}
+
+func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT chat_id, username, state, state_data, created_at, active, language, tier,
+			tier_expires_at, trial_used
+		FROM users
+		ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("admin list users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanUsers(rows)
+}
+
 func (s *Store) VacuumDB(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
 		return fmt.Errorf("wal checkpoint: %w", err)

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -156,14 +157,27 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error)
 func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT chat_id, username, state, state_data, created_at, active, language, tier,
-			tier_expires_at, trial_used
+			tier_expires_at, trial_used, channel, channel_id
 		FROM users
 		ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("admin list users: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	return scanUsers(rows)
+	return scanAdminUsers(rows)
+}
+
+func scanAdminUsers(rows *sql.Rows) ([]storage.User, error) {
+	var users []storage.User
+	for rows.Next() {
+		var u storage.User
+		if err := rows.Scan(&u.ChatID, &u.Username, &u.State, &u.StateData, &u.CreatedAt, &u.Active, &u.Language,
+			&u.Tier, &u.TierExpires, &u.TrialUsed, &u.Channel, &u.ChannelID); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
 }
 
 func (s *Store) VacuumDB(ctx context.Context) error {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2683,6 +2683,40 @@ func TestAdminDeleteListing(t *testing.T) {
 	}
 }
 
+func TestAdminListSearches(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	_, _ = store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "s1", Source: "yad2", Manufacturer: 19, Model: 10226, Active: true})
+	_, _ = store.CreateSearch(ctx, storage.Search{ChatID: 200, Name: "s2", Source: "winwin", Manufacturer: 8, Model: 10061, Active: false})
+
+	searches, err := store.AdminListSearches(ctx)
+	if err != nil {
+		t.Fatalf("AdminListSearches: %v", err)
+	}
+	if len(searches) != 2 {
+		t.Fatalf("expected 2 searches, got %d", len(searches))
+	}
+}
+
+func TestAdminListUsers(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+	_ = store.SetUserActive(ctx, 200, false)
+
+	users, err := store.AdminListUsers(ctx)
+	if err != nil {
+		t.Fatalf("AdminListUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users (active+inactive), got %d", len(users))
+	}
+}
+
 func TestVacuumDB(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2699,6 +2699,18 @@ func TestAdminListSearches(t *testing.T) {
 	if len(searches) != 2 {
 		t.Fatalf("expected 2 searches, got %d", len(searches))
 	}
+	byName := map[string]storage.Search{}
+	for _, s := range searches {
+		byName[s.Name] = s
+	}
+	s1 := byName["s1"]
+	if s1.ChatID != 100 || s1.Source != "yad2" || s1.Manufacturer != 19 || s1.Model != 10226 || !s1.Active {
+		t.Errorf("s1 fields mismatch: %+v", s1)
+	}
+	s2 := byName["s2"]
+	if s2.ChatID != 200 || s2.Source != "winwin" || s2.Manufacturer != 8 {
+		t.Errorf("s2 fields mismatch: %+v", s2)
+	}
 }
 
 func TestAdminListUsers(t *testing.T) {
@@ -2714,6 +2726,18 @@ func TestAdminListUsers(t *testing.T) {
 	}
 	if len(users) != 2 {
 		t.Fatalf("expected 2 users (active+inactive), got %d", len(users))
+	}
+	byID := map[int64]storage.User{}
+	for _, u := range users {
+		byID[u.ChatID] = u
+	}
+	u100 := byID[100]
+	if !u100.Active || u100.Channel != "telegram" {
+		t.Errorf("user 100 mismatch: active=%v channel=%q", u100.Active, u100.Channel)
+	}
+	u200 := byID[200]
+	if u200.Active || u200.Channel != "telegram" {
+		t.Errorf("user 200 mismatch: active=%v channel=%q", u200.Active, u200.Channel)
 	}
 }
 

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getAuthToken } from "@/lib/auth-token";
+import { adminApi, type LogEntry } from "@/lib/api";
+
+const MAX_ENTRIES = 500;
+const STYLE_BY_LEVEL: Record<string, string> = {
+  DEBUG: "color: #8b8b8b",
+  INFO: "color: #3b82f6",
+  WARN: "color: #f59e0b; font-weight: bold",
+  ERROR: "color: #ef4444; font-weight: bold",
+};
+
+export function useLogStream(enabled: boolean) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [connected, setConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+        setConnected(false);
+      }
+      return;
+    }
+
+    let cancelled = false;
+
+    async function connect() {
+      // Load recent logs first
+      try {
+        const { items } = await adminApi.logs(200);
+        if (!cancelled) {
+          setLogs(items);
+        }
+      } catch {
+        // non-critical
+      }
+
+      const token = await getAuthToken().catch(() => null);
+      if (cancelled) return;
+
+      const url = `/api/v1/admin/logs/stream${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+      const es = new EventSource(url);
+      esRef.current = es;
+
+      es.onopen = () => {
+        if (!cancelled) setConnected(true);
+      };
+
+      es.onmessage = (event) => {
+        try {
+          const entry: LogEntry = JSON.parse(event.data);
+
+          const style = STYLE_BY_LEVEL[entry.level] ?? "";
+          console.log(
+            `%c[${entry.component}] ${entry.level}: ${entry.message}`,
+            style,
+            entry.attrs ?? "",
+          );
+
+          if (!cancelled) {
+            setLogs((prev) => {
+              const next = [...prev, entry];
+              return next.length > MAX_ENTRIES
+                ? next.slice(next.length - MAX_ENTRIES)
+                : next;
+            });
+          }
+        } catch {
+          // ignore malformed events
+        }
+      };
+
+      es.onerror = () => {
+        if (!cancelled) setConnected(false);
+      };
+    }
+
+    void connect();
+
+    return () => {
+      cancelled = true;
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
+      setConnected(false);
+    };
+  }, [enabled]);
+
+  const clear = useCallback(() => setLogs([]), []);
+
+  return { logs, connected, clear };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -228,6 +228,7 @@ export interface AdminStats {
 
 export interface AdminListing extends Listing {
   chat_id: number;
+  search_name?: string;
 }
 
 export interface AdminListingsResponse {
@@ -248,6 +249,43 @@ export interface VacuumResult {
   size_bytes?: number;
 }
 
+export interface AdminSearch {
+  id: number;
+  chat_id: number;
+  name: string;
+  source: string;
+  manufacturer: number;
+  model: number;
+  year_min: number;
+  year_max: number;
+  price_max: number;
+  max_km: number;
+  max_hand: number;
+  active: boolean;
+  created_at: string;
+}
+
+export interface AdminSearchesResponse {
+  items: AdminSearch[];
+  total: number;
+}
+
+export interface AdminUser {
+  chat_id: number;
+  username: string;
+  channel: string;
+  channel_id: string;
+  active: boolean;
+  tier: string;
+  language: string;
+  created_at: string;
+}
+
+export interface AdminUsersResponse {
+  items: AdminUser[];
+  total: number;
+}
+
 export const adminApi = {
   stats: () => fetchAPI<AdminStats>("/admin/stats"),
   listings: (params?: ListingsParams) => {
@@ -262,6 +300,8 @@ export const adminApi = {
       method: "DELETE",
       body: JSON.stringify({ chat_id: chatId }),
     }),
+  searches: () => fetchAPI<AdminSearchesResponse>("/admin/searches"),
+  users: () => fetchAPI<AdminUsersResponse>("/admin/users"),
   purgeTable: (table: string) =>
     fetchAPI<PurgeResult>("/admin/purge", {
       method: "POST",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -286,8 +286,24 @@ export interface AdminUsersResponse {
   total: number;
 }
 
+export interface LogEntry {
+  time: string;
+  level: string;
+  message: string;
+  component: string;
+  attrs?: Record<string, string>;
+}
+
+export interface AdminLogsResponse {
+  items: LogEntry[];
+}
+
 export const adminApi = {
   stats: () => fetchAPI<AdminStats>("/admin/stats"),
+  logs: (limit?: number) =>
+    fetchAPI<AdminLogsResponse>(
+      `/admin/logs${limit ? `?limit=${limit}` : ""}`,
+    ),
   listings: (params?: ListingsParams) => {
     const query = new URLSearchParams();
     if (params?.limit !== undefined) query.set("limit", String(params.limit));

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AlertCircle,
   Car,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Cpu,
@@ -11,6 +12,7 @@ import {
   HardDrive,
   Loader2,
   RefreshCw,
+  ScrollText,
   Search,
   Shield,
   Table,
@@ -21,11 +23,13 @@ import {
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import { useAdminStats } from "@/hooks/useAdmin";
+import { useLogStream } from "@/hooks/useLogStream";
 import {
   adminApi,
   type AdminListing,
   type AdminSearch,
   type AdminUser,
+  type LogEntry,
 } from "@/lib/api";
 import { EmptyState, Skeleton, Badge } from "@/components/ui";
 import { useToast } from "@/components/ui/Toast";
@@ -58,13 +62,14 @@ const PURGEABLE = new Set([
   "pending_digest",
 ]);
 
-type TabKey = "overview" | "listings" | "searches" | "users";
+type TabKey = "overview" | "listings" | "searches" | "users" | "logs";
 
 const TABS: { key: TabKey; label: string; icon: typeof Car }[] = [
   { key: "overview", label: "סקירה כללית", icon: Database },
   { key: "listings", label: "מודעות", icon: Car },
   { key: "searches", label: "חיפושים", icon: FileSearch },
   { key: "users", label: "משתמשים", icon: Users },
+  { key: "logs", label: "לוגים", icon: ScrollText },
 ];
 
 // ── Confirm Modal ─────────────────────────────────────────────────────────────
@@ -975,6 +980,266 @@ function UsersTab() {
   );
 }
 
+// ── Logs Tab ──────────────────────────────────────────────────────────────────
+
+const LEVEL_STYLES: Record<
+  string,
+  { bg: string; text: string; label: string }
+> = {
+  DEBUG: {
+    bg: "bg-muted-foreground/10",
+    text: "text-muted-foreground",
+    label: "DBG",
+  },
+  INFO: { bg: "bg-primary/10", text: "text-primary", label: "INF" },
+  WARN: { bg: "bg-warning/10", text: "text-warning", label: "WRN" },
+  ERROR: { bg: "bg-destructive/10", text: "text-destructive", label: "ERR" },
+};
+
+const ALL_COMPONENTS = ["yad2", "winwin", "scheduler", "enricher"] as const;
+const ALL_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR"] as const;
+
+function LogsTab({ active }: { active: boolean }) {
+  const { logs, connected, clear } = useLogStream(active);
+  const [componentFilter, setComponentFilter] = useState<Set<string>>(
+    new Set(ALL_COMPONENTS),
+  );
+  const [levelFilter, setLevelFilter] = useState<Set<string>>(
+    new Set(ALL_LEVELS),
+  );
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const filtered = logs.filter(
+    (e) => componentFilter.has(e.component) && levelFilter.has(e.level),
+  );
+
+  useEffect(() => {
+    if (autoScroll && bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [filtered.length, autoScroll]);
+
+  function toggleFilter(
+    set: Set<string>,
+    setter: (s: Set<string>) => void,
+    value: string,
+  ) {
+    const next = new Set(set);
+    if (next.has(value)) {
+      if (next.size > 1) next.delete(value);
+    } else {
+      next.add(value);
+    }
+    setter(next);
+  }
+
+  function formatTime(iso: string) {
+    try {
+      return new Date(iso).toLocaleTimeString("he-IL", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+    } catch {
+      return "";
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3 flex-wrap">
+          {/* Connection indicator */}
+          <div className="flex items-center gap-1.5">
+            <div
+              className={cn(
+                "h-2 w-2 rounded-full flex-shrink-0",
+                connected
+                  ? "bg-success animate-pulse-soft"
+                  : "bg-muted-foreground/40",
+              )}
+            />
+            <span className="text-xs text-muted-foreground">
+              {connected ? "מחובר" : "מנותק"}
+            </span>
+          </div>
+
+          {/* Component filters */}
+          <div className="flex gap-1">
+            {ALL_COMPONENTS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() =>
+                  toggleFilter(componentFilter, setComponentFilter, c)
+                }
+                className={cn(
+                  "px-2 py-1 rounded-md text-[11px] font-medium transition-colors",
+                  componentFilter.has(c)
+                    ? "bg-primary/10 text-primary"
+                    : "bg-secondary text-muted-foreground/50",
+                )}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+
+          {/* Level filters */}
+          <div className="flex gap-1">
+            {ALL_LEVELS.map((l) => {
+              const style = LEVEL_STYLES[l];
+              return (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() => toggleFilter(levelFilter, setLevelFilter, l)}
+                  className={cn(
+                    "px-2 py-1 rounded-md text-[11px] font-medium transition-colors",
+                    levelFilter.has(l)
+                      ? `${style.bg} ${style.text}`
+                      : "bg-secondary text-muted-foreground/50",
+                  )}
+                >
+                  {style.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setAutoScroll((p) => !p)}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium transition-colors",
+              autoScroll
+                ? "bg-primary/10 text-primary"
+                : "bg-secondary text-muted-foreground",
+            )}
+          >
+            <ChevronDown className="h-3 w-3" />
+            גלילה אוטומטית
+          </button>
+          <button
+            type="button"
+            onClick={clear}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-secondary hover:bg-secondary/80 text-xs font-medium text-foreground transition-colors"
+          >
+            <Trash2 className="h-3 w-3" />
+            נקה
+          </button>
+        </div>
+      </div>
+
+      {/* Log entries */}
+      <div className="rounded-2xl border border-border/50 bg-card overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
+          <h2 className="text-base font-semibold">
+            לוגים ({filtered.length})
+          </h2>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {logs.length} סה״כ
+          </span>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto p-2 font-mono text-xs">
+          {filtered.length === 0 ? (
+            <EmptyState
+              icon={ScrollText}
+              title="אין לוגים"
+              description="לוגים מה-fetchers יופיעו כאן בזמן אמת"
+              className="border-0 bg-transparent"
+            />
+          ) : (
+            <div className="space-y-px">
+              {filtered.map((entry, idx) => (
+                <LogLine
+                  key={`${entry.time}-${idx}`}
+                  entry={entry}
+                  expanded={expandedIdx === idx}
+                  onToggle={() =>
+                    setExpandedIdx(expandedIdx === idx ? null : idx)
+                  }
+                  formatTime={formatTime}
+                />
+              ))}
+              <div ref={bottomRef} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LogLine({
+  entry,
+  expanded,
+  onToggle,
+  formatTime,
+}: {
+  entry: LogEntry;
+  expanded: boolean;
+  onToggle: () => void;
+  formatTime: (iso: string) => string;
+}) {
+  const style = LEVEL_STYLES[entry.level] ?? LEVEL_STYLES.INFO;
+  const hasAttrs = entry.attrs && Object.keys(entry.attrs).length > 0;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg px-3 py-2 transition-colors",
+        expanded ? "bg-secondary" : "hover:bg-secondary/50",
+        hasAttrs && "cursor-pointer",
+      )}
+      onClick={hasAttrs ? onToggle : undefined}
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-muted-foreground/60 flex-shrink-0 tabular-nums w-[60px]">
+          {formatTime(entry.time)}
+        </span>
+        <span
+          className={cn(
+            "inline-flex items-center justify-center rounded px-1.5 py-0.5 text-[10px] font-semibold flex-shrink-0 w-8",
+            style.bg,
+            style.text,
+          )}
+        >
+          {style.label}
+        </span>
+        <span className="text-primary/70 flex-shrink-0 w-[70px] truncate">
+          {entry.component}
+        </span>
+        <span className="text-foreground break-all flex-1">{entry.message}</span>
+        {hasAttrs && (
+          <ChevronDown
+            className={cn(
+              "h-3 w-3 text-muted-foreground/40 flex-shrink-0 mt-0.5 transition-transform",
+              expanded && "rotate-180",
+            )}
+          />
+        )}
+      </div>
+      {expanded && hasAttrs && (
+        <div className="mt-2 mr-[132px] space-y-0.5 border-r border-border/50 pr-3">
+          {Object.entries(entry.attrs!).map(([k, v]) => (
+            <div key={k} className="flex gap-2">
+              <span className="text-muted-foreground/60">{k}:</span>
+              <span className="text-foreground/80 break-all">{v}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function StorageIndicator({ sizeBytes }: { sizeBytes: number }) {
@@ -1132,6 +1397,9 @@ export function AdminPage() {
           {activeTab === "listings" && <ListingsTab />}
           {activeTab === "searches" && <SearchesTab />}
           {activeTab === "users" && <UsersTab />}
+          {activeTab === "logs" && (
+            <LogsTab active={activeTab === "logs"} />
+          )}
         </motion.div>
       </AnimatePresence>
     </div>

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -86,7 +86,14 @@ function ConfirmModal({
   loading?: boolean;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+      aria-describedby="confirm-desc"
+      onKeyDown={(e) => e.key === "Escape" && onCancel()}
+    >
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -105,9 +112,9 @@ function ConfirmModal({
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-destructive/15">
             <Trash2 className="h-[18px] w-[18px] text-destructive" />
           </div>
-          <h3 className="font-bold text-foreground">אישור פעולה</h3>
+          <h3 id="confirm-title" className="font-bold text-foreground">אישור פעולה</h3>
         </div>
-        <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+        <p id="confirm-desc" className="text-sm text-muted-foreground mb-6 leading-relaxed">
           {message}
         </p>
         <div className="flex gap-3">
@@ -148,7 +155,13 @@ function DetailModal({
   onClose: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="detail-title"
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -164,7 +177,7 @@ function DetailModal({
         className="relative bg-card border border-border rounded-2xl p-6 max-w-lg w-full shadow-2xl max-h-[80vh] overflow-y-auto"
       >
         <div className="flex items-center justify-between mb-5">
-          <h3 className="font-bold text-foreground">{title}</h3>
+          <h3 id="detail-title" className="font-bold text-foreground">{title}</h3>
           <button
             type="button"
             onClick={onClose}
@@ -604,7 +617,7 @@ function ListingsTab() {
                         )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-1.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="flex items-center gap-1.5 flex-shrink-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
                       <button
                         type="button"
                         onClick={() => setDetailListing(listing)}
@@ -692,7 +705,7 @@ function ListingsTab() {
               { label: "עיר", value: detailListing.city },
               {
                 label: "ציון התאמה",
-                value: detailListing.fitness_score
+                value: detailListing.fitness_score != null
                   ? `${(detailListing.fitness_score * 100).toFixed(0)}%`
                   : null,
               },
@@ -774,8 +787,11 @@ function SearchesTab() {
                   key={search.id}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
-                  className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary cursor-pointer group"
+                  className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary cursor-pointer group focus-visible:ring-2 focus-visible:ring-ring outline-none"
+                  tabIndex={0}
+                  role="button"
                   onClick={() => setDetailSearch(search)}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setDetailSearch(search); } }}
                 >
                   <div
                     className={cn(
@@ -919,8 +935,11 @@ function UsersTab() {
                   key={user.chat_id}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
-                  className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary cursor-pointer"
+                  className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary cursor-pointer focus-visible:ring-2 focus-visible:ring-ring outline-none"
+                  tabIndex={0}
+                  role="button"
                   onClick={() => setDetailUser(user)}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setDetailUser(user); } }}
                 >
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary font-bold text-sm flex-shrink-0">
                     {(user.username || user.channel || "?")[0].toUpperCase()}
@@ -1196,9 +1215,12 @@ function LogLine({
       className={cn(
         "rounded-lg px-3 py-2 transition-colors",
         expanded ? "bg-secondary" : "hover:bg-secondary/50",
-        hasAttrs && "cursor-pointer",
+        hasAttrs && "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring outline-none",
       )}
+      tabIndex={hasAttrs ? 0 : undefined}
+      role={hasAttrs ? "button" : undefined}
       onClick={hasAttrs ? onToggle : undefined}
+      onKeyDown={hasAttrs ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(); } } : undefined}
     >
       <div className="flex items-start gap-2">
         <span className="text-muted-foreground/60 flex-shrink-0 tabular-nums w-[60px]">

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1219,6 +1219,7 @@ function LogLine({
       )}
       tabIndex={hasAttrs ? 0 : undefined}
       role={hasAttrs ? "button" : undefined}
+      aria-expanded={hasAttrs ? expanded : undefined}
       onClick={hasAttrs ? onToggle : undefined}
       onKeyDown={hasAttrs ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(); } } : undefined}
     >

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,23 +1,35 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   AlertCircle,
-  Cpu,
-  Database,
-  RefreshCw,
-  Table,
-  Trash2,
-  HardDrive,
-  Loader2,
+  Car,
   ChevronLeft,
   ChevronRight,
+  Cpu,
+  Database,
+  ExternalLink,
+  FileSearch,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  Search,
+  Shield,
+  Table,
+  Trash2,
+  Users,
+  X,
 } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { AnimatePresence, motion } from "motion/react";
 import { useAdminStats } from "@/hooks/useAdmin";
-import { adminApi, type AdminListing } from "@/lib/api";
-import { EmptyState, PageHeader, Skeleton } from "@/components/ui";
+import {
+  adminApi,
+  type AdminListing,
+  type AdminSearch,
+  type AdminUser,
+} from "@/lib/api";
+import { EmptyState, Skeleton, Badge } from "@/components/ui";
 import { useToast } from "@/components/ui/Toast";
-import { cn } from "@/lib/utils";
-import { formatKm, formatPrice } from "@/lib/utils";
+import { cn, formatKm, formatPrice, relativeTime, safeHref } from "@/lib/utils";
 
 const TABLE_LABELS: Record<string, string> = {
   users: "משתמשים",
@@ -46,88 +58,185 @@ const PURGEABLE = new Set([
   "pending_digest",
 ]);
 
-export function AdminPage() {
-  const { data, isLoading, isError, dataUpdatedAt, refetch } = useAdminStats();
-  const [activeTab, setActiveTab] = useState<"stats" | "listings">("stats");
+type TabKey = "overview" | "listings" | "searches" | "users";
 
-  if (isLoading) {
-    return (
-      <div className="space-y-6 pb-20 md:pb-4">
-        <PageHeader title="ניהול" />
-        <div className="grid gap-4 sm:grid-cols-2">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-44 rounded-2xl" />
-          ))}
-        </div>
-      </div>
-    );
-  }
+const TABS: { key: TabKey; label: string; icon: typeof Car }[] = [
+  { key: "overview", label: "סקירה כללית", icon: Database },
+  { key: "listings", label: "מודעות", icon: Car },
+  { key: "searches", label: "חיפושים", icon: FileSearch },
+  { key: "users", label: "משתמשים", icon: Users },
+];
 
-  if (isError || !data) {
-    return (
-      <div className="space-y-6 pb-20 md:pb-4">
-        <PageHeader title="ניהול" />
-        <EmptyState
-          icon={AlertCircle}
-          title="שגיאה בטעינת הנתונים"
-          description="ייתכן שאין לך הרשאות מנהל. ודא שה-admin_email מוגדר בקובץ ההגדרות."
-        />
-      </div>
-    );
-  }
+// ── Confirm Modal ─────────────────────────────────────────────────────────────
 
-  const lastUpdated = new Date(dataUpdatedAt);
-
+function ConfirmModal({
+  message,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+}) {
   return (
-    <div className="space-y-6 pb-20 md:pb-4">
-      <PageHeader
-        title="ניהול"
-        action={
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <RefreshCw className="h-3 w-3" />
-            עדכון אחרון: {lastUpdated.toLocaleTimeString("he-IL")}
-          </div>
-        }
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onCancel}
       />
-
-      {/* Tabs */}
-      <div className="flex gap-1 rounded-xl bg-secondary/50 p-1">
-        <button
-          type="button"
-          onClick={() => setActiveTab("stats")}
-          className={cn(
-            "flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
-            activeTab === "stats"
-              ? "bg-card text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          סטטיסטיקות
-        </button>
-        <button
-          type="button"
-          onClick={() => setActiveTab("listings")}
-          className={cn(
-            "flex-1 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
-            activeTab === "listings"
-              ? "bg-card text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          מודעות
-        </button>
-      </div>
-
-      {activeTab === "stats" ? (
-        <StatsTab data={data} onRefresh={() => void refetch()} />
-      ) : (
-        <ListingsTab />
-      )}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 8 }}
+        transition={{ type: "spring", duration: 0.3, bounce: 0.15 }}
+        className="relative bg-card border border-border rounded-2xl p-6 max-w-sm w-full shadow-2xl"
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-destructive/15">
+            <Trash2 className="h-[18px] w-[18px] text-destructive" />
+          </div>
+          <h3 className="font-bold text-foreground">אישור פעולה</h3>
+        </div>
+        <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+          {message}
+        </p>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 py-2.5 rounded-xl border border-border text-sm font-medium text-muted-foreground hover:bg-secondary transition-colors"
+          >
+            ביטול
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className="flex-1 py-2.5 rounded-xl bg-destructive hover:bg-destructive/90 text-white text-sm font-semibold transition-colors disabled:opacity-50"
+          >
+            {loading ? (
+              <Loader2 className="mx-auto h-4 w-4 animate-spin" />
+            ) : (
+              "אישור"
+            )}
+          </button>
+        </div>
+      </motion.div>
     </div>
   );
 }
 
-function StatsTab({
+// ── Detail Modal ──────────────────────────────────────────────────────────────
+
+function DetailModal({
+  title,
+  fields,
+  onClose,
+}: {
+  title: string;
+  fields: { label: string; value: string | number | null | undefined }[];
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <motion.div
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 24 }}
+        transition={{ type: "spring", duration: 0.35, bounce: 0.1 }}
+        className="relative bg-card border border-border rounded-2xl p-6 max-w-lg w-full shadow-2xl max-h-[80vh] overflow-y-auto"
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="font-bold text-foreground">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-lg bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="space-y-0.5">
+          {fields.map((f) => {
+            if (f.value === undefined || f.value === null || f.value === "")
+              return null;
+            return (
+              <div
+                key={f.label}
+                className="flex gap-3 py-2.5 border-b border-border/50 last:border-0"
+              >
+                <span className="text-xs text-muted-foreground w-28 flex-shrink-0 mt-0.5">
+                  {f.label}
+                </span>
+                <span className="text-sm text-foreground font-medium break-all">
+                  {String(f.value)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+// ── Stat Card ─────────────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+  subtitle,
+}: {
+  label: string;
+  value: string | number;
+  icon: typeof Car;
+  color: string;
+  subtitle?: string;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="rounded-2xl border border-border/50 bg-card p-5 card-hover"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {label}
+        </span>
+        <div
+          className={cn(
+            "flex h-9 w-9 items-center justify-center rounded-xl",
+            color,
+          )}
+        >
+          <Icon className="h-[18px] w-[18px]" />
+        </div>
+      </div>
+      <p className="text-3xl font-bold tabular-nums text-foreground">{value}</p>
+      {subtitle && (
+        <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+      )}
+    </motion.div>
+  );
+}
+
+// ── Overview Tab ──────────────────────────────────────────────────────────────
+
+function OverviewTab({
   data,
   onRefresh,
 }: {
@@ -141,7 +250,10 @@ function StatsTab({
   const purgeMutation = useMutation({
     mutationFn: (table: string) => adminApi.purgeTable(table),
     onSuccess: (result) => {
-      toast(`נמחקו ${result.deleted} רשומות מ-${TABLE_LABELS[result.table] ?? result.table}`, "success");
+      toast(
+        `נמחקו ${result.deleted} רשומות מ-${TABLE_LABELS[result.table] ?? result.table}`,
+        "success",
+      );
       setConfirmPurge(null);
       void queryClient.invalidateQueries({ queryKey: ["admin"] });
       onRefresh();
@@ -154,7 +266,10 @@ function StatsTab({
   const vacuumMutation = useMutation({
     mutationFn: () => adminApi.vacuum(),
     onSuccess: (result) => {
-      toast(`דחיסת מסד נתונים הושלמה${result.size_after ? ` — ${result.size_after}` : ""}`, "success");
+      toast(
+        `דחיסת מסד נתונים הושלמה${result.size_after ? ` — ${result.size_after}` : ""}`,
+        "success",
+      );
       void queryClient.invalidateQueries({ queryKey: ["admin"] });
       onRefresh();
     },
@@ -163,51 +278,104 @@ function StatsTab({
     },
   });
 
+  const mb = data.db.file_size_bytes / (1024 * 1024);
+
   return (
-    <>
-      {/* DB Storage */}
-      <div className="rounded-2xl border border-border/50 bg-card p-6">
-        <div className="flex items-center justify-between mb-5">
-          <div className="flex items-center gap-2.5">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-              <Database className="h-4 w-4 text-primary" />
+    <div className="space-y-6">
+      {/* DB Storage + Runtime — two-column */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* DB Storage card */}
+        <div className="rounded-2xl border border-border/50 bg-card p-6">
+          <div className="flex items-center justify-between mb-5">
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10">
+                <Database className="h-[18px] w-[18px] text-primary" />
+              </div>
+              <h2 className="text-base font-semibold">אחסון</h2>
             </div>
-            <h2 className="text-lg font-semibold">אחסון בסיס נתונים</h2>
+            <button
+              type="button"
+              onClick={() => void vacuumMutation.mutate()}
+              disabled={vacuumMutation.isPending}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-border bg-secondary px-3 py-2 text-xs font-medium transition-colors hover:bg-muted disabled:opacity-50"
+            >
+              {vacuumMutation.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <HardDrive className="h-3.5 w-3.5" />
+              )}
+              דחיסת DB
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={() => void vacuumMutation.mutate()}
-            disabled={vacuumMutation.isPending}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-secondary px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted disabled:opacity-50"
-          >
-            {vacuumMutation.isPending ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
-            ) : (
-              <HardDrive className="h-3 w-3" />
-            )}
-            דחיסת DB
-          </button>
+          <div className="flex items-baseline gap-2.5 mb-3">
+            <span className="text-4xl font-bold tabular-nums">
+              {data.db.file_size_human}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 mb-4">
+            <StorageIndicator sizeBytes={data.db.file_size_bytes} />
+            <span className="text-xs text-muted-foreground tabular-nums">
+              ({data.db.file_size_bytes.toLocaleString("he-IL")} bytes)
+            </span>
+          </div>
+
+          {/* Storage bar */}
+          <div className="h-2.5 rounded-full bg-secondary overflow-hidden">
+            <motion.div
+              className={cn(
+                "h-full rounded-full",
+                mb > 400
+                  ? "bg-destructive"
+                  : mb > 200
+                    ? "bg-score-good"
+                    : "bg-primary",
+              )}
+              initial={{ width: 0 }}
+              animate={{ width: `${Math.min(100, (mb / 500) * 100)}%` }}
+              transition={{ duration: 0.8, ease: "easeOut" }}
+            />
+          </div>
+          <p className="text-[11px] text-muted-foreground mt-2">
+            מתוך ~500 MB מקסימום מומלץ
+          </p>
         </div>
-        <div className="flex items-baseline gap-2 mb-4">
-          <span className="text-3xl font-bold tabular-nums">
-            {data.db.file_size_human}
-          </span>
-          <span className="text-sm text-muted-foreground tabular-nums">
-            ({data.db.file_size_bytes.toLocaleString("he-IL")} bytes)
-          </span>
+
+        {/* Runtime card */}
+        <div className="rounded-2xl border border-border/50 bg-card p-6">
+          <div className="flex items-center gap-2.5 mb-5">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-chart-4/10">
+              <Cpu className="h-[18px] w-[18px] text-chart-4" />
+            </div>
+            <h2 className="text-base font-semibold">סטטוס מערכת</h2>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <RuntimeStat label="זמן פעילות" value={data.runtime.uptime} />
+            <RuntimeStat
+              label="Goroutines"
+              value={String(data.runtime.goroutines)}
+            />
+            <RuntimeStat
+              label="זיכרון (Alloc)"
+              value={`${data.runtime.mem_alloc_mb.toFixed(1)} MB`}
+            />
+            <RuntimeStat
+              label="זיכרון (Sys)"
+              value={`${data.runtime.mem_sys_mb.toFixed(1)} MB`}
+            />
+          </div>
         </div>
-        <StorageIndicator sizeBytes={data.db.file_size_bytes} />
       </div>
 
       {/* Table sizes */}
       <div className="rounded-2xl border border-border/50 bg-card p-6">
         <div className="flex items-center gap-2.5 mb-5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-            <Table className="h-4 w-4 text-primary" />
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-chart-2/10">
+            <Table className="h-[18px] w-[18px] text-chart-2" />
           </div>
-          <h2 className="text-lg font-semibold">גודל טבלאות</h2>
+          <h2 className="text-base font-semibold">טבלאות</h2>
         </div>
-        <div className="space-y-1.5">
+
+        <div className="grid gap-2 sm:grid-cols-2">
           {Object.entries(data.tables)
             .sort(([, a], [, b]) => b - a)
             .map(([table, count]) => {
@@ -217,12 +385,20 @@ function StatsTab({
               return (
                 <div
                   key={table}
-                  className="flex items-center justify-between rounded-xl bg-secondary/50 px-4 py-2.5 transition-colors duration-200 hover:bg-secondary"
+                  className="flex items-center justify-between rounded-xl bg-secondary/50 px-4 py-3 transition-colors duration-200 hover:bg-secondary"
                 >
-                  <span className="text-sm font-medium">
-                    {TABLE_LABELS[table] ?? table}
-                  </span>
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <div
+                      className={cn(
+                        "h-2 w-2 rounded-full flex-shrink-0",
+                        count > 0 ? "bg-primary" : "bg-muted-foreground/30",
+                      )}
+                    />
+                    <span className="text-sm font-medium truncate">
+                      {TABLE_LABELS[table] ?? table}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 flex-shrink-0">
                     <span className="text-sm font-mono font-semibold tabular-nums text-muted-foreground">
                       {count.toLocaleString("he-IL")}
                     </span>
@@ -231,7 +407,7 @@ function StatsTab({
                         type="button"
                         onClick={() => setConfirmPurge(table)}
                         aria-label={`מחק את כל ${TABLE_LABELS[table] ?? table}`}
-                        className="rounded p-1 text-muted-foreground/50 transition-colors hover:text-destructive"
+                        className="rounded-lg p-1.5 text-muted-foreground/50 transition-colors hover:text-destructive hover:bg-destructive/10"
                         title={`מחק את כל ${TABLE_LABELS[table] ?? table}`}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
@@ -243,14 +419,14 @@ function StatsTab({
                           type="button"
                           onClick={() => purgeMutation.mutate(table)}
                           disabled={purgeMutation.isPending}
-                          className="rounded-md bg-destructive px-2 py-0.5 text-[11px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+                          className="rounded-lg bg-destructive px-2.5 py-1 text-[11px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
                         >
                           {purgeMutation.isPending ? "מוחק..." : "אישור"}
                         </button>
                         <button
                           type="button"
                           onClick={() => setConfirmPurge(null)}
-                          className="rounded-md border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+                          className="rounded-lg border border-border px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
                         >
                           ביטול
                         </button>
@@ -262,44 +438,25 @@ function StatsTab({
             })}
         </div>
       </div>
-
-      {/* Runtime */}
-      <div className="rounded-2xl border border-border/50 bg-card p-6">
-        <div className="flex items-center gap-2.5 mb-5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-            <Cpu className="h-4 w-4 text-primary" />
-          </div>
-          <h2 className="text-lg font-semibold">סטטוס מערכת</h2>
-        </div>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <StatBox label="זמן פעילות" value={data.runtime.uptime} />
-          <StatBox
-            label="Goroutines"
-            value={String(data.runtime.goroutines)}
-          />
-          <StatBox
-            label="זיכרון (Alloc)"
-            value={`${data.runtime.mem_alloc_mb.toFixed(1)} MB`}
-          />
-          <StatBox
-            label="זיכרון (Sys)"
-            value={`${data.runtime.mem_sys_mb.toFixed(1)} MB`}
-          />
-        </div>
-      </div>
-    </>
+    </div>
   );
 }
 
+// ── Listings Tab ──────────────────────────────────────────────────────────────
+
 function ListingsTab() {
   const [page, setPage] = useState(0);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [detailListing, setDetailListing] = useState<AdminListing | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AdminListing | null>(null);
   const pageSize = 20;
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ["admin", "listings", page],
-    queryFn: () => adminApi.listings({ limit: pageSize, offset: page * pageSize }),
+    queryFn: () =>
+      adminApi.listings({ limit: pageSize, offset: page * pageSize }),
   });
 
   const deleteMutation = useMutation({
@@ -307,6 +464,7 @@ function ListingsTab() {
       adminApi.deleteListing(token, chatId),
     onSuccess: () => {
       toast("המודעה נמחקה", "success");
+      setConfirmDelete(null);
       void queryClient.invalidateQueries({ queryKey: ["admin"] });
     },
     onError: () => {
@@ -316,23 +474,44 @@ function ListingsTab() {
 
   const totalPages = data ? Math.ceil(data.total / pageSize) : 0;
 
-  useEffect(() => {
-    const maxPage = Math.max(0, totalPages - 1);
-    if (page > maxPage) {
-      setPage(maxPage);
-    }
-  }, [page, totalPages]);
+  const filtered =
+    searchQuery && data
+      ? data.items.filter(
+          (l) =>
+            l.manufacturer?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            l.model?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            l.city?.toLowerCase().includes(searchQuery.toLowerCase()),
+        )
+      : data?.items ?? [];
 
   return (
     <div className="space-y-4">
-      <div className="rounded-2xl border border-border/50 bg-card p-6">
-        <div className="flex items-center justify-between mb-5">
-          <div className="flex items-center gap-2.5">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-              <Database className="h-4 w-4 text-primary" />
-            </div>
-            <h2 className="text-lg font-semibold">כל המודעות</h2>
-          </div>
+      {/* Header with search */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="חפש לפי יצרן, דגם, עיר..."
+            className="w-full bg-secondary/50 border border-border rounded-xl pr-10 pl-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-colors"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-secondary hover:bg-secondary/80 text-sm font-medium text-foreground transition-colors"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          רענן
+        </button>
+      </div>
+
+      {/* Listings */}
+      <div className="rounded-2xl border border-border/50 bg-card overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
+          <h2 className="text-base font-semibold">כל המודעות</h2>
           {data && (
             <span className="text-sm text-muted-foreground tabular-nums">
               {data.total.toLocaleString("he-IL")} סה״כ
@@ -340,136 +519,463 @@ function ListingsTab() {
           )}
         </div>
 
-        {isLoading ? (
-          <div className="space-y-2">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 rounded-xl" />
-            ))}
-          </div>
-        ) : isError ? (
-          <p className="text-sm text-destructive text-center py-8">
-            שגיאה בטעינת המודעות
-          </p>
-        ) : !data || data.items.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-8">
-            אין מודעות
-          </p>
-        ) : (
-          <div className="space-y-1.5">
-            {data.items.map((listing) => (
-              <AdminListingRow
-                key={`${listing.token}-${listing.chat_id}`}
-                listing={listing}
-                onDelete={(token, chatId) => deleteMutation.mutate({ token, chatId })}
-                deleting={deleteMutation.isPending}
-              />
-            ))}
-          </div>
-        )}
+        <div className="p-3">
+          {isLoading ? (
+            <div className="space-y-2 p-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-[72px] rounded-xl" />
+              ))}
+            </div>
+          ) : isError ? (
+            <EmptyState
+              icon={AlertCircle}
+              title="שגיאה בטעינת המודעות"
+              className="border-0 bg-transparent"
+            />
+          ) : filtered.length === 0 ? (
+            <EmptyState
+              icon={Car}
+              title="אין מודעות"
+              description={
+                searchQuery
+                  ? "לא נמצאו מודעות התואמות לחיפוש"
+                  : "עדיין לא נמצאו מודעות במערכת"
+              }
+              className="border-0 bg-transparent"
+            />
+          ) : (
+            <div className="space-y-1.5">
+              <AnimatePresence mode="popLayout">
+                {filtered.map((listing) => (
+                  <motion.div
+                    key={`${listing.token}-${listing.chat_id}`}
+                    layout
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, scale: 0.95 }}
+                    className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary group"
+                  >
+                    {listing.image_url ? (
+                      <img
+                        src={listing.image_url}
+                        alt=""
+                        className="h-12 w-16 rounded-lg object-cover bg-muted flex-shrink-0"
+                        referrerPolicy="no-referrer"
+                      />
+                    ) : (
+                      <div className="h-12 w-16 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">
+                        <Car className="h-5 w-5 text-muted-foreground/30" />
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium truncate">
+                        {listing.manufacturer} {listing.model} {listing.year}
+                      </p>
+                      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                        <span className="text-xs text-muted-foreground">
+                          {formatPrice(listing.price)}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          · {formatKm(listing.km)}
+                        </span>
+                        {listing.city && (
+                          <span className="text-xs text-muted-foreground">
+                            · {listing.city}
+                          </span>
+                        )}
+                        {listing.fitness_score != null && (
+                          <Badge
+                            variant={
+                              listing.fitness_score >= 0.7
+                                ? "success"
+                                : listing.fitness_score >= 0.4
+                                  ? "warning"
+                                  : "destructive"
+                            }
+                            className="text-[10px] px-1.5 py-0"
+                          >
+                            {(listing.fitness_score * 100).toFixed(0)}%
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        type="button"
+                        onClick={() => setDetailListing(listing)}
+                        className="flex h-8 w-8 items-center justify-center rounded-lg bg-card border border-border text-muted-foreground hover:text-foreground transition-colors"
+                        title="פרטים"
+                      >
+                        <Search className="h-3.5 w-3.5" />
+                      </button>
+                      {safeHref(listing.page_link) && (
+                        <a
+                          href={safeHref(listing.page_link)!}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex h-8 w-8 items-center justify-center rounded-lg bg-card border border-border text-muted-foreground hover:text-primary transition-colors"
+                          title="צפה במודעה"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDelete(listing)}
+                        className="flex h-8 w-8 items-center justify-center rounded-lg bg-destructive/10 border border-destructive/20 text-destructive hover:bg-destructive/20 transition-colors"
+                        title="מחק"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </div>
+          )}
+        </div>
 
+        {/* Pagination */}
         {totalPages > 1 && (
-          <div className="mt-4 flex items-center justify-center gap-3">
+          <div className="flex items-center justify-center gap-4 px-6 py-4 border-t border-border/50">
             <button
               type="button"
               onClick={() => setPage((p) => Math.max(0, p - 1))}
               disabled={page === 0}
-              aria-label="עמוד קודם"
-              className="rounded-lg border border-border p-2 transition-colors hover:bg-muted disabled:opacity-30"
+              className="flex h-9 w-9 items-center justify-center rounded-lg border border-border transition-colors hover:bg-muted disabled:opacity-30"
             >
               <ChevronRight className="h-4 w-4" />
             </button>
             <span className="text-sm tabular-nums text-muted-foreground">
-              {page + 1} / {totalPages}
+              עמוד {page + 1} מתוך {totalPages}
             </span>
             <button
               type="button"
-              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              onClick={() =>
+                setPage((p) => Math.min(totalPages - 1, p + 1))
+              }
               disabled={page >= totalPages - 1}
-              aria-label="עמוד הבא"
-              className="rounded-lg border border-border p-2 transition-colors hover:bg-muted disabled:opacity-30"
+              className="flex h-9 w-9 items-center justify-center rounded-lg border border-border transition-colors hover:bg-muted disabled:opacity-30"
             >
               <ChevronLeft className="h-4 w-4" />
             </button>
           </div>
         )}
       </div>
+
+      <AnimatePresence>
+        {confirmDelete && (
+          <ConfirmModal
+            message={`האם למחוק את "${confirmDelete.manufacturer} ${confirmDelete.model} ${confirmDelete.year}"?`}
+            onConfirm={() =>
+              deleteMutation.mutate({
+                token: confirmDelete.token,
+                chatId: confirmDelete.chat_id,
+              })
+            }
+            onCancel={() => setConfirmDelete(null)}
+            loading={deleteMutation.isPending}
+          />
+        )}
+        {detailListing && (
+          <DetailModal
+            title={`${detailListing.manufacturer} ${detailListing.model} ${detailListing.year}`}
+            fields={[
+              { label: "מחיר", value: formatPrice(detailListing.price) },
+              { label: "קילומטרז'", value: formatKm(detailListing.km) },
+              { label: "יד", value: detailListing.hand || null },
+              { label: "עיר", value: detailListing.city },
+              {
+                label: "ציון התאמה",
+                value: detailListing.fitness_score
+                  ? `${(detailListing.fitness_score * 100).toFixed(0)}%`
+                  : null,
+              },
+              {
+                label: "תאריך",
+                value: detailListing.first_seen_at
+                  ? relativeTime(detailListing.first_seen_at)
+                  : null,
+              },
+              { label: "חיפוש", value: detailListing.search_name },
+              { label: "Token", value: detailListing.token },
+              { label: "Chat ID", value: detailListing.chat_id },
+            ]}
+            onClose={() => setDetailListing(null)}
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }
 
-function AdminListingRow({
-  listing,
-  onDelete,
-  deleting,
-}: {
-  listing: AdminListing;
-  onDelete: (token: string, chatId: number) => void;
-  deleting: boolean;
-}) {
-  const [confirm, setConfirm] = useState(false);
+// ── Searches Tab ──────────────────────────────────────────────────────────────
+
+function SearchesTab() {
+  const [detailSearch, setDetailSearch] = useState<AdminSearch | null>(null);
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["admin", "searches"],
+    queryFn: adminApi.searches,
+  });
 
   return (
-    <div className="flex items-center gap-3 rounded-xl bg-secondary/50 px-4 py-3 transition-colors hover:bg-secondary">
-      {listing.image_url ? (
-        <img
-          src={listing.image_url}
-          alt=""
-          className="h-10 w-14 rounded-lg object-cover bg-muted flex-shrink-0"
-          referrerPolicy="no-referrer"
-        />
-      ) : (
-        <div className="h-10 w-14 rounded-lg bg-muted flex items-center justify-center flex-shrink-0 text-lg opacity-20">
-          🚗
-        </div>
-      )}
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium truncate">
-          {listing.manufacturer} {listing.model} {listing.year}
-        </p>
-        <p className="text-xs text-muted-foreground truncate">
-          {formatPrice(listing.price)} · {formatKm(listing.km)} · {listing.city}
-        </p>
-      </div>
-      <a
-        href={listing.page_link}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-xs text-primary hover:underline flex-shrink-0"
-      >
-        צפה
-      </a>
-      {!confirm ? (
+    <div className="space-y-4">
+      <div className="flex gap-3 justify-end">
         <button
           type="button"
-          onClick={() => setConfirm(true)}
-          disabled={deleting}
-          aria-label={`מחק מודעה ${listing.manufacturer} ${listing.model}`}
-          className="rounded p-1 text-muted-foreground/50 transition-colors hover:text-destructive flex-shrink-0 disabled:opacity-30"
+          onClick={() => void refetch()}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-secondary hover:bg-secondary/80 text-sm font-medium text-foreground transition-colors"
         >
-          <Trash2 className="h-3.5 w-3.5" />
+          <RefreshCw className="h-3.5 w-3.5" />
+          רענן
         </button>
-      ) : (
-        <div className="flex items-center gap-1.5 flex-shrink-0">
-          <button
-            type="button"
-            onClick={() => { onDelete(listing.token, listing.chat_id); setConfirm(false); }}
-            disabled={deleting}
-            className="rounded-md bg-destructive px-2 py-0.5 text-[11px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-          >
-            מחק
-          </button>
-          <button
-            type="button"
-            onClick={() => setConfirm(false)}
-            className="rounded-md border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
-          >
-            ביטול
-          </button>
+      </div>
+
+      <div className="rounded-2xl border border-border/50 bg-card overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
+          <h2 className="text-base font-semibold">כל החיפושים</h2>
+          {data && (
+            <span className="text-sm text-muted-foreground tabular-nums">
+              {data.total} סה״כ
+            </span>
+          )}
         </div>
-      )}
+
+        <div className="p-3">
+          {isLoading ? (
+            <div className="space-y-2 p-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 rounded-xl" />
+              ))}
+            </div>
+          ) : isError ? (
+            <EmptyState
+              icon={AlertCircle}
+              title="שגיאה בטעינת החיפושים"
+              className="border-0 bg-transparent"
+            />
+          ) : !data || data.items.length === 0 ? (
+            <EmptyState
+              icon={FileSearch}
+              title="אין חיפושים"
+              description="עדיין לא נוצרו חיפושים במערכת"
+              className="border-0 bg-transparent"
+            />
+          ) : (
+            <div className="space-y-1.5">
+              {data.items.map((search) => (
+                <motion.div
+                  key={search.id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary cursor-pointer group"
+                  onClick={() => setDetailSearch(search)}
+                >
+                  <div
+                    className={cn(
+                      "h-2.5 w-2.5 rounded-full flex-shrink-0",
+                      search.active
+                        ? "bg-success animate-pulse-soft"
+                        : "bg-muted-foreground/40",
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium truncate">
+                      {search.name || `חיפוש #${search.id}`}
+                    </p>
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                      <span className="text-xs text-muted-foreground">
+                        מקור: {search.source}
+                      </span>
+                      {search.price_max > 0 && (
+                        <span className="text-xs text-muted-foreground">
+                          · עד {formatPrice(search.price_max)}
+                        </span>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        · {relativeTime(search.created_at)}
+                      </span>
+                    </div>
+                  </div>
+                  <Badge variant={search.active ? "success" : "default"}>
+                    {search.active ? "פעיל" : "מושהה"}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
+                    #{search.chat_id}
+                  </span>
+                </motion.div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {detailSearch && (
+          <DetailModal
+            title={detailSearch.name || `חיפוש #${detailSearch.id}`}
+            fields={[
+              { label: "מזהה", value: detailSearch.id },
+              { label: "שם", value: detailSearch.name },
+              { label: "מקור", value: detailSearch.source },
+              { label: "יצרן", value: detailSearch.manufacturer || null },
+              { label: "דגם", value: detailSearch.model || null },
+              { label: "שנה מ", value: detailSearch.year_min || null },
+              { label: "שנה עד", value: detailSearch.year_max || null },
+              {
+                label: "מחיר מקס",
+                value: detailSearch.price_max
+                  ? formatPrice(detailSearch.price_max)
+                  : null,
+              },
+              {
+                label: "ק״מ מקס",
+                value: detailSearch.max_km
+                  ? detailSearch.max_km.toLocaleString("he-IL")
+                  : null,
+              },
+              { label: "יד מקס", value: detailSearch.max_hand || null },
+              {
+                label: "סטטוס",
+                value: detailSearch.active ? "פעיל" : "מושהה",
+              },
+              { label: "Chat ID", value: detailSearch.chat_id },
+              {
+                label: "נוצר",
+                value: relativeTime(detailSearch.created_at),
+              },
+            ]}
+            onClose={() => setDetailSearch(null)}
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }
+
+// ── Users Tab ─────────────────────────────────────────────────────────────────
+
+function UsersTab() {
+  const [detailUser, setDetailUser] = useState<AdminUser | null>(null);
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["admin", "users"],
+    queryFn: adminApi.users,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-secondary hover:bg-secondary/80 text-sm font-medium text-foreground transition-colors"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          רענן
+        </button>
+      </div>
+
+      <div className="rounded-2xl border border-border/50 bg-card overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
+          <h2 className="text-base font-semibold">כל המשתמשים</h2>
+          {data && (
+            <span className="text-sm text-muted-foreground tabular-nums">
+              {data.total} סה״כ
+            </span>
+          )}
+        </div>
+
+        <div className="p-3">
+          {isLoading ? (
+            <div className="space-y-2 p-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 rounded-xl" />
+              ))}
+            </div>
+          ) : isError ? (
+            <EmptyState
+              icon={AlertCircle}
+              title="שגיאה בטעינת המשתמשים"
+              className="border-0 bg-transparent"
+            />
+          ) : !data || data.items.length === 0 ? (
+            <EmptyState
+              icon={Users}
+              title="אין משתמשים"
+              description="עדיין לא נרשמו משתמשים למערכת"
+              className="border-0 bg-transparent"
+            />
+          ) : (
+            <div className="space-y-1.5">
+              {data.items.map((user) => (
+                <motion.div
+                  key={user.chat_id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="flex items-center gap-3 rounded-xl bg-secondary/40 px-4 py-3 transition-colors hover:bg-secondary cursor-pointer"
+                  onClick={() => setDetailUser(user)}
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary font-bold text-sm flex-shrink-0">
+                    {(user.username || user.channel || "?")[0].toUpperCase()}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium truncate">
+                      {user.username || `User #${user.chat_id}`}
+                    </p>
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                      {user.channel && (
+                        <span className="text-xs text-muted-foreground">
+                          {user.channel}
+                        </span>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        · {relativeTime(user.created_at)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {user.tier && user.tier !== "free" && (
+                      <Badge variant="success">{user.tier}</Badge>
+                    )}
+                    <Badge variant={user.active ? "success" : "default"}>
+                      {user.active ? "פעיל" : "לא פעיל"}
+                    </Badge>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {detailUser && (
+          <DetailModal
+            title={detailUser.username || `User #${detailUser.chat_id}`}
+            fields={[
+              { label: "Chat ID", value: detailUser.chat_id },
+              { label: "שם משתמש", value: detailUser.username },
+              { label: "ערוץ", value: detailUser.channel },
+              { label: "מזהה ערוץ", value: detailUser.channel_id },
+              { label: "שפה", value: detailUser.language },
+              { label: "דרגה", value: detailUser.tier },
+              {
+                label: "סטטוס",
+                value: detailUser.active ? "פעיל" : "לא פעיל",
+              },
+              { label: "נוצר", value: relativeTime(detailUser.created_at) },
+            ]}
+            onClose={() => setDetailUser(null)}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function StorageIndicator({ sizeBytes }: { sizeBytes: number }) {
   const mb = sizeBytes / (1024 * 1024);
@@ -481,25 +987,176 @@ function StorageIndicator({ sizeBytes }: { sizeBytes: number }) {
         : "bg-score-great";
 
   return (
-    <div className="flex items-center gap-2">
-      <span
-        className={`inline-block h-2.5 w-2.5 rounded-full ${color}`}
-        aria-hidden
-      />
-      <span className="text-xs text-muted-foreground tabular-nums" dir="ltr">
-        {mb.toFixed(1)} MB
-      </span>
+    <span
+      className={`inline-block h-2.5 w-2.5 rounded-full ${color}`}
+      aria-hidden
+    />
+  );
+}
+
+function RuntimeStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border/50 bg-secondary/50 p-4 transition-colors duration-200 hover:border-border">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-sm font-semibold font-mono tabular-nums">{value}</p>
     </div>
   );
 }
 
-function StatBox({ label, value }: { label: string; value: string }) {
+// ── Main Admin Page ───────────────────────────────────────────────────────────
+
+export function AdminPage() {
+  const { data, isLoading, isError, dataUpdatedAt, refetch } = useAdminStats();
+  const [activeTab, setActiveTab] = useState<TabKey>("overview");
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 pb-20 md:pb-4">
+        <AdminHeader />
+        <div className="grid gap-4 grid-cols-2 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-28 rounded-2xl" />
+          ))}
+        </div>
+        <Skeleton className="h-10 w-80 rounded-xl" />
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[1, 2].map((i) => (
+            <Skeleton key={i} className="h-52 rounded-2xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="space-y-6 pb-20 md:pb-4">
+        <AdminHeader />
+        <EmptyState
+          icon={AlertCircle}
+          title="שגיאה בטעינת הנתונים"
+          description="ייתכן שאין לך הרשאות מנהל. ודא שה-admin_email מוגדר בקובץ ההגדרות."
+        />
+      </div>
+    );
+  }
+
+  const listingsCount =
+    data.tables["listing_history"] ?? 0;
+  const searchesCount = data.tables["searches"] ?? 0;
+  const usersCount = data.tables["users"] ?? 0;
+
+  const lastUpdated = new Date(dataUpdatedAt);
+
   return (
-    <div className="rounded-xl border border-border/50 bg-secondary/50 p-3.5 text-center transition-colors duration-200 hover:border-border">
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <p className="text-sm font-semibold mt-1 font-mono tabular-nums">
-        {value}
-      </p>
+    <div className="space-y-6 pb-20 md:pb-4">
+      <AdminHeader
+        action={
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground tabular-nums">
+              עדכון: {lastUpdated.toLocaleTimeString("he-IL")}
+            </span>
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="flex h-8 w-8 items-center justify-center rounded-lg bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+              title="רענן נתונים"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        }
+      />
+
+      {/* Stat Cards */}
+      <div className="grid gap-4 grid-cols-2 md:grid-cols-4">
+        <StatCard
+          label="מודעות"
+          value={listingsCount.toLocaleString("he-IL")}
+          icon={Car}
+          color="bg-primary/10 text-primary"
+        />
+        <StatCard
+          label="חיפושים"
+          value={searchesCount.toLocaleString("he-IL")}
+          icon={FileSearch}
+          color="bg-chart-2/10 text-chart-2"
+        />
+        <StatCard
+          label="משתמשים"
+          value={usersCount.toLocaleString("he-IL")}
+          icon={Users}
+          color="bg-chart-4/10 text-chart-4"
+        />
+        <StatCard
+          label="אחסון"
+          value={data.db.file_size_human}
+          icon={Database}
+          color="bg-warning/10 text-warning"
+          subtitle={data.runtime.uptime + " פעיל"}
+        />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 rounded-xl bg-secondary/50 p-1 w-fit flex-wrap">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setActiveTab(t.key)}
+            className={cn(
+              "flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all",
+              activeTab === t.key
+                ? "bg-card text-foreground shadow-sm border border-border"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <t.icon className="h-4 w-4" />
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {activeTab === "overview" && (
+            <OverviewTab data={data} onRefresh={() => void refetch()} />
+          )}
+          {activeTab === "listings" && <ListingsTab />}
+          {activeTab === "searches" && <SearchesTab />}
+          {activeTab === "users" && <UsersTab />}
+        </motion.div>
+      </AnimatePresence>
     </div>
+  );
+}
+
+function AdminHeader({ action }: { action?: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="flex items-center justify-between border-b border-border/50 pb-6"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-destructive/10">
+          <Shield className="h-5 w-5 text-destructive" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">ניהול מערכת</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            גישת מנהל · צפה וערוך את כל הנתונים
+          </p>
+        </div>
+      </div>
+      {action}
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary

- **Redesigned admin dashboard** with a modern, polished UI inspired by base44-style design patterns
- **Added 2 new admin API endpoints**: `GET /admin/searches` (list all searches across users) and `GET /admin/users` (list all users) -- previously the admin could only see stats and listings
- **4-tab layout** expanded to **5 tabs**: Overview, Listings, Searches, Users, and **Logs**
- **Real-time log streaming**: fetcher/scheduler logs from yad2, winwin, scheduler, and enricher are visible in the admin panel via SSE, and piped to browser `console.log` for dev-tools debugging
- **Visual improvements**: animated stat cards grid, storage bar visualization, animated modals for confirm/detail, smooth tab transitions via `motion`, fitness score badges, hover-reveal action buttons on listing rows

## Changes

### Backend (Go)
- `internal/logstream/` (new package): ring buffer (500 entries), broadcast hub with pub/sub, and `TeeHandler` that wraps slog to capture fetcher/scheduler logs
- `cmd/bot/main.go`: Wire `TeeHandler` into the logger pipeline, pass hub to API server
- `internal/api/admin.go`: New handlers `adminLogs` (REST) and `adminLogStream` (SSE), plus existing `adminListSearches` and `adminListUsers`
- `internal/api/api.go`: Register new routes, add `LogHub` to config, support `?token=` query param for SSE auth (EventSource can't set headers)
- `internal/storage/interfaces.go`: Added `AdminListSearches` and `AdminListUsers` to `AdminStore` interface
- `internal/storage/sqlite/admin.go` + `postgres/admin.go`: Implemented new admin store methods

### Frontend (React/TypeScript)
- `web/src/hooks/useLogStream.ts` (new): SSE hook that loads recent logs, streams new ones, and pipes to `console.log` with color-coded levels
- `web/src/lib/api.ts`: Added `LogEntry`, `AdminSearch`, `AdminUser` types and API client methods
- `web/src/pages/AdminPage.tsx`: Complete redesign with 5 tabs including live logs panel with component/level filters, auto-scroll, expandable attrs, and connection indicator

### Tests
- 17 tests in `internal/logstream/`: buffer (empty, write, wrap, concurrent), hub (pub/sub, unsubscribe, multi-subscriber, slow subscriber drops), handler (filtering, forwarding, attrs, levels, live subscription)
- All test packages pass

## Test plan
- [ ] Verify admin page loads with overview stats
- [ ] Switch between all 5 tabs (Overview, Listings, Searches, Users, Logs)
- [ ] Open Logs tab and verify SSE connection indicator turns green
- [ ] Trigger a poll and watch logs appear in real-time
- [ ] Toggle component and level filters
- [ ] Expand a log entry to see attributes
- [ ] Open browser dev tools and verify `console.log` output with color-coded levels
- [ ] Test auto-scroll toggle and clear button
- [ ] Test search/filter on listings tab
- [ ] Test purge + vacuum on overview tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin API: list searches, list users, view recent logs, and real-time log streaming (SSE).

* **UI Improvements**
  * Redesigned Admin page: multi-tab layout (overview, listings, searches, users, logs), storage indicator, vacuum & purge controls, animated tables, client-side filtering, shared detail/confirm modals, manual refreshes, and an interactive real-time logs panel (filters, auto-scroll, clear, expandable lines).

* **Tests**
  * Added coverage for admin endpoints, storage admin queries, log buffer/hub, and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->