### PR TITLE
fix: make km enrichment reliable and fix notifications page race

### DIFF
--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -181,4 +181,3 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 	}
 	return enriched
 }
-


### PR DESCRIPTION
## Summary

- **DB pre-fill safety net**: once a listing's km/city/image is learned, it's remembered across scheduler cycles — no more losing enriched data when Yad2 blocks item page requests
- **Smarter enrichment**: shuffle candidate order, jittered delays (1.5-3.5s), soft-resume on bot challenge with proxy rotation instead of full abort
- **Reduced bot trigger rate**: 1.5-2.5s delay between paginated page fetches
- **Proxy rotation fix**: moved into FetchItem directly so the correct proxy gets marked unhealthy
- **Notifications page fix**: removed query invalidation race that cleared the page immediately after marking items as seen
- **Scheduler log readability**: rewrote logs for admin clarity

## Test plan

- [x] All existing unit tests pass (updated tests for shuffle + challenge behavior)
- [x] Verified enrichment pre-fill logic with existing DB data
- [x] Confirmed notification page displays correctly after markSeen
- [x] `go vet ./...` clean
- [x] All CodeRabbit review feedback addressed


Made with [Cursor](https://cursor.com)