### PR TITLE
feat(scoring): shift fitness weights toward specs over price

### DIFF
--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -166,10 +166,10 @@ func abs(x int) int {
 }
 
 const (
-	weightPrice  = 0.35
-	weightKm     = 0.25
+	weightPrice  = 0.25
+	weightKm     = 0.30
 	weightHand   = 0.20
-	weightYear   = 0.15
+	weightYear   = 0.20
 	weightEngine = 0.05
 
 	avgKmPerYear       = 15000 // Israeli average annual mileage

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -256,7 +256,7 @@ func TestFitnessScore(t *testing.T) {
 				Price: 150000, Km: 0, Hand: 1, Year: 2024, EngineVolume: 2000,
 				PriceMax: 200000, MaxKm: 100000, MaxHand: 3, YearMin: 2020, YearMax: 2024, EngineMinCC: 1500,
 			},
-			min: 6.5, max: 8.0,
+			min: 6.5, max: 8.5,
 		},
 		{
 			name: "price exactly at max",

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -27,10 +27,10 @@ export type ScoreBreakdownPct = {
   hand: number;
 };
 
-const W_PRICE = 0.35;
-const W_KM = 0.25;
+const W_PRICE = 0.25;
+const W_KM = 0.30;
 const W_HAND = 0.20;
-const W_YEAR = 0.15;
+const W_YEAR = 0.20;
 const W_ENGINE = 0.05;
 
 const AVG_KM_PER_YEAR = 15000;


### PR DESCRIPTION
## Summary

- **Rebalance fitness score weights** to prioritize non-negotiable specs over asking price
- Price weight reduced from 0.35 → 0.25; km increased to 0.30, year increased to 0.20
- Shifts from 35/65 to 25/75 price-vs-specs ratio

## Motivation

Price is always negotiable on Yad2 — specs (km, year, hand, engine) are fixed constants. A car with great specs near the budget cap should still score well because the buyer can negotiate the asking price face-to-face. The previous 35% price weight excessively penalized listings that were mechanically excellent but listed near budget cap.

This moderate rebalance was validated by three simulated Israeli market personas (Yad2 dealer, experienced buyer, auto mechanic) who all agreed on the direction but recommended a conservative 25/75 split over a more aggressive 15/85 proposal.

## Changes

| Dimension | Before | After | Rationale |
|-----------|--------|-------|-----------|
| Price | 0.35 | **0.25** | Negotiable — reduced influence |
| Km | 0.25 | **0.30** | Strongest non-price signal, fixed |
| Year | 0.15 | **0.20** | Generation/tech proxy, fixed |
| Hand | 0.20 | 0.20 | Unchanged |
| Engine | 0.05 | 0.05 | Unchanged |

## Files changed

- `internal/scoring/scoring.go` — weight constants
- `internal/scoring/scoring_test.go` — widened one test range for the new weight balance
- `web/src/lib/scoringAlgorithm.ts` — demo weights kept in sync

## Test plan

- [x] All Go tests pass (`make test` — 67.5% coverage)
- [x] All TS demo tests pass (24/24)
- [x] Linter clean (`golangci-lint run ./...`)
- [x] Monotonic ordering preserved (better specs → higher score)
- [x] Score range [0, 10] invariant maintained

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the fitness score calculation weights: reduced the influence of vehicle price while increasing the importance of mileage and vehicle age on final scores.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/651)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->