### PR TITLE
feat: add runtime log level control and improve log UX

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -68,8 +68,10 @@ func run(configPath string, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("parse log_level %q: %w", cfg.LogLevel, err)
 	}
-	logHub := logstream.NewHub(500)
-	baseHandler := newLogHandler(cfg.LogFormat, logLevel)
+	var logLevelVar slog.LevelVar
+	logLevelVar.Set(logLevel)
+	logHub := logstream.NewHub(2000)
+	baseHandler := newLogHandler(cfg.LogFormat, &logLevelVar)
 	teeHandler := logstream.NewTeeHandler(baseHandler, logHub, "yad2", "winwin", "scheduler", "enricher")
 	logger = slog.New(teeHandler)
 	slog.SetDefault(logger)
@@ -109,7 +111,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = multi.Disconnect() }()
 
-	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, logger)
+	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, &logLevelVar, logger)
 	if err != nil {
 		return err
 	}
@@ -242,7 +244,7 @@ func buildBot(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 	return botHandler, tgNotif, multi, nil
 }
 
-func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logger *slog.Logger) (*api.Server, error) {
+func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger) (*api.Server, error) {
 	var firebaseAuth api.TokenVerifier
 	if cfg.Firebase.ProjectID != "" {
 		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)
@@ -269,6 +271,7 @@ func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 		FirebaseAuth: firebaseAuth,
 		BotUsername:  cfg.Telegram.BotUsername,
 		LogHub:       logHub,
+		LogLevel:     logLevel,
 	})
 
 	return apiServer, nil
@@ -295,7 +298,7 @@ func buildHTTPServer(cfg *config.Config, h *health.Status, apiServer *api.Server
 	return srv
 }
 
