### PR TITLE
fix: prevent fitness_score wipe and fix enrichment data semantics

### DIFF
--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -55,7 +55,7 @@ const upsertListingSQL = `
 		gear_box = CASE WHEN EXCLUDED.gear_box != '' THEN EXCLUDED.gear_box ELSE listing_history.gear_box END,
 		description = CASE WHEN EXCLUDED.description != '' THEN EXCLUDED.description ELSE listing_history.description END,
 		is_commercial = COALESCE(EXCLUDED.is_commercial, listing_history.is_commercial),
-		fitness_score = EXCLUDED.fitness_score,
+		fitness_score = COALESCE(EXCLUDED.fitness_score, listing_history.fitness_score),
 		median_price = COALESCE(EXCLUDED.median_price, listing_history.median_price),
 		cohort_size = COALESCE(EXCLUDED.cohort_size, listing_history.cohort_size),
 		deal_score = COALESCE(EXCLUDED.deal_score, listing_history.deal_score),
@@ -195,10 +195,10 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 			placeholders[i] = fmt.Sprintf("$%d", i+1)
 		}
 
-		q := `SELECT token, MAX(km), MAX(city), MAX(image_url)
+		q := `SELECT DISTINCT ON (token) token, km, city, image_url
 			FROM listing_history
 			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
-			GROUP BY token`
+			ORDER BY token, first_seen_at DESC`
 
 		rows, err := s.db.QueryContext(ctx, q, args...)
 		if err != nil {

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -305,7 +305,7 @@ func (s *Store) AdminListPriceHistory(ctx context.Context, limit, offset int, to
 			LEFT JOIN (
 				SELECT token, manufacturer, model, year
 				FROM listing_history
-				GROUP BY token
+				WHERE rowid IN (SELECT MAX(rowid) FROM listing_history GROUP BY token)
 			) lh ON ph.token = lh.token
 			WHERE ph.token = ?
 			ORDER BY ph.observed_at DESC
@@ -319,7 +319,7 @@ func (s *Store) AdminListPriceHistory(ctx context.Context, limit, offset int, to
 			LEFT JOIN (
 				SELECT token, manufacturer, model, year
 				FROM listing_history
-				GROUP BY token
+				WHERE rowid IN (SELECT MAX(rowid) FROM listing_history GROUP BY token)
 			) lh ON ph.token = lh.token
 			ORDER BY ph.observed_at DESC
 			LIMIT ? OFFSET ?`

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -36,7 +36,7 @@ const upsertListingSQL = `
 		gear_box = CASE WHEN excluded.gear_box != '' THEN excluded.gear_box ELSE listing_history.gear_box END,
 		description = CASE WHEN excluded.description != '' THEN excluded.description ELSE listing_history.description END,
 		is_commercial = COALESCE(excluded.is_commercial, listing_history.is_commercial),
-		fitness_score = excluded.fitness_score,
+		fitness_score = COALESCE(excluded.fitness_score, listing_history.fitness_score),
 		median_price = COALESCE(excluded.median_price, listing_history.median_price),
 		cohort_size = COALESCE(excluded.cohort_size, listing_history.cohort_size),
 		deal_score = COALESCE(excluded.deal_score, listing_history.deal_score),
@@ -176,10 +176,13 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 			placeholders[i] = "?"
 		}
 
-		q := `SELECT token, MAX(km), MAX(city), MAX(image_url)
+		q := `SELECT token, km, city, image_url
 			FROM listing_history
-			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
-			GROUP BY token`
+			WHERE rowid IN (
+				SELECT MAX(rowid) FROM listing_history
+				WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
+				GROUP BY token
+			)`
 
 		rows, err := s.db.QueryContext(ctx, q, args...)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Use COALESCE for `fitness_score` in upsert conflict to preserve existing score when incoming value is NULL (both Postgres and SQLite)
- Replace lexicographic `MAX(city)`/`MAX(image_url)` in `LookupEnrichmentData` with most-recent-row semantics (`DISTINCT ON` for Postgres, `MAX(rowid)` subquery for SQLite)
- Fix SQLite `AdminListPriceHistory` to use `MAX(rowid)` subquery instead of non-deterministic `GROUP BY` for listing metadata join

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/storage/...` passes
- [ ] Verify fitness scores persist across re-saves in staging

Closes #659, #687, #692

Made with [Cursor](https://cursor.com)