### PR TITLE
fix: security hardening — XFF trust, CSP, secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
               - '.github/workflows/**'
               - 'docker-compose*.yaml'
 
+  secrets:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@44c470ffc35caa8b1eb3e8012ca53c2f2834e96d # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -174,12 +174,38 @@ func (rl *ipRateLimiter) cleanup(ctx context.Context) {
 	}
 }
 
+// privateNets defines CIDRs that are considered trusted proxy sources.
+var privateNets = func() []*net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8", "::1/128",
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, n, _ := net.ParseCIDR(cidr)
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+func isPrivateIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, n := range privateNets {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
 func extractIP(r *http.Request, trustProxy bool) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		host = r.RemoteAddr
 	}
-	if !trustProxy {
+	if !trustProxy || !isPrivateIP(host) {
 		return host
 	}
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -143,12 +143,24 @@ func TestExtractIP_RemoteAddr(t *testing.T) {
 func TestExtractIP_XForwardedFor(t *testing.T) {
 	t.Parallel()
 	r := &http.Request{
-		RemoteAddr: "198.51.100.2:9999",
-		Header:     http.Header{"X-Forwarded-For": {"10.0.0.1, 10.0.0.2"}},
+		RemoteAddr: "172.17.0.1:9999",
+		Header:     http.Header{"X-Forwarded-For": {"203.0.113.5, 10.0.0.2"}},
 	}
 	got := extractIP(r, true)
-	if got != "10.0.0.1" {
-		t.Fatalf("extractIP: got %q want %q", got, "10.0.0.1")
+	if got != "203.0.113.5" {
+		t.Fatalf("extractIP: got %q want %q", got, "203.0.113.5")
+	}
+}
+
+func TestExtractIP_XForwardedForUntrustedSource(t *testing.T) {
+	t.Parallel()
+	r := &http.Request{
+		RemoteAddr: "198.51.100.2:9999",
+		Header:     http.Header{"X-Forwarded-For": {"10.0.0.1"}},
+	}
+	got := extractIP(r, true)
+	if got != "198.51.100.2" {
+		t.Fatalf("extractIP: XFF should be ignored from non-private source, got %q want %q", got, "198.51.100.2")
 	}
 }
 

--- a/internal/spa/spa.go
+++ b/internal/spa/spa.go
@@ -14,7 +14,8 @@ func Handler(distFS fs.FS) http.Handler {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		// Reduce token leakage via Referer when navigating away from admin log streams, etc.
 		w.Header().Set("Referrer-Policy", "no-referrer")
-		// Vite + Firebase need relaxed script/connect; tightened default-src and object-src.
+		// Firebase Auth SDK requires 'unsafe-inline' for scripts; nonce-based CSP
+		// is not supported by Firebase's inline script injection.
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+
 				"script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com https://www.google.com; "+
@@ -25,7 +26,7 @@ func Handler(distFS fs.FS) http.Handler {
 				"https://securetoken.googleapis.com https://identitytoolkit.googleapis.com https://www.googleapis.com "+
 				"https://www.gstatic.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; "+
 				"frame-src https://accounts.google.com https://*.firebaseapp.com https://carwatch-5cabf.firebaseapp.com; "+
-				"frame-ancestors 'none'; base-uri 'self'; object-src 'none'")
+				"frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'")
 
 		path := strings.TrimPrefix(r.URL.Path, "/")
 


### PR DESCRIPTION
## Summary
- Only trust `X-Forwarded-For` from private/loopback IPs to prevent rate limit bypass via spoofed headers
- Add `form-action 'self'` to CSP and document Firebase's requirement for `unsafe-inline`
- Add gitleaks secret scanning step to CI workflow
- Share tokens documented as intentionally public (they ARE the share feature)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/api/...` passes (new test for untrusted XFF source)
- [x] `go test ./internal/spa/...` passes

Closes #665, #666, #681, #689

Made with [Cursor](https://cursor.com)