-func newLogHandler(format string, level slog.Level) slog.Handler {
+func newLogHandler(format string, level slog.Leveler) slog.Handler {
 	fd := os.Stdout.Fd()
 	usePretty := format == "pretty" ||
 		(format == "auto" && (isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)))

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"runtime"
 	"strings"
@@ -329,9 +330,9 @@ func (s *Server) adminVacuum(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) adminLogs(w http.ResponseWriter, r *http.Request) {
-	n := parseIntParam(r, "limit", 200)
-	if n > 500 {
-		n = 500
+	n := parseIntParam(r, "limit", 500)
+	if n > 2000 {
+		n = 2000
 	}
 
 	entries := s.logHub.Recent(n)
@@ -378,4 +379,34 @@ func (s *Server) adminLogStream(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+var validLogLevels = map[string]slog.Level{
+	"DEBUG": slog.LevelDebug,
+	"INFO":  slog.LevelInfo,
+	"WARN":  slog.LevelWarn,
+	"ERROR": slog.LevelError,
+}
+
+func (s *Server) adminGetLogLevel(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"level": s.logLevel.Level().String()})
+}
+
+func (s *Server) adminSetLogLevel(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Level string `json:"level"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	body.Level = strings.ToUpper(strings.TrimSpace(body.Level))
+	lvl, ok := validLogLevels[body.Level]
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid level; must be DEBUG, INFO, WARN, or ERROR")
+		return
+	}
+	s.logLevel.Set(lvl)
+	s.logger.Info("log level changed", "level", body.Level)
+	writeJSON(w, http.StatusOK, map[string]string{"level": s.logLevel.Level().String()})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -43,6 +43,7 @@ type Server struct {
 	hidden    storage.HiddenListingStore
 	notifs    storage.NotificationStore
 	logHub    *logstream.Hub
+	logLevel  *slog.LevelVar
 	poller    PollTrigger
 	logger    *slog.Logger
 	cfg       config.APIConfig
@@ -74,6 +75,7 @@ type Config struct {
 	Hidden       storage.HiddenListingStore
 	Notifs       storage.NotificationStore
 	LogHub       *logstream.Hub
+	LogLevel     *slog.LevelVar
 	Logger       *slog.Logger
 	API          config.APIConfig
 	FirebaseAuth TokenVerifier
@@ -94,6 +96,7 @@ func New(c Config) *Server {
 		hidden:    c.Hidden,
 		notifs:    c.Notifs,
 		logHub:    c.LogHub,
+		logLevel:  c.LogLevel,
 		logger:    c.Logger,
 		cfg:       c.API,
 		botUsername: c.BotUsername,
@@ -132,6 +135,10 @@ func (s *Server) Routes() http.Handler {
 		if s.logHub != nil {
 			mux.HandleFunc("GET /api/v1/admin/logs", s.requireAdmin(s.adminLogs))
 			mux.HandleFunc("GET /api/v1/admin/logs/stream", s.requireAdmin(s.adminLogStream))
+		}
+		if s.logLevel != nil {
+			mux.HandleFunc("GET /api/v1/admin/logs/level", s.requireAdmin(s.adminGetLogLevel))
+			mux.HandleFunc("PUT /api/v1/admin/logs/level", s.requireAdmin(s.adminSetLogLevel))
 		}
 	}
 

--- a/internal/fetcher/winwin/winwin.go
+++ b/internal/fetcher/winwin/winwin.go
@@ -64,11 +64,19 @@ func (f *WinWinFetcher) Fetch(ctx context.Context, params model.SourceParams) ([
 		cli = c
 	}
 	reqURL := buildURL(f.baseURL, params)
-	f.logger.Info("fetching winwin listings", "url", reqURL)
+	f.logger.Info("fetching winwin listings",
+		"url", reqURL,
+		"manufacturer", params.Manufacturer,
+		"model", params.Model,
+	)
 	result, err := cli.Get(ctx, reqURL)
 	if err != nil {
 		return nil, fmt.Errorf("execute request: %w", err)
 	}
+	f.logger.Debug("winwin response received",
+		"status", result.StatusCode,
+		"body_bytes", len(result.Body),
+	)
 	switch result.StatusCode {
 	case http.StatusOK:
 	case http.StatusTooManyRequests:
@@ -84,5 +92,15 @@ func (f *WinWinFetcher) Fetch(ctx context.Context, params model.SourceParams) ([
 		return nil, fmt.Errorf("parse page: %w", err)
 	}
 	f.logger.Info("fetched winwin listings", "count", len(listings))
+	for i, l := range listings {
+		f.logger.Debug("winwin listing parsed",
+			"idx", i,
+			"token", l.Token,
+			"manufacturer", l.Manufacturer,
+			"model", l.Model,
+			"year", l.Year,
+			"price", l.Price,
+		)
+	}
 	return listings, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -674,6 +674,11 @@ func (s *Scheduler) runFetchGroups(ctx context.Context, groups []CanonicalGroup,
 
 func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, marketCache *scoring.MarketCache) (cycleStats, error) {
 	groupStart := time.Now()
+	s.logger.Debug("group starting",
+		"manufacturer", group.Manufacturer,
+		"model", group.Model,
+		"searches", len(group.Searches),
+	)
 	raw, source, err := s.fetchAndEnrich(ctx, group)
 	if err != nil {
 		return cycleStats{}, err
@@ -684,6 +689,12 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 
 	for _, search := range group.Searches {
 		filtered := filter.Apply(buildFilterCriteria(search), raw)
+		s.logger.Debug("search filter applied",
+			"search_id", search.ID,
+			"chat_id", search.ChatID,
+			"total_raw", len(raw),
+			"after_filter", len(filtered),
+		)
 		lang := s.userLang(ctx, search.ChatID)
 		sr := s.processSearchListings(ctx, search, filtered, marketCache, lang)
 		persistOK := true

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { getAuthToken } from "@/lib/auth-token";
 import { adminApi, type LogEntry } from "@/lib/api";
 
-const MAX_ENTRIES = 500;
+const MAX_ENTRIES = 2000;
 const STYLE_BY_LEVEL: Record<string, string> = {
   DEBUG: "color: #8b8b8b",
   INFO: "color: #3b82f6",
@@ -30,7 +30,7 @@ export function useLogStream(enabled: boolean) {
     async function connect() {
       // Load recent logs first
       try {
-        const { items } = await adminApi.logs(200);
+        const { items } = await adminApi.logs(500);
         if (!cancelled) {
           setLogs(items);
         }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -304,6 +304,12 @@ export const adminApi = {
     fetchAPI<AdminLogsResponse>(
       `/admin/logs${limit ? `?limit=${limit}` : ""}`,
     ),
+  getLogLevel: () => fetchAPI<{ level: string }>("/admin/logs/level"),
+  setLogLevel: (level: string) =>
+    fetchAPI<{ level: string }>("/admin/logs/level", {
+      method: "PUT",
+      body: JSON.stringify({ level }),
+    }),
   listings: (params?: ListingsParams) => {
     const query = new URLSearchParams();
     if (params?.limit !== undefined) query.set("limit", String(params.limit));

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1029,6 +1029,21 @@ function LogsTab({ active }: { active: boolean }) {
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const [backendLevel, setBackendLevel] = useState("INFO");
+
+  useEffect(() => {
+    if (!active) return;
+    adminApi.getLogLevel().then((r) => setBackendLevel(r.level)).catch(() => {});
+  }, [active]);
+
+  async function changeBackendLevel(level: string) {
+    try {
+      const { level: newLevel } = await adminApi.setLogLevel(level);
+      setBackendLevel(newLevel);
+    } catch {
+      // non-critical
+    }
+  }
 
   const filtered = logs.filter(
     (e) => componentFilter.has(e.component) && levelFilter.has(e.level),
@@ -1131,6 +1146,33 @@ function LogsTab({ active }: { active: boolean }) {
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Backend log level selector */}
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] text-muted-foreground">רמה:</span>
+            <div className="flex gap-0.5 rounded-lg bg-secondary/50 p-0.5">
+              {ALL_LEVELS.map((l) => {
+                const style = LEVEL_STYLES[l];
+                return (
+                  <button
+                    key={l}
+                    type="button"
+                    onClick={() => changeBackendLevel(l)}
+                    className={cn(
+                      "px-2 py-1 rounded-md text-[11px] font-medium transition-all",
+                      backendLevel === l
+                        ? `${style.bg} ${style.text} ring-1 ring-current/20`
+                        : "text-muted-foreground/40 hover:text-muted-foreground/70",
+                    )}
+                  >
+                    {style.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="h-4 w-px bg-border/50" />
+
           <button
             type="button"
             onClick={() => setAutoScroll((p) => !p)}
@@ -1166,7 +1208,7 @@ function LogsTab({ active }: { active: boolean }) {
           </span>
         </div>
 
-        <div className="max-h-[60vh] overflow-y-auto p-2 font-mono text-xs">
+        <div dir="ltr" className="max-h-[60vh] overflow-y-auto p-2 font-mono text-xs">
           {filtered.length === 0 ? (
             <EmptyState
               icon={ScrollText}
@@ -1250,7 +1292,7 @@ function LogLine({
         )}
       </div>
       {expanded && hasAttrs && (
-        <div className="mt-2 mr-[132px] space-y-0.5 border-r border-border/50 pr-3">
+        <div className="mt-2 ml-[132px] space-y-0.5 border-l border-border/50 pl-3">
           {Object.entries(entry.attrs!).map(([k, v]) => (
             <div key={k} className="flex gap-2">
               <span className="text-muted-foreground/60">{k}:</span>


### PR DESCRIPTION
## Summary

- **Runtime log level control**: New `GET/PUT /api/v1/admin/logs/level` admin endpoints backed by `slog.LevelVar`, allowing the backend log level to be changed at runtime without restart. The admin logs toolbar now includes a level selector (DBG/INF/WRN/ERR) — switch to DEBUG to see detailed fetcher payloads, or raise to WARN/ERROR to reduce noise.
- **LTR log layout**: Fixed RTL direction issue where log lines read right-to-left. Log entries now use `dir="ltr"` so columns read naturally: timestamp → level → component → message.
- **Larger log buffer**: Ring buffer increased from 500 → 2000 entries, default REST fetch from 200 → 500, frontend buffer from 500 → 2000.
- **More debug logs**: Added debug-level logs to the WinWin fetcher (response metadata, individual parsed listings) and scheduler `processGroup` (group start, per-search filter results).

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/logstream/... ./internal/api/...` passes
- [x] `npx tsc --noEmit` passes
- [ ] Verify log entries render left-to-right in the admin panel
- [ ] Verify log level selector updates backend level (switch to DEBUG, confirm debug logs appear in stream)
- [ ] Verify expanded attributes panel renders correctly with LTR direction


Made with [Cursor](https://cursor.com)