### PR TITLE
fix: prevent bot crashes from unchecked type assertions and nil bot

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -198,6 +198,7 @@ func (b *Bot) rateLimited(next tgbot.HandlerFunc) tgbot.HandlerFunc {
 
 func (b *Bot) RegisterHandlers() {
 	if b.bot == nil {
+		b.logger.Warn("RegisterHandlers called with nil bot instance, skipping")
 		return
 	}
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/start", tgbot.MatchTypePrefix, b.rateLimited(b.handleStart))
@@ -253,15 +254,21 @@ func (b *Bot) sendWithKeyboard(ctx context.Context, chatID int64, text string, k
 }
 
 func (b *Bot) lockChat(chatID int64) func() {
-	v, _ := b.chatMu.LoadOrStore(chatID, &chatMuEntry{})
-	entry, ok := v.(*chatMuEntry)
-	if !ok {
-		entry = &chatMuEntry{}
-		b.chatMu.Store(chatID, entry)
+	for {
+		v, _ := b.chatMu.LoadOrStore(chatID, &chatMuEntry{})
+		entry, ok := v.(*chatMuEntry)
+		if ok {
+			entry.mu.Lock()
+			entry.lastUsed.Store(time.Now().UnixNano())
+			return entry.mu.Unlock
+		}
+		candidate := &chatMuEntry{}
+		if b.chatMu.CompareAndSwap(chatID, v, candidate) {
+			candidate.mu.Lock()
+			candidate.lastUsed.Store(time.Now().UnixNano())
+			return candidate.mu.Unlock
+		}
 	}
-	entry.mu.Lock()
-	entry.lastUsed.Store(time.Now().UnixNano())
-	return entry.mu.Unlock
 }
 
 const staleThreshold = 1 * time.Hour

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -197,6 +197,9 @@ func (b *Bot) rateLimited(next tgbot.HandlerFunc) tgbot.HandlerFunc {
 }
 
 func (b *Bot) RegisterHandlers() {
+	if b.bot == nil {
+		return
+	}
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/start", tgbot.MatchTypePrefix, b.rateLimited(b.handleStart))
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/watch", tgbot.MatchTypeExact, b.rateLimited(b.handleWatch))
 	b.bot.RegisterHandler(tgbot.HandlerTypeMessageText, "/list", tgbot.MatchTypeExact, b.rateLimited(b.handleList))
@@ -251,7 +254,11 @@ func (b *Bot) sendWithKeyboard(ctx context.Context, chatID int64, text string, k
 
 func (b *Bot) lockChat(chatID int64) func() {
 	v, _ := b.chatMu.LoadOrStore(chatID, &chatMuEntry{})
-	entry := v.(*chatMuEntry)
+	entry, ok := v.(*chatMuEntry)
+	if !ok {
+		entry = &chatMuEntry{}
+		b.chatMu.Store(chatID, entry)
+	}
 	entry.mu.Lock()
 	entry.lastUsed.Store(time.Now().UnixNano())
 	return entry.mu.Unlock
@@ -299,7 +306,11 @@ func (b *Bot) sweepStaleMaps() {
 	})
 
 	b.chatMu.Range(func(key, value any) bool {
-		entry := value.(*chatMuEntry)
+		entry, ok := value.(*chatMuEntry)
+		if !ok {
+			b.chatMu.CompareAndDelete(key, value)
+			return true
+		}
 		if !entry.mu.TryLock() {
 			return true
 		}


### PR DESCRIPTION
## Summary
- Add comma-ok pattern to `sync.Map` type assertions in `lockChat` and `sweepStaleMaps` to prevent panics on unexpected value types
- Add nil guard in `RegisterHandlers` to prevent panic when bot instance is nil

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/bot/...` passes

Closes #667, #668

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application stability with improved safeguards against potential runtime errors.
  * Strengthened handler registration to prevent failures when bot initialization encounters issues.
  * Hardened internal data management operations to prevent crashes during background maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/695)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->