### PR TITLE
feat: filter listings by private vs dealership seller

### DIFF
--- a/cmd/migrate-sqlite-to-pg/main.go
+++ b/cmd/migrate-sqlite-to-pg/main.go
@@ -43,11 +43,11 @@ func main() {
 
 	tables := []tableSpec{
 		{name: "users", columns: "chat_id, username, state, state_data, created_at, active, digest_mode, digest_interval, digest_last_flushed, language, tier, tier_expires_at, trial_used, daily_digest, daily_digest_time, daily_digest_last_sent, channel, channel_id, linked_web_id, last_seen_at", count: 20},
-		{name: "searches", columns: "id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, share_token", count: 18},
+		{name: "searches", columns: "id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, active, created_at, share_token", count: 19},
 		{name: "seen_listings", columns: "token, chat_id, search_id, first_seen_at", count: 4},
 		{name: "pending_notifications", columns: "id, recipient, search_name, payload, created_at", count: 5},
 		{name: "price_history", columns: "id, token, price, observed_at", count: 4},
-		{name: "listing_history", columns: "token, chat_id, search_id, search_name, manufacturer, model, year, price, km, hand, city, page_link, image_url, fitness_score, first_seen_at", count: 15},
+		{name: "listing_history", columns: "token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, first_seen_at", count: 22},
 		{name: "pending_digest", columns: "id, chat_id, listing_payload, created_at", count: 4},
 		{name: "saved_listings", columns: "chat_id, token, saved_at", count: 3},
 		{name: "hidden_listings", columns: "chat_id, token, hidden_at", count: 3},

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -31,6 +31,7 @@ type adminListingResponse struct {
 	ImageURL     string   `json:"image_url,omitempty"`
 	FitnessScore *float64 `json:"fitness_score,omitempty"`
 	FirstSeenAt  string   `json:"first_seen_at"`
+	IsCommercial *bool    `json:"is_commercial,omitempty"`
 }
 
 type adminStatsResponse struct {
@@ -223,6 +224,7 @@ func (s *Server) adminListListings(w http.ResponseWriter, r *http.Request) {
 			ImageURL:     l.ImageURL,
 			FitnessScore: l.FitnessScore,
 			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
+			IsCommercial: l.IsCommercial,
 		})
 	}
 
@@ -278,6 +280,10 @@ func (s *Server) adminListSearches(w http.ResponseWriter, r *http.Request) {
 		PriceMax     int    `json:"price_max"`
 		MaxKm        int    `json:"max_km"`
 		MaxHand      int    `json:"max_hand"`
+		EngineMinCC  int    `json:"engine_min_cc"`
+		Keywords     string `json:"keywords,omitempty"`
+		ExcludeKeys  string `json:"exclude_keys,omitempty"`
+		SellerFilter string `json:"seller_filter,omitempty"`
 		Active       bool   `json:"active"`
 		CreatedAt    string `json:"created_at"`
 	}
@@ -296,6 +302,10 @@ func (s *Server) adminListSearches(w http.ResponseWriter, r *http.Request) {
 			PriceMax:     s.PriceMax,
 			MaxKm:        s.MaxKm,
 			MaxHand:      s.MaxHand,
+			EngineMinCC:  s.EngineMinCC,
+			Keywords:     s.Keywords,
+			ExcludeKeys:  s.ExcludeKeys,
+			SellerFilter: storage.NormalizeSellerFilter(s.SellerFilter),
 			Active:       s.Active,
 			CreatedAt:    s.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 		})

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -198,6 +198,7 @@ func toListingResponses(records []storage.ListingRecord, saved map[string]bool) 
 			FitnessScore: l.FitnessScore,
 			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
 			Saved:        savedFlag,
