### PR TITLE
feat: add refresh listings button with loading animations

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -114,7 +114,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = multi.Disconnect() }()
 
-	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, &logLevelVar, logger)
+	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, &logLevelVar, logger, fetcherFactory)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func buildBot(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 	return botHandler, tgNotif, multi, nil
 }
 
-func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger) (*api.Server, error) {
+func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger, fetchers *fetcher.Factory) (*api.Server, error) {
 	var firebaseAuth api.TokenVerifier
 	if cfg.Firebase.ProjectID != "" {
 		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)
@@ -281,6 +281,7 @@ func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 		BotUsername:  cfg.Telegram.BotUsername,
 		LogHub:       logHub,
 		LogLevel:     logLevel,
+		Fetchers:     fetchers,
 	})
 
 	return apiServer, nil

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dsionov/carwatch/internal/botcore"
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -57,6 +58,8 @@ type Server struct {
 	rl           *rateLimiter
 	ipRL         *ipRateLimiter
 	vacuumMu     sync.Mutex
+	fetchers     *fetcher.Factory
+	refreshMu    sync.Map
 
 	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
 	httpReqTotal   atomic.Uint64
@@ -96,6 +99,7 @@ type Config struct {
 	API          config.APIConfig
 	FirebaseAuth TokenVerifier
 	BotUsername  string
+	Fetchers     *fetcher.Factory
 }
 
 func New(c Config) *Server {
@@ -119,6 +123,7 @@ func New(c Config) *Server {
 		startTime:    time.Now(),
 		rl:           newRateLimiter(60, time.Second/60),
 		ipRL:         newIPRateLimiter(20, time.Second/10, c.API.TrustForwardedFor),
+		fetchers:     c.Fetchers,
 	}
 }
 
@@ -164,6 +169,7 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("POST /api/v1/searches/{id}/resume", s.resumeSearch)
 
 	mux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
+	mux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
 	mux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
 
 	if s.admin != nil {

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -1008,6 +1009,90 @@ func TestCreateSearch_ReactivatesInactiveUser(t *testing.T) {
 	u, _ = store.GetUser(ctx, int64(999))
 	if !u.Active {
 		t.Error("createSearch should reactivate an inactive user")
+	}
+}
+
+func TestRefreshListings_NoFetcher(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches/1/refresh", nil)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when no fetcher is wired, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRefreshListings_InvalidID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.fetchers = fetcher.NewFactory()
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches/abc/refresh", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid id, got %d", w.Code)
+	}
+}
+
+func TestRefreshListings_SearchNotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.fetchers = fetcher.NewFactory()
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches/99999/refresh", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for nonexistent search, got %d", w.Code)
+	}
+}
+
+func TestRefreshListings_Cooldown(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.fetchers = fetcher.NewFactory()
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2018, YearMax: 2024,
+	})
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	cooldownKey := fmt.Sprintf("%d:%d", 999, created.ID)
+	srv.refreshMu.Store(cooldownKey, time.Now())
+
+	w = doRequest(t, srv, "POST", "/api/v1/searches/"+itoa(created.ID)+"/refresh", nil)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 during cooldown, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header")
+	}
+}
+
+func TestBuildFilterCriteriaFromSearch(t *testing.T) {
+	sr := &storage.Search{
+		Model:       10226,
+		YearMin:     2020,
+		YearMax:     2024,
+		PriceMax:    200000,
+		EngineMinCC: 1800,
+		MaxKm:       100000,
+		MaxHand:     3,
+		PriceOnly:   true,
+		PhotoOnly:   true,
+		Keywords:    "automatic, sunroof",
+		ExcludeKeys: "salvage",
+	}
+	fc := buildFilterCriteriaFromSearch(sr)
+
+	if fc.ModelID != 10226 {
+		t.Errorf("ModelID = %d, want 10226", fc.ModelID)
+	}
+	if fc.YearMin != 2020 || fc.YearMax != 2024 {
+		t.Errorf("year range = %d-%d", fc.YearMin, fc.YearMax)
+	}
+	if !fc.PriceOnly || !fc.PhotoOnly {
+		t.Errorf("filters: priceOnly=%v photoOnly=%v", fc.PriceOnly, fc.PhotoOnly)
+	}
+	if len(fc.Keywords) != 2 || fc.Keywords[0] != "automatic" || fc.Keywords[1] != "sunroof" {
+		t.Errorf("keywords = %v", fc.Keywords)
+	}
+	if len(fc.ExcludeKeys) != 1 || fc.ExcludeKeys[0] != "salvage" {
+		t.Errorf("excludeKeys = %v", fc.ExcludeKeys)
 	}
 }
 

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
+	"github.com/dsionov/carwatch/internal/filter"
+	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -42,6 +47,189 @@ type listingsPageResponse struct {
 	Total  int64             `json:"total"`
 	Limit  int               `json:"limit"`
 	Offset int               `json:"offset"`
+}
+
+type refreshResponse struct {
+	Items   []listingResponse `json:"items"`
+	Total   int64             `json:"total"`
+	Removed int64             `json:"removed"`
+}
+
+func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
+	if s.fetchers == nil {
+		writeError(w, http.StatusServiceUnavailable, "refresh not available")
+		return
+	}
+
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
+	id, ok := parsePathID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid search id")
+		return
+	}
+
+	cooldownKey := fmt.Sprintf("%d:%d", chatID, id)
+	if ts, loaded := s.refreshMu.Load(cooldownKey); loaded {
+		if last, ok := ts.(time.Time); ok {
+			remaining := 60*time.Second - time.Since(last)
+			if remaining > 0 {
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", int(remaining.Seconds())+1))
+				writeError(w, http.StatusTooManyRequests,
+					fmt.Sprintf("please wait %d seconds before refreshing again", int(remaining.Seconds())+1))
+				return
+			}
+		}
+	}
+
+	sr, err := s.searches.GetSearch(r.Context(), id, chatID)
+	if err != nil {
+		s.logger.Error("refresh: get search", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get search")
+		return
+	}
+	if sr == nil {
+		writeError(w, http.StatusNotFound, "search not found")
+		return
+	}
+
+	source := sr.Source
+	if source == "" {
+		source = "yad2"
+	}
+	sources := strings.Split(source, ",")
+	var allRaw []model.RawListing
+	for _, src := range sources {
+		src = strings.TrimSpace(src)
+		f, ok := s.fetchers.Get(src)
+		if !ok {
+			continue
+		}
+		params := model.SourceParams{
+			Manufacturer: sr.Manufacturer,
+			Model:        sr.Model,
+			YearMin:      sr.YearMin,
+			YearMax:      sr.YearMax,
+			PriceMax:     sr.PriceMax,
+			MaxKm:        sr.MaxKm,
+			MaxHand:      sr.MaxHand,
+			EngineMinCC:  sr.EngineMinCC,
+		}
+		raw, fetchErr := f.Fetch(r.Context(), params)
+		if fetchErr != nil {
+			s.logger.Warn("refresh: fetch failed", "source", src, "error", fetchErr)
+			continue
+		}
+		allRaw = append(allRaw, raw...)
+	}
+
+	s.refreshMu.Store(cooldownKey, time.Now())
+
+	criteria := buildFilterCriteriaFromSearch(sr)
+	filtered := filter.Apply(criteria, allRaw)
+
+	freshTokens := make([]string, len(filtered))
+	for i, l := range filtered {
+		freshTokens[i] = l.Token
+	}
+
+	removed, err := s.listings.DeleteStaleListings(r.Context(), chatID, sr.ID, freshTokens)
+	if err != nil {
+		s.logger.Error("refresh: delete stale", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to clean stale listings")
+		return
+	}
+
+	records := make([]storage.ListingRecord, 0, len(filtered))
+	for _, l := range filtered {
+		rec := storage.ListingRecord{
+			Token:        l.Token,
+			ChatID:       chatID,
+			SearchID:     sr.ID,
+			SearchName:   sr.Name,
+			Manufacturer: l.Manufacturer,
+			Model:        l.Model,
+			SubModel:     l.SubModel,
+			SubModelID:   l.SubModelID,
+			Year:         l.Year,
+			Price:        l.Price,
+			Km:           l.Km,
+			Hand:         l.Hand,
+			City:         l.City,
+			PageLink:     l.PageLink,
+			ImageURL:     l.ImageURL,
+			EngineVolume: l.EngineVolume,
+			HorsePower:   l.HorsePower,
+			EngineType:   l.EngineType,
+			GearBox:      l.GearBox,
+			Description:  l.Description,
+			IsCommercial: l.Commercial,
+			FirstSeenAt:  time.Now(),
+		}
+		records = append(records, rec)
+	}
+	if len(records) > 0 {
+		if err := s.listings.SaveListings(r.Context(), records); err != nil {
+			s.logger.Error("refresh: save listings", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to save listings")
+			return
+		}
+	}
+
+	lf := listingFilterFromSearch(sr)
+	listings, err := s.listings.ListSearchListings(r.Context(), chatID, sr.ID, lf, 100, 0, "newest")
+	if err != nil {
+		s.logger.Error("refresh: list listings", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list listings")
+		return
+	}
+	total, err := s.listings.CountSearchListings(r.Context(), chatID, sr.ID, lf)
+	if err != nil {
+		s.logger.Error("refresh: count listings", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count listings")
+		return
+	}
+
+	savedMap := s.savedLookupForRecords(r.Context(), chatID, listings)
+	seenMap := s.seenLookupForRecords(r.Context(), chatID, listings)
+
+	writeJSON(w, http.StatusOK, refreshResponse{
+		Items:   toListingResponses(listings, savedMap, seenMap),
+		Total:   total,
+		Removed: removed,
+	})
+}
+
+func buildFilterCriteriaFromSearch(sr *storage.Search) model.FilterCriteria {
+	criteria := model.FilterCriteria{
+		ModelID:     sr.Model,
+		YearMin:     sr.YearMin,
+		YearMax:     sr.YearMax,
+		PriceMax:    sr.PriceMax,
+		EngineMinCC: float64(sr.EngineMinCC),
+		MaxKm:       sr.MaxKm,
+		MaxHand:     sr.MaxHand,
+		PriceOnly:   sr.PriceOnly,
+		PhotoOnly:   sr.PhotoOnly,
+	}
+
+	if sr.Keywords != "" {
+		for _, kw := range strings.Split(sr.Keywords, ",") {
+			if kw = strings.TrimSpace(kw); kw != "" {
+				criteria.Keywords = append(criteria.Keywords, kw)
+			}
+		}
+	}
+	if sr.ExcludeKeys != "" {
+		for _, ex := range strings.Split(sr.ExcludeKeys, ",") {
+			if ex = strings.TrimSpace(ex); ex != "" {
+				criteria.ExcludeKeys = append(criteria.ExcludeKeys, ex)
+			}
+		}
+	}
+	return criteria
 }
 
 func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -301,3 +301,7 @@ func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (in
 	m.pruneCalls++
 	return 0, nil
 }
+
+func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
+	return 0, nil
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -233,6 +233,7 @@ type ListingStore interface {
 	// applying each search row's price/year/km/hand constraints like CountSearchListings.
 	CountSearchListingsForChat(ctx context.Context, chatID int64) (map[int64]int64, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
+	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
 }
 
 type SavedListingStore interface {

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -432,6 +432,47 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 	return out, rows.Err()
 }
 
+func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
+	if len(keepTokens) == 0 {
+		result, err := s.db.ExecContext(ctx, `
+			DELETE FROM listing_history
+			WHERE chat_id = $1 AND search_id = $2
+			  AND NOT EXISTS (
+			    SELECT 1 FROM saved_listings
+			    WHERE saved_listings.token = listing_history.token
+			      AND saved_listings.chat_id = listing_history.chat_id
+			  )`, chatID, searchID)
+		if err != nil {
+			return 0, err
+		}
+		return result.RowsAffected()
+	}
+
+	args := make([]interface{}, 0, 2+len(keepTokens))
+	args = append(args, chatID, searchID)
+	placeholders := make([]string, len(keepTokens))
+	for i, t := range keepTokens {
+		placeholders[i] = fmt.Sprintf("$%d", i+3)
+		args = append(args, t)
+	}
+
+	query := fmt.Sprintf(`
+		DELETE FROM listing_history
+		WHERE chat_id = $1 AND search_id = $2
+		  AND token NOT IN (%s)
+		  AND NOT EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, strings.Join(placeholders, ","))
+
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, `

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -440,6 +440,47 @@ func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int
 	return result.RowsAffected()
 }
 
+func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
+	if len(keepTokens) == 0 {
+		result, err := s.db.ExecContext(ctx, `
+			DELETE FROM listing_history
+			WHERE chat_id = ? AND search_id = ?
+			  AND NOT EXISTS (
+			    SELECT 1 FROM saved_listings
+			    WHERE saved_listings.token = listing_history.token
+			      AND saved_listings.chat_id = listing_history.chat_id
+			  )`, chatID, searchID)
+		if err != nil {
+			return 0, err
+		}
+		return result.RowsAffected()
+	}
+
+	placeholders := make([]string, len(keepTokens))
+	args := make([]interface{}, 0, 2+len(keepTokens))
+	args = append(args, chatID, searchID)
+	for i, t := range keepTokens {
+		placeholders[i] = "?"
+		args = append(args, t)
+	}
+
+	query := fmt.Sprintf(`
+		DELETE FROM listing_history
+		WHERE chat_id = ? AND search_id = ?
+		  AND token NOT IN (%s)
+		  AND NOT EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, strings.Join(placeholders, ","))
+
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) SaveBookmark(ctx context.Context, chatID int64, token string) error {
 	_, err := s.db.ExecContext(ctx,
 		"INSERT OR IGNORE INTO saved_listings (chat_id, token) VALUES (?, ?)",

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -3146,6 +3146,126 @@ func TestPruneListings_PreservesSaved(t *testing.T) {
 	}
 }
 
+func TestDeleteStaleListings_RemovesUnkept(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	for _, tok := range []string{"a", "b", "c", "d"} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, ChatID: 100, SearchID: searchID, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		}); err != nil {
+			t.Fatalf("SaveListing %s: %v", tok, err)
+		}
+	}
+
+	removed, err := store.DeleteStaleListings(ctx, 100, searchID, []string{"a", "c"})
+	if err != nil {
+		t.Fatalf("DeleteStaleListings: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 removed, got %d", removed)
+	}
+
+	for _, tok := range []string{"a", "c"} {
+		l, _ := store.GetListing(ctx, 100, tok)
+		if l == nil {
+			t.Errorf("listing %q should still exist", tok)
+		}
+	}
+	for _, tok := range []string{"b", "d"} {
+		l, _ := store.GetListing(ctx, 100, tok)
+		if l != nil {
+			t.Errorf("listing %q should be deleted", tok)
+		}
+	}
+}
+
+func TestDeleteStaleListings_PreservesBookmarked(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	for _, tok := range []string{"keep", "stale-but-saved", "stale-unsaved"} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, ChatID: 100, SearchID: searchID, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		}); err != nil {
+			t.Fatalf("SaveListing %s: %v", tok, err)
+		}
+	}
+
+	if err := store.SaveBookmark(ctx, 100, "stale-but-saved"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
+
+	removed, err := store.DeleteStaleListings(ctx, 100, searchID, []string{"keep"})
+	if err != nil {
+		t.Fatalf("DeleteStaleListings: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed (only unsaved stale), got %d", removed)
+	}
+
+	keep, _ := store.GetListing(ctx, 100, "keep")
+	if keep == nil {
+		t.Error("'keep' listing should still exist")
+	}
+	saved, _ := store.GetListing(ctx, 100, "stale-but-saved")
+	if saved == nil {
+		t.Error("bookmarked listing should survive deletion")
+	}
+	unsaved, _ := store.GetListing(ctx, 100, "stale-unsaved")
+	if unsaved != nil {
+		t.Error("unsaved stale listing should be deleted")
+	}
+}
+
+func TestDeleteStaleListings_EmptyKeepTokens(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	for _, tok := range []string{"x", "y"} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, ChatID: 100, SearchID: searchID, SearchName: "test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000,
+		}); err != nil {
+			t.Fatalf("SaveListing %s: %v", tok, err)
+		}
+	}
+
+	removed, err := store.DeleteStaleListings(ctx, 100, searchID, nil)
+	if err != nil {
+		t.Fatalf("DeleteStaleListings: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 removed when keepTokens is empty, got %d", removed)
+	}
+}
+
 func TestUpsertUser_ReactivatesInactiveUser(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -78,7 +78,9 @@ export function ListingCardBody({
           ) : null}
           {listing.fitness_score != null ? (
             <MatchScoreBox score={listing.fitness_score} size="md" />
-          ) : null}
+          ) : (
+            <div className="h-10 w-10 shrink-0 rounded-xl shimmer-skeleton" />
+          )}
           <div className="min-w-0 flex-1">
             <h3 className="font-semibold text-card-foreground">
               {listing.manufacturer} {listing.model}
@@ -114,13 +116,22 @@ export function ListingCardBody({
         </div>
 
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground mb-3">
-          <span className="tabular-nums">{formatKm(listing.km)}</span>
+          {listing.km > 0 ? (
+            <span className="tabular-nums">{formatKm(listing.km)}</span>
+          ) : (
+            <span className="inline-block h-3.5 w-14 rounded shimmer-skeleton align-middle" />
+          )}
           <span className="text-border">·</span>
           <span>יד {listing.hand}</span>
-          {listing.city && (
+          {listing.city ? (
             <>
               <span className="text-border">·</span>
               <span>{listing.city}</span>
+            </>
+          ) : (
+            <>
+              <span className="text-border">·</span>
+              <span className="inline-block h-3.5 w-12 rounded shimmer-skeleton align-middle" />
             </>
           )}
         </div>

--- a/web/src/components/ListingCardSkeleton.tsx
+++ b/web/src/components/ListingCardSkeleton.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/utils";
+
+export function ListingCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-border/50 bg-card overflow-hidden dir-rtl",
+        className,
+      )}
+    >
+      {/* Image area */}
+      <div className="aspect-video w-full shimmer-skeleton" />
+
+      <div className="p-4">
+        {/* Title row: logo + score + name/year + price */}
+        <div className="mb-2 flex items-start gap-3">
+          <div className="h-10 w-10 shrink-0 rounded-lg shimmer-skeleton" />
+          <div className="h-10 w-10 shrink-0 rounded-xl shimmer-skeleton" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-4 w-3/4 rounded shimmer-skeleton" />
+            <div className="h-3 w-12 rounded shimmer-skeleton" />
+          </div>
+          <div className="shrink-0 space-y-1.5 text-end">
+            <div className="h-5 w-20 rounded shimmer-skeleton ms-auto" />
+            <div className="h-3 w-14 rounded shimmer-skeleton ms-auto" />
+          </div>
+        </div>
+
+        {/* Meta line: km · hand · city */}
+        <div className="flex gap-3 mb-3">
+          <div className="h-3.5 w-16 rounded shimmer-skeleton" />
+          <div className="h-3.5 w-10 rounded shimmer-skeleton" />
+          <div className="h-3.5 w-14 rounded shimmer-skeleton" />
+        </div>
+
+        {/* Footer: time + action buttons */}
+        <div className="flex items-center gap-2">
+          <div className="h-3 w-20 rounded shimmer-skeleton me-auto" />
+          <div className="h-7 w-7 rounded-lg shimmer-skeleton" />
+          <div className="h-7 w-7 rounded-lg shimmer-skeleton" />
+          <div className="h-7 w-7 rounded-lg shimmer-skeleton" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/PageHeader.tsx
+++ b/web/src/components/ui/PageHeader.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 export type PageHeaderProps = {
   title: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
   backTo?: string;
   backLabel?: string;
   action?: ReactNode;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -143,6 +143,12 @@ export interface ListingsResponse {
   offset: number;
 }
 
+export interface RefreshResponse {
+  items: Listing[];
+  total: number;
+  removed: number;
+}
+
 export interface ListingsParams {
   limit?: number;
   offset?: number;
@@ -223,6 +229,10 @@ export const api = {
       `/searches/${searchId}/listings${qs ? `?${qs}` : ""}`,
     );
   },
+  refreshListings: (searchId: number) =>
+    fetchAPI<RefreshResponse>(`/searches/${searchId}/refresh`, {
+      method: "POST",
+    }),
 };
 
 export interface NotificationCount {

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router";
 import {
   ExternalLink,
@@ -6,20 +6,24 @@ import {
   Car,
   Eye,
   EyeOff,
+  RefreshCw,
 } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useListings } from "@/hooks/useListings";
 import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
 import { useMarkListingSeen, useUnmarkListingSeen } from "@/hooks/useListingSeen";
 import { safeHref, cn, formatPrice } from "@/lib/utils";
-import type { Listing } from "@/lib/api";
+import { api } from "@/lib/api";
+import type { Listing, RefreshResponse } from "@/lib/api";
 import { ListingCardBody } from "@/components/ListingCardBody";
+import { ListingCardSkeleton } from "@/components/ListingCardSkeleton";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { PageShell } from "@/components/ui/PageShell";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { Pagination } from "@/components/ui/Pagination";
-import { Skeleton } from "@/components/ui/Skeleton";
 import { useToast } from "@/components/ui/Toast";
 
 const SORT_OPTIONS = [
@@ -32,6 +36,7 @@ const SORT_OPTIONS = [
 ];
 
 const PAGE_SIZE = 20;
+const REFRESH_COOLDOWN_S = 60;
 
 function isInteractiveTarget(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
@@ -43,6 +48,32 @@ export function ListingsPage() {
   const searchId = Number(id);
   const [sort, setSort] = useState("newest");
   const [offset, setOffset] = useState(0);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [cooldown, setCooldown] = useState(0);
+  const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCooldown = useCallback(() => {
+    setCooldown(REFRESH_COOLDOWN_S);
+    if (cooldownRef.current) clearInterval(cooldownRef.current);
+    cooldownRef.current = setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          if (cooldownRef.current) clearInterval(cooldownRef.current);
+          cooldownRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (cooldownRef.current) clearInterval(cooldownRef.current);
+    };
+  }, []);
 
   const { data, isLoading, isError } = useListings(
     searchId,
@@ -50,6 +81,33 @@ export function ListingsPage() {
     PAGE_SIZE,
     offset,
   );
+
+  const refreshMutation = useMutation<RefreshResponse, Error>({
+    mutationFn: () => api.refreshListings(searchId),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ["listings", searchId] });
+      queryClient.invalidateQueries({ queryKey: ["searches"] });
+      startCooldown();
+
+      if (res.removed > 0) {
+        toast(`הוסרו ${res.removed} מודעות שכבר לא זמינות`, "info");
+      }
+      toast(
+        `נטענו ${res.total} מודעות מעודכנות`,
+        "success",
+      );
+    },
+    onError: (err) => {
+      if (err.message.includes("wait")) {
+        toast(err.message, "info");
+        startCooldown();
+      } else {
+        toast("שגיאה בעת רענון המודעות", "error");
+      }
+    },
+  });
+
+  const isRefreshing = refreshMutation.isPending;
 
   if (!searchId || Number.isNaN(searchId)) {
     return (
@@ -72,55 +130,87 @@ export function ListingsPage() {
     );
   }
 
-  if (isLoading) {
-    return (
-      <PageShell gap="sm">
-        <PageHeader backTo="/dashboard" title="תוצאות" />
-        <div className="flex flex-wrap gap-2">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <Skeleton key={i} className="h-8 w-16 rounded-md" />
-          ))}
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {[1, 2, 3, 4].map((i) => (
-            <Skeleton key={i} className="h-72 rounded-2xl" />
-          ))}
-        </div>
-      </PageShell>
-    );
-  }
+  const showSkeletons = isLoading || isRefreshing;
 
   const countSubtitle =
-    data != null ? `${data.total.toLocaleString("he-IL")} מודעות` : undefined;
+    !showSkeletons && data != null
+      ? `${data.total.toLocaleString("he-IL")} מודעות`
+      : undefined;
 
   return (
     <PageShell gap="sm">
       <PageHeader
         backTo="/dashboard"
         title="תוצאות"
-        subtitle={countSubtitle}
+        subtitle={
+          showSkeletons ? (
+            <span className="inline-block h-4 w-24 rounded shimmer-skeleton align-middle" />
+          ) : (
+            countSubtitle
+          )
+        }
       />
 
-      {/* Sort pills */}
-      <div className="flex flex-wrap gap-2 dir-rtl">
-        {SORT_OPTIONS.map((opt) => (
-          <Button
-            key={opt.value}
-            type="button"
-            size="sm"
-            variant={sort === opt.value ? "primary" : "secondary"}
-            onClick={() => {
-              setSort(opt.value);
-              setOffset(0);
-            }}
-          >
-            {opt.label}
-          </Button>
-        ))}
+      {/* Sort pills + refresh button */}
+      <div className="flex items-center gap-2 dir-rtl">
+        <div className={cn("flex flex-wrap gap-2 flex-1", isRefreshing && "opacity-60 pointer-events-none")}>
+          {SORT_OPTIONS.map((opt) => (
+            <Button
+              key={opt.value}
+              type="button"
+              size="sm"
+              variant={sort === opt.value ? "primary" : "secondary"}
+              onClick={() => {
+                setSort(opt.value);
+                setOffset(0);
+              }}
+            >
+              {opt.label}
+            </Button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => refreshMutation.mutate()}
+          disabled={isRefreshing || cooldown > 0}
+          aria-label={cooldown > 0 ? `רענון זמין בעוד ${cooldown} שניות` : "רענן מודעות"}
+          className={cn(
+            "relative flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-sm font-medium transition-all duration-300",
+            "bg-primary/10 text-primary hover:bg-primary/20",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+            "focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2",
+          )}
+        >
+          <RefreshCw
+            className={cn(
+              "h-4 w-4 transition-transform duration-500",
+              isRefreshing && "animate-spin",
+            )}
+          />
+          {cooldown > 0 ? (
+            <span className="tabular-nums text-xs">{cooldown}s</span>
+          ) : (
+            <span className="hidden sm:inline">רענן</span>
+          )}
+        </button>
       </div>
 
       {/* Grid */}
-      {!data || data.items.length === 0 ? (
+      {showSkeletons ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <motion.div
+              key={`skel-${i}`}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.06, duration: 0.4, ease: "easeOut" }}
+            >
+              <ListingCardSkeleton />
+            </motion.div>
+          ))}
+        </div>
+      ) : !data || data.items.length === 0 ? (
         <EmptyState
           icon={Car}
           title="אין תוצאות עדיין"
@@ -134,9 +224,25 @@ export function ListingsPage() {
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2">
-            {data.items.map((listing) => (
-              <ListingCard key={listing.token} listing={listing} />
-            ))}
+            <AnimatePresence mode="popLayout">
+              {data.items.map((listing, i) => (
+                <motion.div
+                  key={listing.token}
+                  layout
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  transition={{
+                    delay: i * 0.05,
+                    duration: 0.35,
+                    ease: "easeOut",
+                    layout: { duration: 0.3 },
+                  }}
+                >
+                  <ListingCard listing={listing} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
           </div>
 
           <Pagination


### PR DESCRIPTION
## Summary

- Add a **Refresh Listings** button that re-scrapes Yad2/WinWin, removes stale listings from the DB (preserving bookmarks), and returns fresh results with a polished animated UI
- New `POST /api/v1/searches/{id}/refresh` endpoint with 60-second per-user cooldown and `Retry-After` header
- Skeleton loading cards, staggered card entrance/exit animations, field-level shimmer for pending enrichment data (km, city, fitness score)

## Changes

### Backend
| File | Change |
|------|--------|
| `internal/storage/interfaces.go` | New `DeleteStaleListings` method on `ListingStore` |
| `internal/storage/sqlite/listings.go` | SQLite implementation |
| `internal/storage/postgres/listings.go` | Postgres implementation |
| `internal/api/listings.go` | New refresh endpoint + `buildFilterCriteriaFromSearch` helper |
| `internal/api/api.go` | Wire `fetcher.Factory` + `refreshMu` cooldown map |
| `cmd/bot/main.go` | Pass fetcher factory to API server |

### Frontend
| File | Change |
|------|--------|
| `web/src/components/ListingCardSkeleton.tsx` | New shimmer skeleton matching card layout |
| `web/src/pages/ListingsPage.tsx` | Refresh button, AnimatePresence, staggered animations, skeleton loading |
| `web/src/components/ListingCardBody.tsx` | Field-level shimmer for km/city/fitness_score |
| `web/src/components/ui/PageHeader.tsx` | Accept ReactNode subtitle |
| `web/src/lib/api.ts` | `RefreshResponse` type + `refreshListings()` function |

### Tests
| File | Tests added |
|------|------------|
| `internal/storage/sqlite/sqlite_test.go` | 3 tests: removes unkept, preserves bookmarked, empty keep tokens |
| `internal/api/coverage_test.go` | 5 tests: no fetcher (503), invalid ID (400), not found (404), cooldown (429), filter builder |
| `internal/scheduler/run_test.go` | Mock interface updated |

## Test plan
- [x] `go test ./...` — all pass
- [x] `npx vitest run` — 117 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vite build` — production build succeeds
- [x] `go vet ./...` — clean
- [x] `gofmt` — all formatted

Made with [Cursor](https://cursor.com)