### PR TITLE
fix: align firebase service account filename

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -32,7 +32,7 @@ services:
       - carwatch-data:/data
       - ./config.yaml:/config.yaml:ro
       - ./migrations:/migrations:ro
-      - ./firebase-sa.json:/config/firebase-sa.json:ro
+      - ./firebase-service-account.json:/config/firebase-sa.json:ro
     environment:
       - TZ=Asia/Jerusalem
       - CARWATCH_DOMAIN=${CARWATCH_DOMAIN}

--- a/docs/ops/backup-and-recovery.md
+++ b/docs/ops/backup-and-recovery.md
@@ -129,7 +129,7 @@ start again:
 3. Create the config:
 
    ```bash
-   scp config.yaml firebase-sa.json <user>@<new-ip>:~/carwatch/
+   scp config.yaml firebase-service-account.json <user>@<new-ip>:~/carwatch/
    ```
 
 4. Start the container (creates the named volume with an empty DB):


### PR DESCRIPTION
## Summary
- update the production compose mount to use the ignored `firebase-service-account.json` host filename
- update the VM recovery docs to copy the same credential filename
- keep the in-container path `/config/firebase-sa.json` unchanged so existing app config can continue to point there

Closes #672

## Validation
- `rg -n "firebase-sa\.json|firebase-service-account\.json|firebase-service-account\*" docker-compose.prod.yaml docs .gitignore -S`
- `POSTGRES_PASSWORD=dummy CARWATCH_DOMAIN=example.com TELEGRAM_BOT_TOKEN=dummy docker compose -f docker-compose.prod.yaml config`
- `git diff --check`

The dummy environment values are only for compose interpolation during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Firebase service account configuration file naming throughout the production environment.

* **Documentation**
  * Updated backup and recovery documentation, including VM rebuild procedures, to align with configuration updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/693)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->