### PR TITLE
fix: use azuretls stealth client for pricelist fetcher

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -115,7 +115,14 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = multi.Disconnect() }()
 
-	apiPriceListSvc := pricelist.NewService(store, logger.With("component", "api-pricelist"))
+	plClient, err := yad2.NewClient(cfg.HTTP.UserAgents, cfg.HTTP.Proxy)
+	if err != nil {
+		return fmt.Errorf("create pricelist client: %w", err)
+	}
+	defer plClient.Close()
+	plHTTP := pricelist.NewYad2Client(plClient)
+
+	apiPriceListSvc := pricelist.NewService(store, plHTTP, logger.With("component", "api-pricelist"))
 	apiServer, err := buildAPI(cfg, store, dynCatalog, logHub, &logLevelVar, logger, fetcherFactory, apiPriceListSvc)
 	if err != nil {
 		return err
@@ -148,6 +155,7 @@ func run(configPath string, logger *slog.Logger) error {
 		KmEnricher:       kmEnricher,
 		MarketStore:      store,
 		PriceListStore:   store,
+		PriceListHTTP:    plHTTP,
 		DailyDigestStore: store,
 	})
 	if err != nil {

--- a/internal/pricelist/adapter.go
+++ b/internal/pricelist/adapter.go
@@ -1,0 +1,30 @@
+package pricelist
+
+import (
+	"context"
+
+	"github.com/dsionov/carwatch/internal/fetcher/yad2"
+)
+
+// yad2Adapter wraps a yad2.HTTPDoer to satisfy pricelist.HTTPDoer.
+type yad2Adapter struct {
+	inner yad2.HTTPDoer
+}
+
+// NewYad2Client wraps a yad2.HTTPDoer (azuretls stealth client) for use
+// by the pricelist fetcher, reusing the same TLS fingerprint and proxy
+// configuration that bypasses Yad2's anti-bot protection.
+func NewYad2Client(client yad2.HTTPDoer) HTTPDoer {
+	return &yad2Adapter{inner: client}
+}
+
+func (a *yad2Adapter) Get(ctx context.Context, url string) (*HTTPResult, error) {
+	res, err := a.inner.Get(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPResult{
+		Body:       res.Body,
+		StatusCode: res.StatusCode,
+	}, nil
+}

--- a/internal/pricelist/fetcher.go
+++ b/internal/pricelist/fetcher.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -14,53 +12,36 @@ import (
 
 var basePriceLabelRe = regexp.MustCompile(`(?i)מחיר\s+בסיס[^₪]*₪\s*([\d,]+)`)
 
-var httpClient = &http.Client{
-	Timeout: 15 * time.Second,
-	Transport: &http.Transport{
-		MaxIdleConns:        10,
-		MaxIdleConnsPerHost: 5,
-		IdleConnTimeout:     90 * time.Second,
-	},
+// HTTPResult mirrors yad2.HTTPResult so the pricelist package does not
+// depend on the yad2 package.
+type HTTPResult struct {
+	Body       []byte
+	StatusCode int
 }
 
-func fetch(ctx context.Context, subModelID, year int) fetchResult {
-	return fetchGoHTTP(ctx, subModelID, year)
+// HTTPDoer abstracts HTTP GET requests so the pricelist fetcher can use
+// the same azuretls stealth client that the Yad2 listing scraper uses.
+type HTTPDoer interface {
+	Get(ctx context.Context, url string) (*HTTPResult, error)
 }
 
-func fetchGoHTTP(ctx context.Context, subModelID, year int) fetchResult {
+func fetch(ctx context.Context, client HTTPDoer, subModelID, year int) fetchResult {
 	url := priceListURL(subModelID, year)
 
-	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(reqCtx, "GET", url, nil)
-	if err != nil {
-		return fetchResult{Error: fmt.Sprintf("create request: %v", err)}
-	}
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-	req.Header.Set("Accept-Language", "he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7")
-
 	start := time.Now()
-	resp, err := httpClient.Do(req)
+	res, err := client.Get(ctx, url)
 	if err != nil {
 		return fetchResult{Error: fmt.Sprintf("http get (%s): %v", time.Since(start).Round(time.Millisecond), err)}
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
-		return fetchResult{Error: fmt.Sprintf("http status %d (url=%s, took=%s)", resp.StatusCode, url, time.Since(start).Round(time.Millisecond))}
+	if res.StatusCode != 200 {
+		return fetchResult{Error: fmt.Sprintf("http status %d (url=%s, took=%s)", res.StatusCode, url, time.Since(start).Round(time.Millisecond))}
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
-	if err != nil {
-		return fetchResult{Error: fmt.Sprintf("read body: %v", err)}
-	}
-
-	html := string(body)
+	html := string(res.Body)
 	result := extractPriceFromHTML(html)
 	if result.Error != "" {
-		result.Error = fmt.Sprintf("%s (url=%s, body_len=%d, took=%s)", result.Error, url, len(body), time.Since(start).Round(time.Millisecond))
+		result.Error = fmt.Sprintf("%s (url=%s, body_len=%d, took=%s)", result.Error, url, len(res.Body), time.Since(start).Round(time.Millisecond))
 	}
 	return result
 }

--- a/internal/pricelist/fetcher_test.go
+++ b/internal/pricelist/fetcher_test.go
@@ -1,0 +1,123 @@
+package pricelist
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+type mockHTTPDoer struct {
+	body       []byte
+	statusCode int
+	err        error
+}
+
+func (m *mockHTTPDoer) Get(_ context.Context, _ string) (*HTTPResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &HTTPResult{Body: m.body, StatusCode: m.statusCode}, nil
+}
+
+func TestFetch_Success_HTMLLabel(t *testing.T) {
+	html := `<div>מחיר בסיס ₪ 120,000</div>`
+	client := &mockHTTPDoer{body: []byte(html), statusCode: 200}
+
+	result := fetch(context.Background(), client, 12345, 2020)
+	if result.Error != "" {
+		t.Fatalf("unexpected error: %s", result.Error)
+	}
+	if result.BasePrice != 120000 {
+		t.Errorf("expected base_price=120000, got %d", result.BasePrice)
+	}
+}
+
+func TestFetch_Success_JSONBasePrice(t *testing.T) {
+	html := `<script>{"basePrice": 95000, "title": "Honda Civic"}</script>`
+	client := &mockHTTPDoer{body: []byte(html), statusCode: 200}
+
+	result := fetch(context.Background(), client, 12345, 2020)
+	if result.Error != "" {
+		t.Fatalf("unexpected error: %s", result.Error)
+	}
+	if result.BasePrice != 95000 {
+		t.Errorf("expected base_price=95000, got %d", result.BasePrice)
+	}
+}
+
+func TestFetch_HTTP400(t *testing.T) {
+	client := &mockHTTPDoer{body: nil, statusCode: 400}
+
+	result := fetch(context.Background(), client, 12345, 2020)
+	if result.Error == "" {
+		t.Fatal("expected error for HTTP 400")
+	}
+	if result.BasePrice != 0 {
+		t.Errorf("expected base_price=0, got %d", result.BasePrice)
+	}
+}
+
+func TestFetch_HTTPError(t *testing.T) {
+	client := &mockHTTPDoer{err: fmt.Errorf("connection refused")}
+
+	result := fetch(context.Background(), client, 12345, 2020)
+	if result.Error == "" {
+		t.Fatal("expected error for connection failure")
+	}
+}
+
+func TestFetch_NoPriceInHTML(t *testing.T) {
+	html := `<html><body>No price data here</body></html>`
+	client := &mockHTTPDoer{body: []byte(html), statusCode: 200}
+
+	result := fetch(context.Background(), client, 12345, 2020)
+	if result.Error == "" {
+		t.Fatal("expected error when no price found")
+	}
+	if result.BasePrice != 0 {
+		t.Errorf("expected base_price=0, got %d", result.BasePrice)
+	}
+}
+
+func TestExtractPriceFromHTML_LabelWithCommas(t *testing.T) {
+	html := `מחיר בסיס ₪ 1,234,567`
+	result := extractPriceFromHTML(html)
+	if result.BasePrice != 1234567 {
+		t.Errorf("expected 1234567, got %d", result.BasePrice)
+	}
+}
+
+func TestExtractPriceFromHTML_JSONFallback(t *testing.T) {
+	html := `no label here but {"basePrice": 55000}`
+	result := extractPriceFromHTML(html)
+	if result.BasePrice != 55000 {
+		t.Errorf("expected 55000, got %d", result.BasePrice)
+	}
+}
+
+func TestExtractPriceFromHTML_PriceTooLow(t *testing.T) {
+	html := `מחיר בסיס ₪ 500`
+	result := extractPriceFromHTML(html)
+	if result.Error == "" {
+		t.Error("expected error for price below 1000 threshold")
+	}
+}
+
+func TestParsePrice(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"120,000", 120000},
+		{"55000", 55000},
+		{" 1,234,567 ", 1234567},
+		{"", 0},
+		{"abc", 0},
+	}
+	for _, tt := range tests {
+		got := parsePrice(tt.input)
+		if got != tt.expected {
+			t.Errorf("parsePrice(%q) = %d, want %d", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/internal/pricelist/service.go
+++ b/internal/pricelist/service.go
@@ -18,6 +18,7 @@ const (
 
 type Service struct {
 	store  storage.PriceListStore
+	client HTTPDoer
 	logger *slog.Logger
 
 	mu         sync.Mutex
@@ -25,9 +26,10 @@ type Service struct {
 	fetchCount int
 }
 
-func NewService(store storage.PriceListStore, logger *slog.Logger) *Service {
+func NewService(store storage.PriceListStore, client HTTPDoer, logger *slog.Logger) *Service {
 	return &Service{
 		store:  store,
+		client: client,
 		logger: logger,
 	}
 }
@@ -93,7 +95,7 @@ func (s *Service) Lookup(ctx context.Context, subModelID, year int) (basePrice i
 		"sub_model_id", subModelID, "year", year, "url", url,
 		"fetch_count", s.fetchCount)
 
-	result := fetch(ctx, subModelID, year)
+	result := fetch(ctx, s.client, subModelID, year)
 	if result.Error != "" {
 		s.logger.Warn("pricelist.Lookup: fetch failed",
 			"sub_model_id", subModelID, "year", year,

--- a/internal/pricelist/service_test.go
+++ b/internal/pricelist/service_test.go
@@ -1,0 +1,159 @@
+package pricelist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+type mockPriceListStore struct {
+	entries map[string]*storage.PriceListEntry
+	setErr  error
+}
+
+func newMockStore() *mockPriceListStore {
+	return &mockPriceListStore{entries: make(map[string]*storage.PriceListEntry)}
+}
+
+func (m *mockPriceListStore) key(subModelID, year int) string {
+	return fmt.Sprintf("%d:%d", subModelID, year)
+}
+
+func (m *mockPriceListStore) GetPriceListEntry(_ context.Context, subModelID, year int) (*storage.PriceListEntry, error) {
+	e, ok := m.entries[m.key(subModelID, year)]
+	if !ok {
+		return nil, nil
+	}
+	return e, nil
+}
+
+func (m *mockPriceListStore) SetPriceListEntry(_ context.Context, e storage.PriceListEntry) error {
+	if m.setErr != nil {
+		return m.setErr
+	}
+	m.entries[m.key(e.SubModelID, e.Year)] = &e
+	return nil
+}
+
+func TestLookup_CacheHit(t *testing.T) {
+	store := newMockStore()
+	store.entries["100:2020"] = &storage.PriceListEntry{
+		SubModelID: 100, Year: 2020, BasePrice: 80000,
+		FetchedAt: time.Now().Add(-1 * time.Hour),
+	}
+
+	client := &mockHTTPDoer{statusCode: 500}
+	svc := NewService(store, client, slog.Default())
+
+	bp, ok := svc.Lookup(context.Background(), 100, 2020)
+	if !ok {
+		t.Fatal("expected ok=true for cache hit")
+	}
+	if bp != 80000 {
+		t.Errorf("expected 80000, got %d", bp)
+	}
+}
+
+func TestLookup_CacheMiss_FetchesAndCaches(t *testing.T) {
+	store := newMockStore()
+	html := `<div>מחיר בסיס ₪ 95,000</div>`
+	client := &mockHTTPDoer{body: []byte(html), statusCode: 200}
+	svc := NewService(store, client, slog.Default())
+
+	bp, ok := svc.Lookup(context.Background(), 200, 2021)
+	if !ok {
+		t.Fatal("expected ok=true after fetch")
+	}
+	if bp != 95000 {
+		t.Errorf("expected 95000, got %d", bp)
+	}
+
+	cached := store.entries["200:2021"]
+	if cached == nil {
+		t.Fatal("expected entry to be cached")
+	}
+	if cached.BasePrice != 95000 {
+		t.Errorf("cached base_price: expected 95000, got %d", cached.BasePrice)
+	}
+}
+
+func TestLookup_InvalidParams(t *testing.T) {
+	svc := NewService(newMockStore(), &mockHTTPDoer{}, slog.Default())
+
+	_, ok := svc.Lookup(context.Background(), 0, 2020)
+	if ok {
+		t.Error("expected ok=false for subModelID=0")
+	}
+
+	_, ok = svc.Lookup(context.Background(), 100, 0)
+	if ok {
+		t.Error("expected ok=false for year=0")
+	}
+}
+
+func TestLookup_FetchFailsFallsBackToStaleCache(t *testing.T) {
+	store := newMockStore()
+	store.entries["100:2020"] = &storage.PriceListEntry{
+		SubModelID: 100, Year: 2020, BasePrice: 70000,
+		FetchedAt: time.Now().Add(-30 * 24 * time.Hour), // stale (>7 days)
+	}
+
+	client := &mockHTTPDoer{statusCode: 400}
+	svc := NewService(store, client, slog.Default())
+
+	bp, ok := svc.Lookup(context.Background(), 100, 2020)
+	if !ok {
+		t.Fatal("expected ok=true with stale fallback")
+	}
+	if bp != 70000 {
+		t.Errorf("expected stale value 70000, got %d", bp)
+	}
+}
+
+func TestLookup_CachedZeroTreatedAsMiss(t *testing.T) {
+	store := newMockStore()
+	store.entries["100:2020"] = &storage.PriceListEntry{
+		SubModelID: 100, Year: 2020, BasePrice: 0,
+		FetchedAt: time.Now().Add(-1 * time.Hour),
+	}
+
+	html := `<div>מחיר בסיס ₪ 85,000</div>`
+	client := &mockHTTPDoer{body: []byte(html), statusCode: 200}
+	svc := NewService(store, client, slog.Default())
+
+	bp, ok := svc.Lookup(context.Background(), 100, 2020)
+	if !ok {
+		t.Fatal("expected ok=true after re-fetch")
+	}
+	if bp != 85000 {
+		t.Errorf("expected 85000, got %d", bp)
+	}
+}
+
+func TestResetCycleCounter(t *testing.T) {
+	svc := NewService(newMockStore(), &mockHTTPDoer{statusCode: 200, body: []byte(`מחיר בסיס ₪ 50,000`)}, slog.Default())
+
+	for i := 0; i < maxFetchPerCycle; i++ {
+		svc.Lookup(context.Background(), i+1, 2020)
+		time.Sleep(fetchCooldown + time.Millisecond)
+	}
+
+	_, ok := svc.Lookup(context.Background(), 999, 2020)
+	if ok {
+		t.Error("expected ok=false after hitting cycle limit")
+	}
+
+	svc.ResetCycleCounter()
+	time.Sleep(fetchCooldown + time.Millisecond)
+	bp, ok := svc.Lookup(context.Background(), 999, 2020)
+	if !ok {
+		t.Error("expected ok=true after reset")
+	}
+	if bp != 50000 {
+		t.Errorf("expected 50000, got %d", bp)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -128,6 +128,7 @@ type Options struct {
 	KmEnricher       KmEnricher
 	MarketStore      storage.MarketStore
 	PriceListStore   storage.PriceListStore
+	PriceListHTTP    pricelist.HTTPDoer
 	DailyDigestStore storage.DailyDigestStore
 }
 
@@ -160,8 +161,8 @@ func NewWithOptions(
 	}
 
 	var plSvc *pricelist.Service
-	if opts.PriceListStore != nil {
-		plSvc = pricelist.NewService(opts.PriceListStore, logger)
+	if opts.PriceListStore != nil && opts.PriceListHTTP != nil {
+		plSvc = pricelist.NewService(opts.PriceListStore, opts.PriceListHTTP, logger)
 	}
 
 	return &Scheduler{


### PR DESCRIPTION
## Summary

- **Root cause**: Yad2 returns HTTP 400 to the pricelist fetcher because it used a plain `net/http` client. Yad2's anti-bot blocks standard Go TLS fingerprints. The main listing scraper uses `azuretls` (Chrome TLS fingerprint) which works fine.
- **Fix**: Replace the plain HTTP client with the same azuretls stealth client, injected via a clean `HTTPDoer` interface + adapter pattern.
- **Tests**: Added 14 tests for the pricelist package (fetcher + service) with mock HTTP client.

## Changes

| File | Change |
|------|--------|
| `internal/pricelist/fetcher.go` | Replace `net/http` with `HTTPDoer` interface |
| `internal/pricelist/adapter.go` | Adapter bridging `yad2.HTTPDoer` → `pricelist.HTTPDoer` |
| `internal/pricelist/service.go` | Accept `HTTPDoer` in constructor |
| `internal/scheduler/scheduler.go` | Accept `PriceListHTTP` option |
| `cmd/bot/main.go` | Create azuretls client and pass to both scheduler and API |
| `internal/pricelist/fetcher_test.go` | 9 tests for fetch + HTML extraction |
| `internal/pricelist/service_test.go` | 5 tests for Lookup (cache hit/miss, fallback, reset) |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all pass (14 new pricelist tests)
- [x] `gofmt` clean
- [ ] Deploy and verify pricelist fetch succeeds (HTTP 200 instead of 400)
- [ ] Verify base_price appears on listing detail page after refresh

Made with [Cursor](https://cursor.com)