### PR TITLE
fix: notification reliability — fallback on unknown channel, add tilde escape

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -11,6 +11,7 @@ var telegramMarkdownEscaper = strings.NewReplacer(
 	"[", "\\[",
 	"]", "\\]",
 	"`", "\\`",
+	"~", "\\~",
 )
 
 func EscapeMarkdown(s string) string {

--- a/internal/notifier/multi.go
+++ b/internal/notifier/multi.go
@@ -90,8 +90,7 @@ func (m *MultiNotifier) resolve(ctx context.Context, recipient string) (Notifier
 			if n, ok := m.notifiers[user.Channel]; ok {
 				return n, nil
 			}
-			m.logger.Debug("no notifier for channel, skipping push delivery", "recipient", recipient, "channel", user.Channel)
-			return nil, ErrNoChannelNotifier
+			m.logger.Warn("unknown channel, falling back to default", "recipient", recipient, "channel", user.Channel, "fallback", m.fallback)
 		}
 	}
 	if n := m.notifiers[m.fallback]; n != nil {


### PR DESCRIPTION
## Summary
- MultiNotifier now falls back to default channel (Telegram) when user's preferred channel has no registered notifier, instead of silently dropping notifications
- Add tilde (~) to Markdown V1 escaper to prevent strikethrough corruption

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/notifier/...` passes
- [x] `go test ./internal/format/...` passes

Closes #669, #670

Made with [Cursor](https://cursor.com)