### PR TITLE
fix: scheduler digest cache TTL, scoring empty dimensions, pricelist heuristic

### DIFF
--- a/internal/pricelist/fetcher.go
+++ b/internal/pricelist/fetcher.go
@@ -89,18 +89,6 @@ func extractPriceFromHTML(html string) fetchResult {
 		}
 	}
 
-	// Strategy 3: find all ₪ prices and pick the largest > 1000
-	matches := priceRe.FindAllStringSubmatch(html, -1)
-	var best int
-	for _, m := range matches {
-		if p := parsePrice(m[1]); p > 1000 && p > best {
-			best = p
-		}
-	}
-	if best > 0 {
-		return fetchResult{BasePrice: best}
-	}
-
 	return fetchResult{Error: "no price found in HTML"}
 }
 

--- a/internal/pricelist/fetcher.go
+++ b/internal/pricelist/fetcher.go
@@ -14,7 +14,6 @@ import (
 	"time"
 )
 
-var priceRe = regexp.MustCompile(`₪\s*([\d,]+)`)
 var basePriceLabelRe = regexp.MustCompile(`(?i)מחיר\s+בסיס[^₪]*₪\s*([\d,]+)`)
 
 // fetch tries Go HTTP first, then falls back to the Python scraper.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -86,7 +86,10 @@ type Scheduler struct {
 type digestMeta struct {
 	mode     string
 	interval string
+	cachedAt time.Time
 }
+
+const digestCacheTTL = 5 * time.Minute
 
 // Stores groups all storage interfaces the scheduler depends on.
 type Stores struct {
@@ -282,11 +285,14 @@ func (s *Scheduler) Run(ctx context.Context) error {
 func (s *Scheduler) deliveryFor(ctx context.Context, chatID int64, lang locale.Lang) DeliveryStrategy {
 	if s.stores.Digests != nil {
 		var mode string
+		needFetch := true
 		if v, ok := s.digestCache.Load(chatID); ok {
-			if dm, ok := v.(digestMeta); ok {
+			if dm, ok := v.(digestMeta); ok && time.Since(dm.cachedAt) < digestCacheTTL {
 				mode = dm.mode
+				needFetch = false
 			}
-		} else {
+		}
+		if needFetch {
 			m, interval, err := s.stores.Digests.GetDigestMode(ctx, chatID)
 			if err != nil {
 				if !errors.Is(err, storage.ErrNotFound) {
@@ -294,7 +300,7 @@ func (s *Scheduler) deliveryFor(ctx context.Context, chatID int64, lang locale.L
 				}
 			} else {
 				mode = m
-				s.digestCache.Store(chatID, digestMeta{mode: m, interval: interval})
+				s.digestCache.Store(chatID, digestMeta{mode: m, interval: interval, cachedAt: time.Now()})
 			}
 		}
 		if mode == "digest" {

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -274,7 +274,7 @@ func FitnessScoreDetailed(p FitnessParams) FitnessResult {
 		totalWeight += d.Weight
 	}
 	if totalWeight <= 0 {
-		return FitnessResult{Total: 5.0, Dims: dims}
+		return FitnessResult{Total: 0, Dims: dims}
 	}
 
 	var weighted float64
@@ -349,7 +349,7 @@ func kmScore(km, maxKm, carYear int) float64 {
 // handScore: base ladder plus a bonus for older cars where more owners are expected.
 func handScore(hand, maxHand, carYear int) float64 {
 	if hand <= 0 {
-		return 0.5
+		return math.NaN()
 	}
 	var base float64
 	if maxHand > 0 {


### PR DESCRIPTION
## Summary
- Add 5-minute TTL to digest cache entries so mode changes propagate faster
- Return 0 fitness score when no dimensions contribute instead of misleading 5.0
- Treat `hand <= 0` as unknown/omitted rather than returning 0.5
- Remove dangerous Strategy 3 price heuristic that could return wrong prices

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/scoring/...` passes
- [x] `go test ./internal/scheduler/...` passes (18s)

Closes #676, #677, #684

Made with [Cursor](https://cursor.com)