+			IsCommercial: l.IsCommercial,
 		})
 	}
 	return items

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -27,6 +27,8 @@ type listingResponse struct {
 	FitnessScore *float64 `json:"fitness_score,omitempty"`
 	FirstSeenAt  string   `json:"first_seen_at"`
 	Saved        bool     `json:"saved,omitempty"`
+	// IsCommercial: omitted when unknown; false = private seller; true = dealer/commercial.
+	IsCommercial *bool `json:"is_commercial,omitempty"`
 }
 
 type listingsPageResponse struct {
@@ -88,17 +90,27 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 		FitnessScore: l.FitnessScore,
 		FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
 		Saved:        savedFlag,
+		IsCommercial: l.IsCommercial,
 	})
 }
 
 func listingFilterFromSearch(sr *storage.Search) storage.ListingFilter {
-	return storage.ListingFilter{
+	f := storage.ListingFilter{
 		PriceMax: sr.PriceMax,
 		YearMin:  sr.YearMin,
 		YearMax:  sr.YearMax,
 		MaxKm:    sr.MaxKm,
 		MaxHand:  sr.MaxHand,
 	}
+	switch storage.NormalizeSellerFilter(sr.SellerFilter) {
+	case storage.SellerFilterPrivate:
+		v := false
+		f.Commercial = &v
+	case storage.SellerFilterCommercial:
+		v := true
+		f.Commercial = &v
+	}
+	return f
 }
 
 func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -24,6 +24,8 @@ type createSearchRequest struct {
 	MaxHand      int    `json:"max_hand"`
 	Keywords     string `json:"keywords"`
 	ExcludeKeys  string `json:"exclude_keys"`
+	// SellerFilter: any (default), private, commercial (also accepts dealer, dealership for commercial).
+	SellerFilter string `json:"seller_filter,omitempty"`
 }
 
 type updateSearchRequest struct {
@@ -35,6 +37,7 @@ type updateSearchRequest struct {
 	MaxHand     int    `json:"max_hand"`
 	Keywords    string `json:"keywords"`
 	ExcludeKeys string `json:"exclude_keys"`
+	SellerFilter *string `json:"seller_filter,omitempty"`
 }
 
 type searchResponse struct {
@@ -53,6 +56,7 @@ type searchResponse struct {
 	MaxHand          int    `json:"max_hand"`
 	Keywords         string `json:"keywords,omitempty"`
 	ExcludeKeys      string `json:"exclude_keys,omitempty"`
+	SellerFilter     string `json:"seller_filter,omitempty"`
 	Active           bool   `json:"active"`
 	CreatedAt        string `json:"created_at"`
 	ListingsCount    int64  `json:"listings_count"`
@@ -123,6 +127,7 @@ func (s *Server) toSearchResponse(sr storage.Search) searchResponse {
 		MaxHand:          sr.MaxHand,
 		Keywords:         sr.Keywords,
 		ExcludeKeys:      sr.ExcludeKeys,
+		SellerFilter:     storage.NormalizeSellerFilter(sr.SellerFilter),
 		Active:           sr.Active,
 		CreatedAt:        sr.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 	}
@@ -235,6 +240,7 @@ func createSearchRecord(chatID int64, name string, req createSearchRequest) stor
 		MaxHand:      req.MaxHand,
 		Keywords:     splitKeywords(req.Keywords),
 		ExcludeKeys:  splitKeywords(req.ExcludeKeys),
+		SellerFilter: storage.NormalizeSellerFilter(req.SellerFilter),
 		Active:       true,
 	}
 }
@@ -362,6 +368,9 @@ func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
 	existing.MaxHand = req.MaxHand
 	existing.Keywords = splitKeywords(req.Keywords)
 	existing.ExcludeKeys = splitKeywords(req.ExcludeKeys)
+	if req.SellerFilter != nil {
+		existing.SellerFilter = storage.NormalizeSellerFilter(*req.SellerFilter)
+	}
 
 	if err := s.searches.UpdateSearch(r.Context(), *existing); err != nil {
 		if errors.Is(err, storage.ErrNotFound) {

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -104,6 +104,7 @@ func (b *Bot) onShareCopy(ctx context.Context, chatID int64, data string) {
 		MaxHand:      src.MaxHand,
 		Keywords:     src.Keywords,
 		ExcludeKeys:  src.ExcludeKeys,
+		SellerFilter: src.SellerFilter,
 	})
 	if err != nil {
 		b.logger.Error("clone search failed", "error", err)

--- a/internal/bot/share_test.go
+++ b/internal/bot/share_test.go
@@ -46,6 +46,7 @@ func TestCloneSearch(t *testing.T) {
 		EngineMinCC:  2000,
 		MaxKm:        120000,
 		MaxHand:      3,
+		SellerFilter: storage.SellerFilterCommercial,
 	})
 	if err != nil {
 		t.Fatalf("create source search: %v", err)
@@ -69,6 +70,7 @@ func TestCloneSearch(t *testing.T) {
 		EngineMinCC:  src.EngineMinCC,
 		MaxKm:        src.MaxKm,
 		MaxHand:      src.MaxHand,
+		SellerFilter: src.SellerFilter,
 	})
 	if err != nil {
 		t.Fatalf("clone search: %v", err)
@@ -108,6 +110,9 @@ func TestCloneSearch(t *testing.T) {
 	}
 	if clone.MaxHand != src.MaxHand {
 		t.Errorf("MaxHand = %d, want %d", clone.MaxHand, src.MaxHand)
+	}
+	if storage.NormalizeSellerFilter(clone.SellerFilter) != storage.NormalizeSellerFilter(src.SellerFilter) {
+		t.Errorf("SellerFilter = %q, want %q", clone.SellerFilter, src.SellerFilter)
 	}
 	if clone.Name != src.Name {
 		t.Errorf("Name = %q, want %q", clone.Name, src.Name)

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -54,7 +54,7 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 
 	if logger != nil && len(items) > 0 && logger.Enabled(context.Background(), slog.LevelDebug) {
 		var probe feedItem
-		if err := json.Unmarshal(items[0], &probe); err == nil {
+		if err := json.Unmarshal(items[0].raw, &probe); err == nil {
 			logger.Debug("yad2 feed item summary",
 				"token", probe.Token,
 				"km", probe.Km,
@@ -63,14 +63,14 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 				"price", probe.Price,
 			)
 		}
-		logger.Debug("raw feed item sample", "json", string(items[0]))
+		logger.Debug("raw feed item sample", "json", string(items[0].raw))
 	}
 
 	listings := make([]model.RawListing, 0, len(items))
 	seen := make(map[string]struct{}, len(items))
 	skipped := 0
-	for _, item := range items {
-		l, err := itemToListing(item)
+	for _, tagged := range items {
+		l, err := itemToListing(tagged.raw, tagged.commercial)
 		if err != nil {
 			skipped++
 			if logger != nil {
@@ -98,7 +98,26 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 
 var listingKeys = []string{"private", "commercial", "platinum", "solo", "boost"}
 
-func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
+type feedTaggedItem struct {
+	raw        json.RawMessage
+	commercial *bool // nil: legacy feed (unknown); false: private; true: dealer/commercial buckets
+}
+
+// listingKeyCommercial maps Yad2 __NEXT_DATA__ bucket keys to seller type.
+func listingKeyCommercial(key string) *bool {
+	switch key {
+	case "private":
+		v := false
+		return &v
+	case "commercial", "platinum", "solo", "boost":
+		v := true
+		return &v
+	default:
+		return nil
+	}
+}
+
+func extractItems(nd nextDataEnvelope) ([]feedTaggedItem, error) {
 	queries := nd.Props.PageProps.DehydratedState.Queries
 	for _, q := range queries {
 		var bucket map[string]json.RawMessage
@@ -106,8 +125,7 @@ func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
 			continue
 		}
 
-		// New format: listings split across private/commercial/platinum/solo/boost keys.
-		var allItems []json.RawMessage
+		var all []feedTaggedItem
 		found := false
 		for _, key := range listingKeys {
 			raw, ok := bucket[key]
@@ -119,10 +137,13 @@ func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
 				continue
 			}
 			found = true
-			allItems = append(allItems, items...)
+			tag := listingKeyCommercial(key)
+			for _, item := range items {
+				all = append(all, feedTaggedItem{raw: item, commercial: tag})
+			}
 		}
 		if found {
-			return allItems, nil
+			return all, nil
 		}
 
 		// Legacy format: data.feed.feed_items.
@@ -135,18 +156,22 @@ func extractItems(nd nextDataEnvelope) ([]json.RawMessage, error) {
 		}
 		if err := json.Unmarshal(q.State.Data, &legacy); err == nil && legacy.Data.Feed.FeedItems != nil {
 			if string(legacy.Data.Feed.FeedItems) == "null" {
-				return []json.RawMessage{}, nil
+				return []feedTaggedItem{}, nil
 			}
 			var items []json.RawMessage
 			if json.Unmarshal(legacy.Data.Feed.FeedItems, &items) == nil {
-				return items, nil
+				out := make([]feedTaggedItem, 0, len(items))
+				for _, item := range items {
+					out = append(out, feedTaggedItem{raw: item, commercial: nil})
+				}
+				return out, nil
 			}
 		}
 	}
 	return nil, fmt.Errorf("no feed items found in __NEXT_DATA__")
 }
 
-func itemToListing(raw json.RawMessage) (model.RawListing, error) {
+func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, error) {
 	var item feedItem
 	if err := json.Unmarshal(raw, &item); err != nil {
 		return model.RawListing{}, err
@@ -203,12 +228,7 @@ func itemToListing(raw json.RawMessage) (model.RawListing, error) {
 			listing.CreatedAt = t
 		}
 	}
-	if updatedAt != "" {
-		if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
-			listing.UpdatedAt = t
-		}
-	}
-
+	listing.Commercial = commercial
 	return listing, nil
 }
 

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -228,6 +228,11 @@ func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, err
 			listing.CreatedAt = t
 		}
 	}
+	if updatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
+			listing.UpdatedAt = t
+		}
+	}
 	listing.Commercial = commercial
 	return listing, nil
 }

--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -25,6 +25,8 @@ type RawListing struct {
 	Description  string
 	ImageURL     string
 	PageLink     string
+	// Commercial: nil unknown; false private; true dealer/commercial (Yad2 feed bucket).
+	Commercial *bool
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -988,6 +988,7 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 			City: l.City, PageLink: l.PageLink, ImageURL: l.ImageURL,
 			EngineVolume: l.EngineVolume, HorsePower: l.HorsePower,
 			EngineType: l.EngineType, GearBox: l.GearBox, Description: l.Description,
+			IsCommercial: l.Commercial,
 			FitnessScore: &listing.FitnessScore, FirstSeenAt: time.Now(),
 		}); err != nil {
 			s.logger.Error("save price-drop listing failed",
@@ -1045,6 +1046,7 @@ func buildNotifications(search storage.Search, listing model.Listing, out *searc
 		City: listing.City, PageLink: listing.PageLink, ImageURL: listing.ImageURL,
 		EngineVolume: listing.EngineVolume, HorsePower: listing.HorsePower,
 		EngineType: listing.EngineType, GearBox: listing.GearBox, Description: listing.Description,
+		IsCommercial: listing.Commercial,
 		FitnessScore: &listing.FitnessScore, FirstSeenAt: time.Now(),
 	})
 }
@@ -1053,6 +1055,9 @@ func (s *Scheduler) processSearchListings(ctx context.Context, search storage.Se
 	var out searchResult
 	hidden := s.loadHiddenTokens(ctx, search.ChatID)
 	for _, l := range filterHiddenListings(filtered, hidden) {
+		if !storage.RawListingMatchesSellerFilter(l.Commercial, search.SellerFilter) {
+			continue
+		}
 		isNew, ok := s.deduplicateListings(ctx, l.Token, search.ChatID, search.ID)
 		if !ok {
 			continue

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -46,6 +46,8 @@ type Search struct {
 	MaxHand      int
 	Keywords     string
 	ExcludeKeys  string
+	// SellerFilter: any (default), private (מוכר פרטי), commercial (מוסך/סוכנות).
+	SellerFilter string
 	Active       bool
 	CreatedAt    time.Time
 	ShareToken   string
@@ -146,6 +148,8 @@ type ListingRecord struct {
 	EngineType   string
 	GearBox      string
 	Description  string
+	// IsCommercial: nil = unknown; false = private seller; true = dealer/commercial (Yad2 bucket).
+	IsCommercial *bool
 	FitnessScore *float64
 	FirstSeenAt  time.Time
 }
@@ -170,6 +174,8 @@ type ListingFilter struct {
 	YearMax  int
 	MaxKm    int
 	MaxHand  int
+	// Commercial: non-nil restricts to private (false) or commercial/dealer (true).
+	Commercial *bool
 }
 
 type ListingStore interface {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -109,7 +109,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				fitness_score, first_seen_at
+				is_commercial, fitness_score, first_seen_at
 			FROM listing_history
 			WHERE search_id = $1
 			ORDER BY first_seen_at DESC
@@ -119,7 +119,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				fitness_score, first_seen_at
+				is_commercial, fitness_score, first_seen_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT $1 OFFSET $2`, limit, offset)
@@ -133,15 +133,17 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 	for rows.Next() {
 		var r storage.ListingRecord
 		var fs sql.NullFloat64
+		var ic sql.NullInt64
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
 			&r.Manufacturer, &r.Model, &r.SubModel, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&fs, &r.FirstSeenAt,
+			&ic, &fs, &r.FirstSeenAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
+		r.IsCommercial = storage.ListingCommercialFromSQL(ic)
 		if fs.Valid {
 			r.FitnessScore = &fs.Float64
 		}
@@ -158,7 +160,8 @@ func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int
 func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
-			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at,
+			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys,
+			COALESCE(seller_filter, 'any'), active, created_at,
 			COALESCE(share_token, '')
 		FROM searches
 		ORDER BY created_at DESC`)

--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -14,6 +14,8 @@ func TestCountSearchListingsForChatQuery_Contract(t *testing.T) {
 		"s.price_max <= 0 OR lh.price <= s.price_max",
 		"s.year_min <= 0 OR lh.year >= s.year_min",
 		"max_km <= 0 OR (lh.km > 0 AND lh.km <= s.max_km)",
+		"s.seller_filter",
+		"lh.is_commercial",
 		"GROUP BY lh.search_id",
 	} {
 		if !strings.Contains(countSearchListingsForChatSQL, frag) {
@@ -127,6 +129,28 @@ func TestBuildFilterClauses_MaxKmIncludesPositiveCheck(t *testing.T) {
 	}
 	if !strings.Contains(clause, "km > 0") {
 		t.Errorf("MaxKm clause should include 'km > 0' check, got: %s", clause)
+	}
+}
+
+func TestBuildFilterClauses_Commercial(t *testing.T) {
+	tVal := true
+	f := storage.ListingFilter{Commercial: &tVal}
+	clause, args, next := buildFilterClauses(f, 2)
+	if !strings.Contains(clause, "is_commercial = $2") {
+		t.Fatalf("expected is_commercial placeholder, got %q", clause)
+	}
+	if len(args) != 1 || next != 3 {
+		t.Fatalf("args=%v next=%d", args, next)
+	}
+
+	fVal := false
+	f2 := storage.ListingFilter{Commercial: &fVal}
+	clause2, args2, next2 := buildFilterClauses(f2, 1)
+	if !strings.Contains(clause2, "is_commercial = $1") {
+		t.Fatalf("expected private clause, got %q", clause2)
+	}
+	if len(args2) != 1 || next2 != 2 {
+		t.Fatalf("args2=%v next2=%d", args2, next2)
 	}
 }
 

--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -15,6 +15,7 @@ func TestCountSearchListingsForChatQuery_Contract(t *testing.T) {
 		"s.year_min <= 0 OR lh.year >= s.year_min",
 		"max_km <= 0 OR (lh.km > 0 AND lh.km <= s.max_km)",
 		"s.seller_filter",
+		"WHEN 'dealer'",
 		"lh.is_commercial",
 		"GROUP BY lh.search_id",
 	} {

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -22,12 +22,15 @@ WHERE lh.chat_id = $1
   AND (s.year_max <= 0 OR lh.year <= s.year_max)
   AND (s.max_km <= 0 OR (lh.km > 0 AND lh.km <= s.max_km))
   AND (s.max_hand <= 0 OR lh.hand <= s.max_hand)
+  AND (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'any'
+       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'private' AND lh.is_commercial = 0)
+       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'commercial' AND lh.is_commercial = 1))
 GROUP BY lh.search_id`
 
 const upsertListingSQL = `
 	INSERT INTO listing_history
-	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, fitness_score, first_seen_at)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, first_seen_at)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
 	ON CONFLICT (token, chat_id) DO UPDATE SET
 		search_id = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_id ELSE listing_history.search_id END,
 		search_name = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_name ELSE listing_history.search_name END,
@@ -46,6 +49,7 @@ const upsertListingSQL = `
 		engine_type = CASE WHEN EXCLUDED.engine_type != '' THEN EXCLUDED.engine_type ELSE listing_history.engine_type END,
 		gear_box = CASE WHEN EXCLUDED.gear_box != '' THEN EXCLUDED.gear_box ELSE listing_history.gear_box END,
 		description = CASE WHEN EXCLUDED.description != '' THEN EXCLUDED.description ELSE listing_history.description END,
+		is_commercial = COALESCE(EXCLUDED.is_commercial, listing_history.is_commercial),
 		fitness_score = EXCLUDED.fitness_score`
 
 type listingScanner interface {
@@ -55,12 +59,14 @@ type listingScanner interface {
 func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
+	var ic sql.NullInt64
 	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&fs, &l.FirstSeenAt); err != nil {
+		&ic, &fs, &l.FirstSeenAt); err != nil {
 		return l, err
 	}
+	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
 	if fs.Valid {
 		l.FitnessScore = &fs.Float64
 	}
@@ -72,6 +78,7 @@ func upsertListingArgs(r storage.ListingRecord) []any {
 		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.SubModel, r.Year, r.Price,
 		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL,
 		r.EngineVolume, r.HorsePower, r.EngineType, r.GearBox, r.Description,
+		storage.ListingCommercialToSQL(r.IsCommercial),
 		r.FitnessScore, r.FirstSeenAt.UTC(),
 	}
 }
@@ -196,7 +203,7 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1 AND token = $2
 		ORDER BY first_seen_at DESC
@@ -216,7 +223,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1
 		ORDER BY first_seen_at DESC, token DESC
@@ -249,7 +256,7 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		ORDER BY first_seen_at DESC
 		LIMIT $1`, limit)
@@ -298,6 +305,16 @@ func buildFilterClauses(f storage.ListingFilter, paramStart int) (string, []any,
 		args = append(args, f.MaxHand)
 		n++
 	}
+	if f.Commercial != nil {
+		if *f.Commercial {
+			clauses = append(clauses, fmt.Sprintf("is_commercial = $%d", n))
+			args = append(args, 1)
+		} else {
+			clauses = append(clauses, fmt.Sprintf("is_commercial = $%d", n))
+			args = append(args, 0)
+		}
+		n++
+	}
 	if len(clauses) == 0 {
 		return "", nil, paramStart
 	}
@@ -330,7 +347,7 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1 AND search_id = $2%s
 		ORDER BY %s
@@ -420,7 +437,7 @@ func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) 
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.fitness_score, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.first_seen_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = $1

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -22,9 +22,13 @@ WHERE lh.chat_id = $1
   AND (s.year_max <= 0 OR lh.year <= s.year_max)
   AND (s.max_km <= 0 OR (lh.km > 0 AND lh.km <= s.max_km))
   AND (s.max_hand <= 0 OR lh.hand <= s.max_hand)
-  AND (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'any'
-       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'private' AND lh.is_commercial = 0)
-       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'commercial' AND lh.is_commercial = 1))
+  AND CASE LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any')))
+    WHEN 'private' THEN lh.is_commercial = 0
+    WHEN 'commercial' THEN lh.is_commercial = 1
+    WHEN 'dealer' THEN lh.is_commercial = 1
+    WHEN 'dealership' THEN lh.is_commercial = 1
+    ELSE TRUE
+  END
 GROUP BY lh.search_id`
 
 const upsertListingSQL = `

--- a/internal/storage/postgres/notifications_center.go
+++ b/internal/storage/postgres/notifications_center.go
@@ -14,7 +14,7 @@ func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.T
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1 AND first_seen_at > $2
 		ORDER BY first_seen_at DESC, token DESC

--- a/internal/storage/postgres/searches.go
+++ b/internal/storage/postgres/searches.go
@@ -46,13 +46,13 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 	var id int64
 	err = tx.QueryRowContext(ctx, `
-		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, user_seq, share_token)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, user_seq, share_token)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		RETURNING id`,
 		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax,
 		search.EngineMinCC, search.MaxKm, search.MaxHand,
-		search.Keywords, search.ExcludeKeys, nextSeq, shareToken).Scan(&id)
+		search.Keywords, search.ExcludeKeys, storage.NormalizeSellerFilter(search.SellerFilter), nextSeq, shareToken).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
@@ -65,7 +65,7 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = $1 ORDER BY created_at DESC`, chatID)
 	if err != nil {
 		return nil, fmt.Errorf("list searches: %w", err)
@@ -76,14 +76,14 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 
 func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE id = $1 AND chat_id = $2`, id, chatID)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
-		&search.Keywords, &search.ExcludeKeys,
+		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -96,14 +96,14 @@ func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage
 
 func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = $1 AND user_seq = $2`, chatID, seq)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
