### PR TITLE
fix: enrich refresh listings with base_price and add pricelist logging

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/notifier/telegram"
+	"github.com/dsionov/carwatch/internal/pricelist"
 	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/spa"
 	"github.com/dsionov/carwatch/internal/storage"
@@ -114,7 +115,8 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = multi.Disconnect() }()
 
-	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, &logLevelVar, logger, fetcherFactory)
+	apiPriceListSvc := pricelist.NewService(store, logger.With("component", "api-pricelist"))
+	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, &logLevelVar, logger, fetcherFactory, apiPriceListSvc)
 	if err != nil {
 		return err
 	}
@@ -252,7 +254,7 @@ func buildBot(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 	return botHandler, tgNotif, multi, nil
 }
 
-func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger, fetchers *fetcher.Factory) (*api.Server, error) {
+func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger, fetchers *fetcher.Factory, plSvc *pricelist.Service) (*api.Server, error) {
 	var firebaseAuth api.TokenVerifier
 	if cfg.Firebase.ProjectID != "" {
 		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)
@@ -282,6 +284,7 @@ func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 		LogHub:       logHub,
 		LogLevel:     logLevel,
 		Fetchers:     fetchers,
+		PriceListSvc: plSvc,
 	})
 
 	return apiServer, nil

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/logstream"
+	"github.com/dsionov/carwatch/internal/pricelist"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -59,6 +60,7 @@ type Server struct {
 	ipRL         *ipRateLimiter
 	vacuumMu     sync.Mutex
 	fetchers     *fetcher.Factory
+	priceListSvc *pricelist.Service
 	refreshMu    sync.Map
 
 	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
@@ -100,6 +102,7 @@ type Config struct {
 	FirebaseAuth TokenVerifier
 	BotUsername  string
 	Fetchers     *fetcher.Factory
+	PriceListSvc *pricelist.Service
 }
 
 func New(c Config) *Server {
@@ -124,6 +127,7 @@ func New(c Config) *Server {
 		rl:           newRateLimiter(60, time.Second/60),
 		ipRL:         newIPRateLimiter(20, time.Second/10, c.API.TrustForwardedFor),
 		fetchers:     c.Fetchers,
+		priceListSvc: c.PriceListSvc,
 	}
 }
 

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -168,6 +168,14 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 			IsCommercial: l.Commercial,
 			FirstSeenAt:  time.Now(),
 		}
