### PR TITLE
feat: add refresh retry logic and pricelist skeleton loading

### DIFF
--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -121,9 +121,26 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 			MaxHand:      sr.MaxHand,
 			EngineMinCC:  sr.EngineMinCC,
 		}
-		raw, fetchErr := f.Fetch(r.Context(), params)
+
+		var raw []model.RawListing
+		var fetchErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			raw, fetchErr = f.Fetch(r.Context(), params)
+			if fetchErr == nil {
+				break
+			}
+			log.Warn("fetch attempt failed", "source", src,
+				"attempt", fmt.Sprintf("%d/3", attempt+1), "error", fetchErr)
+			if attempt < 2 {
+				delay := time.Duration(1<<attempt) * time.Second
+				select {
+				case <-r.Context().Done():
+					break
+				case <-time.After(delay):
+				}
+			}
+		}
 		if fetchErr != nil {
-			log.Warn("fetch failed", "source", src, "error", fetchErr)
 			continue
 		}
 		allRaw = append(allRaw, raw...)

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -105,12 +105,19 @@ export function ListingCardBody({
                 listing.median_price,
                 listing.base_price,
               );
-              if (!mc) return null;
-              return (
-                <p className={cn("text-[11px] font-medium mt-0.5", mc.color)}>
-                  {mc.label}
-                </p>
-              );
+              if (mc) {
+                return (
+                  <p className={cn("text-[11px] font-medium mt-0.5", mc.color)}>
+                    {mc.label}
+                  </p>
+                );
+              }
+              if (listing.price > 0 && !listing.base_price && !listing.median_price) {
+                return (
+                  <span className="inline-block h-3 w-16 mt-1 rounded shimmer-skeleton" />
+                );
+              }
+              return null;
             })()}
           </div>
         </div>

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -325,7 +325,24 @@ function MarketValueCard({
   const hasBase = basePrice != null && basePrice > 0;
   const hasMedian = medianPrice != null && medianPrice > 0;
 
-  if (!hasBase && !hasMedian) return null;
+  if (!hasBase && !hasMedian) {
+    return (
+      <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-3">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="inline-block h-4 w-24 rounded shimmer-skeleton" />
+          <span className="inline-block h-6 w-20 rounded shimmer-skeleton" />
+        </div>
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="inline-block h-3.5 w-28 rounded shimmer-skeleton" />
+          <span className="inline-block h-3.5 w-10 rounded shimmer-skeleton" />
+        </div>
+        <div className="h-2 rounded-full shimmer-skeleton" />
+        <p className="text-[10px] text-muted-foreground text-center">
+          טוען נתוני מחירון...
+        </p>
+      </div>
+    );
+  }
 
   const referenceForBar = hasBase ? basePrice! : medianPrice!;
   const mc = marketComparison(price, medianPrice, basePrice);


### PR DESCRIPTION
## Summary

- **Refresh retry**: the `refreshListings` handler now retries up to 3 times with exponential backoff (1s, 2s) when Yad2 returns transient HTTP 400 errors — production logs showed that manual refreshes were silently failing and returning 0 listings while the scheduler (which has retry logic) succeeded fine
- **Listing card shimmer**: when `base_price` and `median_price` are not yet available, a shimmer skeleton appears under the price where the market comparison label will appear (e.g. "מתחת למחירון")
- **Detail page skeleton**: instead of hiding the entire Market Value card when data hasn't loaded yet, a shimmer skeleton placeholder with "טוען נתוני מחירון..." is shown

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] Go API tests pass
- [x] `npx tsc --noEmit` clean
- [x] Frontend vitest 117/117 pass

Made with [Cursor](https://cursor.com)