### PR TITLE
fix(web): manufacturer logos for Hebrew Yad2 catalog names

### DIFF
--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -10,7 +10,10 @@ import {
 import { cn, formatKm, formatPrice, relativeTime } from "@/lib/utils";
 import type { Search } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
-import { manufacturerLogoSrc } from "@/lib/manufacturerLogo";
+import {
+  manufacturerLogoSrc,
+  manufacturerLogoSrcFromCatalogId,
+} from "@/lib/manufacturerLogo";
 
 export type SearchCardProps = {
   search: Search;
@@ -35,7 +38,9 @@ export function SearchCard({
   const isActive = search.active;
   const listingsPath = `/searches/${search.id}/listings`;
 
-  const mfrLogo = manufacturerLogoSrc(search.manufacturer_name);
+  const mfrLogo =
+    manufacturerLogoSrcFromCatalogId(search.manufacturer_id) ??
+    manufacturerLogoSrc(search.manufacturer_name);
 
   const filterTags = [
     `${search.manufacturer_name} ${search.model_name}`.trim(),

--- a/web/src/lib/manufacturerLogo.test.ts
+++ b/web/src/lib/manufacturerLogo.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { manufacturerLogoSrc } from "./manufacturerLogo";
+import {
+  manufacturerLogoSrc,
+  manufacturerLogoSrcFromCatalogId,
+} from "./manufacturerLogo";
 
 function expectedManufacturerLogo(slug: string): string {
   let base = import.meta.env.BASE_URL;
@@ -20,6 +23,11 @@ describe("manufacturerLogoSrc", () => {
     );
   });
 
+  it("resolves Hebrew catalog display names (Yad2-primary catalog)", () => {
+    expect(manufacturerLogoSrc("טויוטה")).toBe(expectedManufacturerLogo("toyota"));
+    expect(manufacturerLogoSrc("מאזדה")).toBe(expectedManufacturerLogo("mazda"));
+  });
+
   it("maps DS catalog name to dsautomobiles asset", () => {
     expect(manufacturerLogoSrc("DS")).toBe(expectedManufacturerLogo("dsautomobiles"));
   });
@@ -27,5 +35,21 @@ describe("manufacturerLogoSrc", () => {
   it("returns null when no SVG is bundled for the brand", () => {
     expect(manufacturerLogoSrc("BYD")).toBeNull();
     expect(manufacturerLogoSrc("")).toBeNull();
+  });
+});
+
+describe("manufacturerLogoSrcFromCatalogId", () => {
+  it("resolves Toyota and Mazda by Yad2 manufacturer id", () => {
+    expect(manufacturerLogoSrcFromCatalogId(19)).toBe(
+      expectedManufacturerLogo("toyota"),
+    );
+    expect(manufacturerLogoSrcFromCatalogId(27)).toBe(
+      expectedManufacturerLogo("mazda"),
+    );
+  });
+
+  it("returns null for unknown or invalid ids", () => {
+    expect(manufacturerLogoSrcFromCatalogId(99999)).toBeNull();
+    expect(manufacturerLogoSrcFromCatalogId(0)).toBeNull();
   });
 });

--- a/web/src/lib/manufacturerLogo.ts
+++ b/web/src/lib/manufacturerLogo.ts
@@ -1,6 +1,12 @@
 /**
- * Map listing/catalog English manufacturer names to bundled SVGs in /public/manufacturers.
+ * Map manufacturer identity to bundled SVGs in /public/manufacturers.
  * Icons are from Simple Icons (CC0) — see public/manufacturers/README.txt.
+ *
+ * Yad2 often seeds the server catalog with Hebrew as the display `Name`, so
+ * ASCII-only slugging is not enough. We match:
+ * - catalog `manufacturer_id` (stable), and
+ * - Hebrew names from internal/catalog/catalog_data.json `name_he`
+ *   (regenerate maps when that file changes).
  */
 
 /** Slugs that exist under web/public/manufacturers/*.svg */
@@ -55,9 +61,113 @@ const MANUFACTURER_LOGO_SLUGS = new Set([
   "volvo",
 ]);
 
-/** When catalog name does not produce the Simple Icons file slug. */
+/** When English catalog `name` does not produce the Simple Icons file slug. */
 const SLUG_OVERRIDES: Record<string, string> = {
   ds: "dsautomobiles",
+};
+
+/** Catalog manufacturer id → logo file slug (see catalog_data.json). */
+const MANUFACTURER_ID_TO_LOGO_SLUG: Record<number, string> = {
+  1: "audi",
+  2: "opel",
+  3: "infiniti",
+  5: "alfaromeo",
+  6: "mg",
+  7: "bmw",
+  10: "jeep",
+  12: "dacia",
+  14: "dsautomobiles",
+  17: "honda",
+  18: "volvo",
+  19: "toyota",
+  20: "jaguar",
+  21: "hyundai",
+  24: "landrover",
+  27: "mazda",
+  28: "maserati",
+  29: "mini",
+  30: "mitsubishi",
+  31: "mercedes",
+  32: "nissan",
+  35: "subaru",
+  36: "suzuki",
+  37: "seat",
+  38: "citroen",
+  39: "smart",
+  40: "skoda",
+  41: "volkswagen",
+  43: "ford",
+  44: "porsche",
+  45: "fiat",
+  46: "peugeot",
+  47: "cadillac",
+  48: "kia",
+  49: "chrysler",
+  51: "renault",
+  52: "chevrolet",
+  54: "astonmartin",
+  55: "bentley",
+  57: "ferrari",
+  58: "rollsroyce",
+  62: "tesla",
+  63: "lamborghini",
+  73: "mclaren",
+  80: "lada",
+  91: "ram",
+  111: "acura",
+  231: "polestar",
+};
+
+/** catalog_data.json `name_he` → logo file slug */
+const HEBREW_MANUFACTURER_TO_LOGO_SLUG: Record<string, string> = {
+  אקורה: "acura",
+  "אלפא רומיאו": "alfaromeo",
+  "אסטון מרטין": "astonmartin",
+  אאודי: "audi",
+  בנטלי: "bentley",
+  "ב מ וו": "bmw",
+  קאדילק: "cadillac",
+  שברולט: "chevrolet",
+  קרייזלר: "chrysler",
+  סיטרואן: "citroen",
+  "דאצ'יה": "dacia",
+  "די.אס": "dsautomobiles",
+  פרארי: "ferrari",
+  פיאט: "fiat",
+  פורד: "ford",
+  הונדה: "honda",
+  יונדאי: "hyundai",
+  אינפיניטי: "infiniti",
+  יגואר: "jaguar",
+  "ג'יפ": "jeep",
+  קיה: "kia",
+  לאדה: "lada",
+  למבורגיני: "lamborghini",
+  "לנד רובר": "landrover",
+  מזראטי: "maserati",
+  מאזדה: "mazda",
+  מקלארן: "mclaren",
+  מרצדס: "mercedes",
+  "אם ג'י": "mg",
+  מיני: "mini",
+  מיצובישי: "mitsubishi",
+  ניסאן: "nissan",
+  אופל: "opel",
+  "פיג'ו": "peugeot",
+  פולסטאר: "polestar",
+  פורשה: "porsche",
+  ראם: "ram",
+  רנו: "renault",
+  "רולס רויס": "rollsroyce",
+  סיאט: "seat",
+  סקודה: "skoda",
+  סמארט: "smart",
+  סובארו: "subaru",
+  סוזוקי: "suzuki",
+  טסלה: "tesla",
+  טויוטה: "toyota",
+  פולקסווגן: "volkswagen",
+  וולוו: "volvo",
 };
 
 function siSlug(title: string): string {
@@ -77,14 +187,41 @@ function publicAssetUrl(relPath: string): string {
   return `${base}${clean}`;
 }
 
+function urlForSlug(slug: string): string | null {
+  if (!MANUFACTURER_LOGO_SLUGS.has(slug)) return null;
+  return publicAssetUrl(`manufacturers/${slug}.svg`);
+}
+
 /**
- * Public URL for the manufacturer mark, or null if none is bundled.
+ * Logo URL from Yad2/catalog manufacturer id (preferred for search cards).
+ */
+export function manufacturerLogoSrcFromCatalogId(
+  manufacturerId: number,
+): string | null {
+  if (manufacturerId <= 0) return null;
+  const slug = MANUFACTURER_ID_TO_LOGO_SLUG[manufacturerId];
+  if (!slug) return null;
+  return urlForSlug(slug);
+}
+
+/**
+ * Public URL for the manufacturer mark from display name (English or Hebrew), or null.
  */
 export function manufacturerLogoSrc(manufacturerName: string): string | null {
   const raw = manufacturerName.trim();
   if (!raw) return null;
   const key = raw.toLowerCase();
-  const slug = SLUG_OVERRIDES[key] ?? siSlug(raw);
-  if (!MANUFACTURER_LOGO_SLUGS.has(slug)) return null;
-  return publicAssetUrl(`manufacturers/${slug}.svg`);
+
+  const fromOverride = SLUG_OVERRIDES[key];
+  if (fromOverride) return urlForSlug(fromOverride);
+
+  const fromHebrew = HEBREW_MANUFACTURER_TO_LOGO_SLUG[raw];
+  if (fromHebrew) return urlForSlug(fromHebrew);
+
+  const fromAscii = siSlug(raw);
+  if (fromAscii && MANUFACTURER_LOGO_SLUGS.has(fromAscii)) {
+    return publicAssetUrl(`manufacturers/${fromAscii}.svg`);
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Problem

Search cards used `manufacturer_name` from the API, which follows the dynamic catalog primary name. When Yad2 seeds the catalog, that value is often **Hebrew** (e.g. טויוטה). Logo lookup stripped non-ASCII letters → empty slug → generic car icon.

## Fix

- Map **catalog manufacturer id** → logo slug (from `catalog_data.json` English names that have icons).
- Map **Hebrew `name_he`** strings → slug for listing cards that only have display text.
- Search cards: `manufacturerLogoSrcFromCatalogId(id) ?? manufacturerLogoSrc(name)`.

## Tests

Extended `manufacturerLogo.test.ts` for Hebrew strings and ids.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

Made with [Cursor](https://cursor.com)