### PR TITLE
fix: make km enrichment reliable and fix notifications page race

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -83,7 +83,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = store.Close() }()
 
-	yad2Fetcher, cachingFetcher, fetcherFactory, proxyPool, err := buildFetchers(cfg, logger)
+	yad2Fetcher, cachingFetcher, fetcherFactory, _, err := buildFetchers(cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -128,9 +128,7 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
-	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger.With("component", "enricher"), yad2.EnricherConfig{
-		ProxyPool: proxyPool,
-	})
+	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger.With("component", "enricher"), yad2.EnricherConfig{})
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, multi, logger.With("component", "scheduler"), scheduler.Options{
 		Observer:         h,

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -142,6 +142,7 @@ func run(configPath string, logger *slog.Logger) error {
 		DigestStore:      store,
 		HiddenStore:      store,
 		CatalogIngester:  dynCatalog,
+		CarNames:         dynCatalog,
 		KmEnricher:       kmEnricher,
 		MarketStore:      store,
 		DailyDigestStore: store,

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -83,7 +83,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = store.Close() }()
 
-	yad2Fetcher, cachingFetcher, fetcherFactory, err := buildFetchers(cfg, logger)
+	yad2Fetcher, cachingFetcher, fetcherFactory, proxyPool, err := buildFetchers(cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,9 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
-	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger.With("component", "enricher"), yad2.EnricherConfig{})
+	kmEnricher := yad2.NewEnricher(yad2Fetcher, logger.With("component", "enricher"), yad2.EnricherConfig{
+		ProxyPool: proxyPool,
+	})
 
 	sched, err := scheduler.NewWithOptions(cfg, cachingFetcher, store, multi, logger.With("component", "scheduler"), scheduler.Options{
 		Observer:         h,
@@ -163,7 +165,7 @@ func run(configPath string, logger *slog.Logger) error {
 	return sched.Run(ctx)
 }
 
-func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, fetcher.Fetcher, *fetcher.Factory, error) {
+func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, fetcher.Fetcher, *fetcher.Factory, *fetcher.ProxyPool, error) {
 	var proxyPool *fetcher.ProxyPool
 	if len(cfg.HTTP.Proxies) > 0 {
 		proxyPool = fetcher.NewProxyPool(cfg.HTTP.Proxies)
@@ -178,7 +180,7 @@ func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, 
 		yad2Fetcher, err = yad2.NewFetcher(cfg.HTTP.UserAgents, cfg.HTTP.Proxy, yad2Logger)
 	}
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("create fetcher: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("create fetcher: %w", err)
 	}
 
 	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, cfg.HTTP.MaxPages)
@@ -194,7 +196,7 @@ func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, 
 		winwinFetcher, err = winwin.NewFetcher(cfg.HTTP.UserAgents, cfg.HTTP.Proxy, winwinLogger)
 	}
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("create winwin fetcher: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("create winwin fetcher: %w", err)
 	}
 	cachingWinwin := fetcher.NewCachingFetcher(winwinFetcher, 5*time.Minute)
 	winwinCB := fetcher.NewCircuitBreaker(cachingWinwin, 5, 10*time.Minute,
@@ -204,7 +206,7 @@ func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, 
 	fetcherFactory.Register("yad2", yad2CB)
 	fetcherFactory.Register("winwin", winwinCB)
 
-	return yad2Fetcher, cachingFetcher, fetcherFactory, nil
+	return yad2Fetcher, cachingFetcher, fetcherFactory, proxyPool, nil
 }
 
 func openStore(cfg *config.Config) (storage.Store, error) {

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -182,7 +182,8 @@ func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, 
 
 	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, cfg.HTTP.MaxPages)
 	cachingFetcher := fetcher.NewCachingFetcher(paginatingFetcher, 5*time.Minute)
-	yad2CB := fetcher.NewCircuitBreaker(cachingFetcher, 5, 30*time.Minute)
+	yad2CB := fetcher.NewCircuitBreaker(cachingFetcher, 5, 10*time.Minute,
+		fetcher.WithCBLogger(logger.With("component", "circuit_breaker", "source", "yad2")))
 
 	winwinLogger := logger.With("component", "winwin")
 	var winwinFetcher *winwin.WinWinFetcher
@@ -195,7 +196,8 @@ func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, 
 		return nil, nil, nil, fmt.Errorf("create winwin fetcher: %w", err)
 	}
 	cachingWinwin := fetcher.NewCachingFetcher(winwinFetcher, 5*time.Minute)
-	winwinCB := fetcher.NewCircuitBreaker(cachingWinwin, 5, 30*time.Minute)
+	winwinCB := fetcher.NewCircuitBreaker(cachingWinwin, 5, 10*time.Minute,
+		fetcher.WithCBLogger(logger.With("component", "circuit_breaker", "source", "winwin")))
 
 	fetcherFactory := fetcher.NewFactory()
 	fetcherFactory.Register("yad2", yad2CB)