+		if s.priceListSvc != nil && l.SubModelID > 0 && l.Year > 0 {
+			if bp, ok := s.priceListSvc.Lookup(r.Context(), l.SubModelID, l.Year); ok && bp > 0 {
+				rec.BasePrice = &bp
+				s.logger.Debug("refresh: enriched with base_price",
+					"token", l.Token, "sub_model_id", l.SubModelID,
+					"year", l.Year, "base_price", bp)
+			}
+		}
 		records = append(records, rec)
 	}
 	if len(records) > 0 {

--- a/internal/pricelist/fetcher.go
+++ b/internal/pricelist/fetcher.go
@@ -41,14 +41,15 @@ func fetchGoHTTP(ctx context.Context, subModelID, year int) fetchResult {
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7")
 
+	start := time.Now()
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return fetchResult{Error: fmt.Sprintf("http get: %v", err)}
+		return fetchResult{Error: fmt.Sprintf("http get (%s): %v", time.Since(start).Round(time.Millisecond), err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
-		return fetchResult{Error: fmt.Sprintf("http status %d", resp.StatusCode)}
+		return fetchResult{Error: fmt.Sprintf("http status %d (url=%s, took=%s)", resp.StatusCode, url, time.Since(start).Round(time.Millisecond))}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
@@ -57,7 +58,11 @@ func fetchGoHTTP(ctx context.Context, subModelID, year int) fetchResult {
 	}
 
 	html := string(body)
-	return extractPriceFromHTML(html)
+	result := extractPriceFromHTML(html)
+	if result.Error != "" {
+		result.Error = fmt.Sprintf("%s (url=%s, body_len=%d, took=%s)", result.Error, url, len(body), time.Since(start).Round(time.Millisecond))
+	}
+	return result
 }
 
 func extractPriceFromHTML(html string) fetchResult {

--- a/internal/pricelist/service.go
+++ b/internal/pricelist/service.go
@@ -43,22 +43,31 @@ func (s *Service) ResetCycleCounter() {
 // If not cached or stale, it fetches from Yad2 (rate-limited).
 func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice int, ok bool) {
 	if subModelID <= 0 || year <= 0 {
+		s.logger.Debug("pricelist.Lookup: invalid params",
+			"sub_model_id", subModelID, "year", year)
 		return 0, false
 	}
 
 	entry, err := s.store.GetPriceListEntry(ctx, subModelID, year)
 	if err != nil {
-		s.logger.Error("price list cache read failed", "sub_model_id", subModelID, "year", year, "error", err)
+		s.logger.Error("pricelist.Lookup: cache read failed",
+			"sub_model_id", subModelID, "year", year, "error", err)
 		return 0, false
 	}
 
 	if entry != nil && time.Since(entry.FetchedAt) < cacheTTL {
+		s.logger.Debug("pricelist.Lookup: cache hit",
+			"sub_model_id", subModelID, "year", year,
+			"base_price", entry.BasePrice, "age", time.Since(entry.FetchedAt).Round(time.Minute))
 		return entry.BasePrice, true
 	}
 
 	s.mu.Lock()
 	if s.fetchCount >= maxFetchPerCycle {
 		s.mu.Unlock()
+		s.logger.Warn("pricelist.Lookup: cycle fetch limit reached",
+			"sub_model_id", subModelID, "year", year,
+			"fetch_count", s.fetchCount, "max", maxFetchPerCycle)
 		if entry != nil {
 			return entry.BasePrice, true
 		}
@@ -67,6 +76,9 @@ func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice i
 	elapsed := time.Since(s.lastFetch)
 	if elapsed < fetchCooldown {
 		s.mu.Unlock()
+		s.logger.Debug("pricelist.Lookup: cooldown active",
+			"sub_model_id", subModelID, "year", year,
+			"remaining", (fetchCooldown - elapsed).Round(time.Millisecond))
 		if entry != nil {
 			return entry.BasePrice, true
 		}
@@ -76,8 +88,21 @@ func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice i
 	s.lastFetch = time.Now()
 	s.mu.Unlock()
 
+	url := priceListURL(subModelID, year)
+	s.logger.Info("pricelist.Lookup: fetching from Yad2",
+		"sub_model_id", subModelID, "year", year, "url", url,
+		"fetch_count", s.fetchCount)
+
 	result := fetch(ctx, subModelID, year)
+	if result.Error != "" {
+		s.logger.Warn("pricelist.Lookup: fetch failed",
+			"sub_model_id", subModelID, "year", year,
+			"url", url, "error", result.Error)
+	}
 	if result.BasePrice <= 0 {
+		s.logger.Warn("pricelist.Lookup: no price extracted",
+			"sub_model_id", subModelID, "year", year,
+			"url", url, "fetch_error", result.Error)
 		if entry != nil {
 			return entry.BasePrice, true
 		}
@@ -92,15 +117,13 @@ func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice i
 		FetchedAt:  time.Now(),
 	}
 	if err := s.store.SetPriceListEntry(ctx, newEntry); err != nil {
-		s.logger.Error("price list cache write failed", "sub_model_id", subModelID, "year", year, "error", err)
+		s.logger.Error("pricelist.Lookup: cache write failed",
+			"sub_model_id", subModelID, "year", year, "error", err)
 	}
 
-	s.logger.Info("fetched price list",
-		"sub_model_id", subModelID,
-		"year", year,
-		"base_price", result.BasePrice,
-		"title", result.Title,
-	)
+	s.logger.Info("pricelist.Lookup: fetched successfully",
+		"sub_model_id", subModelID, "year", year,
+		"base_price", result.BasePrice, "title", result.Title)
 
 	return result.BasePrice, true
 }

--- a/internal/pricelist/service.go
+++ b/internal/pricelist/service.go
@@ -55,7 +55,7 @@ func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice i
 		return 0, false
 	}
 
-	if entry != nil && time.Since(entry.FetchedAt) < cacheTTL {
+	if entry != nil && time.Since(entry.FetchedAt) < cacheTTL && entry.BasePrice > 0 {
 		s.logger.Debug("pricelist.Lookup: cache hit",
 			"sub_model_id", subModelID, "year", year,
 			"base_price", entry.BasePrice, "age", time.Since(entry.FetchedAt).Round(time.Minute))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1041,13 +1041,41 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 }
 
 func (s *Scheduler) enrichWithBasePrice(ctx context.Context, listing *model.Listing) {
-	if s.priceListSvc == nil || listing.SubModelID <= 0 || listing.Year <= 0 {
+	if s.priceListSvc == nil {
+		s.logger.Debug("enrichWithBasePrice: skipped, pricelist service is nil",
+			"token", listing.Token)
 		return
 	}
-	bp, ok := s.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year)
-	if ok && bp > 0 {
-		listing.BasePrice = &bp
+	if listing.SubModelID <= 0 {
+		s.logger.Debug("enrichWithBasePrice: skipped, no sub_model_id",
+			"token", listing.Token, "sub_model_id", listing.SubModelID,
+			"sub_model", listing.SubModel, "model", listing.Model)
+		return
 	}
+	if listing.Year <= 0 {
+		s.logger.Debug("enrichWithBasePrice: skipped, no year",
+			"token", listing.Token, "year", listing.Year)
+		return
+	}
+
+	bp, ok := s.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year)
+	if !ok {
+		s.logger.Warn("enrichWithBasePrice: lookup failed or returned no price",
+			"token", listing.Token, "sub_model_id", listing.SubModelID,
+			"year", listing.Year)
+		return
+	}
+	if bp <= 0 {
+		s.logger.Warn("enrichWithBasePrice: lookup returned zero/negative price",
+			"token", listing.Token, "sub_model_id", listing.SubModelID,
+			"year", listing.Year, "base_price", bp)
+		return
+	}
+
+	listing.BasePrice = &bp
+	s.logger.Info("enrichWithBasePrice: set base_price",
+		"token", listing.Token, "sub_model_id", listing.SubModelID,
+		"year", listing.Year, "base_price", bp)
 }
 
 func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawListing, marketCache *scoring.MarketCache) model.Listing {


### PR DESCRIPTION
## Summary

- **Fix**: The refresh endpoint was saving listings without calling the pricelist service, so `base_price` was always `NULL` for refreshed listings. Wire `pricelist.Service` into the API server and enrich each listing during refresh.
- **Observability**: Add comprehensive logging across the entire pricelist pipeline (`enrichWithBasePrice`, `pricelist.Lookup`, HTTP fetcher) to diagnose why some listings are missing price list values.

## What was wrong

1. `POST /searches/{id}/refresh` never called the pricelist service — listings saved via refresh always had `base_price = NULL`
2. `enrichWithBasePrice` in the scheduler had **zero logging** — silently returned on every failure path
3. `pricelist.Service.Lookup` only logged errors, not cache hits, rate limit hits, or cooldown skips
4. The HTTP fetcher error messages had no URL, body size, or timing context

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./...` — all tests pass
- [x] `gofmt` — no formatting issues
- [ ] Deploy and monitor logs during next scheduler cycle to identify root cause of missing base_price
- [ ] Verify refresh button populates base_price after deployment

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated price-list service to enrich listings with base price information when available.

* **Improvements**
  * Enhanced error diagnostics with detailed timing and context information in price-list lookups.
  * Added structured logging for cache operations and fetch activities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/709)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->