### PR TITLE
feat(scoring): use market median for fitness price dimension

### DIFF
--- a/internal/locale/scoring.go
+++ b/internal/locale/scoring.go
@@ -11,6 +11,10 @@ var heScoring = map[string]string{
 	"fmt_deal_above_market": "מעל מחיר השוק (חציון ₪%s · %d מודעות)\n",
 	"fmt_deal_no_data":      "📊 _אין מספיק נתוני שוק עדיין_\n",
 
+	"fmt_market_value_below": "📊 שווי שוק: ₪%s · %d%% מתחת · %d מודעות\n",
+	"fmt_market_value_near":  "📊 שווי שוק: ₪%s · קרוב למחיר · %d מודעות\n",
+	"fmt_market_value_above": "📊 שווי שוק: ₪%s · %d%% מעל · %d מודעות\n",
+
 	// daily market digest
 }
 
@@ -24,6 +28,10 @@ var enScoring = map[string]string{
 	"fmt_deal_near_market":  "Near market price (₪%s median · %d listings)\n",
 	"fmt_deal_above_market": "Above market price (₪%s median · %d listings)\n",
 	"fmt_deal_no_data":      "📊 _Not enough market data yet_\n",
+
+	"fmt_market_value_below": "📊 Market value: ₪%s · %d%% below · %d listings\n",
+	"fmt_market_value_near":  "📊 Market value: ₪%s · near market · %d listings\n",
+	"fmt_market_value_above": "📊 Market value: ₪%s · %d%% above · %d listings\n",
 
 	// daily market digest
 }

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -30,6 +30,9 @@ func FormatListing(l model.Listing, lang locale.Lang) string {
 
 	if l.Price > 0 {
 		b.WriteString(locale.Tf(lang, "fmt_price", format.Number(l.Price)))
+		if l.DealScore != nil && l.DealScore.MedianPrice > 0 {
+			b.WriteString(marketValueLine(lang, l.DealScore, l.Price))
+		}
 	}
 
 	if l.Km > 0 {
@@ -185,6 +188,19 @@ func formatBreakdown(dims []model.FitnessDim, lang locale.Lang) string {
 		return locale.Tf(lang, "fmt_fitness_down_only", strings.Join(bad, ", "))
 	}
 	return ""
+}
+
+func marketValueLine(lang locale.Lang, score *model.ScoreInfo, price int) string {
+	medianStr := format.Number(score.MedianPrice)
+	pctDiff := int(math.Round(100.0 * (1.0 - float64(price)/float64(score.MedianPrice))))
+	if pctDiff > 5 {
+		return locale.Tf(lang, "fmt_market_value_below", medianStr, pctDiff, score.CohortSize)
+	}
+	if pctDiff >= -5 {
+		return locale.Tf(lang, "fmt_market_value_near", medianStr, score.CohortSize)
+	}
+	abovePct := -pctDiff
+	return locale.Tf(lang, "fmt_market_value_above", medianStr, abovePct, score.CohortSize)
 }
 
 func dealExplanation(lang locale.Lang, score *model.ScoreInfo, price int) string {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -954,7 +954,7 @@ func (s *Scheduler) deduplicateListings(ctx context.Context, token string, chatI
 	return isNew, true
 }
 
-func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Search, l model.RawListing, lang locale.Lang, out *searchResult) bool {
+func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Search, l model.RawListing, lang locale.Lang, marketCache *scoring.MarketCache, out *searchResult) bool {
 	if s.stores.Prices == nil || l.Price <= 0 {
 		return false
 	}
@@ -972,13 +972,19 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 		"new_price", l.Price,
 	)
 	listing := model.Listing{RawListing: l, SearchName: search.Name}
-	listing.FitnessScore = scoring.FitnessScore(scoring.FitnessParams{
+	fp := scoring.FitnessParams{
 		Price: l.Price, Km: l.Km, Hand: l.Hand, Year: l.Year,
 		EngineVolume: l.EngineVolume, PriceMax: search.PriceMax,
 		MaxKm: search.MaxKm, MaxHand: search.MaxHand,
 		YearMin: search.YearMin, YearMax: search.YearMax,
 		EngineMinCC: search.EngineMinCC,
-	})
+	}
+	if marketCache != nil {
+		if median, _, _, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year); ok {
+			fp.MedianPrice = median
+		}
+	}
+	listing.FitnessScore = scoring.FitnessScore(fp)
 	out.priceDropMessages = append(out.priceDropMessages, notifier.FormatPriceDrop(listing, oldPrice, lang))
 	if s.stores.Listings != nil {
 		if err := s.stores.Listings.SaveListing(ctx, storage.ListingRecord{
@@ -1003,7 +1009,16 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 
 func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawListing, marketCache *scoring.MarketCache) model.Listing {
 	listing := model.Listing{RawListing: l, SearchName: search.Name}
-	detailed := scoring.FitnessScoreDetailed(scoring.FitnessParams{
+
+	// Look up market median before fitness scoring so the price dimension
+	// can score against market value instead of just the budget cap.
+	var medianPrice, medianKm, cohort int
+	var marketOK bool
+	if marketCache != nil && l.Price > 0 {
+		medianPrice, medianKm, cohort, marketOK = marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
+	}
+
+	fp := scoring.FitnessParams{
 		Price:        l.Price,
 		Km:           l.Km,
 		Hand:         l.Hand,
@@ -1015,7 +1030,12 @@ func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawLis
 		YearMin:      search.YearMin,
 		YearMax:      search.YearMax,
 		EngineMinCC:  search.EngineMinCC,
-	})
+	}
+	if marketOK {
+		fp.MedianPrice = medianPrice
+	}
+
+	detailed := scoring.FitnessScoreDetailed(fp)
 	listing.FitnessScore = detailed.Total
 	listing.FitnessBreakdown = make([]model.FitnessDim, len(detailed.Dims))
 	for i, d := range detailed.Dims {
@@ -1023,15 +1043,12 @@ func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawLis
 			Name: d.Name, Score: d.Score, Weight: d.Weight,
 		}
 	}
-	if marketCache != nil && l.Price > 0 {
-		median, medianKm, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
-		if ok {
-			listing.DealScore = &model.ScoreInfo{
-				Score:       scoring.ScoreWithKm(l.Price, l.Km, median, medianKm),
-				MedianPrice: median,
-				MedianKm:    medianKm,
-				CohortSize:  cohort,
-			}
+	if marketOK {
+		listing.DealScore = &model.ScoreInfo{
+			Score:       scoring.ScoreWithKm(l.Price, l.Km, medianPrice, medianKm),
+			MedianPrice: medianPrice,
+			MedianKm:    medianKm,
+			CohortSize:  cohort,
 		}
 	}
 	return listing
@@ -1062,7 +1079,7 @@ func (s *Scheduler) processSearchListings(ctx context.Context, search storage.Se
 		if !ok {
 			continue
 		}
-		if s.tryPriceDropListing(ctx, search, l, lang, &out) {
+		if s.tryPriceDropListing(ctx, search, l, lang, marketCache, &out) {
 			continue
 		}
 		if !isNew {

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -194,6 +194,11 @@ type FitnessParams struct {
 	YearMin     int
 	YearMax     int
 	EngineMinCC int
+
+	// MedianPrice is the market median price for this car's manufacturer+model+year
+	// cohort. When > 0 the price dimension scores against market value instead of
+	// the user's budget cap.
+	MedianPrice int
 }
 
 type DimScore struct {
@@ -222,10 +227,16 @@ func DefaultDimensions() []Dimension {
 			Name:   "price",
 			Weight: weightPrice,
 			Score: func(p FitnessParams) float64 {
-				if p.PriceMax <= 0 || p.Price <= 0 {
+				if p.Price <= 0 {
 					return math.NaN()
 				}
-				return priceScore(p.Price, p.PriceMax)
+				if p.MedianPrice > 0 {
+					return marketPriceScore(p.Price, p.MedianPrice)
+				}
+				if p.PriceMax <= 0 {
+					return math.NaN()
+				}
+				return budgetPriceScore(p.Price, p.PriceMax)
 			},
 		},
 		{Name: "km", Weight: weightKm, Score: func(p FitnessParams) float64 { return kmScore(p.Km, p.MaxKm, p.Year) }},
@@ -277,10 +288,20 @@ func FitnessScoreDetailed(p FitnessParams) FitnessResult {
 	return FitnessResult{Total: total, Dims: dims}
 }
 
-// priceScore: cheaper within budget = better value.
+// marketPriceScore scores the listing price against the market median.
+// Maps [0.7×median, 1.3×median] → [1.0, 0.0] via a sqrt curve.
+// At median the score is ~0.71 (fair asking price); 30%+ above is 0.
+func marketPriceScore(price, medianPrice int) float64 {
+	ratio := float64(price) / float64(medianPrice)
+	normalized := (ratio - 0.7) / 0.6 // 0.7→0, 1.0→0.5, 1.3→1.0
+	normalized = clamp01(normalized)
+	return math.Sqrt(1.0 - normalized)
+}
+
+// budgetPriceScore: cheaper within budget = better value (legacy fallback).
 // sqrt curve so savings have diminishing returns — 50% of budget is great,
 // 80% is decent, at-cap is low but not zero.
-func priceScore(price, priceMax int) float64 {
+func budgetPriceScore(price, priceMax int) float64 {
 	if priceMax <= 0 {
 		return 0.5
 	}

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -696,7 +696,7 @@ func TestHondaAccordScoring(t *testing.T) {
 		dims[d.Name] = d.Score
 	}
 
-	// Price: 39999/50000 = 0.80 ratio, sqrt(0.20) ≈ 0.45 — cheap within budget is good.
+	// Price (budget fallback, no MedianPrice): 39999/50000 = 0.80 ratio, sqrt(0.20) ≈ 0.45.
 	if dims["price"] < 0.40 || dims["price"] > 0.55 {
 		t.Errorf("price dim = %.3f, want [0.40, 0.55]", dims["price"])
 	}
@@ -774,7 +774,7 @@ func TestKmScore_ZeroCarYear(t *testing.T) {
 	}
 }
 
-func TestPriceScore(t *testing.T) {
+func TestBudgetPriceScore(t *testing.T) {
 	tests := []struct {
 		name     string
 		price    int
@@ -787,15 +787,105 @@ func TestPriceScore(t *testing.T) {
 		{"price over max returns 0", 250000, 200000, 0.0, 0},
 		{"price at 50% of max", 100000, 200000, math.Sqrt(0.5), 0.01},
 		{"price at 80% of max", 160000, 200000, math.Sqrt(0.2), 0.01},
-		{"price at 0", 0, 200000, 1.0, 0}, // priceScore itself returns sqrt(1)=1; the dimension wrapper (NaN) handles this upstream
+		{"price at 0", 0, 200000, 1.0, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := priceScore(tt.price, tt.priceMax)
+			got := budgetPriceScore(tt.price, tt.priceMax)
 			if math.Abs(got-tt.want) > tt.tol {
-				t.Errorf("priceScore(%d, %d) = %.4f, want %.4f (±%.2f)", tt.price, tt.priceMax, got, tt.want, tt.tol)
+				t.Errorf("budgetPriceScore(%d, %d) = %.4f, want %.4f (±%.2f)", tt.price, tt.priceMax, got, tt.want, tt.tol)
 			}
 		})
+	}
+}
+
+func TestMarketPriceScore(t *testing.T) {
+	tests := []struct {
+		name   string
+		price  int
+		median int
+		want   float64
+		tol    float64
+	}{
+		{"70% of median → 1.0 (exceptional deal)", 70000, 100000, 1.0, 0.01},
+		{"85% of median → ~0.87 (good deal)", 85000, 100000, 0.87, 0.02},
+		{"at median → ~0.71 (fair price)", 100000, 100000, math.Sqrt(0.5), 0.01},
+		{"115% of median → 0.50 (above market)", 115000, 100000, 0.50, 0.02},
+		{"130% of median → 0 (overpriced)", 130000, 100000, 0.0, 0.01},
+		{"150% of median → 0 (clamped)", 150000, 100000, 0.0, 0.01},
+		{"50% of median → 1.0 (clamped at floor)", 50000, 100000, 1.0, 0.01},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := marketPriceScore(tt.price, tt.median)
+			if math.Abs(got-tt.want) > tt.tol {
+				t.Errorf("marketPriceScore(%d, %d) = %.4f, want %.4f (±%.2f)", tt.price, tt.median, got, tt.want, tt.tol)
+			}
+		})
+	}
+}
+
+func TestFitnessScore_MarketPricePreferred(t *testing.T) {
+	stubCurrentYear(t, 2026)
+
+	base := FitnessParams{
+		Km: 50000, Hand: 2, Year: 2022, EngineVolume: 2000,
+		PriceMax: 200000, MaxKm: 150000, MaxHand: 4,
+		YearMin: 2018, YearMax: 2024, EngineMinCC: 1500,
+	}
+
+	// Car priced at 100k with median 130k → below market, good value.
+	belowMarket := base
+	belowMarket.Price = 100000
+	belowMarket.MedianPrice = 130000
+
+	// Same car priced at 100k with no market data → falls back to budget.
+	noBudget := base
+	noBudget.Price = 100000
+
+	belowResult := FitnessScoreDetailed(belowMarket)
+	budgetResult := FitnessScoreDetailed(noBudget)
+
+	var belowPriceDim, budgetPriceDim float64
+	for _, d := range belowResult.Dims {
+		if d.Name == "price" {
+			belowPriceDim = d.Score
+		}
+	}
+	for _, d := range budgetResult.Dims {
+		if d.Name == "price" {
+			budgetPriceDim = d.Score
+		}
+	}
+
+	// 100k/130k = 0.77 → market score ~0.88; 100k/200k = 0.5 → budget score ~0.71
+	if belowPriceDim <= budgetPriceDim {
+		t.Errorf("below-market car price dim (%.3f) should score higher than budget-only (%.3f)",
+			belowPriceDim, budgetPriceDim)
+	}
+}
+
+func TestFitnessScore_MarketPriceFallback(t *testing.T) {
+	stubCurrentYear(t, 2026)
+
+	// When MedianPrice=0, should fall back to budget-based scoring.
+	p := FitnessParams{
+		Price: 100000, Km: 50000, Hand: 2, Year: 2022, EngineVolume: 2000,
+		PriceMax: 200000, MaxKm: 150000, MaxHand: 4,
+		YearMin: 2018, YearMax: 2024, EngineMinCC: 1500,
+		MedianPrice: 0,
+	}
+	result := FitnessScoreDetailed(p)
+	var priceDim float64
+	for _, d := range result.Dims {
+		if d.Name == "price" {
+			priceDim = d.Score
+		}
+	}
+	// 100k/200k = 0.5 → sqrt(0.5) ≈ 0.707
+	want := math.Sqrt(0.5)
+	if math.Abs(priceDim-want) > 0.01 {
+		t.Errorf("fallback price dim = %.4f, want %.4f (budget-based)", priceDim, want)
 	}
 }
 

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -9,6 +9,7 @@ export type DemoSearchCriteria = {
   price_max: number;
   mileage_max: number;
   hand_max: number;
+  median_price?: number;
 };
 
 export type DemoListingInput = {
@@ -50,11 +51,17 @@ export function scoreListingAgainstSearch(
   listing: DemoListingInput,
   search: DemoSearchCriteria,
 ): { score: number; breakdown: ScoreBreakdownPct } {
-  // Price: cheaper within budget = better (sqrt curve).
-  // Omit dimension when price is unknown (matches Go NaN guard).
+  // Price: when market median is available, score against market value;
+  // otherwise fall back to budget-based scoring (matches Go logic).
   let priceFactor: number;
-  if (listing.price <= 0 || search.price_max <= 0) {
-    priceFactor = listing.price <= 0 ? NaN : 0.5;
+  if (listing.price <= 0) {
+    priceFactor = NaN;
+  } else if (search.median_price && search.median_price > 0) {
+    const ratio = listing.price / search.median_price;
+    const normalized = clamp01((ratio - 0.7) / 0.6);
+    priceFactor = Math.sqrt(1 - normalized);
+  } else if (search.price_max <= 0) {
+    priceFactor = NaN;
   } else {
     const ratio = listing.price / search.price_max;
     priceFactor = ratio >= 1 ? 0 : Math.sqrt(1 - ratio);


### PR DESCRIPTION
## Summary

- Replace the budget-relative fitness price score with a **market-value-based** score that compares listing price against the Yad2 cohort median (same manufacturer+model+year band, min 10 listings)
- Falls back to the original budget-based curve when market data is insufficient (niche models with small sample sizes)
- Add a prominent **market value line** right next to the listing price in Telegram notifications showing Yad2 median and percentage difference
- Wire market cache into price-drop fitness scoring for consistency

### Scoring curve (market mode)

| Listing vs Median | Score | Meaning |
|---|---|---|
| 70% of median | 1.00 | Exceptional deal |
| 85% of median | 0.87 | Good deal |
| 100% of median | 0.71 | Fair asking price |
| 115% of median | 0.50 | Above market |
| 130%+ | 0.00 | Significantly overpriced |

### Notification example

```
💰 מחיר: ₪80,000
📊 שווי שוק: ₪100,000 · 20% מתחת · 40 מודעות
```

## Why not Levi Yitzhak / Yad2 official price list?

Neither has a public API. Levi Yitzhak is a paid commercial subscription; Yad2's price calculator is behind WAF/bot protection. Our median from active Yad2 listings is real-time market data from the same platform — effectively the Yad2 price list computed from actual listings.

## Test plan

- [x] New `TestMarketPriceScore` — 7 cases covering the full curve
- [x] `TestFitnessScore_MarketPricePreferred` — market-based beats budget-based for below-market cars
- [x] `TestFitnessScore_MarketPriceFallback` — budget fallback when no market data
- [x] Existing tests pass unchanged (budget fallback path)
- [x] TypeScript demo updated to mirror Go logic
- [x] `go vet` and `tsc --noEmit` clean


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market value assessment to listings, displaying how prices compare to local market medians.
  * Enhanced the scoring and ranking algorithm to incorporate real market data for more accurate listing recommendations.
  * Listings now display market value indicators showing whether prices are below, near, or above market rates across supported languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/653)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->