### PR TITLE
fix: use correct SHA for gitleaks-action v2.3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@44c470ffc35caa8b1eb3e8012ca53c2f2834e96d # v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The Secret Scanning CI job has been failing on every run because the pinned commit SHA for `gitleaks/gitleaks-action` (`44c470f...`) doesn't exist. This was an invalid SHA introduced in PR #702.

Replaced with the correct SHA `ff98106e4c7b2bc287b24eaf42907196329070c7` which points to the actual `v2.3.9` tag.

## Test plan

- [ ] Verify the Secret Scanning job passes on this PR's CI run

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning infrastructure in the CI/CD pipeline to use a newer version of secret detection tools, enhancing the build process security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/706)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->