### PR TITLE
fix: preserve SellerFilter through wizard edit flow

### DIFF
--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -502,6 +502,7 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 		MaxHand:          search.MaxHand,
 		Keywords:         search.Keywords,
 		ExcludeKeys:      search.ExcludeKeys,
+		SellerFilter:     search.SellerFilter,
 		EditSearchID:     search.ID,
 	}
 	b.saveWizardState(ctx, chatID, StateAskSource, wd)

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -305,6 +305,7 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 			MaxHand:      wd.MaxHand,
 			Keywords:     wd.Keywords,
 			ExcludeKeys:  wd.ExcludeKeys,
+			SellerFilter: wd.SellerFilter,
 		})
 		if err != nil {
 			b.logger.Error("update search failed", "error", err)
@@ -340,6 +341,7 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 		MaxHand:      wd.MaxHand,
 		Keywords:     wd.Keywords,
 		ExcludeKeys:  wd.ExcludeKeys,
+		SellerFilter: wd.SellerFilter,
 	})
 	if err != nil {
 		b.logger.Error("create search failed", "error", err)

--- a/internal/botcore/state.go
+++ b/internal/botcore/state.go
@@ -32,5 +32,6 @@ type WizardData struct {
 	MaxHand          int    `json:"max_hand,omitempty"`
 	Keywords         string `json:"keywords,omitempty"`
 	ExcludeKeys      string `json:"exclude_keys,omitempty"`
+	SellerFilter     string `json:"seller_filter,omitempty"`
 	EditSearchID     int64  `json:"edit_search_id,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add `SellerFilter` field to `WizardData` so it persists through wizard JSON state
- Include `SellerFilter` in `handleEdit` when populating from existing search
- Pass `SellerFilter` through in both `CreateSearch` and `UpdateSearch` paths of `onConfirm`

Note: #673 (filter.Apply mutation) was a false positive — `Apply` already copies slices correctly via `make`. #679 (duplicate search name race) is mitigated by per-chat `lockChat` serialization and deferred to a future PR if needed.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/bot/...` passes
- [x] `go test ./internal/botcore/...` passes

Closes #673, #674, #679

Made with [Cursor](https://cursor.com)