### PR TITLE
fix: dashboard listing count ignores price_only and photo_only filters

### DIFF
--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -29,6 +29,8 @@ WHERE lh.chat_id = $1
     WHEN 'dealership' THEN lh.is_commercial = 1
     ELSE TRUE
   END
+  AND (NOT s.price_only OR lh.price > 0)
+  AND (NOT s.photo_only OR lh.image_url != '')
 GROUP BY lh.search_id`
 
 const upsertListingSQL = `

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -403,6 +403,8 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 		    WHEN 'dealership' THEN lh.is_commercial = 1
 		    ELSE 1
 		  END
+		  AND (NOT s.price_only OR lh.price > 0)
+		  AND (NOT s.photo_only OR lh.image_url != '')
 		GROUP BY lh.search_id`, chatID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

The saved searches dashboard showed a stale/inflated listing count (84) while the listings page correctly showed 11 after applying price_only and photo_only filters.

**Root cause:** The batch count query `CountSearchListingsForChat` (used by `GET /api/v1/searches`) was missing the `price_only` and `photo_only` filter conditions. The per-search count query `CountSearchListings` (used by the listings page) applied them correctly via `buildFilterClauses`.

**Fix:** Added the two missing conditions to both Postgres and SQLite batch queries:
```sql
AND (NOT s.price_only OR lh.price > 0)
AND (NOT s.photo_only OR lh.image_url != '')
```

## Test plan

- [ ] Verify dashboard count matches listings page count when price_only/photo_only are enabled
- [ ] Verify counts are unchanged when neither filter is active

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search filters now properly respect price-only and photo-only settings by excluding listings with non-positive prices and missing images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/707)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->