### PR TITLE
feat: add Price Only and Photo Only listing filters

### DIFF
--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -113,11 +113,13 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 
 func listingFilterFromSearch(sr *storage.Search) storage.ListingFilter {
 	f := storage.ListingFilter{
-		PriceMax: sr.PriceMax,
-		YearMin:  sr.YearMin,
-		YearMax:  sr.YearMax,
-		MaxKm:    sr.MaxKm,
-		MaxHand:  sr.MaxHand,
+		PriceMax:  sr.PriceMax,
+		YearMin:   sr.YearMin,
+		YearMax:   sr.YearMax,
+		MaxKm:     sr.MaxKm,
+		MaxHand:   sr.MaxHand,
+		PriceOnly: sr.PriceOnly,
+		PhotoOnly: sr.PhotoOnly,
 	}
 	switch storage.NormalizeSellerFilter(sr.SellerFilter) {
 	case storage.SellerFilterPrivate:

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -26,18 +26,22 @@ type createSearchRequest struct {
 	ExcludeKeys  string `json:"exclude_keys"`
 	// SellerFilter: any (default), private, commercial (also accepts dealer, dealership for commercial).
 	SellerFilter string `json:"seller_filter,omitempty"`
+	PriceOnly    bool   `json:"price_only,omitempty"`
+	PhotoOnly    bool   `json:"photo_only,omitempty"`
 }
 
 type updateSearchRequest struct {
-	YearMin     int    `json:"year_min"`
-	YearMax     int    `json:"year_max"`
-	PriceMax    int    `json:"price_max"`
-	EngineMinCC int    `json:"engine_min_cc"`
-	MaxKm       int    `json:"max_km"`
-	MaxHand     int    `json:"max_hand"`
-	Keywords    string `json:"keywords"`
-	ExcludeKeys string `json:"exclude_keys"`
+	YearMin      int     `json:"year_min"`
+	YearMax      int     `json:"year_max"`
+	PriceMax     int     `json:"price_max"`
+	EngineMinCC  int     `json:"engine_min_cc"`
+	MaxKm        int     `json:"max_km"`
+	MaxHand      int     `json:"max_hand"`
+	Keywords     string  `json:"keywords"`
+	ExcludeKeys  string  `json:"exclude_keys"`
 	SellerFilter *string `json:"seller_filter,omitempty"`
+	PriceOnly    *bool   `json:"price_only,omitempty"`
+	PhotoOnly    *bool   `json:"photo_only,omitempty"`
 }
 
 type searchResponse struct {
@@ -57,6 +61,8 @@ type searchResponse struct {
 	Keywords         string `json:"keywords,omitempty"`
 	ExcludeKeys      string `json:"exclude_keys,omitempty"`
 	SellerFilter     string `json:"seller_filter,omitempty"`
+	PriceOnly        bool   `json:"price_only,omitempty"`
+	PhotoOnly        bool   `json:"photo_only,omitempty"`
 	Active           bool   `json:"active"`
 	CreatedAt        string `json:"created_at"`
 	ListingsCount    int64  `json:"listings_count"`
@@ -136,6 +142,8 @@ func (s *Server) toSearchResponse(sr storage.Search) searchResponse {
 		Keywords:         sr.Keywords,
 		ExcludeKeys:      sr.ExcludeKeys,
 		SellerFilter:     storage.NormalizeSellerFilter(sr.SellerFilter),
+		PriceOnly:        sr.PriceOnly,
+		PhotoOnly:        sr.PhotoOnly,
 		Active:           sr.Active,
 		CreatedAt:        sr.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 	}
@@ -266,6 +274,8 @@ func createSearchRecord(chatID int64, name string, req createSearchRequest) stor
 		Keywords:     splitKeywords(req.Keywords),
 		ExcludeKeys:  splitKeywords(req.ExcludeKeys),
 		SellerFilter: storage.NormalizeSellerFilter(req.SellerFilter),
+		PriceOnly:    req.PriceOnly,
+		PhotoOnly:    req.PhotoOnly,
 		Active:       true,
 	}
 }
@@ -395,6 +405,12 @@ func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
 	existing.ExcludeKeys = splitKeywords(req.ExcludeKeys)
 	if req.SellerFilter != nil {
 		existing.SellerFilter = storage.NormalizeSellerFilter(*req.SellerFilter)
+	}
+	if req.PriceOnly != nil {
+		existing.PriceOnly = *req.PriceOnly
+	}
+	if req.PhotoOnly != nil {
+		existing.PhotoOnly = *req.PhotoOnly
 	}
 
 	if err := s.searches.UpdateSearch(r.Context(), *existing); err != nil {

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -502,6 +502,9 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 		MaxHand:          search.MaxHand,
 		Keywords:         search.Keywords,
 		ExcludeKeys:      search.ExcludeKeys,
+		SellerFilter:     search.SellerFilter,
+		PriceOnly:        search.PriceOnly,
+		PhotoOnly:        search.PhotoOnly,
 		EditSearchID:     search.ID,
 	}
 	b.saveWizardState(ctx, chatID, StateAskSource, wd)

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -305,6 +305,9 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 			MaxHand:      wd.MaxHand,
 			Keywords:     wd.Keywords,
 			ExcludeKeys:  wd.ExcludeKeys,
+			SellerFilter: wd.SellerFilter,
+			PriceOnly:    wd.PriceOnly,
+			PhotoOnly:    wd.PhotoOnly,
 		})
 		if err != nil {
 			b.logger.Error("update search failed", "error", err)
@@ -340,6 +343,9 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 		MaxHand:      wd.MaxHand,
 		Keywords:     wd.Keywords,
 		ExcludeKeys:  wd.ExcludeKeys,
+		SellerFilter: wd.SellerFilter,
+		PriceOnly:    wd.PriceOnly,
+		PhotoOnly:    wd.PhotoOnly,
 	})
 	if err != nil {
 		b.logger.Error("create search failed", "error", err)

--- a/internal/botcore/state.go
+++ b/internal/botcore/state.go
@@ -32,5 +32,8 @@ type WizardData struct {
 	MaxHand          int    `json:"max_hand,omitempty"`
 	Keywords         string `json:"keywords,omitempty"`
 	ExcludeKeys      string `json:"exclude_keys,omitempty"`
+	SellerFilter     string `json:"seller_filter,omitempty"`
+	PriceOnly        bool   `json:"price_only,omitempty"`
+	PhotoOnly        bool   `json:"photo_only,omitempty"`
 	EditSearchID     int64  `json:"edit_search_id,omitempty"`
 }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -51,6 +51,12 @@ func matches(c model.FilterCriteria, l model.RawListing) bool {
 	if c.MaxHand > 0 && l.Hand > c.MaxHand {
 		return false
 	}
+	if c.PriceOnly && l.Price <= 0 {
+		return false
+	}
+	if c.PhotoOnly && l.ImageURL == "" {
+		return false
+	}
 
 	desc := strings.ToLower(l.Description)
 

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -152,6 +152,46 @@ func TestApply(t *testing.T) {
 			},
 			want: []string{"a"},
 		},
+		{
+			name:     "price only filter",
+			criteria: model.FilterCriteria{PriceOnly: true},
+			listings: []model.RawListing{
+				{Token: "a", Price: 100000},
+				{Token: "b", Price: 0},
+				{Token: "c", Price: -1},
+			},
+			want: []string{"a"},
+		},
+		{
+			name:     "photo only filter",
+			criteria: model.FilterCriteria{PhotoOnly: true},
+			listings: []model.RawListing{
+				{Token: "a", ImageURL: "https://example.com/img.jpg"},
+				{Token: "b", ImageURL: ""},
+				{Token: "c"},
+			},
+			want: []string{"a"},
+		},
+		{
+			name:     "price only disabled passes all",
+			criteria: model.FilterCriteria{PriceOnly: false},
+			listings: []model.RawListing{
+				{Token: "a", Price: 100000},
+				{Token: "b", Price: 0},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name:     "combined price and photo only",
+			criteria: model.FilterCriteria{PriceOnly: true, PhotoOnly: true},
+			listings: []model.RawListing{
+				{Token: "a", Price: 100000, ImageURL: "https://example.com/img.jpg"},
+				{Token: "b", Price: 100000, ImageURL: ""},
+				{Token: "c", Price: 0, ImageURL: "https://example.com/img.jpg"},
+				{Token: "d", Price: 0, ImageURL: ""},
+			},
+			want: []string{"a"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -27,4 +27,6 @@ type FilterCriteria struct {
 	MaxHand     int
 	Keywords    []string
 	ExcludeKeys []string
+	PriceOnly   bool
+	PhotoOnly   bool
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -915,6 +915,8 @@ func buildFilterCriteria(search storage.Search) model.FilterCriteria {
 		EngineMinCC: float64(search.EngineMinCC),
 		MaxKm:       search.MaxKm,
 		MaxHand:     search.MaxHand,
+		PriceOnly:   search.PriceOnly,
+		PhotoOnly:   search.PhotoOnly,
 	}
 
 	if search.Keywords != "" {

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -48,6 +48,8 @@ type Search struct {
 	ExcludeKeys  string
 	// SellerFilter: any (default), private (מוכר פרטי), commercial (מוסך/סוכנות).
 	SellerFilter string
+	PriceOnly    bool
+	PhotoOnly    bool
 	Active       bool
 	CreatedAt    time.Time
 	ShareToken   string
@@ -213,6 +215,8 @@ type ListingFilter struct {
 	MaxHand  int
 	// Commercial: non-nil restricts to private (false) or commercial/dealer (true).
 	Commercial *bool
+	PriceOnly  bool
+	PhotoOnly  bool
 }
 
 type ListingStore interface {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -178,7 +178,7 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error)
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
 			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys,
-			COALESCE(seller_filter, 'any'), active, created_at,
+			COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at,
 			COALESCE(share_token, '')
 		FROM searches
 		ORDER BY created_at DESC`)

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -340,6 +340,12 @@ func buildFilterClauses(f storage.ListingFilter, paramStart int) (string, []any,
 		}
 		n++
 	}
+	if f.PriceOnly {
+		clauses = append(clauses, "price > 0")
+	}
+	if f.PhotoOnly {
+		clauses = append(clauses, "image_url != ''")
+	}
 	if len(clauses) == 0 {
 		return "", nil, paramStart
 	}

--- a/internal/storage/postgres/searches.go
+++ b/internal/storage/postgres/searches.go
@@ -46,13 +46,14 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 	var id int64
 	err = tx.QueryRowContext(ctx, `
-		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, user_seq, share_token)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, price_only, photo_only, user_seq, share_token)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 		RETURNING id`,
 		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax,
 		search.EngineMinCC, search.MaxKm, search.MaxHand,
-		search.Keywords, search.ExcludeKeys, storage.NormalizeSellerFilter(search.SellerFilter), nextSeq, shareToken).Scan(&id)
+		search.Keywords, search.ExcludeKeys, storage.NormalizeSellerFilter(search.SellerFilter),
+		search.PriceOnly, search.PhotoOnly, nextSeq, shareToken).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
@@ -65,7 +66,7 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = $1 ORDER BY created_at DESC`, chatID)
 	if err != nil {
 		return nil, fmt.Errorf("list searches: %w", err)
@@ -76,7 +77,7 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 
 func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE id = $1 AND chat_id = $2`, id, chatID)
 
 	var search storage.Search
@@ -84,6 +85,7 @@ func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
+		&search.PriceOnly, &search.PhotoOnly,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -96,7 +98,7 @@ func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage
 
 func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = $1 AND user_seq = $2`, chatID, seq)
 
 	var search storage.Search
@@ -104,6 +106,7 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
+		&search.PriceOnly, &search.PhotoOnly,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -116,7 +119,7 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 
 func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE share_token = $1`, token)
 
 	var search storage.Search
@@ -124,6 +127,7 @@ func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*stora
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
+		&search.PriceOnly, &search.PhotoOnly,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -142,12 +146,14 @@ func (s *Store) UpdateSearch(ctx context.Context, search storage.Search) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE searches SET name=$1, source=$2, manufacturer=$3, model=$4,
 			year_min=$5, year_max=$6, price_max=$7, engine_min_cc=$8,
-			max_km=$9, max_hand=$10, keywords=$11, exclude_keys=$12, seller_filter=$13
-		WHERE id=$14 AND chat_id=$15`,
+			max_km=$9, max_hand=$10, keywords=$11, exclude_keys=$12, seller_filter=$13,
+			price_only=$14, photo_only=$15
+		WHERE id=$16 AND chat_id=$17`,
 		search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax, search.EngineMinCC,
 		search.MaxKm, search.MaxHand, search.Keywords, search.ExcludeKeys,
 		storage.NormalizeSellerFilter(search.SellerFilter),
+		search.PriceOnly, search.PhotoOnly,
 		search.ID, search.ChatID)
 	if err != nil {
 		return fmt.Errorf("update search: %w", err)
@@ -225,7 +231,7 @@ func (s *Store) SetSearchActive(ctx context.Context, id int64, chatID int64, act
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), s.active, s.created_at, COALESCE(s.share_token, '')
+		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), s.price_only, s.photo_only, s.active, s.created_at, COALESCE(s.share_token, '')
 		FROM searches s
 		JOIN users u ON s.chat_id = u.chat_id
 		WHERE s.active = true AND u.active = true
@@ -266,6 +272,7 @@ func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 			&s.YearMin, &s.YearMax, &s.PriceMax,
 			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
 			&s.Keywords, &s.ExcludeKeys, &s.SellerFilter,
+			&s.PriceOnly, &s.PhotoOnly,
 			&s.Active, &s.CreatedAt, &s.ShareToken); err != nil {
 			return nil, err
 		}

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -187,7 +187,7 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error)
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
 			price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys,
-			COALESCE(seller_filter, 'any'), active, created_at,
+			COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at,
 			COALESCE(share_token, '')
 		FROM searches
 		ORDER BY created_at DESC`)

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -311,6 +311,12 @@ func buildFilterClauses(f storage.ListingFilter) (string, []any) {
 			clauses = append(clauses, "is_commercial = 0")
 		}
 	}
+	if f.PriceOnly {
+		clauses = append(clauses, "price > 0")
+	}
+	if f.PhotoOnly {
+		clauses = append(clauses, "image_url != ''")
+	}
 	if len(clauses) == 0 {
 		return "", nil
 	}

--- a/internal/storage/sqlite/migrate.go
+++ b/internal/storage/sqlite/migrate.go
@@ -46,6 +46,7 @@ func migrate(db *sql.DB) error {
 		migrateListingMarketValue,
 		migrateListingSubModelIDAndBasePrice,
 		migrateListingUserSeen,
+		migrateSearchPricePhotoFilters,
 	}
 	for _, step := range steps {
 		if err := step(db); err != nil {

--- a/internal/storage/sqlite/migrate_steps.go
+++ b/internal/storage/sqlite/migrate_steps.go
@@ -758,6 +758,29 @@ func migrateListingSubModelIDAndBasePrice(db *sql.DB) error {
 	return nil
 }
 
+func migrateSearchPricePhotoFilters(db *sql.DB) error {
+	for _, col := range []struct {
+		name string
+		def  string
+	}{
+		{"price_only", "BOOLEAN NOT NULL DEFAULT false"},
+		{"photo_only", "BOOLEAN NOT NULL DEFAULT false"},
+	} {
+		var exists int
+		if err := db.QueryRow(
+			"SELECT COUNT(*) FROM pragma_table_info('searches') WHERE name = ?", col.name,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("check searches %s: %w", col.name, err)
+		}
+		if exists == 0 {
+			if _, err := db.Exec(fmt.Sprintf("ALTER TABLE searches ADD COLUMN %s %s", col.name, col.def)); err != nil {
+				return fmt.Errorf("add searches %s: %w", col.name, err)
+			}
+		}
+	}
+	return nil
+}
+
 func migrateListingUserSeen(db *sql.DB) error {
 	var n int
 	if err := db.QueryRow(

--- a/internal/storage/sqlite/searches.go
+++ b/internal/storage/sqlite/searches.go
@@ -34,12 +34,13 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 	}
 
 	result, err := tx.ExecContext(ctx, `
-		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, user_seq, share_token)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO searches (chat_id, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, seller_filter, price_only, photo_only, user_seq, share_token)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		search.ChatID, search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax,
 		search.EngineMinCC, search.MaxKm, search.MaxHand,
-		search.Keywords, search.ExcludeKeys, storage.NormalizeSellerFilter(search.SellerFilter), nextSeq, shareToken)
+		search.Keywords, search.ExcludeKeys, storage.NormalizeSellerFilter(search.SellerFilter),
+		search.PriceOnly, search.PhotoOnly, nextSeq, shareToken)
 	if err != nil {
 		return 0, err
 	}
@@ -57,7 +58,7 @@ func (s *Store) CreateSearch(ctx context.Context, search storage.Search) (int64,
 
 func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = ? ORDER BY created_at DESC`, chatID)
 	if err != nil {
 		return nil, fmt.Errorf("list searches: %w", err)
@@ -68,7 +69,7 @@ func (s *Store) ListSearches(ctx context.Context, chatID int64) ([]storage.Searc
 
 func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE id = ? AND chat_id = ?`, id, chatID)
 
 	var search storage.Search
@@ -76,6 +77,7 @@ func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
+		&search.PriceOnly, &search.PhotoOnly,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -88,7 +90,7 @@ func (s *Store) GetSearch(ctx context.Context, id int64, chatID int64) (*storage
 
 func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE chat_id = ? AND user_seq = ?`, chatID, seq)
 
 	var search storage.Search
@@ -96,6 +98,7 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
+		&search.PriceOnly, &search.PhotoOnly,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -108,7 +111,7 @@ func (s *Store) GetSearchBySeq(ctx context.Context, chatID int64, seq int) (*sto
 
 func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*storage.Search, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), active, created_at, COALESCE(share_token, '')
+		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max, price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys, COALESCE(seller_filter, 'any'), price_only, photo_only, active, created_at, COALESCE(share_token, '')
 		FROM searches WHERE share_token = ?`, token)
 
 	var search storage.Search
@@ -116,6 +119,7 @@ func (s *Store) GetSearchByShareToken(ctx context.Context, token string) (*stora
 		&search.YearMin, &search.YearMax, &search.PriceMax,
 		&search.EngineMinCC, &search.MaxKm, &search.MaxHand,
 		&search.Keywords, &search.ExcludeKeys, &search.SellerFilter,
+		&search.PriceOnly, &search.PhotoOnly,
 		&search.Active, &search.CreatedAt, &search.ShareToken)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -134,12 +138,14 @@ func (s *Store) UpdateSearch(ctx context.Context, search storage.Search) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE searches SET name=?, source=?, manufacturer=?, model=?,
 			year_min=?, year_max=?, price_max=?, engine_min_cc=?,
-			max_km=?, max_hand=?, keywords=?, exclude_keys=?, seller_filter=?
+			max_km=?, max_hand=?, keywords=?, exclude_keys=?, seller_filter=?,
+			price_only=?, photo_only=?
 		WHERE id=? AND chat_id=?`,
 		search.Name, source, search.Manufacturer, search.Model,
 		search.YearMin, search.YearMax, search.PriceMax, search.EngineMinCC,
 		search.MaxKm, search.MaxHand, search.Keywords, search.ExcludeKeys,
 		storage.NormalizeSellerFilter(search.SellerFilter),
+		search.PriceOnly, search.PhotoOnly,
 		search.ID, search.ChatID)
 	if err != nil {
 		return fmt.Errorf("update search: %w", err)
@@ -217,7 +223,7 @@ func (s *Store) SetSearchActive(ctx context.Context, id int64, chatID int64, act
 
 func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), s.active, s.created_at, COALESCE(s.share_token, '')
+		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), s.price_only, s.photo_only, s.active, s.created_at, COALESCE(s.share_token, '')
 		FROM searches s
 		JOIN users u ON s.chat_id = u.chat_id
 		WHERE s.active = true AND u.active = true
@@ -258,6 +264,7 @@ func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 			&s.YearMin, &s.YearMax, &s.PriceMax,
 			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
 			&s.Keywords, &s.ExcludeKeys, &s.SellerFilter,
+			&s.PriceOnly, &s.PhotoOnly,
 			&s.Active, &s.CreatedAt, &s.ShareToken); err != nil {
 			return nil, err
 		}

--- a/migrations/000007_search_price_photo_filters.down.sql
+++ b/migrations/000007_search_price_photo_filters.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE searches DROP COLUMN price_only;
+ALTER TABLE searches DROP COLUMN photo_only;

--- a/migrations/000007_search_price_photo_filters.up.sql
+++ b/migrations/000007_search_price_photo_filters.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE searches ADD COLUMN price_only BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE searches ADD COLUMN photo_only BOOLEAN NOT NULL DEFAULT false;

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -55,6 +55,8 @@ export function SearchCard({
       : search.seller_filter === "commercial"
         ? "מוסך / סוכנות"
         : null,
+    search.price_only ? "עם מחיר" : null,
+    search.photo_only ? "עם תמונה" : null,
   ].filter(Boolean) as string[];
 
   const openCardClassName =

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,8 @@ export interface Search {
   created_at: string;
   /** any | private | commercial */
   seller_filter?: string;
+  price_only?: boolean;
+  photo_only?: boolean;
   /** Total listings found for this search; from API when supported. */
   listings_count?: number;
 }
@@ -99,6 +101,8 @@ export interface CreateSearchRequest {
   exclude_keys?: string;
   /** any (default), private, commercial */
   seller_filter?: string;
+  price_only?: boolean;
+  photo_only?: boolean;
 }
 
 export interface Listing {
@@ -357,6 +361,8 @@ export interface AdminSearch {
   exclude_keys?: string;
   /** any | private | commercial */
   seller_filter?: string;
+  price_only?: boolean;
+  photo_only?: boolean;
   active: boolean;
   created_at: string;
 }

--- a/web/src/pages/EditSearchPage.tsx
+++ b/web/src/pages/EditSearchPage.tsx
@@ -57,6 +57,8 @@ export function EditSearchPage() {
     keywords: "",
     excludeKeys: "",
     sellerFilter: "any" as "any" | "private" | "commercial",
+    priceOnly: false,
+    photoOnly: false,
   });
 
   const initializedSearchIdRef = useRef<number | null>(null);
@@ -73,6 +75,8 @@ export function EditSearchPage() {
         keywords: search.keywords,
         excludeKeys: search.exclude_keys,
         sellerFilter: normalizeSellerFilter(search.seller_filter),
+        priceOnly: search.price_only ?? false,
+        photoOnly: search.photo_only ?? false,
       });
       initializedSearchIdRef.current = search.id;
     }
@@ -104,6 +108,8 @@ export function EditSearchPage() {
           keywords: form.keywords || undefined,
           exclude_keys: form.excludeKeys || undefined,
           seller_filter: form.sellerFilter,
+          price_only: form.priceOnly,
+          photo_only: form.photoOnly,
         },
       },
       {
@@ -273,6 +279,27 @@ export function EditSearchPage() {
                 {opt.label}
               </ChipButton>
             ))}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="text-xs font-medium text-muted-foreground">סינון מודעות</h3>
+          <p className="text-xs text-muted-foreground">
+            הצג רק מודעות שעומדות בתנאים הבאים.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <ChipButton
+              selected={form.priceOnly}
+              onClick={() => set("priceOnly", !form.priceOnly)}
+            >
+              עם מחיר בלבד
+            </ChipButton>
+            <ChipButton
+              selected={form.photoOnly}
+              onClick={() => set("photoOnly", !form.photoOnly)}
+            >
+              עם תמונה בלבד
+            </ChipButton>
           </div>
         </div>
       </section>

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -27,6 +27,8 @@ interface FormData {
   keywords: string;
   excludeKeys: string;
   sellerFilter: "any" | "private" | "commercial";
+  priceOnly: boolean;
+  photoOnly: boolean;
 }
 
 const SELLER_FILTER_OPTIONS: { value: FormData["sellerFilter"]; label: string }[] = [
@@ -66,6 +68,8 @@ export function NewSearchPage() {
     keywords: "",
     excludeKeys: "",
     sellerFilter: "any",
+    priceOnly: false,
+    photoOnly: false,
   });
 
   const { data: manufacturers } = useManufacturers();
@@ -103,6 +107,8 @@ export function NewSearchPage() {
         keywords: form.keywords || undefined,
         exclude_keys: form.excludeKeys || undefined,
         seller_filter: form.sellerFilter,
+        price_only: form.priceOnly || undefined,
+        photo_only: form.photoOnly || undefined,
       },
       {
         onSuccess: () => {
@@ -180,6 +186,28 @@ export function NewSearchPage() {
               {opt.label}
             </ChipButton>
           ))}
+        </div>
+      </section>
+
+      {/* Section: Listing quality filters */}
+      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
+        <h2 className="text-sm font-semibold text-foreground">סינון מודעות</h2>
+        <p className="text-xs text-muted-foreground">
+          הצג רק מודעות שעומדות בתנאים הבאים.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <ChipButton
+            selected={form.priceOnly}
+            onClick={() => set("priceOnly", !form.priceOnly)}
+          >
+            עם מחיר בלבד
+          </ChipButton>
+          <ChipButton
+            selected={form.photoOnly}
+            onClick={() => set("photoOnly", !form.photoOnly)}
+          >
+            עם תמונה בלבד
+          </ChipButton>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Add **Price Only** and **Photo Only** toggle filters to searches, excluding listings without a price or without an image
- Applied consistently across all layers: database schema, Go backend (filter engine, SQL clauses, scheduler, API), Telegram bot wizard, and React frontend
- New Postgres migration (`000007`) + SQLite auto-migration add `price_only`/`photo_only` columns to `searches`

## Changes
- **Schema**: `migrations/000007_search_price_photo_filters.{up,down}.sql`, SQLite `migrateSearchPricePhotoFilters`
- **Model**: `FilterCriteria` gets `PriceOnly`/`PhotoOnly`; `ListingFilter` gets matching fields
- **Filter engine**: `filter.Apply` rejects `Price <= 0` / empty `ImageURL` when enabled
- **SQL**: `buildFilterClauses` in both Postgres and SQLite adds `price > 0` / `image_url != ''` clauses
- **API**: `createSearchRequest`, `updateSearchRequest`, `searchResponse` include new fields; `listingFilterFromSearch` wires them
- **Bot**: `WizardData` carries filters through create/edit; `onConfirm` persists them
- **Frontend**: Toggle chips on `NewSearchPage` and `EditSearchPage`; filter tags on `SearchCard`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all 116+ Go tests pass, including 4 new filter tests
- [x] `npx vitest run` — all 116 frontend tests pass
- [x] New filter test cases: price_only, photo_only, combined, disabled-passes-all

Closes #688

Made with [Cursor](https://cursor.com)