### PR TITLE
fix: use VACUUM FULL and report user data size in PostgreSQL

### DIFF
--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -11,9 +11,14 @@ import (
 
 func (s *Store) DBFileSize() (int64, error) {
 	var size int64
-	err := s.db.QueryRowContext(context.Background(), `SELECT pg_database_size(current_database())`).Scan(&size)
+	// Sum actual user-table sizes instead of pg_database_size(), which
+	// includes ~5-8 MB of system catalog overhead that VACUUM cannot reclaim.
+	err := s.db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(SUM(pg_total_relation_size(quote_ident(table_name))), 0)
+		FROM information_schema.tables
+		WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`).Scan(&size)
 	if err != nil {
-		return 0, fmt.Errorf("pg_database_size: %w", err)
+		return 0, fmt.Errorf("pg user table size: %w", err)
 	}
 	return size, nil
 }
@@ -218,8 +223,11 @@ func (s *Store) AdminDeleteUser(ctx context.Context, chatID int64) error {
 }
 
 func (s *Store) VacuumDB(ctx context.Context) error {
-	if _, err := s.db.ExecContext(ctx, `VACUUM`); err != nil {
-		return fmt.Errorf("vacuum: %w", err)
+	// VACUUM FULL rewrites tables and returns freed pages to the OS.
+	// Plain VACUUM only marks dead tuples as reusable within Postgres
+	// without actually shrinking the on-disk files.
+	if _, err := s.db.ExecContext(ctx, `VACUUM FULL`); err != nil {
+		return fmt.Errorf("vacuum full: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **`VACUUM FULL`**: Plain `VACUUM` only marks dead tuples as reusable within Postgres — it does not return space to the OS. `VACUUM FULL` rewrites tables and actually shrinks the on-disk files.
- **`DBFileSize`**: Now sums `pg_total_relation_size()` for public tables instead of `pg_database_size(current_database())`, which includes ~5-8 MB of system catalog overhead that can never be reclaimed. This gives a meaningful number that changes when data is purged or vacuumed.

Closes #507

## Test plan

- [ ] Verify `VACUUM FULL` runs without error on the deployed Postgres instance
- [ ] Confirm reported DB size decreases after purging data and vacuuming
- [ ] Confirm the admin panel shows a meaningful (small) size for a nearly-empty database

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Database Maintenance**
  * Enhanced database cleanup operations now perform more comprehensive maintenance procedures.
  * Database size calculation methodology has been refined.
  * Improved error messaging for database operations to provide clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->