--- a/docs/yad2-anti-bot-strategy.md
+++ b/docs/yad2-anti-bot-strategy.md
@@ -1,0 +1,314 @@
+# Yad2 Anti-Bot Strategy — Problem Analysis & Approach Comparison
+
+**Author:** Daniel Sionov  
+**Date:** 2026-05-06  
+**Status:** Awaiting review from senior engineers / cyber team  
+
+---
+
+## 1. Problem Statement
+
+CarWatch is a personal car-listing aggregator that periodically scrapes Yad2 (Israel's
+largest classifieds site) for vehicle listings matching user-defined criteria.
+
+The application needs to:
+1. Fetch listing feeds (search results pages) — provides basic metadata (model, year, price, token).
+2. Enrich individual listings by fetching each listing's detail page (`/vehicles/item/{token}`) — provides km, city, image URL.
+
+**The km field is critical** — users set a maximum mileage filter. If enrichment fails,
+km remains unknown (0), and the listing is filtered out as a safety measure (we cannot
+show listings that might exceed the user's km limit).
+
+### Anti-Bot System in Use
+
+Yad2 uses **PerimeterX / HUMAN Security** (formerly ShieldSquare). Indicators observed:
+- Challenge pages containing "perfdrive" and "shieldsquare" JavaScript
+- Browser fingerprinting and TLS fingerprint analysis
+- Rate limiting with escalating challenge frequency
+- IP reputation scoring
+
+### Impact on CarWatch
+
+| Failure Mode | User Impact |
+|---|---|
+| Challenge on listing feed | Entire search returns 0 results for that cycle |
+| Challenge on item detail page | Listing's km stays unknown → filtered out |
+| Sustained challenges | Circuit breaker opens → no results for extended period |
+
+---
+
+## 2. What We've Implemented (Current State)
+
+### 2.1 TLS Fingerprinting (azuretls-client)
+
+Uses `azuretls-client` to present a Chrome-like TLS fingerprint (JA3/JA4). This is the
+foundation — without it, Go's default `net/http` TLS handshake is trivially identifiable
+as non-browser traffic.
+
+### 2.2 Realistic Headers & User-Agent Rotation
+
+Randomized User-Agent strings from a pool of real Chrome versions. Full header sets
+mimicking real browser requests (Accept, Accept-Language, sec-ch-ua, etc.).
+
+### 2.3 Proxy Pool with Rotation
+
+A pool of residential/datacenter proxies. On challenge detection, the proxy is marked
+unhealthy and rotated out. Provides IP diversity to avoid IP-based rate limiting.
+
+### 2.4 Jittered Request Delays
+
+- Between paginated pages: 1.5–2.5s (randomized)
+- Between item enrichment requests: 1.5–3.5s (randomized)
+- Prevents fixed-interval detection patterns
+
+### 2.5 Shuffled Enrichment Order
+
+Each cycle, the order of listings to enrich is shuffled randomly. Ensures different
+listings get priority if the per-cycle cap is hit or a challenge aborts the batch.
+
+### 2.6 Soft Resume on Challenge
+
+Instead of aborting all enrichment on the first bot challenge:
+1. Back off for 7 seconds
+2. Rotate to the next proxy
+3. Continue enriching remaining candidates
+4. Only abort if 3 consecutive challenges are hit
+
+### 2.7 DB Pre-Fill (Safety Net)
+
+Once a listing's km/city/image is successfully enriched, it's stored in the database.
+On subsequent cycles, if enrichment fails for that listing, the previously-stored data
+is used. This means a listing only needs to be successfully enriched **once** — after
+that it's immune to enrichment failures.
+
+### 2.8 Circuit Breaker
+
+Protects against cascading failures. If too many consecutive requests fail, the circuit
+opens and stops all requests for a cooldown period, preventing IP/account burning.
+
+---
+
+## 3. Alternative Approaches
+
+### 3.1 Authenticated Session (Login as Real User)
+
+**Description:** Create a real Yad2 account and authenticate before scraping. Maintain
+a session cookie for all requests.
+
+**How it helps:**
+- Authenticated users receive a higher trust score from PerimeterX
+- Fewer initial challenge pages served to logged-in sessions
+- Request pattern looks more like a real user browsing
+
+**Risks:**
+- Account ban = total loss of access (single point of failure)
+- Need to handle login flow, token refresh, CAPTCHA during login
+- More identifiable if Yad2 investigates (linked to phone/email)
+- ToS violation is more clear-cut with an identifiable account
+
+**Complexity:** Medium (login flow, session management, refresh logic)
+
+| Criterion | Score (1-5) |
+|---|---|
+| Effectiveness against bot detection | 4 |
+| Resilience (failure recovery) | 2 |
+| Implementation complexity | 3 |
+| Long-term sustainability | 2 |
+| Risk of total lockout | High |
+| **Overall** | **2.5/5** |
+
+---
+
+### 3.2 Headless Browser (Playwright / Puppeteer)
+
+**Description:** Use a real browser engine to render pages, execute JavaScript challenges
+natively, and extract data from the rendered DOM.
+
+**How it helps:**
+- Passes all JavaScript-based challenges natively (the browser solves them)
+- Real browser fingerprint (not simulated)
+- Can handle dynamic content loading
+
+**Risks:**
+- Very high resource consumption (RAM, CPU) — especially for frequent polling
+- Slower than HTTP-based fetching (full page render per request)
+- Still detectable via WebDriver flags, canvas fingerprinting, etc.
+- Anti-detect browsers (Multilogin, GoLogin) add cost
+- Increases infrastructure complexity significantly
+
+**Complexity:** High (browser lifecycle, resource management, anti-detect config)
+
+| Criterion | Score (1-5) |
+|---|---|
+| Effectiveness against bot detection | 5 |
+| Resilience (failure recovery) | 3 |
+| Implementation complexity | 1 |
+| Long-term sustainability | 3 |
+| Risk of total lockout | Medium |
+| **Overall** | **3.0/5** |
+
+---
+
+### 3.3 Current Approach (Stealth HTTP + Proxy + DB Pre-Fill)
+
+**Description:** The approach currently implemented — TLS fingerprinting, proxy rotation,
+jittered delays, shuffled enrichment, soft challenge recovery, and DB pre-fill.
+
+**How it helps:**
+- No single point of failure (no account to ban, multiple proxies)
+- DB pre-fill means enrichment only needs to succeed once per listing
+- Graceful degradation (partial enrichment is still useful)
+- Low resource footprint
+
+**Risks:**
+- PerimeterX may escalate detection (TLS fingerprint databases update)
+- Residential proxy quality varies
+- If Yad2 moves to mandatory JS challenges on all pages, HTTP-only breaks
+
+**Complexity:** Medium (already implemented)
+
+| Criterion | Score (1-5) |
+|---|---|
+| Effectiveness against bot detection | 3 |
+| Resilience (failure recovery) | 5 |
+| Implementation complexity | 4 (already done) |
+| Long-term sustainability | 4 |
+| Risk of total lockout | Low |
+| **Overall** | **4.0/5** |
+
+---
+
+### 3.4 Hybrid: Authenticated + Anonymous Fallback
+
+**Description:** Primary path uses an authenticated Yad2 session for higher trust score.
+Falls back to anonymous + proxy rotation when the session is challenged or expires.
+
+**How it helps:**
+- Best of both: auth reduces challenge frequency, anonymous provides resilience
+- If account is banned, system continues operating in anonymous mode
+- Can use auth for enrichment (high-value, single-page requests) and anonymous for feeds
+
+**Risks:**
+- Additional complexity managing two code paths
+- Account still at risk of being burned
+- Need to monitor session health and switch automatically
+
+**Complexity:** Medium-High
+
+| Criterion | Score (1-5) |
+|---|---|
+| Effectiveness against bot detection | 4 |
+| Resilience (failure recovery) | 4 |
+| Implementation complexity | 2 |
+| Long-term sustainability | 3 |
+| Risk of total lockout | Low |
+| **Overall** | **3.5/5** |
+
+---
+
+### 3.5 Official API / Data Partnership
+
+**Description:** Contact Yad2 about an official API or data feed. Some classifieds sites
+offer commercial access for aggregators.
+
+**How it helps:**
+- 100% reliable, no anti-bot issues
+- Clean, structured data
+- Legal and sustainable
+
+**Risks:**
+- Yad2 may not offer this (or may not offer it for individual/small projects)
+- May be expensive
+- May have usage restrictions
+
+**Complexity:** Low (technical), High (business/negotiation)
+
+| Criterion | Score (1-5) |
+|---|---|
+| Effectiveness against bot detection | 5 |
+| Resilience (failure recovery) | 5 |
+| Implementation complexity | 5 |
+| Long-term sustainability | 5 |
+| Risk of total lockout | None |
+| **Overall** | **5.0/5** (if available) |
+
+---
+
+### 3.6 RSS / Alternative Data Sources
+
+**Description:** Some aggregator sites or RSS feeds provide Yad2 listing data indirectly
+(e.g., price comparison sites, car valuation services).
+
+**How it helps:**
+- Avoids Yad2's anti-bot entirely
+- May provide pre-enriched data (km, city already included)
+
+**Risks:**
+- Data freshness may lag behind Yad2 directly
+- Coverage may be incomplete
+- Third-party dependency
+
+**Complexity:** Low-Medium
+
+| Criterion | Score (1-5) |
+|---|---|
+| Effectiveness against bot detection | 5 (no bot to fight) |
+| Resilience (failure recovery) | 4 |
+| Implementation complexity | 4 |
+| Long-term sustainability | 3 |
+| Risk of total lockout | Low |
+| **Overall** | **3.5/5** |
+
+---
+
+## 4. Scoring Summary
+
+| # | Approach | Overall Score | Best For |
+|---|---|---|---|
+| 3.5 | Official API | 5.0 | Long-term, if Yad2 offers it |
+| 3.3 | Stealth HTTP + DB Pre-Fill (current) | 4.0 | Resilient daily operation |
+| 3.4 | Hybrid Auth + Anonymous | 3.5 | Reducing challenge rate |
+| 3.6 | Alternative Data Sources | 3.5 | Avoiding the problem entirely |
+| 3.2 | Headless Browser | 3.0 | Guaranteed challenge bypass |
+| 3.1 | Authenticated Only | 2.5 | Quick win, high risk |
+
+---
+
+## 5. Recommendation
+
+**Short-term (now):** Stay with approach 3.3 (current implementation). Monitor success
+rates over the next 1-2 weeks. The DB pre-fill ensures that once a listing is enriched,
+it stays enriched permanently — meaning reliability improves over time as the database
+accumulates data.
+
+**Medium-term (if challenge rate exceeds 30%):** Layer on approach 3.4 (hybrid auth) for
+enrichment requests specifically. Keep anonymous for feed fetching.
+
+**Long-term:** Investigate 3.5 (official API) and 3.6 (alternative sources) to eliminate
+the arms race entirely.
+
+---
+
+## 6. Questions for Review
+
+1. Is the TLS fingerprint approach (`azuretls-client`) sufficient against PerimeterX's
+   current detection, or should we invest in headless browser for enrichment?
+2. What's the risk/reward of using an authenticated session? Is account burn acceptable
+   if we have anonymous fallback?
+3. Are there known Israeli proxy providers with better residential IP reputation for
+   Yad2 specifically?
+4. Should we consider a CAPTCHA-solving service (2captcha, Anti-Captcha) as an
+   additional layer for when challenges are served?
+5. Is there a way to reverse-engineer the PerimeterX challenge cookie generation
+   without a full browser (e.g., isolated JS execution via V8/QuickJS)?
+
+---
+
+## 7. Technical Context
+
+- **Language:** Go
+- **HTTP Client:** azuretls-client (Chrome TLS fingerprint)
+- **Anti-bot system:** PerimeterX / HUMAN Security
+- **Polling interval:** Configurable (default ~10 min with jitter)
+- **Enrichment cap:** Max listings per cycle to limit request volume
+- **Data persistence:** PostgreSQL (prod) / SQLite (dev)

--- a/internal/fetcher/circuitbreaker.go
+++ b/internal/fetcher/circuitbreaker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -42,14 +43,28 @@ type CircuitBreaker struct {
 	cooldown         time.Duration
 	openedAt         time.Time
 	probing          bool
+	logger           *slog.Logger
 }
 
-func NewCircuitBreaker(inner Fetcher, threshold int, cooldown time.Duration) *CircuitBreaker {
-	return &CircuitBreaker{
+func NewCircuitBreaker(inner Fetcher, threshold int, cooldown time.Duration, opts ...func(*CircuitBreaker)) *CircuitBreaker {
+	cb := &CircuitBreaker{
 		inner:            inner,
 		state:            StateClosed,
 		failureThreshold: threshold,
 		cooldown:         cooldown,
+		logger:           slog.Default(),
+	}
+	for _, o := range opts {
+		o(cb)
+	}
+	return cb
+}
+
+func WithCBLogger(l *slog.Logger) func(*CircuitBreaker) {
+	return func(cb *CircuitBreaker) {
+		if l != nil {
+			cb.logger = l
+		}
 	}
 }
 
@@ -58,10 +73,15 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params model.SourceParams) 
 	switch cb.state {
 	case StateOpen:
 		if time.Since(cb.openedAt) >= cb.cooldown {
+			cb.logger.Info("circuit breaker cooldown expired, transitioning to half-open",
+				"cooldown", cb.cooldown.String(),
+				"was_open_for", time.Since(cb.openedAt).Round(time.Second).String(),
+			)
 			cb.state = StateHalfOpen
 		} else {
+			remaining := cb.cooldown - time.Since(cb.openedAt)
 			cb.mu.Unlock()
-			return nil, ErrCircuitOpen
+			return nil, fmt.Errorf("%w (resets in %s)", ErrCircuitOpen, remaining.Round(time.Second))
 		}
 	case StateHalfOpen:
 		if cb.probing {
@@ -85,18 +105,34 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params model.SourceParams) 
 
 	if err != nil {
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			// Partial results with data indicate degradation but not total failure;
+			// don't count them toward opening the circuit.
+			if errors.Is(err, ErrPartialResults) && len(listings) > 0 {
+				return listings, err
+			}
 			cb.failures++
 			if cb.failures >= cb.failureThreshold || cb.state == StateHalfOpen {
+				prev := cb.state
 				cb.state = StateOpen
 				cb.openedAt = time.Now()
+				cb.logger.Warn("circuit breaker opened",
+					"previous_state", prev.String(),
+					"failures", cb.failures,
+					"threshold", cb.failureThreshold,
+					"cooldown", cb.cooldown.String(),
+					"last_error", err.Error(),
+				)
 			}
-		}
-		if errors.Is(err, ErrPartialResults) && len(listings) > 0 {
-			return listings, err
 		}
 		return nil, err
 	}
 
+	if cb.state != StateClosed {
+		cb.logger.Info("circuit breaker recovered, closing",
+			"previous_state", cb.state.String(),
+			"failures_before_reset", cb.failures,
+		)
+	}
 	cb.failures = 0
 	cb.state = StateClosed
 	return listings, nil

--- a/internal/fetcher/circuitbreaker_test.go
+++ b/internal/fetcher/circuitbreaker_test.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -64,6 +65,27 @@ func TestCircuitBreaker_OpenState_RejectsCalls(t *testing.T) {
 	}
 	if inner.calls != 0 {
 		t.Errorf("inner should not be called when circuit is open, got %d calls", inner.calls)
+	}
+}
+
+func TestCircuitBreaker_OpenState_IncludesResetTime(t *testing.T) {
+	inner := &mockFetcherCB{err: errors.New("timeout")}
+	cb := NewCircuitBreaker(inner, 2, 30*time.Second)
+
+	for i := 0; i < 2; i++ {
+		_, _ = cb.Fetch(context.Background(), model.SourceParams{})
+	}
+
+	_, err := cb.Fetch(context.Background(), model.SourceParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	errMsg := err.Error()
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Errorf("expected ErrCircuitOpen, got: %v", err)
+	}
+	if !contains(errMsg, "resets in") {
+		t.Errorf("expected 'resets in' in error message, got: %s", errMsg)
 	}
 }
 
@@ -170,4 +192,58 @@ func TestCircuitBreaker_ChallengeError_CountsAsFailure(t *testing.T) {
 	if cb.State() != StateOpen {
 		t.Errorf("challenge errors should count toward circuit opening, state = %v", cb.State())
 	}
+}
+
+func TestCircuitBreaker_PartialResults_DoNotCountAsFailure(t *testing.T) {
+	listings := []model.RawListing{{Token: "a"}, {Token: "b"}}
+	inner := &mockFetcherCB{
+		listings: listings,
+		err:      fmt.Errorf("%w: page 3: unexpected status 400", ErrPartialResults),
+	}
+	cb := NewCircuitBreaker(inner, 3, 30*time.Second)
+
+	for i := 0; i < 5; i++ {
+		got, err := cb.Fetch(context.Background(), model.SourceParams{})
+		if !errors.Is(err, ErrPartialResults) {
+			t.Fatalf("call %d: expected ErrPartialResults, got: %v", i, err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("call %d: expected 2 listings, got %d", i, len(got))
+		}
+	}
+
+	if cb.State() != StateClosed {
+		t.Errorf("state = %v, want closed (partial results with data should not trip CB)", cb.State())
+	}
+	if cb.Failures() != 0 {
+		t.Errorf("failures = %d, want 0", cb.Failures())
+	}
+}
+
+func TestCircuitBreaker_PartialResultsNoData_CountsAsFailure(t *testing.T) {
+	inner := &mockFetcherCB{
+		listings: nil,
+		err:      fmt.Errorf("%w: page 1: unexpected status 400", ErrPartialResults),
+	}
+	cb := NewCircuitBreaker(inner, 2, 30*time.Second)
+
+	_, _ = cb.Fetch(context.Background(), model.SourceParams{})
+	_, _ = cb.Fetch(context.Background(), model.SourceParams{})
+
+	if cb.State() != StateOpen {
+		t.Errorf("state = %v, want open (partial results with no data should count as failure)", cb.State())
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/fetcher/circuitbreaker_test.go
+++ b/internal/fetcher/circuitbreaker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,7 +85,7 @@ func TestCircuitBreaker_OpenState_IncludesResetTime(t *testing.T) {
 	if !errors.Is(err, ErrCircuitOpen) {
 		t.Errorf("expected ErrCircuitOpen, got: %v", err)
 	}
-	if !contains(errMsg, "resets in") {
+	if !strings.Contains(errMsg, "resets in") {
 		t.Errorf("expected 'resets in' in error message, got: %s", errMsg)
 	}
 }
@@ -235,15 +236,3 @@ func TestCircuitBreaker_PartialResultsNoData_CountsAsFailure(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/fetcher/paginating.go
+++ b/internal/fetcher/paginating.go
@@ -3,24 +3,31 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/model"
 )
 
-const DefaultMaxPages = 5
+const (
+	DefaultMaxPages  = 5
+	defaultPageDelay = 1500 * time.Millisecond
+	pageDelayJitter  = 1000 * time.Millisecond
+)
 
 var ErrPartialResults = fmt.Errorf("partial paginated results")
 
 type PaginatingFetcher struct {
-	inner    Fetcher
-	maxPages int
+	inner     Fetcher
+	maxPages  int
+	pageDelay time.Duration
 }
 
 func NewPaginatingFetcher(inner Fetcher, maxPages int) *PaginatingFetcher {
 	if maxPages <= 0 {
 		maxPages = DefaultMaxPages
 	}
-	return &PaginatingFetcher{inner: inner, maxPages: maxPages}
+	return &PaginatingFetcher{inner: inner, maxPages: maxPages, pageDelay: defaultPageDelay}
 }
 
 func (f *PaginatingFetcher) Fetch(ctx context.Context, params model.SourceParams) ([]model.RawListing, error) {
@@ -28,6 +35,16 @@ func (f *PaginatingFetcher) Fetch(ctx context.Context, params model.SourceParams
 	var all []model.RawListing
 
 	for page := 1; page <= f.maxPages; page++ {
+		if page > 1 && f.pageDelay > 0 {
+			jitter := time.Duration(rand.Int64N(int64(pageDelayJitter)))
+			delay := f.pageDelay + jitter
+			select {
+			case <-ctx.Done():
+				return all, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
 		p := params
 		p.Page = page
 

--- a/internal/fetcher/paginating.go
+++ b/internal/fetcher/paginating.go
@@ -40,7 +40,10 @@ func (f *PaginatingFetcher) Fetch(ctx context.Context, params model.SourceParams
 			delay := f.pageDelay + jitter
 			select {
 			case <-ctx.Done():
-				return all, ctx.Err()
+				if len(all) > 0 {
+					return all, fmt.Errorf("%w: canceled after page %d: %v", ErrPartialResults, page-1, ctx.Err())
+				}
+				return nil, ctx.Err()
 			case <-time.After(delay):
 			}
 		}

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math/rand/v2"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
@@ -14,15 +15,25 @@ const (
 	defaultEnrichDelay     = 2 * time.Second
 	defaultMaxPerCycle     = 25
 	maxConsecutiveFailures = 3
+	// challengeBackoff is how long to wait after a bot challenge before retrying.
+	challengeBackoff = 7 * time.Second
+	// maxChallengeRetries is how many consecutive challenges we tolerate before aborting.
+	maxChallengeRetries = 2
 )
 
 // EnricherConfig controls the enrichment behavior.
 type EnricherConfig struct {
 	// Delay between individual item fetches to avoid rate-limiting.
+	// The actual delay is randomized: [Delay*0.75, Delay*1.75].
 	Delay time.Duration
 	// MaxPerCycle caps successful enrichments per Enrich call (not fetch attempts).
 	// 0 (default) applies defaultMaxPerCycle (25); override in config as needed. Negative means no limit.
 	MaxPerCycle int
+	// ChallengeBackoff is how long to wait after a bot challenge before retrying.
+	// 0 (default) uses 7 seconds.
+	ChallengeBackoff time.Duration
+	// ProxyPool enables proxy rotation on challenge. Optional.
+	ProxyPool *fetcher.ProxyPool
 }
 
 // Enricher fills in missing km data by fetching individual listing pages.
@@ -40,27 +51,48 @@ func NewEnricher(fetcher *Yad2Fetcher, logger *slog.Logger, cfg EnricherConfig) 
 	if cfg.MaxPerCycle == 0 {
 		cfg.MaxPerCycle = defaultMaxPerCycle
 	}
+	if cfg.ChallengeBackoff == 0 {
+		cfg.ChallengeBackoff = challengeBackoff
+	}
 	return &Enricher{fetcher: fetcher, logger: logger, cfg: cfg}
 }
 
-// Enrich fills in missing Km and ImageURL for listings.
+// jitteredDelay returns a randomized duration in [base*0.75, base*1.75].
+func jitteredDelay(base time.Duration) time.Duration {
+	lo := float64(base) * 0.75
+	hi := float64(base) * 1.75
+	return time.Duration(lo + rand.Float64()*(hi-lo))
+}
+
+// Enrich fills in missing Km, ImageURL, and City for listings.
+// It shuffles the candidates so different listings are prioritized each cycle.
 // It modifies the slice in place and returns the number of successfully enriched listings.
 func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int {
+	// Build shuffled indices of listings needing enrichment.
+	var candidates []int
+	for i := range listings {
+		if listings[i].Km <= 0 || listings[i].ImageURL == "" || listings[i].City == "" {
+			candidates = append(candidates, i)
+		}
+	}
+	if len(candidates) == 0 {
+		return 0
+	}
+	rand.Shuffle(len(candidates), func(a, b int) {
+		candidates[a], candidates[b] = candidates[b], candidates[a]
+	})
+
 	enriched := 0
 	attempts := 0
 	consecutiveFailures := 0
-	for i := range listings {
-		needsKm := listings[i].Km <= 0
-		needsImg := listings[i].ImageURL == ""
-		needsCity := listings[i].City == ""
-		if !needsKm && !needsImg && !needsCity {
-			continue
-		}
+	challengeRetries := 0
+
+	for _, i := range candidates {
 		if e.cfg.MaxPerCycle > 0 && enriched >= e.cfg.MaxPerCycle {
 			e.logger.Debug("enrichment limit reached",
 				"enriched", enriched,
 				"attempts", attempts,
-				"remaining", countNeedingEnrichment(listings[i:]),
+				"remaining", len(candidates)-attempts,
 			)
 			break
 		}
@@ -72,10 +104,11 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 
 		if attempts > 0 {
+			delay := jitteredDelay(e.cfg.Delay)
 			select {
 			case <-ctx.Done():
 				return enriched
-			case <-time.After(e.cfg.Delay):
+			case <-time.After(delay):
 			}
 		}
 
@@ -83,11 +116,29 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		details, err := e.fetcher.FetchItem(ctx, listings[i].Token)
 		if err != nil {
 			if errors.Is(err, fetcher.ErrChallenge) {
-				e.logger.Warn("enrichment blocked by anti-bot protection, skipping remaining items",
-					"attempts", attempts,
-					"remaining", countNeedingEnrichment(listings[i:]),
+				challengeRetries++
+				if e.cfg.ProxyPool != nil {
+					e.cfg.ProxyPool.MarkUnhealthy(e.currentProxy())
+				}
+				if challengeRetries >= maxChallengeRetries {
+					e.logger.Warn("enrichment aborted after repeated challenges",
+						"challenges", challengeRetries,
+						"attempts", attempts,
+						"enriched", enriched,
+						"remaining", len(candidates)-attempts,
+					)
+					return enriched
+				}
+				e.logger.Warn("challenge detected, backing off before retry",
+					"challenge_count", challengeRetries,
+					"backoff", e.cfg.ChallengeBackoff,
 				)
-				return enriched
+				select {
+				case <-ctx.Done():
+					return enriched
+				case <-time.After(e.cfg.ChallengeBackoff):
+				}
+				continue
 			}
 			consecutiveFailures++
 			e.logger.Warn("enrichment failed",
@@ -98,7 +149,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 				e.logger.Warn("enrichment aborted after consecutive failures",
 					"consecutive_failures", consecutiveFailures,
 					"attempts", attempts,
-					"remaining", countNeedingEnrichment(listings[i:]),
+					"remaining", len(candidates)-attempts,
 				)
 				return enriched
 			}
@@ -106,16 +157,17 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 
 		consecutiveFailures = 0
+		challengeRetries = 0
 		changed := false
-		if needsKm && details.Km > 0 {
+		if listings[i].Km <= 0 && details.Km > 0 {
 			listings[i].Km = details.Km
 			changed = true
 		}
-		if needsImg && details.ImageURL != "" {
+		if listings[i].ImageURL == "" && details.ImageURL != "" {
 			listings[i].ImageURL = details.ImageURL
 			changed = true
 		}
-		if needsCity && details.City != "" {
+		if listings[i].City == "" && details.City != "" {
 			listings[i].City = details.City
 			changed = true
 		}
@@ -133,6 +185,14 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 	}
 	return enriched
+}
+
+// currentProxy returns the last proxy URL used by the fetcher's pool, or empty string.
+func (e *Enricher) currentProxy() string {
+	if e.cfg.ProxyPool == nil {
+		return ""
+	}
+	return e.cfg.ProxyPool.Next()
 }
 
 func countNeedingEnrichment(listings []model.RawListing) int {

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -32,8 +32,6 @@ type EnricherConfig struct {
 	// ChallengeBackoff is how long to wait after a bot challenge before retrying.
 	// 0 (default) uses 7 seconds.
 	ChallengeBackoff time.Duration
-	// ProxyPool enables proxy rotation on challenge. Optional.
-	ProxyPool *fetcher.ProxyPool
 }
 
 // Enricher fills in missing km data by fetching individual listing pages.
@@ -117,9 +115,6 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		if err != nil {
 			if errors.Is(err, fetcher.ErrChallenge) {
 				challengeRetries++
-				if e.cfg.ProxyPool != nil {
-					e.cfg.ProxyPool.MarkUnhealthy(e.currentProxy())
-				}
 				if challengeRetries >= maxChallengeRetries {
 					e.logger.Warn("enrichment aborted after repeated challenges",
 						"challenges", challengeRetries,
@@ -185,22 +180,4 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 	}
 	return enriched
-}
-
-// currentProxy returns the last proxy URL used by the fetcher's pool, or empty string.
-func (e *Enricher) currentProxy() string {
-	if e.cfg.ProxyPool == nil {
-		return ""
-	}
-	return e.cfg.ProxyPool.Next()
-}
-
-func countNeedingEnrichment(listings []model.RawListing) int {
-	n := 0
-	for _, l := range listings {
-		if l.Km <= 0 || l.ImageURL == "" || l.City == "" {
-			n++
-		}
-	}
-	return n
 }

--- a/internal/fetcher/yad2/enricher_test.go
+++ b/internal/fetcher/yad2/enricher_test.go
@@ -173,11 +173,15 @@ func TestEnricher_RespectsMaxPerCycle(t *testing.T) {
 	if count != 1 {
 		t.Errorf("enriched = %d, want 1 (max per cycle)", count)
 	}
-	if listings[0].Km != 10000 {
-		t.Errorf("listing[0].Km = %d, want 10000", listings[0].Km)
+	// With shuffle, exactly 1 listing is enriched (any of the 3).
+	enrichedCount := 0
+	for _, l := range listings {
+		if l.Km == 10000 {
+			enrichedCount++
+		}
 	}
-	if listings[1].Km != 0 {
-		t.Errorf("listing[1].Km = %d, want 0 (not enriched)", listings[1].Km)
+	if enrichedCount != 1 {
+		t.Errorf("listings with km=10000: %d, want 1", enrichedCount)
 	}
 	if got := requestCount.Load(); got != 1 {
 		t.Errorf("requests = %d, want 1 (budget limits successful enrichments)", got)
@@ -329,6 +333,9 @@ func TestEnricher_FillsKmAndCity(t *testing.T) {
 }
 
 func TestEnricher_AbortsOnBotChallenge(t *testing.T) {
+	// With soft resume: one challenge backs off and continues; 2 consecutive
+	// challenges abort. Here only tok-b triggers a challenge, so the enricher
+	// backs off once and continues to the remaining items.
 	var requestCount atomic.Int32
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
@@ -342,7 +349,10 @@ func TestEnricher_AbortsOnBotChallenge(t *testing.T) {
 </script></html>`)
 	})
 
-	enricher := newTestEnricher(t, handler, EnricherConfig{Delay: time.Millisecond})
+	enricher := newTestEnricher(t, handler, EnricherConfig{
+		Delay:            time.Millisecond,
+		ChallengeBackoff: time.Millisecond,
+	})
 
 	listings := []model.RawListing{
 		{Token: "tok-a", Km: 0},
@@ -352,17 +362,47 @@ func TestEnricher_AbortsOnBotChallenge(t *testing.T) {
 	}
 
 	count := enricher.Enrich(context.Background(), listings)
-	if count != 1 {
-		t.Errorf("enriched = %d, want 1 (should stop after challenge on tok-b)", count)
+	// 3 out of 4 should be enriched (all except tok-b which triggers challenge).
+	if count != 3 {
+		t.Errorf("enriched = %d, want 3 (soft resume continues after one challenge)", count)
 	}
-	if got := requestCount.Load(); got != 2 {
-		t.Errorf("requests = %d, want 2 (tok-a success, tok-b challenge, then abort)", got)
+	if got := requestCount.Load(); got != 4 {
+		t.Errorf("requests = %d, want 4 (all tokens attempted)", got)
 	}
-	if listings[0].Km != 10000 {
-		t.Errorf("listing[0].Km = %d, want 10000", listings[0].Km)
+	// tok-b should NOT be enriched.
+	if listings[1].Km != 0 {
+		t.Errorf("listing[1] (tok-b).Km = %d, want 0 (challenge token)", listings[1].Km)
 	}
-	if listings[2].Km != 0 {
-		t.Errorf("listing[2].Km = %d, want 0 (skipped)", listings[2].Km)
+}
+
+func TestEnricher_AbortsAfterRepeatedChallenges(t *testing.T) {
+	// When ALL tokens trigger a challenge, the enricher should abort after
+	// maxChallengeRetries consecutive challenges.
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `<html>validate.perfdrive.com - Are you for real?</html>`)
+	})
+
+	enricher := newTestEnricher(t, handler, EnricherConfig{
+		Delay:            time.Millisecond,
+		ChallengeBackoff: time.Millisecond,
+	})
+
+	listings := []model.RawListing{
+		{Token: "a", Km: 0},
+		{Token: "b", Km: 0},
+		{Token: "c", Km: 0},
+		{Token: "d", Km: 0},
+	}
+
+	count := enricher.Enrich(context.Background(), listings)
+	if count != 0 {
+		t.Errorf("enriched = %d, want 0 (all challenges)", count)
+	}
+	if got := requestCount.Load(); got != int32(maxChallengeRetries) {
+		t.Errorf("requests = %d, want %d (abort after maxChallengeRetries)", got, maxChallengeRetries)
 	}
 }
 

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -111,17 +111,40 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 	base.RawQuery = ""
 	itemURL := base.String()
 
-	result, err := f.itemClient.Get(ctx, itemURL)
+	client := f.itemClient
+	var usedProxy string
+	if f.proxyPool != nil {
+		usedProxy = f.proxyPool.Next()
+		if f.clientPool != nil {
+			c, err := f.clientPool.Get(usedProxy)
+			if err != nil {
+				f.logger.Warn("failed to get pooled client for item fetch, using fallback", "proxy", redactProxy(usedProxy), "error", err)
+			} else {
+				client = c
+			}
+		}
+	}
+
+	result, err := client.Get(ctx, itemURL)
 	if err != nil {
+		if f.clientPool != nil && usedProxy != "" {
+			f.clientPool.Evict(usedProxy)
+		}
 		return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, err)
 	}
 
 	if result.StatusCode != http.StatusOK {
 		if looksLikeBotProtection(result.Body) {
+			if f.proxyPool != nil && usedProxy != "" {
+				f.proxyPool.MarkUnhealthy(usedProxy)
+			}
 			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
 		}
 		if (result.StatusCode == http.StatusBadRequest || result.StatusCode == http.StatusForbidden) &&
 			looksLikeGenericError(result.Body) {
+			if f.proxyPool != nil && usedProxy != "" {
+				f.proxyPool.MarkUnhealthy(usedProxy)
+			}
 			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
 		}
 		snippet := string(result.Body)

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -185,6 +185,9 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 
 	if result.StatusCode != http.StatusOK {
 		if looksLikeBotProtection(result.Body) {
+			if f.proxyPool != nil && usedProxy != "" {
+				f.proxyPool.MarkUnhealthy(usedProxy)
+			}
 			return nil, fmt.Errorf("yad2: %w", fetcher.ErrChallenge)
 		}
 		body := string(result.Body)

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -235,7 +235,8 @@ func recipientBlockedError(err error) error {
 	}
 	errMsg := strings.ToLower(err.Error())
 	if strings.Contains(errMsg, "bot was blocked by the user") ||
-		strings.Contains(errMsg, "user is deactivated") {
+		strings.Contains(errMsg, "user is deactivated") ||
+		strings.Contains(errMsg, "chat not found") {
 		return fmt.Errorf("%w: %v", notifier.ErrRecipientBlocked, err)
 	}
 	return nil

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -296,6 +296,25 @@ func TestSendMessage_APIError_Blocked(t *testing.T) {
 	}
 }
 
+func TestSendMessage_APIError_ChatNotFound(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		resp, _ := json.Marshal(map[string]any{
+			"ok":          false,
+			"description": "Bad Request: chat not found",
+		})
+		_, _ = w.Write(resp)
+	}))
+
+	err := n.NotifyRaw(context.Background(), "123", "test message body")
+	if err == nil {
+		t.Fatal("expected error for chat not found")
+	}
+	if !errors.Is(err, notifier.ErrRecipientBlocked) {
+		t.Errorf("expected ErrRecipientBlocked for chat not found, got: %v", err)
+	}
+}
+
 func TestSendMessage_LargeMessage_MultipleChunks(t *testing.T) {
 	var sendCalls atomic.Int32
 	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -269,6 +269,10 @@ func (m *mockListingStore) BackfillListings(_ context.Context, _ []storage.Listi
 	return nil
 }
 
+func (m *mockListingStore) LookupEnrichmentData(_ context.Context, _ []string) (map[string]storage.EnrichmentRecord, error) {
+	return nil, nil
+}
+
 func (m *mockListingStore) GetListing(_ context.Context, _ int64, _ string) (*storage.ListingRecord, error) {
 	return nil, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -795,14 +795,70 @@ func (s *Scheduler) fetchAndEnrich(ctx context.Context, group CanonicalGroup) ([
 				"enriched", enriched,
 				"total", len(raw),
 			)
-			// Backfill: persist enriched km/city/image for existing listings.
 			if s.stores.Listings != nil {
 				s.backfillEnrichedListings(ctx, raw)
 			}
 		}
+
+		// Pre-fill: load previously-known km/city/image from DB for listings
+		// that still lack km after enrichment.
+		if s.stores.Listings != nil {
+			s.prefillFromDB(ctx, raw)
+		}
 	}
 
 	return raw, source, nil
+}
+
+// prefillFromDB fills in km/city/image from listing_history for listings
+// that the enricher could not reach this cycle. Once a listing's km is
+// learned in any previous cycle, it is remembered here.
+func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListing) {
+	var tokens []string
+	for i := range listings {
+		if listings[i].Km <= 0 || listings[i].City == "" || listings[i].ImageURL == "" {
+			tokens = append(tokens, listings[i].Token)
+		}
+	}
+	if len(tokens) == 0 {
+		return
+	}
+
+	data, err := s.stores.Listings.LookupEnrichmentData(ctx, tokens)
+	if err != nil {
+		s.logger.Error("prefill from DB failed", "error", err)
+		return
+	}
+	if len(data) == 0 {
+		return
+	}
+
+	filled := 0
+	for i := range listings {
+		rec, ok := data[listings[i].Token]
+		if !ok {
+			continue
+		}
+		changed := false
+		if listings[i].Km <= 0 && rec.Km > 0 {
+			listings[i].Km = rec.Km
+			changed = true
+		}
+		if listings[i].City == "" && rec.City != "" {
+			listings[i].City = rec.City
+			changed = true
+		}
+		if listings[i].ImageURL == "" && rec.ImageURL != "" {
+			listings[i].ImageURL = rec.ImageURL
+			changed = true
+		}
+		if changed {
+			filled++
+		}
+	}
+	if filled > 0 {
+		s.logger.Info("prefilled from DB", "filled", filled, "looked_up", len(tokens))
+	}
 }
 
 // backfillEnrichedListings upserts listing_history for listings that gained

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -464,7 +464,19 @@ func (s *Scheduler) retryPending(ctx context.Context) {
 			"msg_preview", truncateStr(p.Payload, 100),
 		)
 		if err := s.notifier.NotifyRaw(ctx, p.Recipient, p.Payload); err != nil {
+			if errors.Is(err, notifier.ErrRecipientBlocked) {
+				s.logger.Warn("purging notification for unreachable recipient",
+					"id", p.ID,
+					"recipient", maskPhone(p.Recipient),
+					"error", err,
+				)
+				if ackErr := s.stores.Queue.AckNotification(ctx, p.ID); ackErr != nil {
+					s.logger.Error("ack unreachable notification failed", "id", p.ID, "error", ackErr)
+				}
+				continue
+			}
 			s.logger.Error("retry notification failed",
+				"id", p.ID,
 				"recipient", maskPhone(p.Recipient),
 				"error", err,
 			)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1406,6 +1406,9 @@ func (s *Scheduler) carName(manufacturerID, modelID int) string {
 	}
 	mfr := s.carNames.ManufacturerName(manufacturerID)
 	mdl := s.carNames.ModelName(manufacturerID, modelID)
+	if mfr == "" || mdl == "" {
+		return fmt.Sprintf("%d/%d", manufacturerID, modelID)
+	}
 	return mfr + " " + mdl
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -45,6 +45,13 @@ type CatalogIngester interface {
 	Flush(ctx context.Context)
 }
 
+// CarNameResolver translates numeric manufacturer/model IDs into
+// human-readable names for log messages.
+type CarNameResolver interface {
+	ManufacturerName(id int) string
+	ModelName(manufacturerID, modelID int) string
+}
+
 // KmEnricher fills in missing km data by fetching individual listing pages.
 type KmEnricher interface {
 	Enrich(ctx context.Context, listings []model.RawListing) int
@@ -65,6 +72,7 @@ type Scheduler struct {
 	observer          CycleObserver
 	fetcherFactory    *fetcher.Factory
 	catalogIngester   CatalogIngester
+	carNames          CarNameResolver
 	kmEnricher        KmEnricher
 	triggerCh         chan struct{}
 
@@ -110,6 +118,7 @@ type Options struct {
 	DigestStore      storage.DigestStore
 	HiddenStore      storage.HiddenListingStore
 	CatalogIngester  CatalogIngester
+	CarNames         CarNameResolver
 	KmEnricher       KmEnricher
 	MarketStore      storage.MarketStore
 	DailyDigestStore storage.DailyDigestStore
@@ -165,6 +174,7 @@ func NewWithOptions(
 		observer:          obs,
 		fetcherFactory:    opts.FetcherFactory,
 		catalogIngester:   opts.CatalogIngester,
+		carNames:          opts.CarNames,
 		kmEnricher:        opts.KmEnricher,
 		triggerCh:         make(chan struct{}, 1),
 	}, nil
@@ -183,7 +193,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	logJitter := s.cfg.Polling.Jitter
 	s.cfgMu.RUnlock()
 	s.logger.Info("scheduler started",
-		"interval", logInterval.String(),
+		"check_interval", logInterval.String(),
 		"jitter", logJitter.String(),
 	)
 
@@ -221,7 +231,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			}
 		}
 
-		s.logger.Info("next poll", "delay", delay.Round(time.Second).String())
+		s.logger.Info("next scan", "in", delay.Round(time.Second).String())
 
 		timer.Reset(delay)
 
@@ -240,7 +250,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			if !timer.Stop() {
 				<-timer.C
 			}
-			s.logger.Info("poll triggered")
+			s.logger.Info("scan triggered manually")
 		case <-timer.C:
 		}
 
@@ -252,7 +262,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			if errors.Is(err, context.Canceled) {
 				return err
 			}
-			s.logger.Error("cycle failed", "error", err)
+			s.logger.Error("scan failed", "error", err)
 		}
 	}
 }
@@ -301,11 +311,10 @@ func (s *Scheduler) fetchWithRetryUsing(ctx context.Context, f fetcher.Fetcher, 
 		lastErr = err
 
 		if errors.Is(err, fetcher.ErrPartialResults) && len(listings) > 0 {
-			s.logger.Warn("fetch returned partial results",
+			s.logger.Warn("partial results (some pages failed)",
+				"car", s.carName(params.Manufacturer, params.Model),
+				"listings_returned", len(listings),
 				"error", err,
-				"count", len(listings),
-				"manufacturer", params.Manufacturer,
-				"model", params.Model,
 			)
 			return listings, nil
 		}
@@ -317,11 +326,9 @@ func (s *Scheduler) fetchWithRetryUsing(ctx context.Context, f fetcher.Fetcher, 
 		if attempt < maxRetries-1 {
 			delay := retryBaseDelay * (1 << attempt)
 			s.logger.Warn("fetch failed, retrying",
-				"attempt", attempt+1,
-				"max_attempts", maxRetries,
-				"delay", delay.String(),
-				"manufacturer", params.Manufacturer,
-				"model", params.Model,
+				"car", s.carName(params.Manufacturer, params.Model),
+				"attempt", fmt.Sprintf("%d/%d", attempt+1, maxRetries),
+				"retry_in", delay.String(),
 				"error", err,
 			)
 			select {
@@ -443,7 +450,7 @@ func (s *Scheduler) retryPending(ctx context.Context) {
 	if len(pending) == 0 {
 		return
 	}
-	s.logger.Info("retrying pending notifications", "count", len(pending))
+	s.logger.Info("retrying queued messages", "count", len(pending))
 	for _, p := range pending {
 		if notifier.IsMalformedMessage(p.Payload) {
 			s.logger.Error("purging malformed pending notification",
@@ -494,7 +501,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	cycle := s.cycleCount
 	cycleStart := time.Now()
 
-	s.logger.Info("poll cycle started", "cycle", cycle)
+	s.logger.Info("checking for new listings", "scan", cycle)
 
 	s.langCache.Range(func(k, _ any) bool { s.langCache.Delete(k); return true })
 	s.digestCache.Range(func(k, _ any) bool { s.digestCache.Delete(k); return true })
@@ -508,13 +515,17 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.processExpiredPremium(ctx)
 
 	if len(searches) == 0 {
-		s.logger.Info("poll cycle done", "cycle", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond), "searches", 0)
+		s.logger.Info("scan complete (no active searches)", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
 		return nil
 	}
 
 	marketCache := s.buildMarketCache(ctx)
 	groups := GroupSearches(searches)
-	s.logger.Info("grouped searches", "cycle", cycle, "groups", len(groups), "total_searches", len(searches))
+	s.logger.Info("active searches loaded",
+		"scan", cycle,
+		"car_models", len(groups),
+		"searches", len(searches),
+	)
 
 	allFailed, stats := s.runFetchGroups(ctx, groups, marketCache)
 
@@ -525,20 +536,20 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.processDigests(ctx)
 	s.processDailyDigests(ctx)
 
-	s.logger.Info("poll cycle done",
-		"cycle", cycle,
+	s.logger.Info("scan complete",
+		"scan", cycle,
 		"elapsed", time.Since(cycleStart).Round(time.Millisecond),
-		"groups", len(groups),
+		"car_models", len(groups),
 		"searches", len(searches),
-		"listings_fetched", stats.listingsFetched,
-		"new_listings", stats.newListings,
+		"listings_checked", stats.listingsFetched,
+		"new_matches", stats.newListings,
 		"notifications_sent", stats.notificationsSent,
-		"groups_failed", stats.groupsFailed,
+		"failed", stats.groupsFailed,
 	)
 
 	if allFailed && len(groups) > 0 {
 		s.observer.RecordError()
-		return fmt.Errorf("all %d groups failed", len(groups))
+		return fmt.Errorf("all %d car models failed to fetch", len(groups))
 	}
 
 	s.observer.RecordSuccess()
@@ -650,9 +661,8 @@ func (s *Scheduler) runFetchGroups(ctx context.Context, groups []CanonicalGroup,
 			defer func() { <-sem }()
 			defer func() {
 				if r := recover(); r != nil {
-					s.logger.Error("panic in processGroup",
-						"manufacturer", g.Manufacturer,
-						"model", g.Model,
+					s.logger.Error("unexpected crash while fetching listings",
+						"car", s.carName(g.Manufacturer, g.Model),
 						"panic", r,
 						"stack", string(debug.Stack()))
 					s.observer.RecordError()
@@ -661,9 +671,9 @@ func (s *Scheduler) runFetchGroups(ctx context.Context, groups []CanonicalGroup,
 
 			gs, err := s.processGroup(ctx, g, marketCache)
 			if err != nil {
-				s.logger.Error("group failed",
-					"manufacturer", g.Manufacturer,
-					"model", g.Model,
+				s.logger.Error("failed to fetch listings",
+					"car", s.carName(g.Manufacturer, g.Model),
+					"source", g.Source,
 					"error", err)
 				if errors.Is(err, fetcher.ErrChallenge) {
 					s.boMu.Lock()
@@ -692,9 +702,8 @@ func (s *Scheduler) runFetchGroups(ctx context.Context, groups []CanonicalGroup,
 
 func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, marketCache *scoring.MarketCache) (cycleStats, error) {
 	groupStart := time.Now()
-	s.logger.Debug("group starting",
-		"manufacturer", group.Manufacturer,
-		"model", group.Model,
+	s.logger.Debug("fetching car model",
+		"car", s.carName(group.Manufacturer, group.Model),
 		"searches", len(group.Searches),
 	)
 	raw, source, err := s.fetchAndEnrich(ctx, group)
@@ -735,13 +744,12 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		}
 	}
 
-	s.logger.Info("group done",
+	s.logger.Info("car model checked",
+		"car", s.carName(group.Manufacturer, group.Model),
 		"source", source,
-		"manufacturer", group.Manufacturer,
-		"model", group.Model,
 		"listings", len(raw),
-		"new", gs.newListings,
-		"user_searches", len(group.Searches),
+		"new_matches", gs.newListings,
+		"searches", len(group.Searches),
 		"elapsed", time.Since(groupStart).Round(time.Millisecond),
 	)
 
@@ -782,11 +790,10 @@ func (s *Scheduler) fetchAndEnrich(ctx context.Context, group CanonicalGroup) ([
 		defer cancelEnrich()
 		enriched := s.kmEnricher.Enrich(enrichCtx, raw)
 		if enriched > 0 {
-			s.logger.Info("km enrichment complete",
+			s.logger.Info("mileage data enriched",
+				"car", s.carName(group.Manufacturer, group.Model),
 				"enriched", enriched,
 				"total", len(raw),
-				"manufacturer", group.Manufacturer,
-				"model", group.Model,
 			)
 			// Backfill: persist enriched km/city/image for existing listings.
 			if s.stores.Listings != nil {
@@ -1050,7 +1057,7 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 
 	s.observer.RecordListingsFound(len(sr.newListings))
 
-	s.logger.Info("new listings for user",
+	s.logger.Info("notifying user of new listings",
 		"chat_id", search.ChatID,
 		"search", search.Name,
 		"count", len(sr.newListings),
@@ -1335,6 +1342,15 @@ func (s *Scheduler) userLang(ctx context.Context, chatID int64) locale.Lang {
 	}
 	s.langCache.Store(chatID, lang)
 	return lang
+}
+
+func (s *Scheduler) carName(manufacturerID, modelID int) string {
+	if s.carNames == nil {
+		return fmt.Sprintf("%d/%d", manufacturerID, modelID)
+	}
+	mfr := s.carNames.ManufacturerName(manufacturerID)
+	mdl := s.carNames.ModelName(manufacturerID, modelID)
+	return mfr + " " + mdl
 }
 
 func maskPhone(phone string) string {

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -526,7 +528,37 @@ func TestRetryPending_NotifyRawFails(t *testing.T) {
 	s.retryPending(context.Background())
 
 	if q.acked != nil && q.acked[1] {
-		t.Error("should not ack notification when retry fails")
+		t.Error("should not ack notification when retry fails with transient error")
+	}
+}
+
+func TestRetryPending_PurgesUnreachableRecipient(t *testing.T) {
+	n := &errNotifier{rawErr: fmt.Errorf("%w: chat not found", notifier.ErrRecipientBlocked)}
+	q := &errNotificationQueue{
+		mockNotificationQueue: mockNotificationQueue{
+			pending: []storage.PendingNotification{
+				{ID: 1, Recipient: "200000000001", Payload: "valid notification message"},
+				{ID: 2, Recipient: "200000000001", Payload: "another valid notification"},
+			},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, logger, Options{Queue: q})
+	s.retryPending(context.Background())
+
+	if !q.acked[1] {
+		t.Error("unreachable notification id=1 should be acked (purged)")
+	}
+	if !q.acked[2] {
+		t.Error("unreachable notification id=2 should be acked (purged)")
+	}
+
+	logOutput := logBuf.String()
+	if !strings.Contains(logOutput, "purging notification for unreachable recipient") {
+		t.Errorf("expected purge log message, got: %s", logOutput)
 	}
 }
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -149,6 +149,13 @@ type PricePoint struct {
 	ObservedAt time.Time
 }
 
+// EnrichmentRecord holds km/city/image data previously learned for a listing token.
+type EnrichmentRecord struct {
+	Km       int
+	City     string
+	ImageURL string
+}
+
 // ListingFilter restricts which listing_history rows are returned.
 // Zero values are ignored (no constraint applied for that field).
 type ListingFilter struct {
@@ -163,6 +170,7 @@ type ListingStore interface {
 	SaveListing(ctx context.Context, r ListingRecord) error
 	SaveListings(ctx context.Context, records []ListingRecord) error
 	BackfillListings(ctx context.Context, records []ListingRecord) error
+	LookupEnrichmentData(ctx context.Context, tokens []string) (map[string]EnrichmentRecord, error)
 	GetListing(ctx context.Context, chatID int64, token string) (*ListingRecord, error)
 	ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]ListingRecord, error)
 	CountUserListings(ctx context.Context, chatID int64) (int64, error)

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -117,6 +117,56 @@ func (s *Store) BackfillListings(ctx context.Context, records []storage.ListingR
 	return tx.Commit()
 }
 
+const lookupEnrichmentBatchSize = 500
+
+func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[string]storage.EnrichmentRecord, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]storage.EnrichmentRecord, len(tokens))
+	for start := 0; start < len(tokens); start += lookupEnrichmentBatchSize {
+		end := start + lookupEnrichmentBatchSize
+		if end > len(tokens) {
+			end = len(tokens)
+		}
+		batch := tokens[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, t := range batch {
+			args[i] = t
+			placeholders[i] = fmt.Sprintf("$%d", i+1)
+		}
+
+		q := `SELECT token, MAX(km), MAX(city), MAX(image_url)
+			FROM listing_history
+			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND km > 0
+			GROUP BY token`
+
+		rows, err := s.db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("lookup enrichment data: %w", err)
+		}
+
+		for rows.Next() {
+			var tok, city, img string
+			var km int
+			if err := rows.Scan(&tok, &km, &city, &img); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan enrichment data: %w", err)
+			}
+			out[tok] = storage.EnrichmentRecord{Km: km, City: city, ImageURL: img}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("enrichment rows: %w", err)
+		}
+		_ = rows.Close()
+	}
+	return out, nil
+}
+
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price,

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -141,7 +141,7 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 
 		q := `SELECT token, MAX(km), MAX(city), MAX(image_url)
 			FROM listing_history
-			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND km > 0
+			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
 			GROUP BY token`
 
 		rows, err := s.db.QueryContext(ctx, q, args...)

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -143,7 +143,7 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 
 		q := `SELECT token, MAX(km), MAX(city), MAX(image_url)
 			FROM listing_history
-			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND km > 0
+			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
 			GROUP BY token`
 
 		rows, err := s.db.QueryContext(ctx, q, args...)

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -119,6 +119,56 @@ func (s *Store) BackfillListings(ctx context.Context, records []storage.ListingR
 	return tx.Commit()
 }
 
+const lookupEnrichmentBatchSize = 500
+
+func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[string]storage.EnrichmentRecord, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]storage.EnrichmentRecord, len(tokens))
+	for start := 0; start < len(tokens); start += lookupEnrichmentBatchSize {
+		end := start + lookupEnrichmentBatchSize
+		if end > len(tokens) {
+			end = len(tokens)
+		}
+		batch := tokens[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, t := range batch {
+			args[i] = t
+			placeholders[i] = "?"
+		}
+
+		q := `SELECT token, MAX(km), MAX(city), MAX(image_url)
+			FROM listing_history
+			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND km > 0
+			GROUP BY token`
+
+		rows, err := s.db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("lookup enrichment data: %w", err)
+		}
+
+		for rows.Next() {
+			var tok, city, img string
+			var km int
+			if err := rows.Scan(&tok, &km, &city, &img); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan enrichment data: %w", err)
+			}
+			out[tok] = storage.EnrichmentRecord{Km: km, City: city, ImageURL: img}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("enrichment rows: %w", err)
+		}
+		_ = rows.Close()
+	}
+	return out, nil
+}
+
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT token, search_name, manufacturer, model, year, price,

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -22,7 +22,6 @@ export function useMarkNotificationsSeen() {
     mutationFn: () => notificationsApi.markSeen(),
     onSuccess: () => {
       queryClient.setQueryData(["notification-count"], { count: 0 });
-      queryClient.invalidateQueries({ queryKey: ["notifications"] });
     },
   });
 }


### PR DESCRIPTION
## Summary

- **DB pre-fill safety net**: once a listing's km/city/image is learned, it's remembered across scheduler cycles — no more losing enriched data when Yad2 blocks item page requests
- **Smarter enrichment**: shuffle candidate order, jittered delays (1.5-3.5s), soft-resume on bot challenge with proxy rotation instead of full abort
- **Reduced bot trigger rate**: 1.5-2.5s delay between paginated page fetches
- **Notifications page fix**: removed query invalidation race that cleared the page immediately after marking items as seen

## Test plan

- [x] All existing unit tests pass (updated tests for shuffle + challenge behavior)
- [x] Verified enrichment pre-fill logic with existing DB data
- [x] Confirmed notification page displays correctly after markSeen


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic mileage enrichment and car name display for listings.
  * Implemented proxy rotation for more reliable data fetching with anti-bot resilience.
  * Introduced inter-page delay with jitter to optimize pagination requests.

* **Bug Fixes**
  * Improved Telegram notification error detection for unreachable chat recipients.

* **Improvements**
  * Enhanced circuit breaker with detailed logging and better failure handling for partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->