### PR TITLE
fix: frontend bugs and health check false-positive 503

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -161,6 +161,7 @@ func run(configPath string, logger *slog.Logger) error {
 		"health", "http://"+cfg.HTTP.Bind+"/healthz",
 	)
 
+	h.MarkSchedulerStarted()
 	return sched.Run(ctx)
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -46,6 +46,7 @@ type Status struct {
 	lastSuccessUnixNs atomic.Int64
 	listingsFound     atomic.Int64
 	notificationsSent atomic.Int64
+	schedulerStarted  atomic.Bool
 
 	sourceMu sync.RWMutex
 	sources  map[string]*SourceMetrics
@@ -91,6 +92,10 @@ func (s *Status) SetDBSizer(d DBSizer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.dbSizer = d
+}
+
+func (s *Status) MarkSchedulerStarted() {
+	s.schedulerStarted.Store(true)
 }
 
 func (s *Status) RecordSuccess() {
@@ -164,7 +169,7 @@ func (s *Status) coreMetrics() map[string]any {
 
 	status := "ok"
 	uptime := time.Since(s.startTime)
-	if cycles > 0 && (lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold) {
+	if s.schedulerStarted.Load() && cycles > 0 && (lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold) {
 		if uptime > startupGracePeriod {
 			status = "degraded"
 		} else {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -291,6 +291,7 @@ func TestStatus_NoSourcesBeforeFetch(t *testing.T) {
 
 func TestStatus_StartingDuringGracePeriod(t *testing.T) {
 	s := New()
+	s.MarkSchedulerStarted()
 	s.RecordError()
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
@@ -313,6 +314,7 @@ func TestStatus_StartingDuringGracePeriod(t *testing.T) {
 func TestStatus_DegradedAfterGracePeriod(t *testing.T) {
 	s := New()
 	s.startTime = time.Now().Add(-10 * time.Minute)
+	s.MarkSchedulerStarted()
 	s.RecordError()
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)

--- a/web/src/components/admin/ActivityChart.tsx
+++ b/web/src/components/admin/ActivityChart.tsx
@@ -52,12 +52,12 @@ export function ActivityChart() {
         <AreaChart data={formatted} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
           <defs>
             <linearGradient id="gradListings" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0} />
+              <stop offset="5%" stopColor="var(--color-chart-1)" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="var(--color-chart-1)" stopOpacity={0} />
             </linearGradient>
             <linearGradient id="gradPriceDrops" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="hsl(var(--chart-2))" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="hsl(var(--chart-2))" stopOpacity={0} />
+              <stop offset="5%" stopColor="var(--color-chart-2)" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="var(--color-chart-2)" stopOpacity={0} />
             </linearGradient>
           </defs>
           <CartesianGrid strokeDasharray="3 3" className="stroke-border/30" />
@@ -65,10 +65,10 @@ export function ActivityChart() {
           <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" />
           <Tooltip
             contentStyle={{
-              backgroundColor: "hsl(var(--popover))",
-              border: "1px solid hsl(var(--border))",
+              backgroundColor: "var(--color-popover)",
+              border: "1px solid var(--color-border)",
               borderRadius: "0.5rem",
-              color: "hsl(var(--popover-foreground))",
+              color: "var(--color-popover-foreground)",
               fontSize: 13,
             }}
           />
@@ -77,7 +77,7 @@ export function ActivityChart() {
             type="monotone"
             dataKey="new_listings"
             name="מודעות חדשות"
-            stroke="hsl(var(--chart-1))"
+            stroke="var(--color-chart-1)"
             fill="url(#gradListings)"
             strokeWidth={2}
           />
@@ -85,7 +85,7 @@ export function ActivityChart() {
             type="monotone"
             dataKey="price_drops"
             name="ירידות מחיר"
-            stroke="hsl(var(--chart-2))"
+            stroke="var(--color-chart-2)"
             fill="url(#gradPriceDrops)"
             strokeWidth={2}
           />

--- a/web/src/components/admin/ListingsTab.tsx
+++ b/web/src/components/admin/ListingsTab.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   AlertCircle,
   Car,
@@ -34,11 +34,9 @@ export function ListingsTab({
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  const prevSearchId = useRef(searchId);
-  if (prevSearchId.current !== searchId) {
-    prevSearchId.current = searchId;
+  useEffect(() => {
     setPage(0);
-  }
+  }, [searchId]);
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ["admin", "listings", page, searchId],

--- a/web/src/components/landing/LandingNav.tsx
+++ b/web/src/components/landing/LandingNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Link } from "react-router";
 import { Car, Sun, Moon, Menu, X } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
@@ -9,12 +9,50 @@ export function LandingNav() {
   const mobileMenuId = useId();
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const menuToggleRef = useRef<HTMLButtonElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const fn = () => setScrolled(window.scrollY > 20);
     fn();
     window.addEventListener("scroll", fn);
     return () => window.removeEventListener("scroll", fn);
+  }, []);
+
+  useEffect(() => {
+    if (!mobileOpen || !mobileMenuRef.current) return;
+
+    const menu = mobileMenuRef.current;
+    const focusable = menu.querySelectorAll<HTMLElement>(
+      'a[href], button, [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusable.length > 0) focusable[0].focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileOpen(false);
+        menuToggleRef.current?.focus();
+        return;
+      }
+      if (e.key !== "Tab" || focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [mobileOpen]);
+
+  const closeMobileMenu = useCallback(() => {
+    setMobileOpen(false);
+    menuToggleRef.current?.focus();
   }, []);
 
   const links = [
@@ -73,6 +111,7 @@ export function LandingNav() {
             התחל עכשיו
           </Link>
           <button
+            ref={menuToggleRef}
             type="button"
             onClick={() => setMobileOpen((o) => !o)}
             className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground lg:hidden"
@@ -86,6 +125,7 @@ export function LandingNav() {
       </div>
 
       <div
+        ref={mobileMenuRef}
         id={mobileMenuId}
         role="navigation"
         aria-label="ניווט ראשי — נייד"
@@ -97,7 +137,7 @@ export function LandingNav() {
             <a
               key={l.href}
               href={l.href}
-              onClick={() => setMobileOpen(false)}
+              onClick={closeMobileMenu}
               className="block py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               {l.label}
@@ -105,7 +145,7 @@ export function LandingNav() {
           ))}
           <Link
             to="/signup"
-            onClick={() => setMobileOpen(false)}
+            onClick={closeMobileMenu}
             className="mt-2 block w-full rounded-xl bg-primary py-2.5 text-center text-sm font-semibold text-white"
           >
             התחל עכשיו

--- a/web/src/components/landing/SmartScoreSection.tsx
+++ b/web/src/components/landing/SmartScoreSection.tsx
@@ -58,19 +58,19 @@ const factors = [
     icon: TrendingUp,
     label: "מחיר מול תקציב",
     desc: "ציון גבוה לרכבים שנמצאים מתחת לתקציב שהגדרת",
-    weight: "35%",
+    weight: "25%",
   },
   {
     icon: Gauge,
     label: "קילומטרז",
     desc: "ק\"מ מותאם לגיל הרכב — פחות בלאי ביחס לצפוי = ציון גבוה",
-    weight: "25%",
+    weight: "30%",
   },
   {
     icon: Calendar,
     label: "שנת ייצור",
     desc: "רכבים חדשים יותר בטווח המבוקש מקבלים עדיפות",
-    weight: "15%",
+    weight: "20%",
   },
   {
     icon: Users,

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -155,4 +155,10 @@ describe("relativeTime", () => {
   it("returns dash for invalid date", () => {
     expect(relativeTime("not-a-date")).toBe("—");
   });
+
+  it("returns formatted date for future timestamps", () => {
+    const result = relativeTime("2026-06-10T06:00:00Z");
+    expect(result).not.toBe("היום");
+    expect(result.length).toBeGreaterThan(0);
+  });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -103,7 +103,10 @@ export function relativeTime(dateStr: string): string {
   if (Number.isNaN(date.getTime())) return "—";
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
+  if (diffMs < 0) {
+    return date.toLocaleDateString("he-IL");
+  }
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
   if (diffDays === 0) return "היום";
   if (diffDays === 1) return "אתמול";

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
-import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MutationCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { AuthProvider } from "./contexts/AuthContext";
@@ -17,13 +17,9 @@ const queryClient = new QueryClient({
       retry: 1,
     },
   },
-  queryCache: new QueryCache({
-    onError: (error) => {
-      showGlobalToast(errorToHebrew(error), "error");
-    },
-  }),
   mutationCache: new MutationCache({
-    onError: (error) => {
+    onError: (error, _variables, _context, mutation) => {
+      if (mutation.options.meta?.suppressToast) return;
       showGlobalToast(errorToHebrew(error), "error");
     },
   }),


### PR DESCRIPTION
## Summary
- Remove global `QueryCache.onError` toast to prevent duplicate error messages; keep mutation toast with `meta.suppressToast` opt-out
- Fix `ActivityChart` CSS variables to use Tailwind v4 token names (`var(--color-chart-N)`)
- Move `ListingsTab` page reset from render-time `setState` to `useEffect`
- Align SmartScore landing page weights with actual scoring algorithm
- Handle future timestamps in `relativeTime` (return formatted date instead of "today")
- Add focus trap to mobile nav drawer with Escape key support and return-focus
- Only mark health as degraded after scheduler has started (prevent false-positive 503)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/health/...` passes
- [x] `npx vitest run` — all 117 tests pass

Closes #660, #661, #662, #680, #685, #686, #691

Made with [Cursor](https://cursor.com)