### PR TITLE
feat: integrate Yad2 official price list into listings pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apk add --no-cache ca-certificates tzdata \
 USER bot
 COPY --from=builder /bot /bot
 COPY --from=builder /app/migrations /migrations
+COPY --from=builder /app/scripts/yad2_price_scraper.py /scripts/yad2_price_scraper.py
 VOLUME /data
 HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
   CMD wget -q --spider http://localhost:8080/healthz || exit 1

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -145,6 +145,7 @@ func run(configPath string, logger *slog.Logger) error {
 		CarNames:         dynCatalog,
 		KmEnricher:       kmEnricher,
 		MarketStore:      store,
+		PriceListStore:   store,
 		DailyDigestStore: store,
 	})
 	if err != nil {

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -221,6 +221,7 @@ func toListingResponses(records []storage.ListingRecord, saved, seen map[string]
 			MedianPrice:  l.MedianPrice,
 			CohortSize:   l.CohortSize,
 			DealScore:    l.DealScore,
+			BasePrice:    l.BasePrice,
 			FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
 			Saved:        savedFlag,
 			Seen:         seenFlag,

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -28,6 +28,7 @@ type listingResponse struct {
 	MedianPrice  *int     `json:"median_price,omitempty"`
 	CohortSize   *int     `json:"cohort_size,omitempty"`
 	DealScore    *int     `json:"deal_score,omitempty"`
+	BasePrice    *int     `json:"base_price,omitempty"`
 	FirstSeenAt  string   `json:"first_seen_at"`
 	Saved        bool     `json:"saved,omitempty"`
 	// Seen: user dismissed this listing from the new-items feed (notifications).
@@ -102,6 +103,7 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 		MedianPrice:  l.MedianPrice,
 		CohortSize:   l.CohortSize,
 		DealScore:    l.DealScore,
+		BasePrice:    l.BasePrice,
 		FirstSeenAt:  l.FirstSeenAt.UTC().Format("2006-01-02T15:04:05Z"),
 		Saved:        savedFlag,
 		Seen:         seenFlag,

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -198,6 +198,7 @@ func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, err
 		ModelID:            item.Model.ID,
 		ModelNameHe:        item.Model.Text,
 		SubModel:         textFromField(item.SubModel),
+		SubModelID:       item.SubModel.ID,
 		Year:         year,
 		Month:        item.Month,
 		EngineVolume: engineVol,

--- a/internal/locale/scoring.go
+++ b/internal/locale/scoring.go
@@ -15,6 +15,10 @@ var heScoring = map[string]string{
 	"fmt_market_value_near":  "📊 שווי שוק: ₪%s · קרוב למחיר · %d מודעות\n",
 	"fmt_market_value_above": "📊 שווי שוק: ₪%s · %d%% מעל · %d מודעות\n",
 
+	"fmt_base_price_below": "📋 מחירון: ₪%s · %d%% מתחת למחירון\n",
+	"fmt_base_price_near":  "📋 מחירון: ₪%s · קרוב למחירון\n",
+	"fmt_base_price_above": "📋 מחירון: ₪%s · %d%% מעל המחירון\n",
+
 	// daily market digest
 }
 
@@ -32,6 +36,10 @@ var enScoring = map[string]string{
 	"fmt_market_value_below": "📊 Market value: ₪%s · %d%% below · %d listings\n",
 	"fmt_market_value_near":  "📊 Market value: ₪%s · near market · %d listings\n",
 	"fmt_market_value_above": "📊 Market value: ₪%s · %d%% above · %d listings\n",
+
+	"fmt_base_price_below": "📋 Price list: ₪%s · %d%% below list price\n",
+	"fmt_base_price_near":  "📋 Price list: ₪%s · near list price\n",
+	"fmt_base_price_above": "📋 Price list: ₪%s · %d%% above list price\n",
 
 	// daily market digest
 }

--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -11,6 +11,7 @@ type RawListing struct {
 	ModelID            int
 	ModelNameHe        string
 	SubModel     string
+	SubModelID   int
 	Year         int
 	Month        int
 	EngineVolume float64
@@ -50,4 +51,5 @@ type Listing struct {
 	DealScore        *ScoreInfo
 	FitnessScore     float64
 	FitnessBreakdown []FitnessDim
+	BasePrice        *int
 }

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -30,6 +30,9 @@ func FormatListing(l model.Listing, lang locale.Lang) string {
 
 	if l.Price > 0 {
 		b.WriteString(locale.Tf(lang, "fmt_price", format.Number(l.Price)))
+		if l.BasePrice != nil && *l.BasePrice > 0 {
+			b.WriteString(basePriceLine(lang, *l.BasePrice, l.Price))
+		}
 		if l.DealScore != nil && l.DealScore.MedianPrice > 0 {
 			b.WriteString(marketValueLine(lang, l.DealScore, l.Price))
 		}
@@ -188,6 +191,18 @@ func formatBreakdown(dims []model.FitnessDim, lang locale.Lang) string {
 		return locale.Tf(lang, "fmt_fitness_down_only", strings.Join(bad, ", "))
 	}
 	return ""
+}
+
+func basePriceLine(lang locale.Lang, basePrice, price int) string {
+	bpStr := format.Number(basePrice)
+	pctDiff := int(math.Round(100.0 * (1.0 - float64(price)/float64(basePrice))))
+	if pctDiff > 5 {
+		return locale.Tf(lang, "fmt_base_price_below", bpStr, pctDiff)
+	}
+	if pctDiff >= -5 {
+		return locale.Tf(lang, "fmt_base_price_near", bpStr)
+	}
+	return locale.Tf(lang, "fmt_base_price_above", bpStr, -pctDiff)
 }
 
 func marketValueLine(lang locale.Lang, score *model.ScoreInfo, price int) string {

--- a/internal/pricelist/fetcher.go
+++ b/internal/pricelist/fetcher.go
@@ -1,0 +1,158 @@
+package pricelist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var priceRe = regexp.MustCompile(`₪\s*([\d,]+)`)
+var basePriceLabelRe = regexp.MustCompile(`(?i)מחיר\s+בסיס[^₪]*₪\s*([\d,]+)`)
+
+// fetch tries Go HTTP first, then falls back to the Python scraper.
+func fetch(ctx context.Context, subModelID, year int, logger *slog.Logger) fetchResult {
+	result := fetchGoHTTP(ctx, subModelID, year, logger)
+	if result.BasePrice > 0 {
+		return result
+	}
+
+	result = fetchPythonScraper(ctx, subModelID, year, logger)
+	return result
+}
+
+// fetchGoHTTP attempts to fetch the price list page with a plain HTTP client
+// and extract the base price from the HTML (works if the page is server-rendered
+// or embeds data in __NEXT_DATA__).
+func fetchGoHTTP(ctx context.Context, subModelID, year int, logger *slog.Logger) fetchResult {
+	url := priceListURL(subModelID, year)
+
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, "GET", url, nil)
+	if err != nil {
+		return fetchResult{Error: fmt.Sprintf("create request: %v", err)}
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fetchResult{Error: fmt.Sprintf("http get: %v", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return fetchResult{Error: fmt.Sprintf("http status %d", resp.StatusCode)}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return fetchResult{Error: fmt.Sprintf("read body: %v", err)}
+	}
+
+	html := string(body)
+	return extractPriceFromHTML(html)
+}
+
+func extractPriceFromHTML(html string) fetchResult {
+	// Strategy 1: look for "מחיר בסיס" label followed by a price
+	if m := basePriceLabelRe.FindStringSubmatch(html); len(m) > 1 {
+		if price := parsePrice(m[1]); price > 1000 {
+			return fetchResult{BasePrice: price}
+		}
+	}
+
+	// Strategy 2: look for __NEXT_DATA__ JSON with price info
+	if idx := strings.Index(html, `"basePrice"`); idx >= 0 {
+		start := strings.LastIndex(html[:idx], "{")
+		if start >= 0 {
+			end := strings.Index(html[idx:], "}")
+			if end >= 0 {
+				snippet := html[start : idx+end+1]
+				var obj map[string]interface{}
+				if json.Unmarshal([]byte(snippet), &obj) == nil {
+					if bp, ok := obj["basePrice"].(float64); ok && bp > 1000 {
+						return fetchResult{BasePrice: int(bp)}
+					}
+				}
+			}
+		}
+	}
+
+	// Strategy 3: find all ₪ prices and pick the largest > 1000
+	matches := priceRe.FindAllStringSubmatch(html, -1)
+	var best int
+	for _, m := range matches {
+		if p := parsePrice(m[1]); p > 1000 && p > best {
+			best = p
+		}
+	}
+	if best > 0 {
+		return fetchResult{BasePrice: best}
+	}
+
+	return fetchResult{Error: "no price found in HTML"}
+}
+
+func parsePrice(s string) int {
+	s = strings.ReplaceAll(s, ",", "")
+	s = strings.TrimSpace(s)
+	v, _ := strconv.Atoi(s)
+	return v
+}
+
+// fetchPythonScraper shells out to the Python Yad2 price scraper as a fallback.
+func fetchPythonScraper(ctx context.Context, subModelID, year int, logger *slog.Logger) fetchResult {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		return fetchResult{Error: "python3 not found"}
+	}
+
+	scriptPath := "scripts/yad2_price_scraper.py"
+	cmdCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, python, scriptPath,
+		"--json",
+		strconv.Itoa(subModelID),
+		strconv.Itoa(year),
+	)
+
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Debug("python scraper failed", "sub_model_id", subModelID, "year", year, "error", err)
+		return fetchResult{Error: fmt.Sprintf("python scraper: %v", err)}
+	}
+
+	var result struct {
+		BasePrice *int   `json:"base_price"`
+		Title     string `json:"title"`
+		Error     string `json:"error"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return fetchResult{Error: fmt.Sprintf("parse scraper output: %v", err)}
+	}
+
+	if result.BasePrice != nil && *result.BasePrice > 0 {
+		return fetchResult{
+			BasePrice: *result.BasePrice,
+			Title:     result.Title,
+		}
+	}
+
+	errMsg := "no price from scraper"
+	if result.Error != "" {
+		errMsg = result.Error
+	}
+	return fetchResult{Error: errMsg}
+}

--- a/internal/pricelist/service.go
+++ b/internal/pricelist/service.go
@@ -1,0 +1,116 @@
+package pricelist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+const (
+	cacheTTL         = 7 * 24 * time.Hour
+	maxFetchPerCycle = 20
+	fetchCooldown    = 2 * time.Second
+)
+
+type Service struct {
+	store  storage.PriceListStore
+	logger *slog.Logger
+
+	mu        sync.Mutex
+	lastFetch time.Time
+	fetchCount int
+}
+
+func NewService(store storage.PriceListStore, logger *slog.Logger) *Service {
+	return &Service{
+		store:  store,
+		logger: logger,
+	}
+}
+
+// ResetCycleCounter resets the per-cycle fetch counter. Call at the start of each scan cycle.
+func (s *Service) ResetCycleCounter() {
+	s.mu.Lock()
+	s.fetchCount = 0
+	s.mu.Unlock()
+}
+
+// Lookup returns the cached base price for a sub-model/year pair.
+// If not cached or stale, it fetches from Yad2 (rate-limited).
+func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice int, ok bool) {
+	if subModelID <= 0 || year <= 0 {
+		return 0, false
+	}
+
+	entry, err := s.store.GetPriceListEntry(ctx, subModelID, year)
+	if err != nil {
+		s.logger.Error("price list cache read failed", "sub_model_id", subModelID, "year", year, "error", err)
+		return 0, false
+	}
+
+	if entry != nil && time.Since(entry.FetchedAt) < cacheTTL {
+		return entry.BasePrice, true
+	}
+
+	s.mu.Lock()
+	if s.fetchCount >= maxFetchPerCycle {
+		s.mu.Unlock()
+		if entry != nil {
+			return entry.BasePrice, true
+		}
+		return 0, false
+	}
+	elapsed := time.Since(s.lastFetch)
+	if elapsed < fetchCooldown {
+		s.mu.Unlock()
+		if entry != nil {
+			return entry.BasePrice, true
+		}
+		return 0, false
+	}
+	s.fetchCount++
+	s.lastFetch = time.Now()
+	s.mu.Unlock()
+
+	result := fetch(ctx, subModelID, year, s.logger)
+	if result.BasePrice <= 0 {
+		if entry != nil {
+			return entry.BasePrice, true
+		}
+		return 0, false
+	}
+
+	newEntry := storage.PriceListEntry{
+		SubModelID: subModelID,
+		Year:       year,
+		BasePrice:  result.BasePrice,
+		Title:      result.Title,
+		FetchedAt:  time.Now(),
+	}
+	if err := s.store.SetPriceListEntry(ctx, newEntry); err != nil {
+		s.logger.Error("price list cache write failed", "sub_model_id", subModelID, "year", year, "error", err)
+	}
+
+	s.logger.Info("fetched price list",
+		"sub_model_id", subModelID,
+		"year", year,
+		"base_price", result.BasePrice,
+		"title", result.Title,
+	)
+
+	return result.BasePrice, true
+}
+
+type fetchResult struct {
+	BasePrice int
+	Title     string
+	Error     string
+}
+
+func priceListURL(subModelID, year int) string {
+	return fmt.Sprintf("https://www.yad2.co.il/price-list/sub-model/%d/%d", subModelID, year)
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/pricelist"
 	"github.com/dsionov/carwatch/internal/scoring"
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -74,6 +75,7 @@ type Scheduler struct {
 	catalogIngester   CatalogIngester
 	carNames          CarNameResolver
 	kmEnricher        KmEnricher
+	priceListSvc      *pricelist.Service
 	triggerCh         chan struct{}
 
 	langCache   sync.Map
@@ -97,6 +99,7 @@ type Stores struct {
 	Digests      storage.DigestStore
 	Hidden       storage.HiddenListingStore
 	Market       storage.MarketStore
+	PriceList    storage.PriceListStore
 	DailyDigests storage.DailyDigestStore
 }
 
@@ -121,6 +124,7 @@ type Options struct {
 	CarNames         CarNameResolver
 	KmEnricher       KmEnricher
 	MarketStore      storage.MarketStore
+	PriceListStore   storage.PriceListStore
 	DailyDigestStore storage.DailyDigestStore
 }
 
@@ -151,6 +155,12 @@ func NewWithOptions(
 	if obs == nil {
 		obs = nopObserver{}
 	}
+
+	var plSvc *pricelist.Service
+	if opts.PriceListStore != nil {
+		plSvc = pricelist.NewService(opts.PriceListStore, logger)
+	}
+
 	return &Scheduler{
 		cfg:        cfg,
 		configPath: opts.ConfigPath,
@@ -165,6 +175,7 @@ func NewWithOptions(
 			Digests:      opts.DigestStore,
 			Hidden:       opts.HiddenStore,
 			Market:       opts.MarketStore,
+			PriceList:    opts.PriceListStore,
 			DailyDigests: opts.DailyDigestStore,
 		},
 		notifier:          n,
@@ -176,6 +187,7 @@ func NewWithOptions(
 		catalogIngester:   opts.CatalogIngester,
 		carNames:          opts.CarNames,
 		kmEnricher:        opts.KmEnricher,
+		priceListSvc:      plSvc,
 		triggerCh:         make(chan struct{}, 1),
 	}, nil
 }
@@ -505,6 +517,9 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	s.langCache.Range(func(k, _ any) bool { s.langCache.Delete(k); return true })
 	s.digestCache.Range(func(k, _ any) bool { s.digestCache.Delete(k); return true })
+	if s.priceListSvc != nil {
+		s.priceListSvc.ResetCycleCounter()
+	}
 
 	searches, err := s.stores.Searches.ListAllActiveSearches(ctx)
 	if err != nil {
@@ -990,6 +1005,7 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 		rec := storage.ListingRecord{
 			Token: l.Token, ChatID: search.ChatID, SearchID: search.ID, SearchName: search.Name,
 			Manufacturer: l.Manufacturer, Model: l.Model, SubModel: l.SubModel,
+			SubModelID: l.SubModelID,
 			Year: l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
 			City: l.City, PageLink: l.PageLink, ImageURL: l.ImageURL,
 			EngineVolume: l.EngineVolume, HorsePower: l.HorsePower,
@@ -1014,6 +1030,16 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 		}
 	}
 	return true
+}
+
+func (s *Scheduler) enrichWithBasePrice(ctx context.Context, listing *model.Listing) {
+	if s.priceListSvc == nil || listing.SubModelID <= 0 || listing.Year <= 0 {
+		return
+	}
+	bp, ok := s.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year)
+	if ok && bp > 0 {
+		listing.BasePrice = &bp
+	}
 }
 
 func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawListing, marketCache *scoring.MarketCache) model.Listing {
@@ -1068,12 +1094,13 @@ func buildNotifications(search storage.Search, listing model.Listing, out *searc
 	rec := storage.ListingRecord{
 		Token: listing.Token, ChatID: search.ChatID, SearchID: search.ID, SearchName: search.Name,
 		Manufacturer: listing.Manufacturer, Model: listing.Model, SubModel: listing.SubModel,
+		SubModelID: listing.SubModelID,
 		Year: listing.Year, Price: listing.Price, Km: listing.Km, Hand: listing.Hand,
 		City: listing.City, PageLink: listing.PageLink, ImageURL: listing.ImageURL,
 		EngineVolume: listing.EngineVolume, HorsePower: listing.HorsePower,
 		EngineType: listing.EngineType, GearBox: listing.GearBox, Description: listing.Description,
 		IsCommercial: listing.Commercial,
-		FitnessScore: &listing.FitnessScore, FirstSeenAt: time.Now(),
+		FitnessScore: &listing.FitnessScore, BasePrice: listing.BasePrice, FirstSeenAt: time.Now(),
 	}
 	if listing.DealScore != nil {
 		rec.MedianPrice = &listing.DealScore.MedianPrice
@@ -1101,6 +1128,7 @@ func (s *Scheduler) processSearchListings(ctx context.Context, search storage.Se
 			continue
 		}
 		listing := s.scoreAndRecordListings(search, l, marketCache)
+		s.enrichWithBasePrice(ctx, &listing)
 		buildNotifications(search, listing, &out)
 	}
 	return out

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -136,6 +136,7 @@ type ListingRecord struct {
 	Manufacturer string
 	Model        string
 	SubModel     string
+	SubModelID   int
 	Year         int
 	Price        int
 	Km           int
@@ -154,6 +155,7 @@ type ListingRecord struct {
 	MedianPrice  *int
 	CohortSize   *int
 	DealScore    *int
+	BasePrice    *int
 	FirstSeenAt  time.Time
 }
 
@@ -248,6 +250,19 @@ type HiddenListingStore interface {
 	ListHidden(ctx context.Context, chatID int64, limit, offset int) ([]string, error)
 	CountHidden(ctx context.Context, chatID int64) (int64, error)
 	ClearHidden(ctx context.Context, chatID int64) error
+}
+
+type PriceListEntry struct {
+	SubModelID int
+	Year       int
+	BasePrice  int
+	Title      string
+	FetchedAt  time.Time
+}
+
+type PriceListStore interface {
+	GetPriceListEntry(ctx context.Context, subModelID, year int) (*PriceListEntry, error)
+	SetPriceListEntry(ctx context.Context, e PriceListEntry) error
 }
 
 type MarketListing struct {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -107,20 +107,20 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 	var err error
 	if searchID > 0 {
 		rows, err = s.db.QueryContext(ctx, `
-			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 			FROM listing_history
 			WHERE search_id = $1
 			ORDER BY first_seen_at DESC
 			LIMIT $2 OFFSET $3`, searchID, limit, offset)
 	} else {
 		rows, err = s.db.QueryContext(ctx, `
-			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT $1 OFFSET $2`, limit, offset)
@@ -134,13 +134,13 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 	for rows.Next() {
 		var r storage.ListingRecord
 		var fs sql.NullFloat64
-		var ic, mp, cs, ds sql.NullInt64
+		var ic, mp, cs, ds, bp sql.NullInt64
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
-			&r.Manufacturer, &r.Model, &r.SubModel, &r.Year, &r.Price,
+			&r.Manufacturer, &r.Model, &r.SubModel, &r.SubModelID, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&ic, &fs, &mp, &cs, &ds, &r.FirstSeenAt,
+			&ic, &fs, &mp, &cs, &ds, &bp, &r.FirstSeenAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
@@ -159,6 +159,10 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		if ds.Valid {
 			v := int(ds.Int64)
 			r.DealScore = &v
+		}
+		if bp.Valid {
+			v := int(bp.Int64)
+			r.BasePrice = &v
 		}
 		items = append(items, r)
 	}

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -33,14 +33,15 @@ GROUP BY lh.search_id`
 
 const upsertListingSQL = `
 	INSERT INTO listing_history
-	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
+	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
 	ON CONFLICT (token, chat_id) DO UPDATE SET
 		search_id = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_id ELSE listing_history.search_id END,
 		search_name = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_name ELSE listing_history.search_name END,
 		manufacturer = CASE WHEN EXCLUDED.manufacturer != '' THEN EXCLUDED.manufacturer ELSE listing_history.manufacturer END,
 		model = CASE WHEN EXCLUDED.model != '' THEN EXCLUDED.model ELSE listing_history.model END,
 		sub_model = CASE WHEN EXCLUDED.sub_model != '' THEN EXCLUDED.sub_model ELSE listing_history.sub_model END,
+		sub_model_id = CASE WHEN EXCLUDED.sub_model_id > 0 THEN EXCLUDED.sub_model_id ELSE listing_history.sub_model_id END,
 		year = CASE WHEN EXCLUDED.year > 0 THEN EXCLUDED.year ELSE listing_history.year END,
 		price = EXCLUDED.price,
 		km = CASE WHEN EXCLUDED.km > 0 THEN EXCLUDED.km ELSE listing_history.km END,
@@ -57,7 +58,8 @@ const upsertListingSQL = `
 		fitness_score = EXCLUDED.fitness_score,
 		median_price = COALESCE(EXCLUDED.median_price, listing_history.median_price),
 		cohort_size = COALESCE(EXCLUDED.cohort_size, listing_history.cohort_size),
-		deal_score = COALESCE(EXCLUDED.deal_score, listing_history.deal_score)`
+		deal_score = COALESCE(EXCLUDED.deal_score, listing_history.deal_score),
+		base_price = COALESCE(EXCLUDED.base_price, listing_history.base_price)`
 
 type listingScanner interface {
 	Scan(dest ...any) error
@@ -66,11 +68,11 @@ type listingScanner interface {
 func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
-	var ic, mp, cs, ds sql.NullInt64
-	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel,
+	var ic, mp, cs, ds, bp sql.NullInt64
+	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel, &l.SubModelID,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&ic, &fs, &mp, &cs, &ds, &l.FirstSeenAt); err != nil {
+		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt); err != nil {
 		return l, err
 	}
 	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
@@ -89,16 +91,20 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 		v := int(ds.Int64)
 		l.DealScore = &v
 	}
+	if bp.Valid {
+		v := int(bp.Int64)
+		l.BasePrice = &v
+	}
 	return l, nil
 }
 
 func upsertListingArgs(r storage.ListingRecord) []any {
 	return []any{
-		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.SubModel, r.Year, r.Price,
+		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.SubModel, r.SubModelID, r.Year, r.Price,
 		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL,
 		r.EngineVolume, r.HorsePower, r.EngineType, r.GearBox, r.Description,
 		storage.ListingCommercialToSQL(r.IsCommercial),
-		r.FitnessScore, r.MedianPrice, r.CohortSize, r.DealScore, r.FirstSeenAt.UTC(),
+		r.FitnessScore, r.MedianPrice, r.CohortSize, r.DealScore, r.BasePrice, r.FirstSeenAt.UTC(),
 	}
 }
 
@@ -219,10 +225,10 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1 AND token = $2
 		ORDER BY first_seen_at DESC
@@ -239,10 +245,10 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 
 func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1
 		ORDER BY first_seen_at DESC, token DESC
@@ -273,9 +279,9 @@ func (s *Store) CountUserListings(ctx context.Context, chatID int64) (int64, err
 
 func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		ORDER BY first_seen_at DESC
 		LIMIT $1`, limit)
@@ -363,10 +369,10 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 	args = append(args, limit, offset)
 
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE chat_id = $1 AND search_id = $2%s
 		ORDER BY %s
@@ -453,10 +459,10 @@ func (s *Store) RemoveBookmark(ctx context.Context, chatID int64, token string) 
 
 func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.year, lh.price,
+		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = $1

--- a/internal/storage/postgres/notifications_center.go
+++ b/internal/storage/postgres/notifications_center.go
@@ -10,10 +10,10 @@ import (
 
 func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history lh
 		WHERE lh.chat_id = $1 AND lh.first_seen_at > $2
 		AND NOT EXISTS (

--- a/internal/storage/postgres/pricelist.go
+++ b/internal/storage/postgres/pricelist.go
@@ -1,0 +1,41 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func (s *Store) GetPriceListEntry(ctx context.Context, subModelID, year int) (*storage.PriceListEntry, error) {
+	var e storage.PriceListEntry
+	err := s.db.QueryRowContext(ctx,
+		`SELECT sub_model_id, year, base_price, title, fetched_at
+		 FROM price_list_cache
+		 WHERE sub_model_id = $1 AND year = $2`, subModelID, year,
+	).Scan(&e.SubModelID, &e.Year, &e.BasePrice, &e.Title, &e.FetchedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get price list entry: %w", err)
+	}
+	return &e, nil
+}
+
+func (s *Store) SetPriceListEntry(ctx context.Context, e storage.PriceListEntry) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO price_list_cache (sub_model_id, year, base_price, title, fetched_at)
+		 VALUES ($1, $2, $3, $4, NOW())
+		 ON CONFLICT (sub_model_id, year) DO UPDATE SET
+			base_price = EXCLUDED.base_price,
+			title = EXCLUDED.title,
+			fetched_at = NOW()`,
+		e.SubModelID, e.Year, e.BasePrice, e.Title,
+	)
+	if err != nil {
+		return fmt.Errorf("set price list entry: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -107,20 +107,20 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 	var err error
 	if searchID > 0 {
 		rows, err = s.db.QueryContext(ctx, `
-			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 			FROM listing_history
 			WHERE search_id = ?
 			ORDER BY first_seen_at DESC
 			LIMIT ? OFFSET ?`, searchID, limit, offset)
 	} else {
 		rows, err = s.db.QueryContext(ctx, `
-			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price,
+			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT ? OFFSET ?`, limit, offset)
@@ -135,14 +135,14 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		var r storage.ListingRecord
 		var score *float64
 		var ic sql.NullInt64
-		var mp, cs, ds sql.NullInt64
+		var mp, cs, ds, bp sql.NullInt64
 		var firstSeen string
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
-			&r.Manufacturer, &r.Model, &r.SubModel, &r.Year, &r.Price,
+			&r.Manufacturer, &r.Model, &r.SubModel, &r.SubModelID, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&ic, &score, &mp, &cs, &ds, &firstSeen,
+			&ic, &score, &mp, &cs, &ds, &bp, &firstSeen,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
@@ -159,6 +159,10 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		if ds.Valid {
 			v := int(ds.Int64)
 			r.DealScore = &v
+		}
+		if bp.Valid {
+			v := int(bp.Int64)
+			r.BasePrice = &v
 		}
 		parsed, parseErr := parseFlexibleTime(firstSeen)
 		if parseErr != nil {

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -14,14 +14,15 @@ const firstSeenAtLayout = "2006-01-02 15:04:05.000000"
 
 const upsertListingSQL = `
 	INSERT INTO listing_history
-	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(token, chat_id) DO UPDATE SET
 		search_id = CASE WHEN excluded.search_id > 0 THEN excluded.search_id ELSE listing_history.search_id END,
 		search_name = CASE WHEN excluded.search_id > 0 THEN excluded.search_name ELSE listing_history.search_name END,
 		manufacturer = CASE WHEN excluded.manufacturer != '' THEN excluded.manufacturer ELSE listing_history.manufacturer END,
 		model = CASE WHEN excluded.model != '' THEN excluded.model ELSE listing_history.model END,
 		sub_model = CASE WHEN excluded.sub_model != '' THEN excluded.sub_model ELSE listing_history.sub_model END,
+		sub_model_id = CASE WHEN excluded.sub_model_id > 0 THEN excluded.sub_model_id ELSE listing_history.sub_model_id END,
 		year = CASE WHEN excluded.year > 0 THEN excluded.year ELSE listing_history.year END,
 		price = excluded.price,
 		km = CASE WHEN excluded.km > 0 THEN excluded.km ELSE listing_history.km END,
@@ -38,7 +39,8 @@ const upsertListingSQL = `
 		fitness_score = excluded.fitness_score,
 		median_price = COALESCE(excluded.median_price, listing_history.median_price),
 		cohort_size = COALESCE(excluded.cohort_size, listing_history.cohort_size),
-		deal_score = COALESCE(excluded.deal_score, listing_history.deal_score)`
+		deal_score = COALESCE(excluded.deal_score, listing_history.deal_score),
+		base_price = COALESCE(excluded.base_price, listing_history.base_price)`
 
 type listingScanner interface {
 	Scan(dest ...any) error
@@ -47,11 +49,11 @@ type listingScanner interface {
 func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
-	var ic, mp, cs, ds sql.NullInt64
-	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel,
+	var ic, mp, cs, ds, bp sql.NullInt64
+	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel, &l.SubModelID,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&ic, &fs, &mp, &cs, &ds, &l.FirstSeenAt); err != nil {
+		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt); err != nil {
 		return l, err
 	}
 	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
@@ -70,16 +72,20 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 		v := int(ds.Int64)
 		l.DealScore = &v
 	}
+	if bp.Valid {
+		v := int(bp.Int64)
+		l.BasePrice = &v
+	}
 	return l, nil
 }
 
 func upsertListingArgs(r storage.ListingRecord) []any {
 	return []any{
-		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.SubModel, r.Year, r.Price,
+		r.Token, r.ChatID, r.SearchID, r.SearchName, r.Manufacturer, r.Model, r.SubModel, r.SubModelID, r.Year, r.Price,
 		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL,
 		r.EngineVolume, r.HorsePower, r.EngineType, r.GearBox, r.Description,
 		storage.ListingCommercialToSQL(r.IsCommercial),
-		r.FitnessScore, r.MedianPrice, r.CohortSize, r.DealScore, r.FirstSeenAt.UTC().Format(firstSeenAtLayout),
+		r.FitnessScore, r.MedianPrice, r.CohortSize, r.DealScore, r.BasePrice, r.FirstSeenAt.UTC().Format(firstSeenAtLayout),
 	}
 }
 
@@ -200,10 +206,10 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ? AND token = ?
 		ORDER BY rowid DESC LIMIT 1`, chatID, token)
@@ -219,10 +225,10 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 
 func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ?
 		ORDER BY first_seen_at DESC, token DESC
@@ -253,9 +259,9 @@ func (s *Store) CountUserListings(ctx context.Context, chatID int64) (int64, err
 
 func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price, km, hand, city, page_link, image_url,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE rowid IN (SELECT MAX(rowid) FROM listing_history GROUP BY token)
 		ORDER BY first_seen_at DESC LIMIT ?`, limit)
@@ -334,10 +340,10 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 	args = append(args, limit, offset)
 
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history
 		WHERE chat_id = ? AND search_id = ?%s
 		ORDER BY %s
@@ -439,10 +445,10 @@ func (s *Store) RemoveBookmark(ctx context.Context, chatID int64, token string) 
 
 func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.year, lh.price,
+		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = ?

--- a/internal/storage/sqlite/migrate.go
+++ b/internal/storage/sqlite/migrate.go
@@ -44,6 +44,7 @@ func migrate(db *sql.DB) error {
 		migrateListingVehicleDetails,
 		migrateSellerFilterAndListingCommercial,
 		migrateListingMarketValue,
+		migrateListingSubModelIDAndBasePrice,
 		migrateListingUserSeen,
 	}
 	for _, step := range steps {

--- a/internal/storage/sqlite/migrate_steps.go
+++ b/internal/storage/sqlite/migrate_steps.go
@@ -713,6 +713,51 @@ func migrateListingMarketValue(db *sql.DB) error {
 	return nil
 }
 
+func migrateListingSubModelIDAndBasePrice(db *sql.DB) error {
+	columns := []struct {
+		name string
+		def  string
+	}{
+		{"sub_model_id", "INTEGER NOT NULL DEFAULT 0"},
+		{"base_price", "INTEGER"},
+	}
+	for _, col := range columns {
+		var exists int
+		if err := db.QueryRow(
+			"SELECT COUNT(*) FROM pragma_table_info('listing_history') WHERE name = ?", col.name,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("check listing_history %s: %w", col.name, err)
+		}
+		if exists == 0 {
+			if _, err := db.Exec(fmt.Sprintf(
+				"ALTER TABLE listing_history ADD COLUMN %s %s", col.name, col.def)); err != nil {
+				return fmt.Errorf("add listing_history %s: %w", col.name, err)
+			}
+		}
+	}
+
+	var tblCount int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='price_list_cache'",
+	).Scan(&tblCount); err != nil {
+		return fmt.Errorf("check price_list_cache table: %w", err)
+	}
+	if tblCount == 0 {
+		if _, err := db.Exec(`
+			CREATE TABLE price_list_cache (
+				sub_model_id INTEGER NOT NULL,
+				year         INTEGER NOT NULL,
+				base_price   INTEGER NOT NULL,
+				title        TEXT,
+				fetched_at   TEXT NOT NULL DEFAULT (datetime('now')),
+				PRIMARY KEY (sub_model_id, year)
+			)`); err != nil {
+			return fmt.Errorf("create price_list_cache: %w", err)
+		}
+	}
+	return nil
+}
+
 func migrateListingUserSeen(db *sql.DB) error {
 	var n int
 	if err := db.QueryRow(

--- a/internal/storage/sqlite/notifications_center.go
+++ b/internal/storage/sqlite/notifications_center.go
@@ -10,10 +10,10 @@ import (
 
 func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, year, price,
+		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
 		FROM listing_history lh
 		WHERE lh.chat_id = ? AND lh.first_seen_at > ?
 		AND NOT EXISTS (

--- a/internal/storage/sqlite/pricelist.go
+++ b/internal/storage/sqlite/pricelist.go
@@ -1,0 +1,41 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func (s *Store) GetPriceListEntry(ctx context.Context, subModelID, year int) (*storage.PriceListEntry, error) {
+	var e storage.PriceListEntry
+	err := s.db.QueryRowContext(ctx,
+		`SELECT sub_model_id, year, base_price, title, fetched_at
+		 FROM price_list_cache
+		 WHERE sub_model_id = ? AND year = ?`, subModelID, year,
+	).Scan(&e.SubModelID, &e.Year, &e.BasePrice, &e.Title, &e.FetchedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get price list entry: %w", err)
+	}
+	return &e, nil
+}
+
+func (s *Store) SetPriceListEntry(ctx context.Context, e storage.PriceListEntry) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO price_list_cache (sub_model_id, year, base_price, title, fetched_at)
+		 VALUES (?, ?, ?, ?, datetime('now'))
+		 ON CONFLICT (sub_model_id, year) DO UPDATE SET
+			base_price = excluded.base_price,
+			title = excluded.title,
+			fetched_at = datetime('now')`,
+		e.SubModelID, e.Year, e.BasePrice, e.Title,
+	)
+	if err != nil {
+		return fmt.Errorf("set price list entry: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -16,6 +16,7 @@ type Store interface {
 	SavedListingStore
 	HiddenListingStore
 	MarketStore
+	PriceListStore
 	DailyDigestStore
 	AdminStore
 	NotificationStore

--- a/migrations/000006_sub_model_id_and_price_list.down.sql
+++ b/migrations/000006_sub_model_id_and_price_list.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS price_list_cache;
+ALTER TABLE listing_history DROP COLUMN IF EXISTS base_price;
+ALTER TABLE listing_history DROP COLUMN IF EXISTS sub_model_id;

--- a/migrations/000006_sub_model_id_and_price_list.up.sql
+++ b/migrations/000006_sub_model_id_and_price_list.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE listing_history ADD COLUMN IF NOT EXISTS sub_model_id INTEGER DEFAULT 0;
+ALTER TABLE listing_history ADD COLUMN IF NOT EXISTS base_price INTEGER;
+
+CREATE TABLE IF NOT EXISTS price_list_cache (
+    sub_model_id INTEGER NOT NULL,
+    year         INTEGER NOT NULL,
+    base_price   INTEGER NOT NULL,
+    title        TEXT,
+    fetched_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (sub_model_id, year)
+);

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -98,7 +98,11 @@ export function ListingCardBody({
               {formatPrice(listing.price)}
             </span>
             {(() => {
-              const mc = marketComparison(listing.price, listing.median_price);
+              const mc = marketComparison(
+                listing.price,
+                listing.median_price,
+                listing.base_price,
+              );
               if (!mc) return null;
               return (
                 <p className={cn("text-[11px] font-medium mt-0.5", mc.color)}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -120,6 +120,7 @@ export interface Listing {
   description?: string;
   fitness_score?: number;
   median_price?: number;
+  base_price?: number;
   cohort_size?: number;
   deal_score?: number;
   first_seen_at: string;

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { formatPrice, formatKm, safeHref, relativeTime, cn } from "./utils";
+import { formatPrice, formatKm, safeHref, relativeTime, cn, marketComparison } from "./utils";
 
 describe("cn", () => {
   it("merges class names", () => {
@@ -78,6 +78,47 @@ describe("safeHref", () => {
 
   it("returns null for data: protocol", () => {
     expect(safeHref("data:text/html,<h1>hi</h1>")).toBeNull();
+  });
+});
+
+describe("marketComparison", () => {
+  it("returns null when neither median nor base is usable", () => {
+    expect(marketComparison(100_000)).toBeNull();
+    expect(marketComparison(100_000, undefined, 0)).toBeNull();
+    expect(marketComparison(100_000, -1)).toBeNull();
+  });
+
+  it("prefers base_price over median when both are set", () => {
+    const r = marketComparison(80_000, 100_000, 90_000);
+    expect(r).not.toBeNull();
+    expect(r!.source).toBe("base");
+    expect(r!.diffPercent).toBe(11); // 100*(1-80000/90000)
+    expect(r!.label).toContain("מחירון");
+    expect(r!.label).not.toContain("ממוצע");
+  });
+
+  it("uses median when base is absent", () => {
+    const r = marketComparison(85_000, 100_000);
+    expect(r).not.toBeNull();
+    expect(r!.source).toBe("median");
+    expect(r!.diffPercent).toBe(15);
+    expect(r!.label).toContain("ממוצע");
+    expect(r!.isBelow).toBe(true);
+  });
+
+  it("uses base when median is absent", () => {
+    const r = marketComparison(95_000, undefined, 100_000);
+    expect(r).not.toBeNull();
+    expect(r!.source).toBe("base");
+    expect(r!.diffPercent).toBe(5); // boundary: neutral band
+    expect(r!.label).toBe("קרוב למחירון");
+  });
+
+  it("marks listing above reference", () => {
+    const r = marketComparison(120_000, 100_000);
+    expect(r!.isBelow).toBe(false);
+    expect(r!.diffPercent).toBe(-20);
+    expect(r!.label).toContain("מעל הממוצע");
   });
 });
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -27,41 +27,75 @@ export function safeHref(raw: string): string | null {
 }
 
 export type MarketComparison = {
-  pctDiff: number;
-  absDiff: number;
   label: string;
+  /** Positive when listing price is below reference (better deal vs reference). */
+  diffPercent: number;
+  isBelow: boolean;
+  source: "base" | "median";
+  /** Signed reference − listing (positive when listing is cheaper than reference). */
+  absDiff: number;
   color: string;
 };
 
-export function marketComparison(
+function marketComparisonAgainstRef(
   price: number,
-  medianPrice: number | undefined,
+  referencePrice: number,
+  source: "base" | "median",
 ): MarketComparison | null {
-  if (!medianPrice || medianPrice <= 0 || price <= 0) return null;
-  const pctDiff = Math.round(100 * (1 - price / medianPrice));
-  const absDiff = medianPrice - price;
-  if (pctDiff > 5) {
+  if (!referencePrice || referencePrice <= 0 || price <= 0) return null;
+  const diffPercent = Math.round(100 * (1 - price / referencePrice));
+  const absDiff = referencePrice - price;
+  const isBelow = price < referencePrice;
+
+  if (diffPercent > 5) {
     return {
-      pctDiff,
+      diffPercent,
       absDiff,
-      label: `${pctDiff}% מתחת לשוק`,
+      isBelow,
+      source,
+      label:
+        source === "base"
+          ? `${diffPercent}% מתחת למחירון`
+          : `${diffPercent}% מתחת לממוצע`,
       color: "text-emerald-500",
     };
   }
-  if (pctDiff >= -5) {
+  if (diffPercent >= -5) {
     return {
-      pctDiff,
+      diffPercent,
       absDiff,
-      label: "קרוב למחיר השוק",
+      isBelow,
+      source,
+      label: source === "base" ? "קרוב למחירון" : "קרוב לממוצע",
       color: "text-muted-foreground",
     };
   }
   return {
-    pctDiff,
+    diffPercent,
     absDiff,
-    label: `${-pctDiff}% מעל השוק`,
+    isBelow,
+    source,
+    label:
+      source === "base"
+        ? `${-diffPercent}% מעל המחירון`
+        : `${-diffPercent}% מעל הממוצע`,
     color: "text-amber-500",
   };
+}
+
+/** Compare listing price to Yad2 price list (base) when present, else to cohort median. */
+export function marketComparison(
+  price: number,
+  medianPrice?: number,
+  basePrice?: number,
+): MarketComparison | null {
+  if (basePrice != null && basePrice > 0) {
+    return marketComparisonAgainstRef(price, basePrice, "base");
+  }
+  if (medianPrice != null && medianPrice > 0) {
+    return marketComparisonAgainstRef(price, medianPrice, "median");
+  }
+  return null;
 }
 
 export function relativeTime(dateStr: string): string {

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -229,7 +229,12 @@ function ListingDetailContent({
       </div>
 
       {/* Market value comparison */}
-      <MarketValueCard price={listing.price} medianPrice={listing.median_price} cohortSize={listing.cohort_size} />
+      <MarketValueCard
+        price={listing.price}
+        medianPrice={listing.median_price}
+        basePrice={listing.base_price}
+        cohortSize={listing.cohort_size}
+      />
 
       {/* Vehicle specs grid */}
       {hasVehicleSpecs && (
@@ -309,63 +314,71 @@ function ListingDetailContent({
 function MarketValueCard({
   price,
   medianPrice,
+  basePrice,
   cohortSize,
 }: {
   price: number;
   medianPrice?: number;
+  basePrice?: number;
   cohortSize?: number;
 }) {
-  const mc = marketComparison(price, medianPrice);
-  if (!mc || !medianPrice) return null;
+  const hasBase = basePrice != null && basePrice > 0;
+  const hasMedian = medianPrice != null && medianPrice > 0;
 
-  const ratio = Math.min(Math.max(price / medianPrice, 0.5), 1.5);
+  if (!hasBase && !hasMedian) return null;
+
+  const referenceForBar = hasBase ? basePrice! : medianPrice!;
+  const mc = marketComparison(price, medianPrice, basePrice);
+  if (!mc) return null;
+
+  const ratio = Math.min(Math.max(price / referenceForBar, 0.5), 1.5);
   const pct = ((ratio - 0.5) / 1.0) * 100;
+
+  const barTint =
+    mc.diffPercent > 5
+      ? "bg-emerald-500/30"
+      : mc.diffPercent >= -5
+        ? "bg-muted-foreground/20"
+        : "bg-amber-500/30";
+  const markerTint =
+    mc.diffPercent > 5
+      ? "bg-emerald-500"
+      : mc.diffPercent >= -5
+        ? "bg-muted-foreground"
+        : "bg-amber-500";
 
   return (
     <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-3">
       <div className="flex items-baseline justify-between gap-2">
-        <h2 className="text-sm font-semibold text-foreground">שווי שוק</h2>
+        <h2 className="text-sm font-semibold text-foreground">
+          {hasBase ? "מחירון Yad2" : "שווי שוק"}
+        </h2>
         <span className="text-xl font-bold tabular-nums text-foreground">
-          {formatPrice(medianPrice)}
+          {formatPrice(referenceForBar)}
         </span>
       </div>
 
       <div className="flex items-baseline justify-between gap-2">
-        <span className={cn("text-sm font-medium", mc.color)}>
-          {mc.absDiff > 0
-            ? `₪${Math.abs(mc.absDiff).toLocaleString("he-IL")} ${mc.pctDiff > 5 ? "מתחת" : mc.pctDiff >= -5 ? "קרוב" : "מעל"} לשוק`
-            : mc.label}
-        </span>
+        <span className={cn("text-sm font-medium", mc.color)}>{mc.label}</span>
         <span className={cn("text-sm font-semibold tabular-nums", mc.color)}>
-          {mc.pctDiff > 5
-            ? `${mc.pctDiff}%−`
-            : mc.pctDiff >= -5
+          {mc.diffPercent > 5
+            ? `${mc.diffPercent}%−`
+            : mc.diffPercent >= -5
               ? "≈"
-              : `${-mc.pctDiff}%+`}
+              : `${-mc.diffPercent}%+`}
         </span>
       </div>
 
-      {/* Visual bar */}
+      {/* Visual bar — listing vs reference (Yad2 price list or cohort median) */}
       <div className="relative h-2 rounded-full bg-secondary overflow-hidden">
         <div
-          className={cn(
-            "absolute inset-y-0 start-0 rounded-full transition-all",
-            mc.pctDiff > 5
-              ? "bg-emerald-500/30"
-              : mc.pctDiff >= -5
-                ? "bg-muted-foreground/20"
-                : "bg-amber-500/30",
-          )}
+          className={cn("absolute inset-y-0 start-0 rounded-full transition-all", barTint)}
           style={{ width: `${pct}%` }}
         />
         <div
           className={cn(
             "absolute top-1/2 -translate-y-1/2 h-4 w-1 rounded-full",
-            mc.pctDiff > 5
-              ? "bg-emerald-500"
-              : mc.pctDiff >= -5
-                ? "bg-muted-foreground"
-                : "bg-amber-500",
+            markerTint,
           )}
           style={{ insetInlineStart: `${pct}%` }}
         />
@@ -376,8 +389,17 @@ function MarketValueCard({
       </div>
       <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums">
         <span>{formatPrice(price)}</span>
-        <span>חציון</span>
+        <span>{hasBase ? "מחירון" : "חציון"}</span>
       </div>
+
+      {hasBase && hasMedian ? (
+        <p className="text-xs text-muted-foreground text-center">
+          מחיר ממוצע במודעות:{" "}
+          <span className="tabular-nums font-medium text-foreground/90">
+            {formatPrice(medianPrice!)}
+          </span>
+        </p>
+      ) : null}
 
       {cohortSize != null && cohortSize > 0 && (
         <p className="text-[11px] text-muted-foreground text-center">


### PR DESCRIPTION
## Summary

- Captures `sub_model_id` from Yad2 feed JSON and uses it to look up official base prices (מחירון) via a new `PriceListService` with Go HTTP fetch + Python scraper fallback, cached in `price_list_cache` (7-day TTL, rate-limited to 20 lookups/cycle)
- Displays the official base price as the **primary** market value indicator in the web UI (MarketValueCard, deal tags), Telegram notifications, and API responses — the existing median-from-listings is shown as secondary context
- Full-stack change spanning data model, migration 000006, storage interfaces (Postgres + SQLite), scheduler enrichment, API responses, frontend components, Telegram locale strings, and Dockerfile

## Architecture

```
Yad2 Feed → parser (captures sub_model_id) → scheduler
  → PriceListService.Lookup(sub_model_id, year)
    → cache hit? return
    → Go HTTP fetch (HTML parse / __NEXT_DATA__)
    → Python scraper fallback (undetected_chromedriver)
    → store in price_list_cache
  → base_price on ListingRecord → API → Web UI / Telegram
```

## What changed

| Layer | Files | What |
|-------|-------|------|
| Data model | `model/listing.go`, `storage/interfaces.go` | `SubModelID`, `BasePrice` fields; `PriceListStore` interface |
| Migration | `migrations/000006_*` | `sub_model_id`, `base_price` columns + `price_list_cache` table |
| Storage | `postgres/`, `sqlite/` listings, admin, notifications, pricelist | Updated upsert/scan for new columns; `PriceListStore` impl |
| Service | `internal/pricelist/` | `service.go` (cache + rate limit), `fetcher.go` (Go HTTP + Python fallback) |
| Scheduler | `scheduler.go` | `enrichWithBasePrice` after scoring; cycle counter reset |
| API | `api/listings.go`, `api/bookmarks.go` | `base_price` in JSON responses |
| Frontend | `utils.ts`, `ListingCardBody.tsx`, `ListingDetailPage.tsx` | `marketComparison` prioritizes base price; redesigned MarketValueCard |
| Telegram | `formatter.go`, `locale/scoring.go` | `basePriceLine`; he/en מחירון strings |
| Docker | `Dockerfile` | Copies `scripts/yad2_price_scraper.py` into image |

## Test plan

- [x] `make test` — all Go packages pass (65.4% coverage)
- [x] `npx vitest run` — all 116 frontend tests pass (includes new `marketComparison` tests)
- [x] `golangci-lint run ./...` — clean
- [x] `npm run build` — frontend builds successfully
- [ ] Deploy to staging, verify price list lookups populate for listings with known sub_model_ids
- [ ] Verify MarketValueCard shows "מחירון Yad2" as primary when base_price exists
- [ ] Verify Telegram notifications include מחירון line


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added base price comparison for listings, showing how prices compare against manufacturer reference prices when available.
  * Implemented price-list caching to reduce external fetch requests and improve performance.

* **Improvements**
  * Enhanced market comparison logic to prioritize base prices over median prices for more accurate pricing context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/658)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->