### PR TITLE
fix: admin activity chart PG query and JSON serialization

### DIFF
--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -176,10 +176,10 @@ type AdminSeenRecord struct {
 }
 
 type AdminDayActivity struct {
-	Date        string
-	NewListings int
-	PriceDrops  int
-	NewUsers    int
+	Date        string `json:"date"`
+	NewListings int    `json:"new_listings"`
+	PriceDrops  int    `json:"price_drops"`
+	NewUsers    int    `json:"new_users"`
 }
 
 type DBPoolStats struct {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -344,7 +344,7 @@ func (s *Store) AdminActivityStats(ctx context.Context, days int) ([]storage.Adm
 	rows, err := s.db.QueryContext(ctx, `
 		WITH days AS (
 			SELECT generate_series(
-				CURRENT_DATE - ($1 || ' days')::interval,
+				CURRENT_DATE - $1 * interval '1 day',
 				CURRENT_DATE,
 				'1 day'::interval
 			)::date AS day
@@ -357,19 +357,19 @@ func (s *Store) AdminActivityStats(ctx context.Context, days int) ([]storage.Adm
 		LEFT JOIN (
 			SELECT first_seen_at::date AS day, COUNT(*) AS cnt
 			FROM listing_history
-			WHERE first_seen_at >= CURRENT_DATE - ($1 || ' days')::interval
+			WHERE first_seen_at >= CURRENT_DATE - $1 * interval '1 day'
 			GROUP BY first_seen_at::date
 		) l ON d.day = l.day
 		LEFT JOIN (
 			SELECT observed_at::date AS day, COUNT(*) AS cnt
 			FROM price_history
-			WHERE observed_at >= CURRENT_DATE - ($1 || ' days')::interval
+			WHERE observed_at >= CURRENT_DATE - $1 * interval '1 day'
 			GROUP BY observed_at::date
 		) p ON d.day = p.day
 		LEFT JOIN (
 			SELECT created_at::date AS day, COUNT(*) AS cnt
 			FROM users
-			WHERE created_at >= CURRENT_DATE - ($1 || ' days')::interval
+			WHERE created_at >= CURRENT_DATE - $1 * interval '1 day'
 			GROUP BY created_at::date
 		) u ON d.day = u.day
 		ORDER BY d.day`, days)


### PR DESCRIPTION
## Summary

- Fix PostgreSQL activity stats query that failed with `unable to encode 30 into text format for text (OID 25)` — the `||` string concat expects text but `$1` was passed as int. Changed to `$1 * interval '1 day'`.
- Add missing `json` struct tags to `AdminDayActivity` so the API returns `snake_case` fields (`date`, `new_listings`, `price_drops`, `new_users`) matching the frontend TypeScript types.

## Test plan

- [x] `make test` passes
- [x] `go vet ./...` clean
- [ ] After deploy: verify the admin activity chart loads at `/admin` overview tab

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in admin activity data formatting.
  * Optimized date calculation logic for activity statistics queries to improve performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->