### PR TITLE
test: add missing test files for timeutil, postgres helpers, and migrate tool

### DIFF
--- a/cmd/migrate-sqlite-to-pg/main_test.go
+++ b/cmd/migrate-sqlite-to-pg/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildPlaceholders(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, ""},
+		{1, "$1"},
+		{2, "$1, $2"},
+		{3, "$1, $2, $3"},
+		{5, "$1, $2, $3, $4, $5"},
+	}
+
+	for _, tt := range tests {
+		got := buildPlaceholders(tt.n)
+		if got != tt.want {
+			t.Errorf("buildPlaceholders(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestConvertValue_TimeStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		year  int
+		month time.Month
+		day   int
+	}{
+		{"RFC3339Nano", "2024-06-15T10:30:45.123456789Z", 2024, time.June, 15},
+		{"RFC3339", "2024-06-15T10:30:45+03:00", 2024, time.June, 15},
+		{"datetime with tz offset", "2024-06-15 10:30:45.123456-05:00", 2024, time.June, 15},
+		{"datetime microseconds", "2024-06-15 10:30:45.123456", 2024, time.June, 15},
+		{"datetime no frac", "2024-06-15 10:30:45", 2024, time.June, 15},
+		{"ISO with Z", "2024-06-15T10:30:45Z", 2024, time.June, 15},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertValue(tt.input)
+			tm, ok := got.(time.Time)
+			if !ok {
+				t.Fatalf("expected time.Time, got %T: %v", got, got)
+			}
+			if tm.Location() != time.UTC {
+				t.Errorf("expected UTC, got %v", tm.Location())
+			}
+			if tm.Year() != tt.year || tm.Month() != tt.month || tm.Day() != tt.day {
+				t.Errorf("got %v, expected date %d-%02d-%02d", tm, tt.year, tt.month, tt.day)
+			}
+		})
+	}
+}
+
+func TestConvertValue_NonTimeStrings(t *testing.T) {
+	tests := []string{
+		"hello",
+		"2024-06-15",
+		"not a date",
+		"",
+		"12345",
+	}
+
+	for _, input := range tests {
+		got := convertValue(input)
+		s, ok := got.(string)
+		if !ok {
+			t.Errorf("convertValue(%q) returned %T, want string", input, got)
+			continue
+		}
+		if s != input {
+			t.Errorf("convertValue(%q) = %q, want same string back", input, s)
+		}
+	}
+}
+
+func TestConvertValue_ByteSlice(t *testing.T) {
+	input := []byte("hello world")
+	got := convertValue(input)
+	s, ok := got.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", got)
+	}
+	if s != "hello world" {
+		t.Errorf("got %q, want %q", s, "hello world")
+	}
+}
+
+func TestConvertValue_OtherTypes(t *testing.T) {
+	tests := []any{
+		int64(42),
+		float64(3.14),
+		true,
+		nil,
+	}
+
+	for _, input := range tests {
+		got := convertValue(input)
+		if got != input {
+			t.Errorf("convertValue(%v) = %v, want same value", input, got)
+		}
+	}
+}

