### PR TITLE
feat: close security audit issues (log stream auth, HTTP metrics)

### DIFF
--- a/internal/api/accesslog.go
+++ b/internal/api/accesslog.go
@@ -25,6 +25,8 @@ func (s *Server) withAccessLog(next http.Handler) http.Handler {
 		start := time.Now()
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rec, r)
+		dur := time.Since(start)
+		s.observeHTTPRequest(rec.status, dur)
 
 		reqID := ""
 		if v, ok := r.Context().Value(requestIDKey).(string); ok {
@@ -34,7 +36,7 @@ func (s *Server) withAccessLog(next http.Handler) http.Handler {
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", rec.status,
-			"duration_ms", time.Since(start).Milliseconds(),
+			"duration_ms", dur.Milliseconds(),
 			"request_id", reqID,
 		)
 	})

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -34,9 +34,10 @@ type adminListingResponse struct {
 }
 
 type adminStatsResponse struct {
-	DB      dbStats      `json:"db"`
+	DB      dbStats          `json:"db"`
 	Tables  map[string]int64 `json:"tables"`
-	Runtime runtimeStats `json:"runtime"`
+	Runtime runtimeStats     `json:"runtime"`
+	HTTP    httpStats        `json:"http"`
 }
 
 type dbStats struct {
@@ -45,10 +46,18 @@ type dbStats struct {
 }
 
 type runtimeStats struct {
-	Goroutines int    `json:"goroutines"`
+	Goroutines int     `json:"goroutines"`
 	MemAllocMB float64 `json:"mem_alloc_mb"`
 	MemSysMB   float64 `json:"mem_sys_mb"`
-	Uptime     string `json:"uptime"`
+	Uptime     string  `json:"uptime"`
+}
+
+type httpStats struct {
+	RequestsTotal uint64  `json:"requests_total"`
+	Status2xx     uint64  `json:"status_2xx"`
+	Status4xx     uint64  `json:"status_4xx"`
+	Status5xx     uint64  `json:"status_5xx"`
+	AvgDurationMs float64 `json:"avg_duration_ms"`
 }
 
 func (s *Server) isAdmin(chatID int64, email string) bool {
@@ -99,6 +108,12 @@ func (s *Server) adminStats(w http.ResponseWriter, r *http.Request) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
+	total, n2xx, n4xx, n5xx, durSum := s.httpMetricsSnapshot()
+	var avgMs float64
+	if total > 0 {
+		avgMs = float64(durSum) / float64(total)
+	}
+
 	writeJSON(w, http.StatusOK, adminStatsResponse{
 		DB: dbStats{
 			FileSizeBytes: fileSize,
@@ -110,6 +125,13 @@ func (s *Server) adminStats(w http.ResponseWriter, r *http.Request) {
 			MemAllocMB: float64(mem.Alloc) / 1024 / 1024,
 			MemSysMB:   float64(mem.Sys) / 1024 / 1024,
 			Uptime:     time.Since(s.startTime).Truncate(time.Second).String(),
+		},
+		HTTP: httpStats{
+			RequestsTotal: total,
+			Status2xx:     n2xx,
+			Status4xx:     n4xx,
+			Status5xx:     n5xx,
+			AvgDurationMs: avgMs,
 		},
 	})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	fbauth "firebase.google.com/go/v4/auth"
@@ -56,6 +57,13 @@ type Server struct {
 	rl        *rateLimiter
 	ipRL      *ipRateLimiter
 	vacuumMu  sync.Mutex
+
+	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
+	httpReqTotal   atomic.Uint64
+	http2xx        atomic.Uint64
+	http4xx        atomic.Uint64
+	http5xx        atomic.Uint64
+	httpDurationMs atomic.Uint64
 }
 
 func (s *Server) SetPollTrigger(p PollTrigger) {
@@ -250,13 +258,6 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHdr := r.Header.Get("Authorization")
 		bearer := bearerFromAuthHeader(authHdr)
-
-		// Allow token via query param for SSE only (EventSource can't set headers).
-		if bearer == "" && strings.HasPrefix(r.URL.Path, "/api/v1/admin/logs/") {
-			if qt := r.URL.Query().Get("token"); qt != "" {
-				bearer = qt
-			}
-		}
 
 		var chatID int64
 

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"time"
+)
+
+// observeHTTPRequest records aggregate request metrics for admin stats (issue #641).
+func (s *Server) observeHTTPRequest(status int, duration time.Duration) {
+	if s == nil {
+		return
+	}
+	s.httpReqTotal.Add(1)
+	switch {
+	case status >= 500:
+		s.http5xx.Add(1)
+	case status >= 400:
+		s.http4xx.Add(1)
+	default:
+		s.http2xx.Add(1)
+	}
+	s.httpDurationMs.Add(uint64(duration.Milliseconds()))
+}
+
+func (s *Server) httpMetricsSnapshot() (total, ok2xx, ok4xx, ok5xx, durationSumMs uint64) {
+	if s == nil {
+		return
+	}
+	return s.httpReqTotal.Load(), s.http2xx.Load(), s.http4xx.Load(), s.http5xx.Load(), s.httpDurationMs.Load()
+}

--- a/web/src/components/admin/OverviewTab.tsx
+++ b/web/src/components/admin/OverviewTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  Activity,
   Cpu,
   Database,
   HardDrive,
@@ -195,6 +196,38 @@ export function OverviewTab({
               value={`${data.runtime.mem_sys_mb.toFixed(1)} MB`}
             />
           </div>
+        </div>
+      </div>
+
+      {/* HTTP API aggregates (since server start) */}
+      <div className="rounded-2xl border border-border/50 bg-card p-6">
+        <div className="flex items-center gap-2.5 mb-5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-chart-3/10">
+            <Activity className="h-[18px] w-[18px] text-chart-3" />
+          </div>
+          <h2 className="text-base font-semibold">בקשות API (מאז הפעלת השרת)</h2>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          <RuntimeStat
+            label="סה״כ בקשות"
+            value={data.http.requests_total.toLocaleString("he-IL")}
+          />
+          <RuntimeStat
+            label="2xx"
+            value={data.http.status_2xx.toLocaleString("he-IL")}
+          />
+          <RuntimeStat
+            label="4xx"
+            value={data.http.status_4xx.toLocaleString("he-IL")}
+          />
+          <RuntimeStat
+            label="5xx"
+            value={data.http.status_5xx.toLocaleString("he-IL")}
+          />
+          <RuntimeStat
+            label="זמן תגובה ממוצע"
+            value={`${data.http.avg_duration_ms.toFixed(2)} ms`}
+          />
         </div>
       </div>
 

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -26,7 +26,7 @@ async function openLogStream(signal: AbortSignal): Promise<Response | null> {
     return h;
   };
 
-  let token = await getAuthToken().catch(() => null);
+  const token = await getAuthToken().catch(() => null);
   if (!token) {
     return null;
   }

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { getAuthToken } from "@/lib/auth-token";
 import { adminApi, type LogEntry } from "@/lib/api";
+import { feedSSE } from "@/lib/sse-parse";
 
 const MAX_ENTRIES = 2000;
+const STREAM_URL = "/api/v1/admin/logs/stream";
+const RECONNECT_MS = 2000;
+
 const STYLE_BY_LEVEL: Record<string, string> = {
   DEBUG: "color: #8b8b8b",
   INFO: "color: #3b82f6",
@@ -10,25 +14,56 @@ const STYLE_BY_LEVEL: Record<string, string> = {
   ERROR: "color: #ef4444; font-weight: bold",
 };
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function openLogStream(signal: AbortSignal): Promise<Response | null> {
+  const headersFor = (token: string) => {
+    const h = new Headers();
+    h.set("Accept", "text/event-stream");
+    h.set("Authorization", `Bearer ${token}`);
+    return h;
+  };
+
+  let token = await getAuthToken().catch(() => null);
+  if (!token) {
+    return null;
+  }
+
+  let res = await fetch(STREAM_URL, {
+    headers: headersFor(token),
+    signal,
+  });
+
+  if (res.status === 401) {
+    const fresh = await getAuthToken(true).catch(() => null);
+    if (!fresh) {
+      return res;
+    }
+    res = await fetch(STREAM_URL, {
+      headers: headersFor(fresh),
+      signal,
+    });
+  }
+
+  return res;
+}
+
 export function useLogStream(enabled: boolean) {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [connected, setConnected] = useState(false);
-  const esRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
     if (!enabled) {
-      if (esRef.current) {
-        esRef.current.close();
-        esRef.current = null;
-        setConnected(false);
-      }
+      setConnected(false);
       return;
     }
 
+    const ac = new AbortController();
     let cancelled = false;
 
-    async function connect() {
-      // Load recent logs first
+    async function run() {
       try {
         const { items } = await adminApi.logs(500);
         if (!cancelled) {
@@ -38,54 +73,81 @@ export function useLogStream(enabled: boolean) {
         // non-critical
       }
 
-      const token = await getAuthToken().catch(() => null);
-      if (cancelled) return;
-
-      const url = `/api/v1/admin/logs/stream${token ? `?token=${encodeURIComponent(token)}` : ""}`;
-      const es = new EventSource(url);
-      esRef.current = es;
-
-      es.onopen = () => {
-        if (!cancelled) setConnected(true);
-      };
-
-      es.onmessage = (event) => {
+      while (!cancelled && !ac.signal.aborted) {
+        let res: Response | null;
         try {
-          const entry: LogEntry = JSON.parse(event.data);
+          res = await openLogStream(ac.signal);
+        } catch {
+          if (cancelled || ac.signal.aborted) {
+            return;
+          }
+          setConnected(false);
+          await delay(RECONNECT_MS);
+          continue;
+        }
 
-          const style = STYLE_BY_LEVEL[entry.level] ?? "";
-          console.log(
-            `%c[${entry.component}] ${entry.level}: ${entry.message}`,
-            style,
-            entry.attrs ?? "",
-          );
+        if (cancelled || ac.signal.aborted) {
+          return;
+        }
 
-          if (!cancelled) {
-            setLogs((prev) => {
-              const next = [...prev, entry];
-              return next.length > MAX_ENTRIES
-                ? next.slice(next.length - MAX_ENTRIES)
-                : next;
+        if (!res || !res.ok || !res.body) {
+          setConnected(false);
+          await delay(RECONNECT_MS);
+          continue;
+        }
+
+        setConnected(true);
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let sseBuf = "";
+
+        try {
+          while (!cancelled && !ac.signal.aborted) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            const text = decoder.decode(value, { stream: true });
+            sseBuf = feedSSE(text, sseBuf, (payload) => {
+              try {
+                const entry: LogEntry = JSON.parse(payload);
+                const style = STYLE_BY_LEVEL[entry.level] ?? "";
+                console.log(
+                  `%c[${entry.component}] ${entry.level}: ${entry.message}`,
+                  style,
+                  entry.attrs ?? "",
+                );
+                if (!cancelled) {
+                  setLogs((prev) => {
+                    const next = [...prev, entry];
+                    return next.length > MAX_ENTRIES
+                      ? next.slice(next.length - MAX_ENTRIES)
+                      : next;
+                  });
+                }
+              } catch {
+                // ignore malformed events
+              }
             });
           }
-        } catch {
-          // ignore malformed events
+        } finally {
+          reader.releaseLock();
         }
-      };
 
-      es.onerror = () => {
-        if (!cancelled) setConnected(false);
-      };
+        if (cancelled || ac.signal.aborted) {
+          return;
+        }
+        setConnected(false);
+        await delay(RECONNECT_MS);
+      }
     }
 
-    void connect();
+    void run();
 
     return () => {
       cancelled = true;
-      if (esRef.current) {
-        esRef.current.close();
-        esRef.current = null;
-      }
+      ac.abort();
       setConnected(false);
     };
   }, [enabled]);

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -1,18 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { getAuthToken } from "@/lib/auth-token";
-import { adminApi, type LogEntry } from "@/lib/api";
+import { adminApi, BASE_URL, type LogEntry } from "@/lib/api";
 import { feedSSE } from "@/lib/sse-parse";
 
 const MAX_ENTRIES = 2000;
-const STREAM_URL = "/api/v1/admin/logs/stream";
+const STREAM_URL = `${BASE_URL}/admin/logs/stream`;
 const RECONNECT_MS = 2000;
-
-const STYLE_BY_LEVEL: Record<string, string> = {
-  DEBUG: "color: #8b8b8b",
-  INFO: "color: #3b82f6",
-  WARN: "color: #f59e0b; font-weight: bold",
-  ERROR: "color: #ef4444; font-weight: bold",
-};
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -112,12 +105,6 @@ export function useLogStream(enabled: boolean) {
             sseBuf = feedSSE(text, sseBuf, (payload) => {
               try {
                 const entry: LogEntry = JSON.parse(payload);
-                const style = STYLE_BY_LEVEL[entry.level] ?? "";
-                console.log(
-                  `%c[${entry.component}] ${entry.level}: ${entry.message}`,
-                  style,
-                  entry.attrs ?? "",
-                );
                 if (!cancelled) {
                   setLogs((prev) => {
                     const next = [...prev, entry];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -232,6 +232,13 @@ export interface AdminStats {
     mem_sys_mb: number;
     uptime: string;
   };
+  http: {
+    requests_total: number;
+    status_2xx: number;
+    status_4xx: number;
+    status_5xx: number;
+    avg_duration_ms: number;
+  };
 }
 
 export interface AdminListing extends Listing {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { getAuthToken } from "@/lib/auth-token";
 
-const BASE_URL = "/api/v1";
+/** Base path for versioned REST API (same origin). */
+export const BASE_URL = "/api/v1";
 
 class ApiError extends Error {
   constructor(

--- a/web/src/lib/sse-parse.test.ts
+++ b/web/src/lib/sse-parse.test.ts
@@ -43,4 +43,10 @@ describe("feedSSE", () => {
     expect(onData).toHaveBeenNthCalledWith(1, "a");
     expect(onData).toHaveBeenNthCalledWith(2, "b");
   });
+
+  it("strips at most one space after data: per SSE spec", () => {
+    const onData = vi.fn();
+    feedSSE("data:  spaced\n\n", "", onData);
+    expect(onData).toHaveBeenCalledWith(" spaced");
+  });
 });

--- a/web/src/lib/sse-parse.test.ts
+++ b/web/src/lib/sse-parse.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { feedSSE } from "./sse-parse";
+
+describe("feedSSE", () => {
+  it("ignores comment-only blocks (keepalive)", () => {
+    const onData = vi.fn();
+    const rest = feedSSE(": keepalive\n\n", "", onData);
+    expect(rest).toBe("");
+    expect(onData).not.toHaveBeenCalled();
+  });
+
+  it("parses a single data line", () => {
+    const onData = vi.fn();
+    feedSSE('data: {"a":1}\n\n', "", onData);
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith('{"a":1}');
+  });
+
+  it("joins multi-line data fields per SSE spec", () => {
+    const onData = vi.fn();
+    let buf = feedSSE("data: hello\n", "", onData);
+    expect(onData).not.toHaveBeenCalled();
+    buf = feedSSE("data: world\n\n", buf, onData);
+    expect(onData).toHaveBeenCalledWith("hello\nworld");
+    expect(buf).toBe("");
+  });
+
+  it("buffers incomplete events", () => {
+    const onData = vi.fn();
+    let buf = feedSSE('data: {"x":', "", onData);
+    expect(onData).not.toHaveBeenCalled();
+    buf = feedSSE("1}\n", buf, onData);
+    expect(onData).not.toHaveBeenCalled();
+    buf = feedSSE("\n", buf, onData);
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith('{"x":1}');
+    expect(buf).toBe("");
+  });
+
+  it("handles multiple events in one chunk", () => {
+    const onData = vi.fn();
+    feedSSE('data: a\n\ndata: b\n\n', "", onData);
+    expect(onData).toHaveBeenNthCalledWith(1, "a");
+    expect(onData).toHaveBeenNthCalledWith(2, "b");
+  });
+});

--- a/web/src/lib/sse-parse.ts
+++ b/web/src/lib/sse-parse.ts
@@ -1,0 +1,38 @@
+/**
+ * Incremental SSE (Server-Sent Events) parser for blocks terminated by "\n\n".
+ * Calls onData with the reconstructed `data:` payload (joined lines) per event.
+ * Comment lines (`:` ...) and heartbeats produce no callback.
+ */
+export function feedSSE(
+  chunk: string,
+  buffer: string,
+  onData: (payload: string) => void,
+): string {
+  let buf = buffer + chunk;
+  for (;;) {
+    const idx = buf.indexOf("\n\n");
+    if (idx === -1) {
+      return buf;
+    }
+    const block = buf.slice(0, idx);
+    buf = buf.slice(idx + 2);
+    const payload = dataPayloadFromSSEBlock(block);
+    if (payload !== null) {
+      onData(payload);
+    }
+  }
+}
+
+function dataPayloadFromSSEBlock(block: string): string | null {
+  const lines = block.split("\n");
+  const parts: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("data:")) {
+      parts.push(line.slice(5).trimStart());
+    }
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.join("\n");
+}

--- a/web/src/lib/sse-parse.ts
+++ b/web/src/lib/sse-parse.ts
@@ -28,7 +28,8 @@ function dataPayloadFromSSEBlock(block: string): string | null {
   const parts: string[] = [];
   for (const line of lines) {
     if (line.startsWith("data:")) {
-      parts.push(line.slice(5).trimStart());
+      const val = line.slice(5);
+      parts.push(val.startsWith(" ") ? val.slice(1) : val);
     }
   }
   if (parts.length === 0) {


### PR DESCRIPTION
## Issues (auto-close on merge)

Closes #636  
Closes #637  
Closes #638  
Closes #639  
Closes #640  
Closes #641  
Closes #642  
Closes #643  

## Summary

**`main` already contains [#644](https://github.com/Danielsio/carwatch/pull/644)** (listing UX, batch search counts, CSP, access logs, etc.), but several audit issues stayed **open** and **#642 / #641** were not fully addressed there.

This PR:

- **#642** — Removes `?token=` auth for admin log paths and implements the log **SSE client with `fetch` + `Authorization`** (and 401 refresh), so tokens are not put in the URL.
- **#641** — Adds **process-wide HTTP aggregates** (total requests, 2xx/4xx/5xx counts, sum of durations → average ms) in the **access-log middleware**, returned on **`GET /api/v1/admin/stats`**, and shown on the **admin overview** tab. (Prometheus/OTel remains a possible follow-up.)
- **#643** — Adds **`sse-parse` unit tests** (parser used by the stream hook).

Items **#636–#640** are already satisfied on `main` via #644; this PR’s **Closes** lines ensure GitHub closes the full audit set once this merges.

## Verification

- `make test`
- `cd web && npm run lint && npx tsc -b && npm test && npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin overview now displays HTTP API request metrics since server start, including request counts by status code (2xx, 4xx, 5xx) and average response duration.

* **Improvements**
  * Enhanced admin log stream with improved authentication handling and automatic reconnection resilience for better stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/645)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->