### PR TITLE
fix: reactivate inactive users when they create searches or log in

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -374,6 +374,20 @@ func (s *Server) adminSetUserActive(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"chat_id": chatID, "active": body.Active})
 }
 
+func (s *Server) adminSyncUserStatus(w http.ResponseWriter, r *http.Request) {
+	activated, deactivated, err := s.admin.SyncUserActiveStatus(r.Context())
+	if err != nil {
+		s.logger.Error("admin: sync user status", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to sync user status")
+		return
+	}
+	s.logger.Info("admin: synced user active status", "activated", activated, "deactivated", deactivated)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"activated":   activated,
+		"deactivated": deactivated,
+	})
+}
+
 func (s *Server) adminVacuum(w http.ResponseWriter, r *http.Request) {
 	if !s.vacuumMu.TryLock() {
 		writeError(w, http.StatusConflict, "vacuum already in progress")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -165,6 +165,7 @@ func (s *Server) Routes() http.Handler {
 		mux.HandleFunc("DELETE /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminDeleteUser))
 		mux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
 		mux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))
+		mux.HandleFunc("POST /api/v1/admin/sync-user-status", s.requireAdmin(s.adminSyncUserStatus))
 		if s.logHub != nil {
 			mux.HandleFunc("GET /api/v1/admin/logs", s.requireAdmin(s.adminLogs))
 			mux.HandleFunc("GET /api/v1/admin/logs/stream", s.requireAdmin(s.adminLogStream))

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -732,6 +732,10 @@ func (f *failingAdminStore) VacuumDB(_ context.Context) error {
 	return nil
 }
 
+func (f *failingAdminStore) SyncUserActiveStatus(_ context.Context) (int64, int64, error) {
+	return 0, 0, nil
+}
+
 func TestAdminStats_DBFileSizeError(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	srv.admin = &failingAdminStore{failDBFileSize: true}

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -954,3 +954,64 @@ func TestAdminDeleteUser_InvalidID(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestCreateSearch_ReactivatesInactiveUser(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SetUserActive(ctx, 999, false); err != nil {
+		t.Fatal(err)
+	}
+
+	u, _ := store.GetUser(ctx, int64(999))
+	if u.Active {
+		t.Fatal("user should be inactive before test")
+	}
+
+	body := map[string]any{"manufacturer": 27, "model": 10332, "source": "yad2"}
+	w := doRequest(t, srv, "POST", "/api/v1/searches", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	u, _ = store.GetUser(ctx, int64(999))
+	if !u.Active {
+		t.Error("createSearch should reactivate an inactive user")
+	}
+}
+
+func TestAdminSyncUserStatus(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.UpsertUser(ctx, 100, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "active-s", Source: "yad2",
+		Manufacturer: 27, Model: 10332, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetUserActive(ctx, 100, false); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "POST", "/api/v1/admin/sync-user-status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["activated"] != float64(1) {
+		t.Errorf("expected 1 activated, got %v", resp["activated"])
+	}
+
+	u, _ := store.GetUser(ctx, 100)
+	if !u.Active {
+		t.Error("user should be active after sync")
+	}
+}

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -58,6 +58,20 @@ type searchResponse struct {
 	ListingsCount    int64  `json:"listings_count"`
 }
 
+func (s *Server) ensureUserActive(ctx context.Context, chatID int64) {
+	user, err := s.users.GetUser(ctx, chatID)
+	if err != nil || user == nil {
+		return
+	}
+	if !user.Active {
+		if err := s.users.SetUserActive(ctx, chatID, true); err != nil {
+			s.logger.Error("reactivate user on search create", "chat_id", chatID, "error", err)
+			return
+		}
+		s.logger.Info("reactivated inactive user on search action", "chat_id", chatID)
+	}
+}
+
 func isValidSource(source string) bool {
 	switch source {
 	case "yad2", "winwin", "yad2,winwin", "winwin,yad2":
@@ -262,6 +276,7 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.ensureUserActive(r.Context(), chatID)
 	s.writeCreatedSearch(w, r, chatID, id)
 }
 
@@ -374,6 +389,10 @@ func (s *Server) pauseSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) resumeSearch(w http.ResponseWriter, r *http.Request) {
+	chatID, ok := chatIDFromContext(r.Context())
+	if ok {
+		s.ensureUserActive(r.Context(), chatID)
+	}
 	s.setSearchActive(w, r, true)
 }
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -253,6 +253,7 @@ type AdminStore interface {
 	AdminListUsers(ctx context.Context) ([]User, error)
 	AdminDeleteUser(ctx context.Context, chatID int64) error
 	VacuumDB(ctx context.Context) error
+	SyncUserActiveStatus(ctx context.Context) (activated, deactivated int64, err error)
 }
 
 type NotificationStore interface {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -233,3 +233,25 @@ func (s *Store) VacuumDB(ctx context.Context) error {
 	}
 	return nil
 }
+
+func (s *Store) SyncUserActiveStatus(ctx context.Context) (activated, deactivated int64, err error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE users SET active = true
+		WHERE active = false
+		  AND chat_id IN (SELECT DISTINCT chat_id FROM searches WHERE active = true)`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("activate users with searches: %w", err)
+	}
+	activated, _ = res.RowsAffected()
+
+	res, err = s.db.ExecContext(ctx, `
+		UPDATE users SET active = false
+		WHERE active = true
+		  AND chat_id NOT IN (SELECT DISTINCT chat_id FROM searches WHERE active = true)`)
+	if err != nil {
+		return activated, 0, fmt.Errorf("deactivate users without searches: %w", err)
+	}
+	deactivated, _ = res.RowsAffected()
+
+	return activated, deactivated, nil
+}

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -22,6 +22,7 @@ func (s *Store) UpsertUser(ctx context.Context, chatID int64, username string) e
 		INSERT INTO users (chat_id, username, channel_id) VALUES ($1, $2, $3)
 		ON CONFLICT (chat_id) DO UPDATE SET
 			username = excluded.username,
+			active = true,
 			channel_id = CASE WHEN users.channel_id = '' THEN excluded.channel_id ELSE users.channel_id END`,
 		chatID, username, channelID)
 	return err
@@ -77,6 +78,8 @@ func (s *Store) upsertChannelUser(ctx context.Context, channel, channelID, usern
 		`SELECT chat_id FROM users WHERE channel = $1 AND channel_id = $2`,
 		channel, channelID).Scan(&existingID)
 	if err == nil {
+		_, _ = tx.ExecContext(ctx, `UPDATE users SET active = true WHERE chat_id = $1`, existingID)
+		_ = tx.Commit()
 		return existingID, nil
 	}
 	if err != sql.ErrNoRows {

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -247,3 +247,25 @@ func (s *Store) VacuumDB(ctx context.Context) error {
 	}
 	return nil
 }
+
+func (s *Store) SyncUserActiveStatus(ctx context.Context) (activated, deactivated int64, err error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE users SET active = true
+		WHERE active = false
+		  AND chat_id IN (SELECT DISTINCT chat_id FROM searches WHERE active = true)`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("activate users with searches: %w", err)
+	}
+	activated, _ = res.RowsAffected()
+
+	res, err = s.db.ExecContext(ctx, `
+		UPDATE users SET active = false
+		WHERE active = true
+		  AND chat_id NOT IN (SELECT DISTINCT chat_id FROM searches WHERE active = true)`)
+	if err != nil {
+		return activated, 0, fmt.Errorf("deactivate users without searches: %w", err)
+	}
+	deactivated, _ = res.RowsAffected()
+
+	return activated, deactivated, nil
+}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2986,3 +2986,111 @@ func TestPruneListings_PreservesSaved(t *testing.T) {
 	}
 }
 
+func TestUpsertUser_ReactivatesInactiveUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	seedUser(t, store, 100)
+	if err := store.SetUserActive(ctx, 100, false); err != nil {
+		t.Fatal(err)
+	}
+
+	u, _ := store.GetUser(ctx, 100)
+	if u.Active {
+		t.Fatal("user should be inactive before re-upsert")
+	}
+
+	if err := store.UpsertUser(ctx, 100, "alice"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	u, _ = store.GetUser(ctx, 100)
+	if !u.Active {
+		t.Error("UpsertUser should reactivate an inactive user")
+	}
+}
+
+func TestUpsertWebUser_ReactivatesInactiveUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	id, err := store.UpsertWebUser(ctx, "firebase-uid-1", "a@example.com")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := store.SetUserActive(ctx, id, false); err != nil {
+		t.Fatal(err)
+	}
+
+	u, _ := store.GetUser(ctx, id)
+	if u.Active {
+		t.Fatal("user should be inactive before re-login")
+	}
+
+	id2, err := store.UpsertWebUser(ctx, "firebase-uid-1", "a@example.com")
+	if err != nil {
+		t.Fatalf("re-login: %v", err)
+	}
+	if id2 != id {
+		t.Error("should return same ID")
+	}
+
+	u, _ = store.GetUser(ctx, id)
+	if !u.Active {
+		t.Error("UpsertWebUser should reactivate an inactive user on login")
+	}
+}
+
+func TestSyncUserActiveStatus(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+	seedUser(t, store, 300)
+
+	if _, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "s1", Source: "yad2", Manufacturer: 27, Model: 10332, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetUserActive(ctx, 100, false); err != nil {
+		t.Fatal(err)
+	}
+
+	id3, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 300, Name: "s3", Source: "yad2", Manufacturer: 19, Model: 10226, Active: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetSearchActive(ctx, id3, 300, false); err != nil {
+		t.Fatal(err)
+	}
+
+	activated, deactivated, err := store.SyncUserActiveStatus(ctx)
+	if err != nil {
+		t.Fatalf("SyncUserActiveStatus: %v", err)
+	}
+	if activated != 1 {
+		t.Errorf("expected 1 activated, got %d", activated)
+	}
+	if deactivated != 2 {
+		t.Errorf("expected 2 deactivated, got %d", deactivated)
+	}
+
+	u100, _ := store.GetUser(ctx, 100)
+	if !u100.Active {
+		t.Error("user 100 should be active (has active search)")
+	}
+	u200, _ := store.GetUser(ctx, 200)
+	if u200.Active {
+		t.Error("user 200 should be inactive (no searches)")
+	}
+	u300, _ := store.GetUser(ctx, 300)
+	if u300.Active {
+		t.Error("user 300 should be inactive (only paused search)")
+	}
+}
+

--- a/internal/storage/sqlite/users.go
+++ b/internal/storage/sqlite/users.go
@@ -22,6 +22,7 @@ func (s *Store) UpsertUser(ctx context.Context, chatID int64, username string) e
 		INSERT INTO users (chat_id, username, channel_id) VALUES (?, ?, ?)
 		ON CONFLICT(chat_id) DO UPDATE SET
 			username = excluded.username,
+			active = true,
 			channel_id = CASE WHEN users.channel_id = '' THEN excluded.channel_id ELSE users.channel_id END`,
 		chatID, username, channelID)
 	return err
@@ -77,6 +78,8 @@ func (s *Store) upsertChannelUser(ctx context.Context, channel, channelID, usern
 		"SELECT chat_id FROM users WHERE channel = ? AND channel_id = ?",
 		channel, channelID).Scan(&existingID)
 	if err == nil {
+		_, _ = tx.ExecContext(ctx, "UPDATE users SET active = true WHERE chat_id = ?", existingID)
+		_ = tx.Commit()
 		return existingID, nil
 	}
 	if err != sql.ErrNoRows {


### PR DESCRIPTION
## Summary

- **Bug**: Users who became inactive (e.g. after Telegram bot block) were never reactivated when returning via the web UI. The scheduler's `ListAllActiveSearches` query requires `u.active = true`, making new searches from inactive users invisible to the scanner.
- **Fix**: Reactivate users at every entry point — `UpsertUser` (Telegram), `upsertChannelUser` (web/whatsapp login), and API `createSearch`/`resumeSearch` handlers.
- **Data repair**: Added `POST /admin/sync-user-status` endpoint and `SyncUserActiveStatus` storage method to bulk-fix inconsistent user states (activates users with active searches, deactivates users with none).

## Root Cause

`ListAllActiveSearches` joins `searches` with `users` using `WHERE s.active = true AND u.active = true`. When a user became inactive (via `ErrRecipientBlocked` or other means), none of their code paths ever restored `active = true`:
- `UpsertUser` only updated `username` on conflict
- `upsertChannelUser` returned early without touching `active`
- `createSearch` / `resumeSearch` never checked user active status

## Test plan

- [x] `TestUpsertUser_ReactivatesInactiveUser` — verifies Telegram user reactivation
- [x] `TestUpsertWebUser_ReactivatesInactiveUser` — verifies web user reactivation on login
- [x] `TestSyncUserActiveStatus` — verifies bulk sync (activates 1, deactivates 2)
- [x] `TestCreateSearch_ReactivatesInactiveUser` — verifies API handler reactivation
- [x] `TestAdminSyncUserStatus` — verifies admin endpoint
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean


Made with [Cursor](https://cursor.com)