--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -1,0 +1,156 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func TestQuoteIdent(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"users", `"users"`},
+		{"listing_history", `"listing_history"`},
+		{`evil"table`, `"evil""table"`},
+		{`a""b`, `"a""""b"`},
+		{"", `""`},
+	}
+
+	for _, tt := range tests {
+		got := quoteIdent(tt.input)
+		if got != tt.want {
+			t.Errorf("quoteIdent(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildFilterClauses_Empty(t *testing.T) {
+	clause, args, nextParam := buildFilterClauses(storage.ListingFilter{}, 1)
+	if clause != "" {
+		t.Errorf("expected empty clause, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+	if nextParam != 1 {
+		t.Errorf("expected nextParam=1, got %d", nextParam)
+	}
+}
+
+func TestBuildFilterClauses_AllFields(t *testing.T) {
+	f := storage.ListingFilter{
+		PriceMax: 100000,
+		YearMin:  2018,
+		YearMax:  2023,
+		MaxKm:    150000,
+		MaxHand:  2,
+	}
+	clause, args, nextParam := buildFilterClauses(f, 3)
+
+	if clause == "" {
+		t.Fatal("expected non-empty clause")
+	}
+
+	if len(args) != 5 {
+		t.Fatalf("expected 5 args, got %d: %v", len(args), args)
+	}
+
+	if args[0] != 100000 {
+		t.Errorf("args[0] = %v, want 100000", args[0])
+	}
+	if args[1] != 2018 {
+		t.Errorf("args[1] = %v, want 2018", args[1])
+	}
+	if args[2] != 2023 {
+		t.Errorf("args[2] = %v, want 2023", args[2])
+	}
+	if args[3] != 150000 {
+		t.Errorf("args[3] = %v, want 150000", args[3])
+	}
+	if args[4] != 2 {
+		t.Errorf("args[4] = %v, want 2", args[4])
+	}
+
+	if nextParam != 8 {
+		t.Errorf("nextParam = %d, want 8 (started at 3, used 5)", nextParam)
+	}
+}
+
+func TestBuildFilterClauses_PartialFields(t *testing.T) {
+	f := storage.ListingFilter{
+		PriceMax: 70000,
+		MaxKm:    120000,
+	}
+	clause, args, nextParam := buildFilterClauses(f, 5)
+
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(args))
+	}
+	if args[0] != 70000 {
+		t.Errorf("args[0] = %v, want 70000", args[0])
+	}
+	if args[1] != 120000 {
+		t.Errorf("args[1] = %v, want 120000", args[1])
+	}
+	if nextParam != 7 {
+		t.Errorf("nextParam = %d, want 7", nextParam)
+	}
+	if clause == "" {
+		t.Error("expected non-empty clause")
+	}
+}
+
+func TestBuildFilterClauses_MaxKmIncludesPositiveCheck(t *testing.T) {
+	f := storage.ListingFilter{MaxKm: 50000}
+	clause, _, _ := buildFilterClauses(f, 1)
+
+	if clause == "" {
+		t.Fatal("expected clause")
+	}
+	if !strings.Contains(clause, "km > 0") {
+		t.Errorf("MaxKm clause should include 'km > 0' check, got: %s", clause)
+	}
+}
+
+func TestGenerateShareToken(t *testing.T) {
+	token, err := generateShareToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(token) != 32 {
+		t.Errorf("expected 32-char hex token, got len=%d: %q", len(token), token)
+	}
+
+	token2, _ := generateShareToken()
+	if token == token2 {
+		t.Error("two consecutive tokens should differ")
+	}
+}
+
+func TestPurgeableAllowlist(t *testing.T) {
+	allowed := []string{
+		"listing_history",
+		"price_history",
+		"seen_listings",
+		"pending_notifications",
+		"saved_listings",
+		"hidden_listings",
+		"pending_digest",
+	}
+	for _, table := range allowed {
+		if !purgeable[table] {
+			t.Errorf("%q should be purgeable", table)
+		}
+	}
+
+	forbidden := []string{"users", "searches", "link_tokens", "whatever"}
+	for _, table := range forbidden {
+		if purgeable[table] {
+			t.Errorf("%q should NOT be purgeable", table)
+		}
+	}
+}
+

--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -124,7 +124,10 @@ func TestGenerateShareToken(t *testing.T) {
 		t.Errorf("expected 32-char hex token, got len=%d: %q", len(token), token)
 	}
 
-	token2, _ := generateShareToken()
+	token2, err := generateShareToken()
+	if err != nil {
+		t.Fatalf("unexpected error on second token: %v", err)
+	}
 	if token == token2 {
 		t.Error("two consecutive tokens should differ")
 	}

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -1,0 +1,98 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseFlexible_ValidFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect time.Time
+	}{
+		{
+			name:   "datetime with fractional seconds",
+			input:  "2024-03-15 10:30:45.123456789",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 123456789, time.UTC),
+		},
+		{
+			name:   "datetime with timezone offset",
+			input:  "2024-03-15 10:30:45.123-05:00",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 123000000, time.FixedZone("", -5*3600)),
+		},
+		{
+			name:   "datetime without fractional seconds",
+			input:  "2024-03-15 10:30:45",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.UTC),
+		},
+		{
+			name:   "RFC3339Nano",
+			input:  "2024-03-15T10:30:45.123456789Z",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 123456789, time.UTC),
+		},
+		{
+			name:   "RFC3339",
+			input:  "2024-03-15T10:30:45Z",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.UTC),
+		},
+		{
+			name:   "RFC3339 with offset",
+			input:  "2024-03-15T10:30:45+03:00",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.FixedZone("", 3*3600)),
+		},
+		{
+			name:   "ISO datetime without timezone",
+			input:  "2024-03-15T10:30:45",
+			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFlexible(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.expect) {
+				t.Errorf("got %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestParseFlexible_InvalidFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"plain date no time", "2024-03-15"},
+		{"garbage", "not-a-date"},
+		{"US format", "03/15/2024"},
+		{"unix timestamp", "1710500000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseFlexible(tt.input)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if got := err.Error(); len(got) == 0 {
+				t.Error("error message should not be empty")
+			}
+		})
+	}
+}
+
+func TestParseFlexible_FirstMatchWins(t *testing.T) {
+	input := "2024-03-15 10:30:45.500000000"
+	got, err := ParseFlexible(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Nanosecond() != 500000000 {
+		t.Errorf("expected fractional seconds to be preserved, got ns=%d", got.Nanosecond())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #547

Adds dedicated test files to Go packages that previously had none:

- **`internal/timeutil`** — `ParseFlexible` format matching, error cases, priority order
- **`internal/storage/postgres`** — `quoteIdent` escaping, `buildFilterClauses` SQL generation, `generateShareToken` randomness, `purgeable` allowlist
- **`cmd/migrate-sqlite-to-pg`** — `buildPlaceholders` generation, `convertValue` time parsing + type coercion

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] No external dependencies needed (pure unit tests)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for migration and data conversion logic, including placeholder generation and value conversion scenarios.
  * Added comprehensive tests for PostgreSQL storage helper behaviors such as identifier quoting, filter clause building, token handling, and purgeable checks.
  * Enhanced time parsing test suite to cover multiple formats, error cases, and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->