### PR TITLE
fix: storage housekeeping — orphan cleanup and DailyStats join

### DIFF
--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -241,6 +241,14 @@ func (s *Store) AdminDeleteUser(ctx context.Context, chatID int64) error {
 		}
 	}
 
+	recipientStr := fmt.Sprintf("%d", chatID)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM pending_notifications WHERE recipient = $1`, recipientStr); err != nil {
+		return fmt.Errorf("admin delete user pending_notifications: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM link_tokens WHERE web_chat_id = $1`, chatID); err != nil {
+		return fmt.Errorf("admin delete user link_tokens: %w", err)
+	}
+
 	if _, err := tx.ExecContext(ctx, `DELETE FROM users WHERE chat_id = $1`, chatID); err != nil {
 		return fmt.Errorf("admin delete user: %w", err)
 	}

--- a/internal/storage/postgres/digest.go
+++ b/internal/storage/postgres/digest.go
@@ -192,7 +192,7 @@ func (s *Store) DailyStats(ctx context.Context, chatID int64) ([]storage.DailySe
 			SELECT s.id AS search_id, s.name AS search_name,
 			       lh.price, lh.page_link, lh.first_seen_at
 			FROM listing_history lh
-			JOIN searches s ON s.name = lh.search_name AND s.chat_id = lh.chat_id
+			JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 			WHERE lh.chat_id = $1 AND s.active = true AND lh.price > 0
 		)
 		SELECT

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -250,6 +250,14 @@ func (s *Store) AdminDeleteUser(ctx context.Context, chatID int64) error {
 		}
 	}
 
+	recipientStr := fmt.Sprintf("%d", chatID)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM pending_notifications WHERE recipient = ?`, recipientStr); err != nil {
+		return fmt.Errorf("admin delete user pending_notifications: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM link_tokens WHERE web_chat_id = ?`, chatID); err != nil {
+		return fmt.Errorf("admin delete user link_tokens: %w", err)
+	}
+
 	if _, err := tx.ExecContext(ctx, "DELETE FROM users WHERE chat_id = ?", chatID); err != nil {
 		return fmt.Errorf("admin delete user: %w", err)
 	}

--- a/internal/storage/sqlite/digest.go
+++ b/internal/storage/sqlite/digest.go
@@ -154,7 +154,7 @@ func (s *Store) DailyStats(ctx context.Context, chatID int64) ([]storage.DailySe
 			SELECT s.id AS search_id, s.name AS search_name,
 			       lh.price, lh.page_link, lh.first_seen_at
 			FROM listing_history lh
-			JOIN searches s ON s.name = lh.search_name AND s.chat_id = lh.chat_id
+			JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 			WHERE lh.chat_id = ? AND s.active = true AND lh.price > 0
 		)
 		SELECT

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -1801,15 +1801,14 @@ func TestDailyStats_WithListings(t *testing.T) {
 	ctx := context.Background()
 	seedUser(t, store, 100)
 
-	_, _ = store.CreateSearch(ctx, storage.Search{
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "mazda-3", Source: "yad2",
 		Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024,
 	})
 
-	// Insert enough listings to pass the HAVING COUNT(*) >= 5 threshold.
 	for i := range 6 {
 		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: "tok" + string(rune('a'+i)), ChatID: 100, SearchName: "mazda-3",
+			Token: "tok" + string(rune('a'+i)), ChatID: 100, SearchID: searchID, SearchName: "mazda-3",
 			Manufacturer: "Mazda", Model: "3", Year: 2021,
 			Price: 90000 + i*5000, PageLink: "https://example.com/" + string(rune('a'+i)),
 		})
@@ -1849,15 +1848,14 @@ func TestDailyStats_BelowThreshold(t *testing.T) {
 	ctx := context.Background()
 	seedUser(t, store, 100)
 
-	_, _ = store.CreateSearch(ctx, storage.Search{
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
 		ChatID: 100, Name: "test", Source: "yad2",
 		Manufacturer: 1, Model: 1,
 	})
 
-	// Only 3 listings -- below the HAVING COUNT(*) >= 5 threshold
 	for i := range 3 {
 		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: "tok" + string(rune('a'+i)), ChatID: 100, SearchName: "test",
+			Token: "tok" + string(rune('a'+i)), ChatID: 100, SearchID: searchID, SearchName: "test",
 			Manufacturer: "Test", Model: "Car", Year: 2021, Price: 100000,
 		})
 	}


### PR DESCRIPTION
## Summary
- Delete `pending_notifications` and `link_tokens` rows when admin-deleting a user (both Postgres and SQLite)
- Fix `DailyStats` query to join on `search_id` instead of `search_name` to avoid incorrect aggregation when searches share the same name
- Update test data to include `SearchID` for DailyStats tests

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/storage/...` passes

Closes #675, #678, #671

Made with [Cursor](https://cursor.com)