### PR TITLE
fix: clear React Query cache on auth change + elastic search criteria

### DIFF
--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -186,12 +186,26 @@ func TestCreateSearch_InvalidBody(t *testing.T) {
 	}
 }
 
-func TestCreateSearch_MissingManufacturerModel(t *testing.T) {
+func TestCreateSearch_AllCars(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for all-cars search (manufacturer=0, model=0), got %d: %s", w.Code, w.Body.String())
+	}
+	var resp searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Name != "all-cars" {
+		t.Errorf("name = %q, want all-cars", resp.Name)
+	}
+}
+
+func TestCreateSearch_ModelRequiresManufacturer(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{Model: 10226})
 	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for missing manufacturer/model, got %d: %s", w.Code, w.Body.String())
+		t.Fatalf("expected 400 when model is set without manufacturer, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -200,6 +200,23 @@ func TestCreateSearch_AllCars(t *testing.T) {
 	}
 }
 
+func TestCreateSearch_ManufacturerAllModels(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{Manufacturer: 19})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for manufacturer-only search, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.ManufacturerID != 19 || resp.ModelID != 0 {
+		t.Fatalf("unexpected IDs: manufacturer=%d model=%d", resp.ManufacturerID, resp.ModelID)
+	}
+	if !strings.HasSuffix(resp.Name, "-all") || resp.Name == "all-cars" {
+		t.Errorf("name = %q, want '<manufacturer>-all'", resp.Name)
+	}
+}
+
 func TestCreateSearch_ModelRequiresManufacturer(t *testing.T) {
 	srv, _ := setupTestServer(t)
 

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -111,14 +111,22 @@ func validateSearchRanges(yearMin, yearMax, priceMax, maxKm, maxHand, engineMinC
 }
 
 func (s *Server) toSearchResponse(sr storage.Search) searchResponse {
+	mfrName := "כל היצרנים"
+	if sr.Manufacturer > 0 {
+		mfrName = s.catalog.ManufacturerName(sr.Manufacturer)
+	}
+	mdlName := "כל הדגמים"
+	if sr.Model > 0 {
+		mdlName = s.catalog.ModelName(sr.Manufacturer, sr.Model)
+	}
 	return searchResponse{
 		ID:               sr.ID,
 		Name:             sr.Name,
 		Source:           sr.Source,
 		ManufacturerID:   sr.Manufacturer,
-		ManufacturerName: s.catalog.ManufacturerName(sr.Manufacturer),
+		ManufacturerName: mfrName,
 		ModelID:          sr.Model,
-		ModelName:        s.catalog.ModelName(sr.Manufacturer, sr.Model),
+		ModelName:        mdlName,
 		YearMin:          sr.YearMin,
 		YearMax:          sr.YearMax,
 		PriceMax:         sr.PriceMax,
@@ -182,10 +190,11 @@ func (s *Server) listSearches(w http.ResponseWriter, r *http.Request) {
 }
 
 // validateCreateSearchInput checks catalog IDs, range validation, and duplicate names.
+// Manufacturer and model are both optional (0 = all).
 // On success returns (name, 0, ""). On failure returns ("", HTTP status, error message).
 func (s *Server) validateCreateSearchInput(ctx context.Context, chatID int64, req *createSearchRequest) (string, int, string) {
-	if req.Manufacturer <= 0 || req.Model <= 0 {
-		return "", http.StatusBadRequest, "manufacturer and model are required"
+	if req.Manufacturer < 0 || req.Model < 0 {
+		return "", http.StatusBadRequest, "manufacturer and model must not be negative"
 	}
 
 	if req.Source == "" {
@@ -199,17 +208,33 @@ func (s *Server) validateCreateSearchInput(ctx context.Context, chatID int64, re
 		return "", http.StatusBadRequest, msg
 	}
 
-	mfrName := s.catalog.ManufacturerName(req.Manufacturer)
-	if mfrName == "" {
-		return "", http.StatusBadRequest, "unknown manufacturer id"
+	var mfrName, modelName string
+	if req.Manufacturer > 0 {
+		mfrName = s.catalog.ManufacturerName(req.Manufacturer)
+		if mfrName == "" {
+			return "", http.StatusBadRequest, "unknown manufacturer id"
+		}
 	}
-	modelName := s.catalog.ModelName(req.Manufacturer, req.Model)
-	if modelName == "" {
-		return "", http.StatusBadRequest, "unknown model id"
+	if req.Model > 0 {
+		if req.Manufacturer <= 0 {
+			return "", http.StatusBadRequest, "model requires a manufacturer"
+		}
+		modelName = s.catalog.ModelName(req.Manufacturer, req.Model)
+		if modelName == "" {
+			return "", http.StatusBadRequest, "unknown model id"
+		}
 	}
+
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
-		name = strings.ToLower(fmt.Sprintf("%s-%s", mfrName, modelName))
+		switch {
+		case req.Manufacturer == 0:
+			name = "all-cars"
+		case req.Model == 0:
+			name = strings.ToLower(mfrName) + "-all"
+		default:
+			name = strings.ToLower(fmt.Sprintf("%s-%s", mfrName, modelName))
+		}
 	}
 
 	existing, err := s.searches.ListSearches(ctx, chatID)

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -219,8 +219,13 @@ func TestKeyboards_ManufacturerKeyboard_RecentSection(t *testing.T) {
 		t.Errorf("row 0 should be search button, got %q", kb.InlineKeyboard[0][0].CallbackData)
 	}
 
-	// Row 1: recent manufacturers (most recent first — Toyota was created last).
-	recentRow := kb.InlineKeyboard[1]
+	// Row 1: "Any manufacturer" button.
+	if kb.InlineKeyboard[1][0].CallbackData != cbAnyMfr {
+		t.Errorf("row 1 should be any-manufacturer button, got %q", kb.InlineKeyboard[1][0].CallbackData)
+	}
+
+	// Row 2: recent manufacturers (most recent first — Toyota was created last).
+	recentRow := kb.InlineKeyboard[2]
 	if len(recentRow) != 2 {
 		t.Fatalf("expected 2 recent buttons, got %d", len(recentRow))
 	}
@@ -240,8 +245,8 @@ func TestKeyboards_ManufacturerKeyboard_RecentSection(t *testing.T) {
 		t.Errorf("expected מאזדה and טויוטה in recent, got %v", names)
 	}
 
-	// Row 2: separator.
-	if kb.InlineKeyboard[2][0].CallbackData != "noop" {
+	// Row 3: separator.
+	if kb.InlineKeyboard[3][0].CallbackData != "noop" {
 		t.Error("expected separator row after recent manufacturers")
 	}
 }
@@ -255,12 +260,15 @@ func TestKeyboards_ManufacturerKeyboard_NoRecentForNewUser(t *testing.T) {
 
 	kb := tb.bot.manufacturerKeyboard(ctx, chatID, 0, locale.English)
 
-	// Row 0: search button, row 1: first manufacturer (no recent section).
+	// Row 0: search button, row 1: any-manufacturer button, row 2: first manufacturer (no recent section).
 	if kb.InlineKeyboard[0][0].CallbackData != cbMfrSearch {
 		t.Errorf("row 0 should be search button, got %q", kb.InlineKeyboard[0][0].CallbackData)
 	}
-	// Second row should be actual manufacturers, not a separator.
-	if kb.InlineKeyboard[1][0].CallbackData == "noop" {
+	if kb.InlineKeyboard[1][0].CallbackData != cbAnyMfr {
+		t.Errorf("row 1 should be any-manufacturer button, got %q", kb.InlineKeyboard[1][0].CallbackData)
+	}
+	// Third row should be actual manufacturers, not a separator.
+	if kb.InlineKeyboard[2][0].CallbackData == "noop" {
 		t.Error("new user should not have a recent/separator row")
 	}
 }
@@ -308,9 +316,9 @@ func TestKeyboards_ManufacturerKeyboard_RecentCappedAt4(t *testing.T) {
 
 	kb := tb.bot.manufacturerKeyboard(ctx, chatID, 0, locale.English)
 
-	// Count recent manufacturer buttons (between search row and separator).
+	// Count recent manufacturer buttons (between any-mfr row and separator).
 	recentCount := 0
-	for i := 1; i < len(kb.InlineKeyboard); i++ {
+	for i := 2; i < len(kb.InlineKeyboard); i++ {
 		if kb.InlineKeyboard[i][0].CallbackData == "noop" {
 			break
 		}
@@ -341,7 +349,7 @@ func TestKeyboards_ManufacturerKeyboard_RecentDeduplicates(t *testing.T) {
 
 	// Should have exactly 1 recent button (Mazda), not 3.
 	recentCount := 0
-	for i := 1; i < len(kb.InlineKeyboard); i++ {
+	for i := 2; i < len(kb.InlineKeyboard); i++ {
 		if kb.InlineKeyboard[i][0].CallbackData == "noop" {
 			break
 		}

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -35,6 +35,7 @@ const (
 	cbMdlPage         = "mdl_pg:"
 	cbMdlSearch       = "mdl_search"
 	cbAnyModel        = "mdl:0"
+	cbAnyMfr          = "mfr:0"
 	cbHistoryPage     = "hist_pg:"
 	cbSourceToggle    = "src_toggle:"
 	cbSourceDone      = "src_done"
@@ -85,6 +86,10 @@ func (b *Bot) manufacturerKeyboard(ctx context.Context, chatID int64, page int, 
 	kb := paginatedKeyboard(mfrs, page, cbPrefixMfr, cbMfrPage, cbMfrSearch, "", lang)
 
 	if page == 0 {
+		anyMfrRow := []tgmodels.InlineKeyboardButton{
+			{Text: locale.T(lang, "btn_any_manufacturer"), CallbackData: cbAnyMfr},
+		}
+
 		recent := b.recentManufacturers(ctx, chatID)
 		if len(recent) > 0 {
 			var recentRows [][]tgmodels.InlineKeyboardButton
@@ -104,9 +109,16 @@ func (b *Bot) manufacturerKeyboard(ctx context.Context, chatID int64, page int, 
 				{Text: "───────────", CallbackData: "noop"},
 			})
 
-			newRows := make([][]tgmodels.InlineKeyboardButton, 0, len(kb.InlineKeyboard)+len(recentRows))
+			newRows := make([][]tgmodels.InlineKeyboardButton, 0, len(kb.InlineKeyboard)+len(recentRows)+1)
 			newRows = append(newRows, kb.InlineKeyboard[0]) // search button
+			newRows = append(newRows, anyMfrRow)
 			newRows = append(newRows, recentRows...)
+			newRows = append(newRows, kb.InlineKeyboard[1:]...)
+			kb.InlineKeyboard = newRows
+		} else {
+			newRows := make([][]tgmodels.InlineKeyboardButton, 0, len(kb.InlineKeyboard)+1)
+			newRows = append(newRows, kb.InlineKeyboard[0]) // search button
+			newRows = append(newRows, anyMfrRow)
 			newRows = append(newRows, kb.InlineKeyboard[1:]...)
 			kb.InlineKeyboard = newRows
 		}

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -122,11 +122,22 @@ func (b *Bot) onManufacturerSelected(ctx context.Context, chatID int64, data str
 
 	wd := b.loadWizardData(ctx, chatID)
 	wd.Manufacturer = id
+	lang := b.getUserLang(ctx, chatID)
+
+	if id == 0 {
+		wd.ManufacturerName = locale.T(lang, "btn_any_manufacturer")
+		wd.Model = 0
+		wd.ModelName = locale.T(lang, "btn_any_model")
+		b.logger.Debug("any manufacturer selected, skipping model step", "chat_id", chatID)
+		b.saveWizardState(ctx, chatID, StateAskYearMin, wd)
+		b.send(ctx, chatID, locale.T(lang, "wizard_year_min"))
+		return
+	}
+
 	wd.ManufacturerName = b.catalog.ManufacturerName(id)
 	b.logger.Debug("manufacturer selected", "chat_id", chatID, "id", id, "name", wd.ManufacturerName)
 	b.saveWizardState(ctx, chatID, StateAskModel, wd)
 
-	lang := b.getUserLang(ctx, chatID)
 	b.sendWithKeyboard(ctx, chatID,
 		locale.Tf(lang, "wizard_model_prompt", wd.ManufacturerName),
 		b.modelKeyboard(id, 0, lang))
@@ -255,13 +266,6 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 	}
 
 	wd := b.loadWizardData(ctx, chatID)
-	if wd.Manufacturer == 0 {
-		if err := b.users.UpdateUserState(ctx, chatID, StateIdle, "{}"); err != nil {
-			b.logger.Error("reset wizard state failed", "chat_id", chatID, "error", err)
-		}
-		b.send(ctx, chatID, locale.T(lang, "wizard_session_expired"))
-		return
-	}
 	b.logger.Debug("confirm clicked", "chat_id", chatID, "wizard_data", wd)
 
 	source := wd.Source
@@ -269,7 +273,15 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 		source = "yad2,winwin"
 	}
 
-	name := fmt.Sprintf("%s-%s", strings.ToLower(wd.ManufacturerName), strings.ToLower(wd.ModelName))
+	var name string
+	switch {
+	case wd.Manufacturer == 0:
+		name = "all-cars"
+	case wd.Model == 0:
+		name = strings.ToLower(wd.ManufacturerName) + "-all"
+	default:
+		name = fmt.Sprintf("%s-%s", strings.ToLower(wd.ManufacturerName), strings.ToLower(wd.ModelName))
+	}
 
 	if wd.EditSearchID > 0 {
 		err := b.searches.UpdateSearch(ctx, storage.Search{

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -120,9 +120,15 @@ func (b *Bot) onManufacturerSelected(ctx context.Context, chatID int64, data str
 		return
 	}
 
+	lang := b.getUserLang(ctx, chatID)
+	if id < 0 {
+		b.logger.Warn("negative manufacturer ID in callback", "chat_id", chatID, "id", id)
+		b.send(ctx, chatID, locale.T(lang, "error_wrong_state"))
+		return
+	}
+
 	wd := b.loadWizardData(ctx, chatID)
 	wd.Manufacturer = id
-	lang := b.getUserLang(ctx, chatID)
 
 	if id == 0 {
 		wd.ManufacturerName = locale.T(lang, "btn_any_manufacturer")

--- a/internal/locale/commands.go
+++ b/internal/locale/commands.go
@@ -144,8 +144,9 @@ var heCommands = map[string]string{
 	// keyboard buttons
 	"btn_done":        "סיום ✓",
 	"btn_search":      "חיפוש",
-	"btn_any_model":   "כל דגם",
-	"btn_previous":    "הקודם",
+	"btn_any_model":          "כל דגם",
+	"btn_any_manufacturer":   "כל היצרנים 🚗",
+	"btn_previous":           "הקודם",
 	"btn_next":        "הבא",
 	"btn_no_results":  "לא נמצאו תוצאות",
 	"btn_back":        "חזרה לרשימה",
@@ -410,8 +411,9 @@ var enCommands = map[string]string{
 	// keyboard buttons
 	"btn_done":        "Done ✓",
 	"btn_search":      "Search",
-	"btn_any_model":   "Any model",
-	"btn_previous":    "Previous",
+	"btn_any_model":          "Any model",
+	"btn_any_manufacturer":   "Any manufacturer 🚗",
+	"btn_previous":           "Previous",
 	"btn_next":        "Next",
 	"btn_no_results":  "No results found",
 	"btn_back":        "Back to list",

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -4,11 +4,13 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
 import type { User } from "firebase/auth";
 import { onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
+import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { auth } from "@/lib/firebase";
 import { setAuthTokenGetter } from "@/lib/auth-token";
@@ -39,6 +41,8 @@ function AuthLoadingScreen() {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
+  const prevUidRef = useRef<string | null>(null);
 
   useEffect(() => {
     setAuthTokenGetter(async (forceRefresh?: boolean) => {
@@ -53,10 +57,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     return onAuthStateChanged(auth, (u) => {
+      const newUid = u?.uid ?? null;
+      if (prevUidRef.current !== null && prevUidRef.current !== newUid) {
+        queryClient.clear();
+      }
+      prevUidRef.current = newUid;
       setUser(u);
       setLoading(false);
     });
-  }, []);
+  }, [queryClient]);
 
   const signOut = useCallback(() => firebaseSignOut(auth), []);
 

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -76,8 +76,6 @@ export function NewSearchPage() {
 
   const validYear = (y: number) => y === 0 || y >= 1990;
   const canSubmit =
-    form.manufacturer > 0 &&
-    form.model > 0 &&
     validYear(form.yearMin) &&
     validYear(form.yearMax) &&
     (form.yearMin === 0 || form.yearMax === 0 || form.yearMin <= form.yearMax) &&
@@ -86,8 +84,8 @@ export function NewSearchPage() {
   function handleFormSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
-    if (form.manufacturer === 0 || form.model === 0) {
-      setError("נא לבחור יצרן ודגם");
+    if (form.model > 0 && form.manufacturer === 0) {
+      setError("יש לבחור יצרן כדי לבחור דגם");
       return;
     }
     createSearch.mutate(
@@ -215,7 +213,9 @@ export function NewSearchPage() {
               disabled={form.manufacturer === 0}
               onChange={(e) => set("model", Number(e.target.value))}
             >
-              <option value={0}>כל הדגמים</option>
+              <option value={0}>
+                {form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים"}
+              </option>
               {models?.map((m) => (
                 <option key={m.id} value={m.id}>
                   {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}


### PR DESCRIPTION
## Summary

- **Cross-account cache leak fix**: When switching Firebase accounts in the same browser session, stale searches from the previous user were briefly visible until a new search was created. Fixed by clearing the React Query cache whenever the Firebase UID changes in `AuthContext`.

- **Elastic search criteria**: Manufacturer and model are now optional when creating a search. Users can:
  - Search for all models of a single manufacturer (manufacturer selected, model = 0)
  - Search for all cars across all manufacturers (manufacturer = 0, model = 0)
  - Updated across all layers: API validation, web search form, and Telegram bot wizard (new "Any manufacturer" button)

## Changes

| File | Change |
|------|--------|
| `web/src/contexts/AuthContext.tsx` | Clear React Query cache on auth state change |
| `internal/api/searches.go` | Relax validation: manufacturer/model 0 = "all"; model requires manufacturer |
| `web/src/pages/NewSearchPage.tsx` | Remove manufacturer/model requirement from `canSubmit` |
| `internal/bot/keyboards.go` | Add "Any manufacturer" button to manufacturer keyboard |
| `internal/bot/wizard.go` | Handle manufacturer=0 (skip model step); fix confirm guard |
| `internal/locale/commands.go` | Add `btn_any_manufacturer` locale strings (HE/EN) |
| `internal/api/coverage_test.go` | Update tests for new validation rules |
| `internal/bot/bot_test.go` | Update keyboard tests for new "Any manufacturer" row |

## Test plan

- [x] All Go tests pass (`make test`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] `go vet ./...` clean
- [ ] Manual: log in with account A, switch to account B → verify no stale searches
- [ ] Manual: create search with manufacturer only (no model) via web
- [ ] Manual: create search with no manufacturer via Telegram bot

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Any manufacturer" option to the manufacturer keyboard
  * Support for creating "all cars" and "all models under manufacturer" searches
  * Dynamic model placeholder that prompts choosing a manufacturer first

* **Bug Fixes**
  * More specific validation and error messaging when a model is chosen without a manufacturer

* **Tests**
  * Updated test coverage for new search creation scenarios and revised keyboard layout

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/655)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->