### PR TITLE
fix: sort catalog entries by Hebrew name instead of English

### DIFF
--- a/internal/catalog/dynamic.go
+++ b/internal/catalog/dynamic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"sort"
-	"strings"
 	"sync"
 )
 
@@ -199,11 +198,11 @@ func (d *DynamicCatalog) rebuildSlices() {
 		mfrs = append(mfrs, Entry{ID: id, Name: name, NameHe: d.mfrHeMap[id]})
 	}
 	sort.Slice(mfrs, func(i, j int) bool {
-		li, lj := strings.ToLower(mfrs[i].Name), strings.ToLower(mfrs[j].Name)
-		if li == lj {
+		di, dj := mfrs[i].DisplayName(), mfrs[j].DisplayName()
+		if di == dj {
 			return mfrs[i].ID < mfrs[j].ID
 		}
-		return li < lj
+		return di < dj
 	})
 	d.mfrs = mfrs
 
@@ -219,11 +218,11 @@ func (d *DynamicCatalog) rebuildSlices() {
 			list = append(list, Entry{ID: id, Name: name, NameHe: he})
 		}
 		sort.Slice(list, func(i, j int) bool {
-			li, lj := strings.ToLower(list[i].Name), strings.ToLower(list[j].Name)
-			if li == lj {
+			di, dj := list[i].DisplayName(), list[j].DisplayName()
+			if di == dj {
 				return list[i].ID < list[j].ID
 			}
-			return li < lj
+			return di < dj
 		})
 		models[mfrID] = list
 	}

--- a/internal/catalog/static.go
+++ b/internal/catalog/static.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"sort"
 	"strconv"
-	"strings"
 )
 
 //go:embed catalog_data.json
@@ -39,7 +38,11 @@ func init() {
 		defaultManufacturers = append(defaultManufacturers, Entry(m))
 	}
 	sort.Slice(defaultManufacturers, func(i, j int) bool {
-		return strings.ToLower(defaultManufacturers[i].Name) < strings.ToLower(defaultManufacturers[j].Name)
+		di, dj := defaultManufacturers[i].DisplayName(), defaultManufacturers[j].DisplayName()
+		if di == dj {
+			return defaultManufacturers[i].ID < defaultManufacturers[j].ID
+		}
+		return di < dj
 	})
 
 	defaultModels = make(map[int][]Entry, len(data.Models))
@@ -53,7 +56,11 @@ func init() {
 			entries = append(entries, Entry(m))
 		}
 		sort.Slice(entries, func(i, j int) bool {
-			return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
+			di, dj := entries[i].DisplayName(), entries[j].DisplayName()
+			if di == dj {
+				return entries[i].ID < entries[j].ID
+			}
+			return di < dj
 		})
 		defaultModels[mfrID] = entries
 	}


### PR DESCRIPTION
## Summary

- Sorts manufacturer and model dropdowns by Hebrew name (via `DisplayName()`) instead of English name, matching the expected reading order for Hebrew-speaking users.

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes — all catalog tests green
- [ ] Verify in web UI that manufacturers dropdown shows Hebrew alphabetical order (א → ת)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting of manufacturers and models in the catalog to ensure consistent ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->