### PR TITLE
feat: admin search management with listings filter and improved error messages

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -17,6 +17,7 @@ import (
 type adminListingResponse struct {
 	ChatID       int64    `json:"chat_id"`
 	Token        string   `json:"token"`
+	SearchID     int64    `json:"search_id"`
 	SearchName   string   `json:"search_name,omitempty"`
 	Manufacturer string   `json:"manufacturer"`
 	Model        string   `json:"model"`
@@ -162,8 +163,9 @@ func (s *Server) adminListListings(w http.ResponseWriter, r *http.Request) {
 	if offset < 0 {
 		offset = 0
 	}
+	searchID := int64(parseIntParam(r, "search_id", 0))
 
-	items, total, err := s.admin.AdminListListings(r.Context(), limit, offset)
+	items, total, err := s.admin.AdminListListings(r.Context(), limit, offset, searchID)
 	if err != nil {
 		s.logger.Error("admin: list listings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list listings")
@@ -175,6 +177,7 @@ func (s *Server) adminListListings(w http.ResponseWriter, r *http.Request) {
 		resp = append(resp, adminListingResponse{
 			ChatID:       l.ChatID,
 			Token:        l.Token,
+			SearchID:     l.SearchID,
 			SearchName:   l.SearchName,
 			Manufacturer: l.Manufacturer,
 			Model:        l.Model,
@@ -265,6 +268,22 @@ func (s *Server) adminListSearches(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": resp, "total": len(resp)})
+}
+
+func (s *Server) adminDeleteSearch(w http.ResponseWriter, r *http.Request) {
+	id, ok := parsePathID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "valid search id is required")
+		return
+	}
+
+	if err := s.admin.AdminDeleteSearch(r.Context(), id); err != nil {
+		s.logger.Error("admin: delete search", "id", id, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete search")
+		return
+	}
+	s.logger.Info("admin: deleted search", "id", id)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) adminListUsers(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -129,6 +129,7 @@ func (s *Server) Routes() http.Handler {
 		mux.HandleFunc("GET /api/v1/admin/listings", s.requireAdmin(s.adminListListings))
 		mux.HandleFunc("DELETE /api/v1/admin/listings/{token}", s.requireAdmin(s.adminDeleteListing))
 		mux.HandleFunc("GET /api/v1/admin/searches", s.requireAdmin(s.adminListSearches))
+		mux.HandleFunc("DELETE /api/v1/admin/searches/{id}", s.requireAdmin(s.adminDeleteSearch))
 		mux.HandleFunc("GET /api/v1/admin/users", s.requireAdmin(s.adminListUsers))
 		mux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
 		mux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -704,7 +704,7 @@ func (f *failingAdminStore) PurgeTable(_ context.Context, _ string) (int64, erro
 	return 0, nil
 }
 
-func (f *failingAdminStore) AdminListListings(_ context.Context, _, _ int) ([]storage.ListingRecord, int64, error) {
+func (f *failingAdminStore) AdminListListings(_ context.Context, _, _ int, _ int64) ([]storage.ListingRecord, int64, error) {
 	return nil, 0, nil
 }
 
@@ -714,6 +714,10 @@ func (f *failingAdminStore) AdminDeleteListing(_ context.Context, _ string, _ in
 
 func (f *failingAdminStore) AdminListSearches(_ context.Context) ([]storage.Search, error) {
 	return nil, nil
+}
+
+func (f *failingAdminStore) AdminDeleteSearch(_ context.Context, _ int64) error {
+	return nil
 }
 
 func (f *failingAdminStore) AdminListUsers(_ context.Context) ([]storage.User, error) {

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -777,6 +777,53 @@ func TestAdminListSearches(t *testing.T) {
 	}
 }
 
+func TestAdminDeleteSearch(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.UpsertUser(ctx, 999, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 999, Name: "to-delete", Source: "yad2",
+		Manufacturer: 19, Model: 10226, Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "DELETE", fmt.Sprintf("/api/v1/admin/searches/%d", id), nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	searches, err := store.AdminListSearches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(searches) != 0 {
+		t.Fatalf("expected 0 searches after delete, got %d", len(searches))
+	}
+}
+
+func TestAdminDeleteSearch_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "DELETE", "/api/v1/admin/searches/999", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminDeleteSearch_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "DELETE", "/api/v1/admin/searches/abc", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAdminListUsers(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()

--- a/internal/fetcher/winwin/winwin.go
+++ b/internal/fetcher/winwin/winwin.go
@@ -85,7 +85,11 @@ func (f *WinWinFetcher) Fetch(ctx context.Context, params model.SourceParams) ([
 		if looksLikeChallenge(string(result.Body)) {
 			return nil, fetcher.ErrChallenge
 		}
-		return nil, fmt.Errorf("unexpected status: %d", result.StatusCode)
+		body := string(result.Body)
+		if len(body) > 512 {
+			body = body[:512] + "…"
+		}
+		return nil, fmt.Errorf("unexpected status %d: %s", result.StatusCode, body)
 	}
 	listings, err := ParseListingsPage(bytes.NewReader(result.Body))
 	if err != nil {

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -171,7 +171,11 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 		if looksLikeBotProtection(result.Body) {
 			return nil, fmt.Errorf("yad2: %w", fetcher.ErrChallenge)
 		}
-		return nil, fmt.Errorf("unexpected status: %d", result.StatusCode)
+		body := string(result.Body)
+		if len(body) > 512 {
+			body = body[:512] + "…"
+		}
+		return nil, fmt.Errorf("unexpected status %d: %s", result.StatusCode, body)
 	}
 
 	listings, err := ParseListingsPageWithLogger(bytes.NewReader(result.Body), f.logger)

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -231,9 +231,10 @@ type AdminStore interface {
 	CountAllListings(ctx context.Context) (int64, error)
 	TableSizes(ctx context.Context) (map[string]int64, error)
 	PurgeTable(ctx context.Context, table string) (int64, error)
-	AdminListListings(ctx context.Context, limit, offset int) ([]ListingRecord, int64, error)
+	AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]ListingRecord, int64, error)
 	AdminDeleteListing(ctx context.Context, token string, chatID int64) error
 	AdminListSearches(ctx context.Context) ([]Search, error)
+	AdminDeleteSearch(ctx context.Context, id int64) error
 	AdminListUsers(ctx context.Context) ([]User, error)
 	VacuumDB(ctx context.Context) error
 }

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -85,18 +85,36 @@ func (s *Store) PurgeTable(ctx context.Context, table string) (int64, error) {
 	return result.RowsAffected()
 }
 
-func (s *Store) AdminListListings(ctx context.Context, limit, offset int) ([]storage.ListingRecord, int64, error) {
+func (s *Store) AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]storage.ListingRecord, int64, error) {
 	var total int64
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM listing_history`).Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("count listings: %w", err)
+	if searchID > 0 {
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM listing_history WHERE search_id = $1`, searchID).Scan(&total); err != nil {
+			return nil, 0, fmt.Errorf("count listings: %w", err)
+		}
+	} else {
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM listing_history`).Scan(&total); err != nil {
+			return nil, 0, fmt.Errorf("count listings: %w", err)
+		}
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, chat_id, search_id, search_name, manufacturer, model, year, price,
-			km, hand, city, page_link, image_url, fitness_score, first_seen_at
-		FROM listing_history
-		ORDER BY first_seen_at DESC
-		LIMIT $1 OFFSET $2`, limit, offset)
+	var rows *sql.Rows
+	var err error
+	if searchID > 0 {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, year, price,
+				km, hand, city, page_link, image_url, fitness_score, first_seen_at
+			FROM listing_history
+			WHERE search_id = $1
+			ORDER BY first_seen_at DESC
+			LIMIT $2 OFFSET $3`, searchID, limit, offset)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, year, price,
+				km, hand, city, page_link, image_url, fitness_score, first_seen_at
+			FROM listing_history
+			ORDER BY first_seen_at DESC
+			LIMIT $1 OFFSET $2`, limit, offset)
+	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("query listings: %w", err)
 	}
@@ -139,6 +157,15 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error)
 	}
 	defer func() { _ = rows.Close() }()
 	return scanSearches(rows)
+}
+
+func (s *Store) AdminDeleteSearch(ctx context.Context, id int64) error {
+	var chatID int64
+	err := s.db.QueryRowContext(ctx, `SELECT chat_id FROM searches WHERE id = $1`, id).Scan(&chatID)
+	if err != nil {
+		return fmt.Errorf("lookup search: %w", err)
+	}
+	return s.DeleteSearch(ctx, id, chatID)
 }
 
 func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -90,18 +90,36 @@ func (s *Store) PurgeTable(ctx context.Context, table string) (int64, error) {
 	return result.RowsAffected()
 }
 
-func (s *Store) AdminListListings(ctx context.Context, limit, offset int) ([]storage.ListingRecord, int64, error) {
+func (s *Store) AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]storage.ListingRecord, int64, error) {
 	var total int64
-	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM listing_history").Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("count listings: %w", err)
+	if searchID > 0 {
+		if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM listing_history WHERE search_id = ?", searchID).Scan(&total); err != nil {
+			return nil, 0, fmt.Errorf("count listings: %w", err)
+		}
+	} else {
+		if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM listing_history").Scan(&total); err != nil {
+			return nil, 0, fmt.Errorf("count listings: %w", err)
+		}
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, chat_id, search_id, search_name, manufacturer, model, year, price,
-			km, hand, city, page_link, image_url, fitness_score, first_seen_at
-		FROM listing_history
-		ORDER BY first_seen_at DESC
-		LIMIT ? OFFSET ?`, limit, offset)
+	var rows *sql.Rows
+	var err error
+	if searchID > 0 {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, year, price,
+				km, hand, city, page_link, image_url, fitness_score, first_seen_at
+			FROM listing_history
+			WHERE search_id = ?
+			ORDER BY first_seen_at DESC
+			LIMIT ? OFFSET ?`, searchID, limit, offset)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, year, price,
+				km, hand, city, page_link, image_url, fitness_score, first_seen_at
+			FROM listing_history
+			ORDER BY first_seen_at DESC
+			LIMIT ? OFFSET ?`, limit, offset)
+	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("query listings: %w", err)
 	}
@@ -152,6 +170,15 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error)
 	}
 	defer func() { _ = rows.Close() }()
 	return scanSearches(rows)
+}
+
+func (s *Store) AdminDeleteSearch(ctx context.Context, id int64) error {
+	var chatID int64
+	err := s.db.QueryRowContext(ctx, "SELECT chat_id FROM searches WHERE id = ?", id).Scan(&chatID)
+	if err != nil {
+		return fmt.Errorf("lookup search: %w", err)
+	}
+	return s.DeleteSearch(ctx, id, chatID)
 }
 
 func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2645,7 +2645,7 @@ func TestAdminListListings(t *testing.T) {
 		}
 	}
 
-	items, total, err := store.AdminListListings(ctx, 2, 0)
+	items, total, err := store.AdminListListings(ctx, 2, 0, 0)
 	if err != nil {
 		t.Fatalf("AdminListListings: %v", err)
 	}
@@ -2714,6 +2714,39 @@ func TestAdminListSearches(t *testing.T) {
 	s2 := byName["s2"]
 	if s2.ChatID != 200 || s2.Source != "winwin" || s2.Manufacturer != 8 {
 		t.Errorf("s2 fields mismatch: %+v", s2)
+	}
+}
+
+func TestAdminDeleteSearch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	id, err := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "s1", Source: "yad2", Manufacturer: 19, Model: 10226, Active: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.AdminDeleteSearch(ctx, id); err != nil {
+		t.Fatalf("AdminDeleteSearch: %v", err)
+	}
+
+	searches, err := store.AdminListSearches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(searches) != 0 {
+		t.Fatalf("expected 0 searches after admin delete, got %d", len(searches))
+	}
+}
+
+func TestAdminDeleteSearch_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.AdminDeleteSearch(ctx, 999)
+	if err == nil {
+		t.Fatal("expected error for non-existent search")
 	}
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -228,6 +228,7 @@ export interface AdminStats {
 
 export interface AdminListing extends Listing {
   chat_id: number;
+  search_id: number;
   search_name?: string;
 }
 
@@ -310,10 +311,11 @@ export const adminApi = {
       method: "PUT",
       body: JSON.stringify({ level }),
     }),
-  listings: (params?: ListingsParams) => {
+  listings: (params?: ListingsParams & { search_id?: number }) => {
     const query = new URLSearchParams();
     if (params?.limit !== undefined) query.set("limit", String(params.limit));
     if (params?.offset !== undefined) query.set("offset", String(params.offset));
+    if (params?.search_id) query.set("search_id", String(params.search_id));
     const qs = query.toString();
     return fetchAPI<AdminListingsResponse>(`/admin/listings${qs ? `?${qs}` : ""}`);
   },
@@ -323,6 +325,8 @@ export const adminApi = {
       body: JSON.stringify({ chat_id: chatId }),
     }),
   searches: () => fetchAPI<AdminSearchesResponse>("/admin/searches"),
+  deleteSearch: (id: number) =>
+    fetchAPI<void>(`/admin/searches/${id}`, { method: "DELETE" }),
   users: () => fetchAPI<AdminUsersResponse>("/admin/users"),
   purgeTable: (table: string) =>
     fetchAPI<PurgeResult>("/admin/purge", {

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -39,9 +39,9 @@ import { cn, formatKm, formatPrice, relativeTime, safeHref } from "@/lib/utils";
 const TABLE_LABELS: Record<string, string> = {
   users: "משתמשים",
   searches: "חיפושים",
-  listing_history: "מודעות",
+  listing_history: "היסטוריית מודעות",
   price_history: "היסטוריית מחירים",
-  dedup_seen: "מודעות שזוהו",
+  dedup_seen: "סינון כפילויות",
   seen_listings: "מודעות שנצפו",
   notifications: "התראות",
   pending_notifications: "התראות ממתינות",
@@ -49,6 +49,7 @@ const TABLE_LABELS: Record<string, string> = {
   saved_listings: "מודעות שמורות",
   hidden_listings: "מודעות מוסתרות",
   pending_digest: "תקצירים ממתינים",
+  link_tokens: "טוקנים לקישור",
 };
 
 const PURGEABLE = new Set([
@@ -156,10 +157,12 @@ function DetailModal({
   title,
   fields,
   onClose,
+  actions,
 }: {
   title: string;
   fields: { label: string; value: string | number | null | undefined }[];
   onClose: () => void;
+  actions?: React.ReactNode;
 }) {
   return (
     <div
@@ -212,6 +215,11 @@ function DetailModal({
             );
           })}
         </div>
+        {actions && (
+          <div className="flex justify-end mt-4 pt-4 border-t border-border/50">
+            {actions}
+          </div>
+        )}
       </motion.div>
     </div>
   );
@@ -469,7 +477,13 @@ function OverviewTab({
 
 // ── Listings Tab ──────────────────────────────────────────────────────────────
 
-function ListingsTab() {
+function ListingsTab({
+  searchId,
+  onClearFilter,
+}: {
+  searchId: number | null;
+  onClearFilter: () => void;
+}) {
   const [page, setPage] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [detailListing, setDetailListing] = useState<AdminListing | null>(null);
@@ -478,10 +492,20 @@ function ListingsTab() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
+  const prevSearchId = useRef(searchId);
+  if (prevSearchId.current !== searchId) {
+    prevSearchId.current = searchId;
+    setPage(0);
+  }
+
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["admin", "listings", page],
+    queryKey: ["admin", "listings", page, searchId],
     queryFn: () =>
-      adminApi.listings({ limit: pageSize, offset: page * pageSize }),
+      adminApi.listings({
+        limit: pageSize,
+        offset: page * pageSize,
+        ...(searchId ? { search_id: searchId } : {}),
+      }),
   });
 
   const deleteMutation = useMutation({
@@ -511,6 +535,28 @@ function ListingsTab() {
 
   return (
     <div className="space-y-4">
+      {/* Filter banner */}
+      {searchId && (
+        <div className="flex items-center justify-between rounded-xl bg-primary/5 border border-primary/20 px-4 py-3">
+          <span className="text-sm text-foreground">
+            מסנן לפי חיפוש #{searchId}
+            {data && (
+              <span className="text-muted-foreground mr-2">
+                · {data.total} מודעות
+              </span>
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={onClearFilter}
+            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+          >
+            <X className="h-3 w-3" />
+            הסר סינון
+          </button>
+        </div>
+      )}
+
       {/* Header with search */}
       <div className="flex flex-col sm:flex-row gap-3">
         <div className="relative flex-1">
@@ -536,7 +582,9 @@ function ListingsTab() {
       {/* Listings */}
       <div className="rounded-2xl border border-border/50 bg-card overflow-hidden">
         <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
-          <h2 className="text-base font-semibold">כל המודעות</h2>
+          <h2 className="text-base font-semibold">
+            {searchId ? "מודעות לחיפוש" : "כל המודעות"}
+          </h2>
           {data && (
             <span className="text-sm text-muted-foreground tabular-nums">
               {data.total.toLocaleString("he-IL")} סה״כ
@@ -736,12 +784,28 @@ function ListingsTab() {
 
 // ── Searches Tab ──────────────────────────────────────────────────────────────
 
-function SearchesTab() {
+function SearchesTab({ onViewListings }: { onViewListings: (searchId: number) => void }) {
   const [detailSearch, setDetailSearch] = useState<AdminSearch | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AdminSearch | null>(null);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ["admin", "searches"],
     queryFn: adminApi.searches,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => adminApi.deleteSearch(id),
+    onSuccess: () => {
+      toast("החיפוש נמחק בהצלחה", "success");
+      setConfirmDelete(null);
+      setDetailSearch(null);
+      void queryClient.invalidateQueries({ queryKey: ["admin"] });
+    },
+    onError: () => {
+      toast("שגיאה במחיקת החיפוש", "error");
+    },
   });
 
   return (
@@ -829,6 +893,26 @@ function SearchesTab() {
                   <Badge variant={search.active ? "success" : "default"}>
                     {search.active ? "פעיל" : "מושהה"}
                   </Badge>
+                  <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); onViewListings(search.id); }}
+                      aria-label="צפה במודעות"
+                      title="צפה במודעות"
+                      className="rounded-lg p-1.5 text-muted-foreground/50 transition-colors hover:text-primary hover:bg-primary/10"
+                    >
+                      <Car className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); setConfirmDelete(search); }}
+                      aria-label={`מחק חיפוש ${search.name || search.id}`}
+                      title="מחק חיפוש"
+                      className="rounded-lg p-1.5 text-muted-foreground/50 transition-colors hover:text-destructive hover:bg-destructive/10"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
                   <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
                     #{search.chat_id}
                   </span>
@@ -849,21 +933,21 @@ function SearchesTab() {
               { label: "מקור", value: detailSearch.source },
               { label: "יצרן", value: detailSearch.manufacturer || null },
               { label: "דגם", value: detailSearch.model || null },
-              { label: "שנה מ", value: detailSearch.year_min || null },
+              { label: "שנה מ-", value: detailSearch.year_min || null },
               { label: "שנה עד", value: detailSearch.year_max || null },
               {
-                label: "מחיר מקס",
+                label: "מחיר מקס׳",
                 value: detailSearch.price_max
                   ? formatPrice(detailSearch.price_max)
                   : null,
               },
               {
-                label: "ק״מ מקס",
+                label: "ק״מ מקס׳",
                 value: detailSearch.max_km
                   ? detailSearch.max_km.toLocaleString("he-IL")
                   : null,
               },
-              { label: "יד מקס", value: detailSearch.max_hand || null },
+              { label: "יד מקס׳", value: detailSearch.max_hand || null },
               {
                 label: "סטטוס",
                 value: detailSearch.active ? "פעיל" : "מושהה",
@@ -875,6 +959,37 @@ function SearchesTab() {
               },
             ]}
             onClose={() => setDetailSearch(null)}
+            actions={
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => { setDetailSearch(null); onViewListings(detailSearch.id); }}
+                  className="inline-flex items-center gap-1.5 rounded-xl bg-primary/10 px-3 py-2 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+                >
+                  <Car className="h-3 w-3" />
+                  צפה במודעות
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setDetailSearch(null); setConfirmDelete(detailSearch); }}
+                  className="inline-flex items-center gap-1.5 rounded-xl bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20"
+                >
+                  <Trash2 className="h-3 w-3" />
+                  מחק חיפוש
+                </button>
+              </div>
+            }
+          />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {confirmDelete && (
+          <ConfirmModal
+            message={`למחוק את החיפוש "${confirmDelete.name || `#${confirmDelete.id}`}" של משתמש #${confirmDelete.chat_id}? פעולה זו תמחק גם את כל המודעות וההיסטוריה המשויכים.`}
+            onConfirm={() => deleteMutation.mutate(confirmDelete.id)}
+            onCancel={() => setConfirmDelete(null)}
+            loading={deleteMutation.isPending}
           />
         )}
       </AnimatePresence>
@@ -1362,6 +1477,12 @@ function RuntimeStat({ label, value }: { label: string; value: string }) {
 export function AdminPage() {
   const { data, isLoading, isError, dataUpdatedAt, refetch } = useAdminStats();
   const [activeTab, setActiveTab] = useState<TabKey>("overview");
+  const [listingsSearchId, setListingsSearchId] = useState<number | null>(null);
+
+  function viewListingsForSearch(searchId: number) {
+    setListingsSearchId(searchId);
+    setActiveTab("listings");
+  }
 
   if (isLoading) {
     return (
@@ -1483,8 +1604,15 @@ export function AdminPage() {
           {activeTab === "overview" && (
             <OverviewTab data={data} onRefresh={() => void refetch()} />
           )}
-          {activeTab === "listings" && <ListingsTab />}
-          {activeTab === "searches" && <SearchesTab />}
+          {activeTab === "listings" && (
+            <ListingsTab
+              searchId={listingsSearchId}
+              onClearFilter={() => setListingsSearchId(null)}
+            />
+          )}
+          {activeTab === "searches" && (
+            <SearchesTab onViewListings={viewListingsForSearch} />
+          )}
           {activeTab === "users" && <UsersTab />}
           {activeTab === "logs" && (
             <LogsTab active={activeTab === "logs"} />


### PR DESCRIPTION
## Summary

- **Admin delete search**: New `DELETE /admin/searches/{id}` endpoint with full cascade cleanup. Delete button on each search row and in the search detail modal with confirmation dialog.
- **Search → Listings link**: Each search row has a "view listings" button that switches to the Listings tab filtered by that search's ID. A filter banner shows the active filter with a clear button.
- **Better fetcher errors**: yad2 and winwin fetchers now include the response body (up to 512 chars) in error messages instead of just the HTTP status code.
- **Translation fixes**: Improved Hebrew labels for `listing_history`, `dedup_seen`, added missing `link_tokens` label.
- **Tests**: 5 new tests covering `AdminDeleteSearch` at both storage and API levels.

## Test plan

- [x] `go test ./...` — all pass
- [x] `npx tsc --noEmit` — clean
- [x] `go vet ./...` — clean
- [ ] Verify search delete cascade works end-to-end
- [ ] Verify "view listings" filter navigation works in admin panel


Made with [Cursor](https://cursor.com)