-		&search.Keywords, &search.ExcludeKeys,
+		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -116,14 +116,14 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 
 func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE share_token = $1`, token)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
-		&search.Keywords, &search.ExcludeKeys,
+		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -142,11 +142,12 @@ func (s *Store) UpdateSearch(ctx context.Context, search storage.Search) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE searches SET name=$1, source=$2, manufacturer=$3, model=$4,
 			year_min=$5, year_max=$6, price_max=$7, engine_min_cc=$8,
-			max_km=$9, max_hand=$10, keywords=$11, exclude_keys=$12
-		WHERE id=$13 AND chat_id=$14`,
+			max_km=$9, max_hand=$10, keywords=$11, exclude_keys=$12, seller_filter=$13
+		WHERE id=$14 AND chat_id=$15`,
 		search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax, search.EngineMinCC,
 		search.MaxKm, search.MaxHand, search.Keywords, search.ExcludeKeys,
+		storage.NormalizeSellerFilter(search.SellerFilter),
 		search.ID, search.ChatID)
 	if err != nil {
 		return fmt.Errorf("update search: %w", err)
@@ -224,7 +225,7 @@ func (s *Store) SetSearchActive(ctx context.Context, id int64, chatID int64, act
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, s.active, s.created_at, COALESCE(s.share_token, '')
+		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), s.active, s.created_at, COALESCE(s.share_token, '')
 		FROM searches s
 		JOIN users u ON s.chat_id = u.chat_id
 		WHERE s.active = true AND u.active = true
@@ -264,7 +265,7 @@ func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 		if err := rows.Scan(&s.ID, &s.ChatID, &s.UserSeq, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
 			&s.YearMin, &s.YearMax, &s.PriceMax,
 			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
-			&s.Keywords, &s.ExcludeKeys,
+			&s.Keywords, &s.ExcludeKeys, &s.SellerFilter,
 			&s.Active, &s.CreatedAt, &s.ShareToken); err != nil {
 			return nil, err
 		}

--- a/internal/storage/seller_filter.go
+++ b/internal/storage/seller_filter.go
@@ -1,0 +1,36 @@
+package storage
+
+import "strings"
+
+// Seller filter values (stored on Search.seller_filter).
+const (
+	SellerFilterAny        = "any"
+	SellerFilterPrivate    = "private"
+	SellerFilterCommercial = "commercial"
+)
+
+// NormalizeSellerFilter returns any | private | commercial; invalid input becomes "any".
+func NormalizeSellerFilter(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case SellerFilterPrivate:
+		return SellerFilterPrivate
+	case SellerFilterCommercial, "dealer", "dealership":
+		return SellerFilterCommercial
+	default:
+		return SellerFilterAny
+	}
+}
+
+// RawListingMatchesSellerFilter returns whether a scraped listing should be processed
+// for searches with the given seller_filter (use NormalizeSellerFilter first), based on
+// Commercial: nil = unknown (does not match private or commercial-only filters).
+func RawListingMatchesSellerFilter(commercial *bool, sellerFilter string) bool {
+	switch NormalizeSellerFilter(sellerFilter) {
+	case SellerFilterPrivate:
+		return commercial != nil && !*commercial
+	case SellerFilterCommercial:
+		return commercial != nil && *commercial
+	default:
+		return true
+	}
+}

--- a/internal/storage/seller_filter_test.go
+++ b/internal/storage/seller_filter_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import "testing"
+
+func TestNormalizeSellerFilter(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", SellerFilterAny},
+		{"any", SellerFilterAny},
+		{"ANY", SellerFilterAny},
+		{"private", SellerFilterPrivate},
+		{" commercial ", SellerFilterCommercial},
+		{"dealer", SellerFilterCommercial},
+		{"dealership", SellerFilterCommercial},
+		{"bogus", SellerFilterAny},
+	}
+	for _, tt := range tests {
+		if got := NormalizeSellerFilter(tt.in); got != tt.want {
+			t.Errorf("NormalizeSellerFilter(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRawListingMatchesSellerFilter(t *testing.T) {
+	priv := false
+	dealer := true
+
+	tests := []struct {
+		name       string
+		commerce   *bool
+		filter     string
+		wantMatch  bool
+	}{
+		{"any nil", nil, SellerFilterAny, true},
+		{"any private", &priv, SellerFilterAny, true},
+		{"private matches", &priv, SellerFilterPrivate, true},
+		{"private dealer no", &dealer, SellerFilterPrivate, false},
+		{"private unknown no", nil, SellerFilterPrivate, false},
+		{"commercial matches", &dealer, SellerFilterCommercial, true},
+		{"commercial private no", &priv, SellerFilterCommercial, false},
+		{"commercial unknown no", nil, SellerFilterCommercial, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RawListingMatchesSellerFilter(tt.commerce, tt.filter); got != tt.wantMatch {
+				t.Fatalf("RawListingMatchesSellerFilter(%v, %q) = %v, want %v", tt.commerce, tt.filter, got, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/internal/storage/sql_helpers.go
+++ b/internal/storage/sql_helpers.go
@@ -1,0 +1,23 @@
+package storage
+
+import "database/sql"
+
+// ListingCommercialToSQL converts a tri-state commercial flag for SQL INTEGER NULL/0/1.
+func ListingCommercialToSQL(c *bool) any {
+	if c == nil {
+		return nil
+	}
+	if *c {
+		return 1
+	}
+	return 0
+}
+
+// ListingCommercialFromSQL scans a nullable INTEGER into *bool (nil if SQL NULL).
+func ListingCommercialFromSQL(nt sql.NullInt64) *bool {
+	if !nt.Valid {
+		return nil
+	}
+	v := nt.Int64 != 0
+	return &v
+}

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -109,7 +109,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				fitness_score, first_seen_at
+				is_commercial, fitness_score, first_seen_at
 			FROM listing_history
 			WHERE search_id = ?
 			ORDER BY first_seen_at DESC
@@ -119,7 +119,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				fitness_score, first_seen_at
+				is_commercial, fitness_score, first_seen_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT ? OFFSET ?`, limit, offset)
@@ -133,16 +133,18 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 	for rows.Next() {
 		var r storage.ListingRecord
 		var score *float64
+		var ic sql.NullInt64
 		var firstSeen string
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
 			&r.Manufacturer, &r.Model, &r.SubModel, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&score, &firstSeen,
+			&ic, &score, &firstSeen,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
+		r.IsCommercial = storage.ListingCommercialFromSQL(ic)
 		r.FitnessScore = score
 		parsed, parseErr := parseFlexibleTime(firstSeen)
 		if parseErr != nil {
@@ -166,7 +168,8 @@ func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int
 func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
-			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at,
+			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys,
+			COALESCE(seller_filter, 'any'), active, created_at,
 			COALESCE(share_token, '')
 		FROM searches
 		ORDER BY created_at DESC`)

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -14,8 +14,8 @@ const firstSeenAtLayout = "2006-01-02 15:04:05.000000"
 
 const upsertListingSQL = `
 	INSERT INTO listing_history
-	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, fitness_score, first_seen_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, first_seen_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(token, chat_id) DO UPDATE SET
 		search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
 		search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
@@ -34,6 +34,7 @@ const upsertListingSQL = `
 		engine_type = CASE WHEN excluded.engine_type != '' THEN excluded.engine_type ELSE listing_history.engine_type END,
 		gear_box = CASE WHEN excluded.gear_box != '' THEN excluded.gear_box ELSE listing_history.gear_box END,
 		description = CASE WHEN excluded.description != '' THEN excluded.description ELSE listing_history.description END,
+		is_commercial = COALESCE(excluded.is_commercial, listing_history.is_commercial),
 		fitness_score = excluded.fitness_score`
 
 type listingScanner interface {
@@ -43,12 +44,14 @@ type listingScanner interface {
 func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
+	var ic sql.NullInt64
 	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&fs, &l.FirstSeenAt); err != nil {
+		&ic, &fs, &l.FirstSeenAt); err != nil {
 		return l, err
 	}
+	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
 	if fs.Valid {
 		l.FitnessScore = &fs.Float64
 	}
@@ -60,6 +63,7 @@ func upsertListingArgs(r storage.ListingRecord) []any {
 		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.SubModel, r.Year, r.Price,
 		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL,
 		r.EngineVolume, r.HorsePower, r.EngineType, r.GearBox, r.Description,
+		storage.ListingCommercialToSQL(r.IsCommercial),
 		r.FitnessScore, r.FirstSeenAt.UTC().Format(firstSeenAtLayout),
 	}
 }
@@ -184,7 +188,7 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ? AND token = ?
 		ORDER BY rowid DESC LIMIT 1`, chatID, token)
@@ -203,7 +207,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ?
 		ORDER BY first_seen_at DESC, token DESC
@@ -236,7 +240,7 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE rowid IN (SELECT MAX(rowid) FROM listing_history GROUP BY token)
 		ORDER BY first_seen_at DESC LIMIT ?`, limit)
@@ -279,6 +283,13 @@ func buildFilterClauses(f storage.ListingFilter) (string, []any) {
 		clauses = append(clauses, "hand <= ?")
 		args = append(args, f.MaxHand)
 	}
+	if f.Commercial != nil {
+		if *f.Commercial {
+			clauses = append(clauses, "is_commercial = 1")
+		} else {
+			clauses = append(clauses, "is_commercial = 0")
+		}
+	}
 	if len(clauses) == 0 {
 		return "", nil
 	}
@@ -311,7 +322,7 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ? AND search_id = ?%s
 		ORDER BY %s
@@ -355,6 +366,9 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 		  AND (s.year_max <= 0 OR lh.year <= s.year_max)
 		  AND (s.max_km <= 0 OR (lh.km > 0 AND lh.km <= s.max_km))
 		  AND (s.max_hand <= 0 OR lh.hand <= s.max_hand)
+		  AND (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'any'
+		       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'private' AND lh.is_commercial = 0)
+		       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'commercial' AND lh.is_commercial = 1))
 		GROUP BY lh.search_id`, chatID)
 	if err != nil {
 		return nil, err
@@ -409,7 +423,7 @@ func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) 
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.fitness_score, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.first_seen_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = ?

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -366,9 +366,13 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 		  AND (s.year_max <= 0 OR lh.year <= s.year_max)
 		  AND (s.max_km <= 0 OR (lh.km > 0 AND lh.km <= s.max_km))
 		  AND (s.max_hand <= 0 OR lh.hand <= s.max_hand)
-		  AND (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'any'
-		       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'private' AND lh.is_commercial = 0)
-		       OR (LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any'))) = 'commercial' AND lh.is_commercial = 1))
+		  AND CASE LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any')))
+		    WHEN 'private' THEN lh.is_commercial = 0
+		    WHEN 'commercial' THEN lh.is_commercial = 1
+		    WHEN 'dealer' THEN lh.is_commercial = 1
+		    WHEN 'dealership' THEN lh.is_commercial = 1
+		    ELSE 1
+		  END
 		GROUP BY lh.search_id`, chatID)
 	if err != nil {
 		return nil, err

--- a/internal/storage/sqlite/migrate.go
+++ b/internal/storage/sqlite/migrate.go
@@ -42,6 +42,7 @@ func migrate(db *sql.DB) error {
 		migrateUsersActiveIndex,
 		migrateMissingIndexes,
 		migrateListingVehicleDetails,
+		migrateSellerFilterAndListingCommercial,
 	}
 	for _, step := range steps {
 		if err := step(db); err != nil {

--- a/internal/storage/sqlite/migrate_steps.go
+++ b/internal/storage/sqlite/migrate_steps.go
@@ -668,3 +668,29 @@ func migrateListingVehicleDetails(db *sql.DB) error {
 	}
 	return nil
 }
+
+func migrateSellerFilterAndListingCommercial(db *sql.DB) error {
+	var hasSF int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('searches') WHERE name = 'seller_filter'",
+	).Scan(&hasSF); err != nil {
+		return fmt.Errorf("check searches seller_filter: %w", err)
+	}
+	if hasSF == 0 {
+		if _, err := db.Exec(`ALTER TABLE searches ADD COLUMN seller_filter TEXT NOT NULL DEFAULT 'any'`); err != nil {
+			return fmt.Errorf("add searches seller_filter: %w", err)
+		}
+	}
+	var hasIC int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('listing_history') WHERE name = 'is_commercial'",
+	).Scan(&hasIC); err != nil {
+		return fmt.Errorf("check listing_history is_commercial: %w", err)
+	}
+	if hasIC == 0 {
+		if _, err := db.Exec(`ALTER TABLE listing_history ADD COLUMN is_commercial INTEGER`); err != nil {
+			return fmt.Errorf("add listing_history is_commercial: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/storage/sqlite/notifications_center.go
+++ b/internal/storage/sqlite/notifications_center.go
@@ -13,7 +13,7 @@ func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.T
 		SELECT token, search_name, manufacturer, model, sub_model, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			fitness_score, first_seen_at
+			is_commercial, fitness_score, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ? AND first_seen_at > ?
 		ORDER BY first_seen_at DESC, token DESC

--- a/internal/storage/sqlite/searches.go
+++ b/internal/storage/sqlite/searches.go
@@ -34,12 +34,12 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 	}
 
 	result, err := tx.ExecContext(ctx, `
-		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, user_seq, share_token)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, user_seq, share_token)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax,
 		search.EngineMinCC, search.MaxKm, search.MaxHand,
-		search.Keywords, search.ExcludeKeys, nextSeq, shareToken)
+		search.Keywords, search.ExcludeKeys, storage.NormalizeSellerFilter(search.SellerFilter), nextSeq, shareToken)
 	if err != nil {
 		return 0, err
 	}
@@ -57,7 +57,7 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = ? ORDER BY created_at DESC`, chatID)
 	if err != nil {
 		return nil, fmt.Errorf("list searches: %w", err)
@@ -68,14 +68,14 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 
 func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE id = ? AND chat_id = ?`, id, chatID)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
-		&search.Keywords, &search.ExcludeKeys,
+		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -88,14 +88,14 @@ func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage
 
 func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = ? AND user_seq = ?`, chatID, seq)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
-		&search.Keywords, &search.ExcludeKeys,
+		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -108,14 +108,14 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 
 func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE share_token = ?`, token)
 
 	var search storage.Search
 	err := row.Scan(&search.ID, &search.ChatID, &search.UserSeq, &search.Name, &search.Source, &search.Manufacturer, &search.Model,
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
-		&search.Keywords, &search.ExcludeKeys,
+		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -134,11 +134,12 @@ func (s *Store) UpdateSearch(ctx context.Context, search storage.Search) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE searches SET name=?, source=?, manufacturer=?, model=?,
 			year_min=?, year_max=?, price_max=?, engine_min_cc=?,
-			max_km=?, max_hand=?, keywords=?, exclude_keys=?
+			max_km=?, max_hand=?, keywords=?, exclude_keys=?, seller_filter=?
 		WHERE id=? AND chat_id=?`,
 		search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax, search.EngineMinCC,
 		search.MaxKm, search.MaxHand, search.Keywords, search.ExcludeKeys,
+		storage.NormalizeSellerFilter(search.SellerFilter),
 		search.ID, search.ChatID)
 	if err != nil {
 		return fmt.Errorf("update search: %w", err)
@@ -216,7 +217,7 @@ func (s *Store) SetSearchActive(ctx context.Context, id int64, chatID int64, act
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, s.active, s.created_at, COALESCE(s.share_token, '')
+		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), s.active, s.created_at, COALESCE(s.share_token, '')
 		FROM searches s
 		JOIN users u ON s.chat_id = u.chat_id
 		WHERE s.active = true AND u.active = true
@@ -256,7 +257,7 @@ func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 		if err := rows.Scan(&s.ID, &s.ChatID, &s.UserSeq, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
 			&s.YearMin, &s.YearMax, &s.PriceMax,
 			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
-			&s.Keywords, &s.ExcludeKeys,
+			&s.Keywords, &s.ExcludeKeys, &s.SellerFilter,
 			&s.Active, &s.CreatedAt, &s.ShareToken); err != nil {
 			return nil, err
 		}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -27,6 +27,8 @@ func seedUser(t *testing.T, store *Store, chatID int64) {
 	}
 }
 
+func ptrBool(b bool) *bool { return &b }
+
 // --- User Tests ---
 
 func TestUpsertUser(t *testing.T) {
@@ -2265,12 +2267,14 @@ func TestListSearchListings(t *testing.T) {
 	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "lsl-1", ChatID: 100, SearchID: idMazda3, SearchName: "mazda3",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 120000, Km: 50000, Hand: 2,
+		IsCommercial: ptrBool(true),
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "lsl-2", ChatID: 100, SearchID: idMazda3, SearchName: "mazda3",
 		Manufacturer: "Mazda", Model: "3", Year: 2022, Price: 90000, Km: 30000, Hand: 1,
+		IsCommercial: ptrBool(false),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -2395,6 +2399,16 @@ func TestListSearchListings(t *testing.T) {
 				filter: storage.ListingFilter{PriceMax: 50000},
 				want:   nil,
 			},
+			{
+				name:   "is_commercial private only",
+				filter: storage.ListingFilter{Commercial: ptrBool(false)},
+				want:   []string{"lsl-2"},
+			},
+			{
+				name:   "is_commercial dealer only",
+				filter: storage.ListingFilter{Commercial: ptrBool(true)},
+				want:   []string{"lsl-1"},
+			},
 		}
 
 		for _, tc := range cases {
@@ -2489,6 +2503,51 @@ func TestCountSearchListingsForChat(t *testing.T) {
 	}
 	if int64(got[idCapped]) != wantCapped {
 		t.Errorf("batch capped %d vs CountSearchListings %d", got[idCapped], wantCapped)
+	}
+}
+
+func TestCountSearchListingsForChat_SellerFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	idPriv, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "seller_priv", Source: "yad2",
+		Manufacturer: 8, Model: 10061, Active: true,
+		SellerFilter: storage.SellerFilterPrivate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "sf-1", ChatID: 100, SearchID: idPriv, SearchName: "seller_priv",
+		Manufacturer: "Mazda", Model: "3", Year: 2022, Price: 90000, Km: 30000, Hand: 1,
+		IsCommercial: ptrBool(false),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "sf-2", ChatID: 100, SearchID: idPriv, SearchName: "seller_priv",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 120000, Km: 50000, Hand: 2,
+		IsCommercial: ptrBool(true),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.CountSearchListingsForChat(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[idPriv] != 1 {
+		t.Fatalf("batch count: got %d, want 1", got[idPriv])
+	}
+	f := storage.ListingFilter{Commercial: ptrBool(false)}
+	want, err := store.CountSearchListings(ctx, 100, idPriv, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want != 1 {
+		t.Fatalf("CountSearchListings: got %d, want 1", want)
 	}
 }
 

--- a/migrations/000003_seller_filter.down.sql
+++ b/migrations/000003_seller_filter.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE searches DROP COLUMN IF EXISTS seller_filter;
+
+ALTER TABLE listing_history DROP COLUMN IF EXISTS is_commercial;

--- a/migrations/000003_seller_filter.up.sql
+++ b/migrations/000003_seller_filter.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE searches ADD COLUMN IF NOT EXISTS seller_filter TEXT NOT NULL DEFAULT 'any';
+
+ALTER TABLE listing_history ADD COLUMN IF NOT EXISTS is_commercial INTEGER;

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -42,6 +42,11 @@ export function SearchCard({
     search.price_max > 0 ? `עד ${formatPrice(search.price_max)}` : null,
     search.max_km > 0 ? `עד ${formatKm(search.max_km)}` : null,
     search.max_hand > 0 ? `עד יד ${search.max_hand}` : null,
+    search.seller_filter === "private"
+      ? "מוכר פרטי"
+      : search.seller_filter === "commercial"
+        ? "מוסך / סוכנות"
+        : null,
   ].filter(Boolean) as string[];
 
   const openCardClassName =

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -78,6 +78,8 @@ export interface Search {
   exclude_keys: string;
   active: boolean;
   created_at: string;
+  /** any | private | commercial */
+  seller_filter?: string;
   /** Total listings found for this search; from API when supported. */
   listings_count?: number;
 }
@@ -95,6 +97,8 @@ export interface CreateSearchRequest {
   max_hand?: number;
   keywords?: string;
   exclude_keys?: string;
+  /** any (default), private, commercial */
+  seller_filter?: string;
 }
 
 export interface Listing {
@@ -118,6 +122,8 @@ export interface Listing {
   first_seen_at: string;
   /** Present when API includes bookmark state */
   saved?: boolean;
+  /** From Yad2 bucket: true = dealer/commercial, false = private, absent when unknown. */
+  is_commercial?: boolean | null;
 }
 
 export interface ListingsResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -282,8 +282,13 @@ export interface AdminSearch {
   year_min: number;
   year_max: number;
   price_max: number;
+  engine_min_cc: number;
   max_km: number;
   max_hand: number;
+  keywords?: string;
+  exclude_keys?: string;
+  /** any | private | commercial */
+  seller_filter?: string;
   active: boolean;
   created_at: string;
 }

--- a/web/src/pages/EditSearchPage.tsx
+++ b/web/src/pages/EditSearchPage.tsx
@@ -15,6 +15,24 @@ import { useToast } from "@/components/ui/Toast";
 
 const HAND_OPTIONS = [0, 1, 2, 3, 4];
 
+const SELLER_FILTER_OPTIONS: {
+  value: "any" | "private" | "commercial";
+  label: string;
+}[] = [
+  { value: "any", label: "הכל" },
+  { value: "private", label: "מוכר פרטי" },
+  { value: "commercial", label: "מוסך / סוכנות" },
+];
+
+function normalizeSellerFilter(v: string | undefined): "any" | "private" | "commercial" {
+  const s = (v ?? "any").toLowerCase().trim();
+  if (s === "private") return "private";
+  if (s === "commercial" || s === "dealer" || s === "dealership") {
+    return "commercial";
+  }
+  return "any";
+}
+
 function formatKmLabel(value: number): string {
   if (value === 0) return "ללא הגבלה";
   return `${value.toLocaleString("he-IL")} ק"מ`;
@@ -38,6 +56,7 @@ export function EditSearchPage() {
     maxHand: 0,
     keywords: "",
     excludeKeys: "",
+    sellerFilter: "any" as "any" | "private" | "commercial",
   });
 
   const initializedSearchIdRef = useRef<number | null>(null);
@@ -53,6 +72,7 @@ export function EditSearchPage() {
         maxHand: search.max_hand,
         keywords: search.keywords,
         excludeKeys: search.exclude_keys,
+        sellerFilter: normalizeSellerFilter(search.seller_filter),
       });
       initializedSearchIdRef.current = search.id;
     }
@@ -83,6 +103,7 @@ export function EditSearchPage() {
           max_hand: form.maxHand,
           keywords: form.keywords || undefined,
           exclude_keys: form.excludeKeys || undefined,
+          seller_filter: form.sellerFilter,
         },
       },
       {
@@ -236,6 +257,24 @@ export function EditSearchPage() {
             ))}
           </div>
         </FormField>
+
+        <div className="space-y-3">
+          <h3 className="text-xs font-medium text-muted-foreground">סוג מוכר</h3>
+          <p className="text-xs text-muted-foreground">
+            מסנן לפי מודעות ממוכר פרטי או ממוסך/סוכנות.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {SELLER_FILTER_OPTIONS.map((opt) => (
+              <ChipButton
+                key={opt.value}
+                selected={form.sellerFilter === opt.value}
+                onClick={() => set("sellerFilter", opt.value)}
+              >
+                {opt.label}
+              </ChipButton>
+            ))}
+          </div>
+        </div>
       </section>
 
       <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-5">

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -26,7 +26,14 @@ interface FormData {
   maxHand: number;
   keywords: string;
   excludeKeys: string;
+  sellerFilter: "any" | "private" | "commercial";
 }
+
+const SELLER_FILTER_OPTIONS: { value: FormData["sellerFilter"]; label: string }[] = [
+  { value: "any", label: "הכל" },
+  { value: "private", label: "מוכר פרטי" },
+  { value: "commercial", label: "מוסך / סוכנות" },
+];
 
 const SOURCE_OPTIONS = [
   { value: "yad2", label: "יד2" },
@@ -58,6 +65,7 @@ export function NewSearchPage() {
     maxHand: 0,
     keywords: "",
     excludeKeys: "",
+    sellerFilter: "any",
   });
 
   const { data: manufacturers } = useManufacturers();
@@ -96,6 +104,7 @@ export function NewSearchPage() {
         max_hand: form.maxHand,
         keywords: form.keywords || undefined,
         exclude_keys: form.excludeKeys || undefined,
+        seller_filter: form.sellerFilter,
       },
       {
         onSuccess: () => {
@@ -153,6 +162,24 @@ export function NewSearchPage() {
               onClick={() => set("source", src.value)}
             >
               {src.label}
+            </ChipButton>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
+        <h2 className="text-sm font-semibold text-foreground">סוג מוכר</h2>
+        <p className="text-xs text-muted-foreground">
+          מסנן לפי מודעות ממוכר פרטי או ממוסך/סוכנות (כשהמקור זיהוי זאת במודעה).
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {SELLER_FILTER_OPTIONS.map((opt) => (
+            <ChipButton
+              key={opt.value}
+              selected={form.sellerFilter === opt.value}
+              onClick={() => set("sellerFilter", opt.value)}
+            >
+              {opt.label}
             </ChipButton>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Adds `seller_filter` on saved searches: **`any`** (default), **`private`** (private seller), or **`commercial`** (dealership / paid Yad2 buckets).
- Yad2 parser tags each scraped listing with `Commercial` where the feed structure allows; value is stored as nullable `is_commercial` on `listing_history` (SQLite migration + Postgres `000003` migration).
- Scheduler applies the filter **before** dedup / notifications so users only get alerts that match their seller preference; `IsCommercial` is persisted on saved rows.
- REST API: create/update/search responses include `seller_filter`; listing payloads include optional `is_commercial`. Admin search list includes the new fields; SQLite→PG migrator column lists updated.
- Web: new/edit search UI (Hebrew) and dashboard card chip when filtering by seller type.

## How to verify

- `make test`
- `cd web && npx tsc -b && npm test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seller type filtering for searches—users can now filter for private sellers, commercial dealers, or any seller type.
  * Listings now display whether they are from private sellers or commercial dealers.
  * Search creation and editing pages now include a "seller type" selector.
  * Search cards show seller type filter tags in results.

* **Chores**
  * Database schema updated to support seller filtering and listing categorization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/646)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->