### PR TITLE
feat: add JSON export button to admin logs tab

### DIFF
--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1199,8 +1199,10 @@ function LogsTab({ active }: { active: boolean }) {
               const a = document.createElement("a");
               a.href = url;
               a.download = `carwatch-logs-${new Date().toISOString().slice(0, 19).replace(/:/g, "-")}.json`;
+              document.body.appendChild(a);
               a.click();
-              URL.revokeObjectURL(url);
+              a.remove();
+              setTimeout(() => URL.revokeObjectURL(url), 0);
             }}
             disabled={filtered.length === 0}
             className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-secondary hover:bg-secondary/80 text-xs font-medium text-foreground transition-colors disabled:opacity-40 disabled:pointer-events-none"

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   Cpu,
   Database,
+  Download,
   ExternalLink,
   FileSearch,
   HardDrive,
@@ -1189,6 +1190,23 @@ function LogsTab({ active }: { active: boolean }) {
           >
             <ChevronDown className="h-3 w-3" />
             גלילה אוטומטית
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const blob = new Blob([JSON.stringify(filtered, null, 2)], { type: "application/json" });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = `carwatch-logs-${new Date().toISOString().slice(0, 19).replace(/:/g, "-")}.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            disabled={filtered.length === 0}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-secondary hover:bg-secondary/80 text-xs font-medium text-foreground transition-colors disabled:opacity-40 disabled:pointer-events-none"
+          >
+            <Download className="h-3 w-3" />
+            ייצוא JSON
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Adds a download button to the admin logs toolbar that exports the current filtered log entries as a raw JSON file
- File is named with timestamp (e.g. `carwatch-logs-2026-05-04T22-44-00.json`)
- Button is disabled when there are no logs to export
- Purely frontend — no backend changes needed

## Test plan
- [ ] Open admin page, switch to logs tab
- [ ] Verify "ייצוא JSON" button appears in toolbar
- [ ] Click it — a `.json` file should download with the current logs
- [ ] Verify button is disabled when log list is empty

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "ייצוא JSON" action in the Logs tab toolbar to download the currently filtered logs as a timestamped .json file.
  * Export runs entirely in the browser and produces a client-side downloadable file.
  * The export control is disabled when no logs match the current filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->