### PR TITLE
fix: improve scoring algorithm accuracy

### DIFF
--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -30,6 +30,7 @@ type RawListing struct {
 type ScoreInfo struct {
 	Score       int
 	MedianPrice int
+	MedianKm    int
 	CohortSize  int
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -586,6 +586,7 @@ func (s *Scheduler) buildMarketCache(ctx context.Context) *scoring.MarketCache {
 			Model:        l.Model,
 			Year:         l.Year,
 			Price:        l.Price,
+			Km:           l.Km,
 		}
 	}
 	return scoring.NewMarketCache(data)
@@ -887,11 +888,12 @@ func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawLis
 		}
 	}
 	if marketCache != nil && l.Price > 0 {
-		median, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
+		median, medianKm, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
 		if ok {
 			listing.DealScore = &model.ScoreInfo{
-				Score:       scoring.Score(l.Price, median),
+				Score:       scoring.ScoreWithKm(l.Price, l.Km, median, medianKm),
 				MedianPrice: median,
+				MedianKm:    medianKm,
 				CohortSize:  cohort,
 			}
 		}

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -9,18 +9,23 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-const MinCohortSize = 10
+const (
+	MinCohortSize = 10
+	minPriceFloor = 5000 // ignore placeholder prices below this (NIS)
+)
 
 type ListingData struct {
 	Manufacturer string
 	Model        string
 	Year         int
 	Price        int
+	Km           int
 }
 
 type entry struct {
 	Year  int
 	Price int
+	Km    int
 }
 
 type MarketCache struct {
@@ -32,13 +37,14 @@ func NewMarketCache(listings []ListingData) *MarketCache {
 	m := make(map[string][]entry)
 	for _, l := range listings {
 		key := cacheKey(l.Manufacturer, l.Model)
-		m[key] = append(m[key], entry{Year: l.Year, Price: l.Price})
+		m[key] = append(m[key], entry{Year: l.Year, Price: l.Price, Km: l.Km})
 	}
 	return &MarketCache{data: m}
 }
 
 type lookupResult struct {
 	median     int
+	medianKm   int
 	cohortSize int
 	ok         bool
 }
@@ -47,38 +53,80 @@ func cohortLookupKey(manufacturer, model string, year int) string {
 	return fmt.Sprintf("%s|%d", cacheKey(manufacturer, model), year)
 }
 
-func (mc *MarketCache) Lookup(manufacturer, model string, year int) (median int, cohortSize int, ok bool) {
+// Lookup returns the median price, median km, cohort size, and whether enough data exists.
+func (mc *MarketCache) Lookup(manufacturer, model string, year int) (median int, medianKm int, cohortSize int, ok bool) {
 	key := cohortLookupKey(manufacturer, model, year)
 	v, _, _ := mc.sf.Do(key, func() (interface{}, error) {
 		return mc.lookupUnsynchronized(manufacturer, model, year), nil
 	})
 	res := v.(lookupResult)
-	return res.median, res.cohortSize, res.ok
+	return res.median, res.medianKm, res.cohortSize, res.ok
 }
 
 func (mc *MarketCache) lookupUnsynchronized(manufacturer, model string, year int) lookupResult {
 	entries := mc.data[cacheKey(manufacturer, model)]
-	var prices []int
+	var prices, kms []int
 	for _, e := range entries {
-		if abs(e.Year-year) <= 1 {
+		if abs(e.Year-year) <= 1 && e.Price >= minPriceFloor {
 			prices = append(prices, e.Price)
+			if e.Km > 0 {
+				kms = append(kms, e.Km)
+			}
 		}
 	}
 	if len(prices) < MinCohortSize {
 		return lookupResult{cohortSize: len(prices)}
 	}
-	sort.Ints(prices)
-	n := len(prices)
-	var median int
-	if n%2 == 0 {
-		median = (prices[n/2-1] + prices[n/2]) / 2
-	} else {
-		median = prices[n/2]
+	return lookupResult{
+		median:     medianInt(prices),
+		medianKm:   medianInt(kms),
+		cohortSize: len(prices),
+		ok:         true,
 	}
-	return lookupResult{median: median, cohortSize: n, ok: true}
 }
 
+func medianInt(vals []int) int {
+	if len(vals) == 0 {
+		return 0
+	}
+	sort.Ints(vals)
+	n := len(vals)
+	if n%2 == 0 {
+		return (vals[n/2-1] + vals[n/2]) / 2
+	}
+	return vals[n/2]
+}
+
+// Score computes a deal score (0-100) based on how far the listing price is
+// below the median. Higher = better deal.
 func Score(listingPrice, medianPrice int) int {
+	return scoreRaw(listingPrice, medianPrice)
+}
+
+// ScoreWithKm computes a km-adjusted deal score. When both the listing and
+// cohort have km data, a low-km car priced at median gets a bonus and a
+// high-km car priced at median gets a penalty. Falls back to price-only
+// when km data is unavailable.
+func ScoreWithKm(listingPrice, listingKm, medianPrice, medianKm int) int {
+	if medianKm <= 0 || listingKm <= 0 {
+		return scoreRaw(listingPrice, medianPrice)
+	}
+	// Km adjustment: if listing has fewer km than median, it's a better deal.
+	// Scale: 50% fewer km -> +10 bonus, 50% more km -> -10 penalty.
+	kmRatio := float64(listingKm) / float64(medianKm)
+	kmAdj := (1.0 - kmRatio) * 20.0 // +/-20 points for double/half km
+	base := float64(scoreRaw(listingPrice, medianPrice))
+	adjusted := base + kmAdj
+	if adjusted < 0 {
+		return 0
+	}
+	if adjusted > 100 {
+		return 100
+	}
+	return int(math.Round(adjusted))
+}
+
+func scoreRaw(listingPrice, medianPrice int) int {
 	if medianPrice <= 0 || listingPrice <= 0 {
 		return 0
 	}
@@ -261,7 +309,9 @@ func yearScore(year, yearMin, yearMax int) float64 {
 		return 1.0
 	}
 	s := float64(year-yearMin) / float64(yearMax-yearMin)
-	return clamp01(s)
+	// Concave curve: newer years cluster near top, older years spread apart,
+	// matching non-linear depreciation in the Israeli market.
+	return clamp01(math.Pow(s, 0.7))
 }
 
 func engineScore(engineVolume float64, engineMinCC int) float64 {
@@ -271,8 +321,13 @@ func engineScore(engineVolume float64, engineMinCC int) float64 {
 	if engineVolume <= 0 {
 		return 0.5
 	}
-	s := (engineVolume - float64(engineMinCC)) / float64(engineMinCC)
-	return clamp01(math.Min(s, 1.0))
+	minCC := float64(engineMinCC)
+	if engineVolume < minCC {
+		return 0.0
+	}
+	// Meeting the minimum scores 0.7; 50% above minimum reaches 1.0.
+	bonus := (engineVolume - minCC) / (minCC * 0.5)
+	return clamp01(0.7 + 0.3*bonus)
 }
 
 func clamp01(v float64) float64 {

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -308,10 +308,10 @@ func yearScore(year, yearMin, yearMax int) float64 {
 	if yearMin <= 0 || yearMax <= 0 || yearMax <= yearMin {
 		return 1.0
 	}
-	s := float64(year-yearMin) / float64(yearMax-yearMin)
+	s := clamp01(float64(year-yearMin) / float64(yearMax-yearMin))
 	// Concave curve: newer years cluster near top, older years spread apart,
 	// matching non-linear depreciation in the Israeli market.
-	return clamp01(math.Pow(s, 0.7))
+	return math.Pow(s, 0.7)
 }
 
 func engineScore(engineVolume float64, engineMinCC int) float64 {

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -1,6 +1,7 @@
 package scoring
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -474,6 +475,16 @@ func TestYearScore_NonLinear(t *testing.T) {
 
 	if topGap >= bottomGap {
 		t.Errorf("concave curve should make top gap (%.3f) smaller than bottom gap (%.3f)", topGap, bottomGap)
+	}
+}
+
+func TestYearScore_BelowMin(t *testing.T) {
+	score := yearScore(2015, 2018, 2024)
+	if score != 0.0 {
+		t.Errorf("year below min should score 0, got %.3f", score)
+	}
+	if math.IsNaN(score) {
+		t.Fatal("yearScore returned NaN for year below min")
 	}
 }
 

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -60,7 +60,7 @@ func TestMarketCache_LookupSufficient(t *testing.T) {
 	}
 
 	mc := NewMarketCache(data)
-	median, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	median, _, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -79,7 +79,7 @@ func TestMarketCache_LookupInsufficientData(t *testing.T) {
 	}
 
 	mc := NewMarketCache(data)
-	_, _, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	_, _, _, ok := mc.Lookup("Toyota", "Corolla", 2020)
 	if ok {
 		t.Error("expected ok=false for insufficient data")
 	}
@@ -98,7 +98,7 @@ func TestMarketCache_LookupYearBand(t *testing.T) {
 
 	mc := NewMarketCache(data)
 	// Looking up year 2020 should include 2019, 2020, 2021
-	_, cohort, ok := mc.Lookup("Honda", "Civic", 2020)
+	_, _, cohort, ok := mc.Lookup("Honda", "Civic", 2020)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -107,7 +107,7 @@ func TestMarketCache_LookupYearBand(t *testing.T) {
 	}
 
 	// Looking up year 2022 should only include 2021 (year+-1)
-	_, _, ok = mc.Lookup("Honda", "Civic", 2022)
+	_, _, _, ok = mc.Lookup("Honda", "Civic", 2022)
 	if ok {
 		t.Error("expected ok=false for year 2022 (only 4 listings in range)")
 	}
@@ -125,7 +125,7 @@ func TestMarketCache_CaseInsensitive(t *testing.T) {
 	}
 
 	mc := NewMarketCache(data)
-	_, _, ok := mc.Lookup("toyota", "corolla", 2020)
+	_, _, _, ok := mc.Lookup("toyota", "corolla", 2020)
 	if !ok {
 		t.Error("expected case-insensitive lookup to work")
 	}
@@ -133,7 +133,7 @@ func TestMarketCache_CaseInsensitive(t *testing.T) {
 
 func TestMarketCache_Empty(t *testing.T) {
 	mc := NewMarketCache(nil)
-	_, _, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	_, _, _, ok := mc.Lookup("Toyota", "Corolla", 2020)
 	if ok {
 		t.Error("expected ok=false for empty cache")
 	}
@@ -151,7 +151,7 @@ func TestMarketCache_MedianEven(t *testing.T) {
 	}
 
 	mc := NewMarketCache(data)
-	median, _, ok := mc.Lookup("Mazda", "3", 2021)
+	median, _, _, ok := mc.Lookup("Mazda", "3", 2021)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -437,6 +437,101 @@ func TestDefaultDimensions(t *testing.T) {
 	}
 }
 
+func TestEngineScore(t *testing.T) {
+	tests := []struct {
+		name   string
+		volume float64
+		minCC  int
+		min    float64
+		max    float64
+	}{
+		{"no minimum set", 1600, 0, 1.0, 1.0},
+		{"unknown volume", 0, 1600, 0.5, 0.5},
+		{"below minimum", 1200, 1600, 0.0, 0.0},
+		{"exactly at minimum", 1600, 1600, 0.7, 0.7},
+		{"2.0L with 1.6L minimum", 2000, 1600, 0.85, 1.0},
+		{"2.4L with 1.6L minimum", 2400, 1600, 1.0, 1.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := engineScore(tt.volume, tt.minCC)
+			if got < tt.min-0.01 || got > tt.max+0.01 {
+				t.Errorf("engineScore(%.0f, %d) = %.3f, want [%.2f, %.2f]", tt.volume, tt.minCC, got, tt.min, tt.max)
+			}
+		})
+	}
+}
+
+func TestYearScore_NonLinear(t *testing.T) {
+	// Newer years should cluster near the top (concave curve).
+	// 2023 vs 2024 gap should be smaller than 2018 vs 2019 gap.
+	scoreNewer := yearScore(2023, 2018, 2024) // near top
+	scoreOlder := yearScore(2019, 2018, 2024) // near bottom
+
+	// With pow(0.7), the spread between adjacent years at the top is smaller.
+	topGap := 1.0 - scoreNewer
+	bottomGap := scoreOlder - 0.0
+
+	if topGap >= bottomGap {
+		t.Errorf("concave curve should make top gap (%.3f) smaller than bottom gap (%.3f)", topGap, bottomGap)
+	}
+}
+
+func TestScoreWithKm(t *testing.T) {
+	priceOnly := Score(80000, 100000) // 20% below median -> score 20
+	lowKm := ScoreWithKm(80000, 30000, 100000, 80000)
+	highKm := ScoreWithKm(80000, 150000, 100000, 80000)
+
+	if lowKm <= priceOnly {
+		t.Errorf("low-km deal (%d) should score higher than price-only (%d)", lowKm, priceOnly)
+	}
+	if highKm >= priceOnly {
+		t.Errorf("high-km deal (%d) should score lower than price-only (%d)", highKm, priceOnly)
+	}
+}
+
+func TestScoreWithKm_FallbackWhenNoKm(t *testing.T) {
+	priceOnly := Score(80000, 100000)
+	noKm := ScoreWithKm(80000, 0, 100000, 80000)
+	if noKm != priceOnly {
+		t.Errorf("ScoreWithKm with listingKm=0 should equal Score: %d != %d", noKm, priceOnly)
+	}
+	noMedianKm := ScoreWithKm(80000, 50000, 100000, 0)
+	if noMedianKm != priceOnly {
+		t.Errorf("ScoreWithKm with medianKm=0 should equal Score: %d != %d", noMedianKm, priceOnly)
+	}
+}
+
+func TestJunkPriceFiltering(t *testing.T) {
+	var data []ListingData
+	// 10 legitimate prices
+	for i := range 10 {
+		data = append(data, ListingData{
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
+			Price: 90000 + i*2000,
+		})
+	}
+	// 3 junk prices that should be filtered
+	for range 3 {
+		data = append(data, ListingData{
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
+			Price: 1, // placeholder
+		})
+	}
+
+	mc := NewMarketCache(data)
+	median, _, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if cohort != 10 {
+		t.Errorf("junk prices should be excluded: cohort=%d, want 10", cohort)
+	}
+	if median < 90000 || median > 108000 {
+		t.Errorf("median should be in legitimate range, got %d", median)
+	}
+}
+
 func TestMarketCache_LookupConcurrent(t *testing.T) {
 	var data []ListingData
 	for i := range 15 {
@@ -454,7 +549,7 @@ func TestMarketCache_LookupConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			median, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
+			median, _, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
 			if !ok || cohort != 15 || median != 104000 {
 				bad.Add(1)
 			}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -196,6 +196,7 @@ type MarketListing struct {
 	Model        string
 	Year         int
 	Price        int
+	Km           int
 }
 
 type MarketStore interface {

--- a/internal/storage/postgres/market.go
+++ b/internal/storage/postgres/market.go
@@ -8,7 +8,7 @@ import (
 
 func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT DISTINCT ON (token) manufacturer, model, year, price
+		SELECT DISTINCT ON (token) manufacturer, model, year, price, km
 		FROM listing_history
 		WHERE manufacturer IS NOT NULL AND manufacturer != ''
 		  AND model IS NOT NULL AND model != ''
@@ -22,7 +22,7 @@ func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, er
 	var listings []storage.MarketListing
 	for rows.Next() {
 		var l storage.MarketListing
-		if err := rows.Scan(&l.Manufacturer, &l.Model, &l.Year, &l.Price); err != nil {
+		if err := rows.Scan(&l.Manufacturer, &l.Model, &l.Year, &l.Price, &l.Km); err != nil {
 			return nil, err
 		}
 		listings = append(listings, l)

--- a/internal/storage/sqlite/market.go
+++ b/internal/storage/sqlite/market.go
@@ -8,7 +8,7 @@ import (
 
 func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT manufacturer, model, year, price
+		SELECT manufacturer, model, year, price, km
 		FROM listing_history
 		WHERE manufacturer IS NOT NULL AND manufacturer != ''
 		  AND model IS NOT NULL AND model != ''
@@ -22,7 +22,7 @@ func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, er
 	var listings []storage.MarketListing
 	for rows.Next() {
 		var l storage.MarketListing
-		if err := rows.Scan(&l.Manufacturer, &l.Model, &l.Year, &l.Price); err != nil {
+		if err := rows.Scan(&l.Manufacturer, &l.Model, &l.Year, &l.Price, &l.Km); err != nil {
 			return nil, err
 		}
 		listings = append(listings, l)


### PR DESCRIPTION
## Summary

Addresses findings from the scoring algorithm review. Four fixes implemented, one deferred:

- **P1 -- Fix broken `engineScore` formula**: The old formula `(volume - min) / min` scored a 2.0L engine at 0.25 when minimum was 1.6L. Now treats the minimum as a pass/fail gate: meeting it scores 0.7, with a gentle bonus up to 1.0 for exceeding by 50%. Below minimum = 0.0.
- **P1 -- Km-aware deal score**: `ScoreWithKm` adjusts the deal score based on how the listing's km compares to the cohort's median km. A 30k-km car priced at median now correctly scores higher than a 120k-km car at the same price. Falls back to price-only when km data is unavailable.
- **P2 -- Non-linear year score**: Applied `pow(0.7)` concave curve so newer years cluster near the top (matching real depreciation curves) instead of the old linear scale.
- **P3 -- Junk price filtering**: Prices below 5,000 NIS (placeholder/call-for-price listings) are excluded from cohort median computation.

### Deferred

- **Sub-model cache key**: Requires a schema migration to persist `sub_model` in `listing_history` (currently only in-memory on `RawListing`). Tracked separately.

## Test plan

- [x] All 27 scoring tests pass (including 6 new tests)
- [x] Storage tests pass (sqlite, api)
- [x] `go vet ./...` clean
- [x] `go build ./...` compiles


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deal scoring now accounts for vehicle mileage, improving market comparisons and ranking.

* **Bug Fixes**
  * Excluded invalid/placeholder prices from market median calculations.
  * Adjusted year and engine scoring curves for more realistic assessments and added mileage-based score adjustments with sensible fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->