### PR TITLE
feat: add PWA, search presets, suspicious detection, market trends, Postgres tests, and WinWin parser robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true'
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: carwatch
+          POSTGRES_PASSWORD: carwatch
+          POSTGRES_DB: carwatch_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -93,6 +107,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gcc
       - name: Run tests
         run: make test
+        env:
+          TEST_POSTGRES_DSN: postgres://carwatch:carwatch@localhost:5432/carwatch_test?sslmode=disable
       - name: Run e2e tests
         timeout-minutes: 5
         run: make test-e2e

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -173,6 +173,7 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("POST /api/v1/searches/{id}/pause", s.pauseSearch)
 	mux.HandleFunc("POST /api/v1/searches/{id}/resume", s.resumeSearch)
 
+	mux.HandleFunc("GET /api/v1/searches/{id}/stats", s.searchStats)
 	mux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
 	mux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
 	mux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1479,3 +1479,61 @@ func TestMarkListingUserSeen(t *testing.T) {
 		t.Errorf("expected count 1 after unmark, got %d", countResp.Count)
 	}
 }
+
+func TestSearchStats(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	// Create a search
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Source: "yad2", Manufacturer: 19, Model: 10226,
+		YearMin: 2018, YearMax: 2024, PriceMax: 200000,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	// Add listings
+	for i, price := range []int{80000, 100000, 120000} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: fmt.Sprintf("stats-tok%d", i), ChatID: 999,
+			SearchID: created.ID, SearchName: created.Name,
+			Manufacturer: "Toyota", Model: "Corolla",
+			Year: 2021, Price: price,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Get stats
+	w = doRequest(t, srv, "GET", fmt.Sprintf("/api/v1/searches/%d/stats", created.ID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("stats: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var stats storage.SearchStats
+	mustUnmarshal(t, w.Body.Bytes(), &stats)
+	if stats.Total != 3 {
+		t.Errorf("Total = %d, want 3", stats.Total)
+	}
+	if stats.MinPrice != 80000 {
+		t.Errorf("MinPrice = %d, want 80000", stats.MinPrice)
+	}
+	if stats.MaxPrice != 120000 {
+		t.Errorf("MaxPrice = %d, want 120000", stats.MaxPrice)
+	}
+	if stats.AvgPrice != 100000 {
+		t.Errorf("AvgPrice = %f, want 100000", stats.AvgPrice)
+	}
+}
+
+func TestSearchStats_NotFound(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "GET", "/api/v1/searches/99999/stats", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -235,7 +235,7 @@ func toListingResponses(records []storage.ListingRecord, saved, seen map[string]
 		if seen != nil && seen[l.Token] {
 			seenFlag = true
 		}
-		items = append(items, listingResponse{
+		resp := listingResponse{
 			Token:        l.Token,
 			SearchName:   l.SearchName,
 			Manufacturer: l.Manufacturer,
@@ -262,7 +262,12 @@ func toListingResponses(records []storage.ListingRecord, saved, seen map[string]
 			Saved:        savedFlag,
 			Seen:         seenFlag,
 			IsCommercial: l.IsCommercial,
-		})
+		}
+		if l.RemovedAt != nil {
+			s := l.RemovedAt.UTC().Format("2006-01-02T15:04:05Z")
+			resp.RemovedAt = &s
+		}
+		items = append(items, resp)
 	}
 	return items
 }

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -40,6 +40,10 @@ type listingResponse struct {
 	Seen bool `json:"seen,omitempty"`
 	// IsCommercial: omitted when unknown; false = private seller; true = dealer/commercial.
 	IsCommercial *bool `json:"is_commercial,omitempty"`
+	// RemovedAt: set when the listing disappeared from the source but is bookmarked.
+	RemovedAt *string `json:"removed_at,omitempty"`
+	// SuspiciousReasons: reasons the listing was flagged as suspicious.
+	SuspiciousReasons []string `json:"suspicious_reasons,omitempty"`
 }
 
 type listingsPageResponse struct {
@@ -309,7 +313,7 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 		seenFlag = true
 	}
 
-	writeJSON(w, http.StatusOK, listingResponse{
+	resp := listingResponse{
 		Token:        l.Token,
 		SearchName:   l.SearchName,
 		Manufacturer: l.Manufacturer,
@@ -336,7 +340,12 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 		Saved:        savedFlag,
 		Seen:         seenFlag,
 		IsCommercial: l.IsCommercial,
-	})
+	}
+	if l.RemovedAt != nil {
+		s := l.RemovedAt.UTC().Format("2006-01-02T15:04:05Z")
+		resp.RemovedAt = &s
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func listingFilterFromSearch(sr *storage.Search) storage.ListingFilter {

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -485,6 +485,45 @@ func (s *Server) deleteSearch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (s *Server) searchStats(w http.ResponseWriter, r *http.Request) {
+	chatID, okChat := requireChatID(w, r)
+	if !okChat {
+		return
+	}
+	id, ok := parsePathID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid search id")
+		return
+	}
+
+	log := s.handlerLogger(r, "op", "search_stats", "search_id", id)
+
+	sr, err := s.searches.GetSearch(r.Context(), id, chatID)
+	if err != nil {
+		log.Error("get search for stats failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get search")
+		return
+	}
+	if sr == nil {
+		writeError(w, http.StatusNotFound, "search not found")
+		return
+	}
+
+	if s.listings == nil {
+		writeError(w, http.StatusServiceUnavailable, "listing store not available")
+		return
+	}
+
+	stats, err := s.listings.SearchStats(r.Context(), chatID, id)
+	if err != nil {
+		log.Error("search stats query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get search stats")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, stats)
+}
+
 func (s *Server) pauseSearch(w http.ResponseWriter, r *http.Request) {
 	s.setSearchActive(w, r, false)
 }

--- a/internal/fetcher/winwin/parser.go
+++ b/internal/fetcher/winwin/parser.go
@@ -3,6 +3,7 @@ package winwin
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -12,6 +13,9 @@ import (
 	"github.com/dsionov/carwatch/internal/model"
 	"golang.org/x/net/html"
 )
+
+// cardClassPatterns are substrings that indicate a listing card container element.
+var cardClassPatterns = []string{"card", "item", "listing", "product", "result", "vehicle"}
 
 var (
 	priceRe      = regexp.MustCompile("(?:" + "\u20aa" + `|ש"ח|NIS|ILS|ILS\s*)\s*([\d,]+)|([\d,]+)\s*` + "\u20aa")
@@ -126,18 +130,41 @@ func resolveWinWinURL(href string) string {
 }
 
 func listingCardScope(a *html.Node) *html.Node {
+	// Walk up to 10 parents looking for an element whose class suggests a card container.
 	n := a
-	for i := 0; i < 6 && n != nil; i++ {
-		if n.Parent != nil {
-			n = n.Parent
-		} else {
-			break
+	for i := 0; i < 10 && n.Parent != nil; i++ {
+		n = n.Parent
+		if looksLikeCardContainer(n) {
+			slog.Debug("listingCardScope: matched card container by class", "level", i+1, "class", attr(n, "class"))
+			return n
 		}
 	}
-	if n == nil {
-		return a
+
+	// Fallback: walk exactly 6 parents from the anchor (original heuristic).
+	slog.Debug("listingCardScope: no card class found, falling back to 6-parent heuristic")
+	n = a
+	for i := 0; i < 6 && n.Parent != nil; i++ {
+		n = n.Parent
 	}
 	return n
+}
+
+// looksLikeCardContainer returns true if the node's class attribute contains
+// a substring that commonly indicates a listing card container.
+func looksLikeCardContainer(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+	cls := strings.ToLower(attr(n, "class"))
+	if cls == "" {
+		return false
+	}
+	for _, pattern := range cardClassPatterns {
+		if strings.Contains(cls, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 func listingTokenFromHref(href string) (string, bool) {
@@ -208,7 +235,7 @@ func firstMatchInt(re *regexp.Regexp, s string) (int, bool) {
 }
 
 func extractCityHeuristic(blob string) string {
-	for _, sep := range []string{"•", "|", "·"} {
+	for _, sep := range []string{"•", "|", "·", " - ", ","} {
 		i := strings.Index(blob, sep)
 		if i >= 0 {
 			frag := strings.TrimSpace(blob[i+len(sep):])

--- a/internal/fetcher/winwin/winwin.go
+++ b/internal/fetcher/winwin/winwin.go
@@ -120,6 +120,12 @@ func (f *WinWinFetcher) Fetch(ctx context.Context, params model.SourceParams) ([
 	if err != nil {
 		return nil, fmt.Errorf("parse page: %w", err)
 	}
+	if len(listings) == 0 && len(result.Body) > 1000 {
+		f.logger.Warn("WinWin returned HTML but parsed 0 listings — page structure may have changed",
+			"body_bytes", len(result.Body),
+			"url", reqURL,
+		)
+	}
 	f.logger.Info("fetched winwin listings", "count", len(listings))
 	for i, l := range listings {
 		f.logger.Debug("winwin listing parsed",

--- a/internal/fetcher/winwin/winwin_test.go
+++ b/internal/fetcher/winwin/winwin_test.go
@@ -140,3 +140,173 @@ func TestParseListingsPage_NilReader(t *testing.T) {
 		t.Fatalf("err=%v listings=%v", err, listings)
 	}
 }
+
+func TestParseListingsPage_Fixture(t *testing.T) {
+	f, err := os.Open("../../../testdata/winwin_page.html")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	listings, err := ParseListingsPage(f)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 3 {
+		t.Fatalf("want 3 listings (4th is duplicate), got %d", len(listings))
+	}
+
+	// Listing 1: Toyota Corolla
+	l := listings[0]
+	if l.Token != "12345" {
+		t.Errorf("listing[0].Token = %q, want 12345", l.Token)
+	}
+	if l.Year != 2022 {
+		t.Errorf("listing[0].Year = %d, want 2022", l.Year)
+	}
+	if l.Price != 149000 {
+		t.Errorf("listing[0].Price = %d, want 149000", l.Price)
+	}
+	if l.Km != 45000 {
+		t.Errorf("listing[0].Km = %d, want 45000", l.Km)
+	}
+	if l.Hand != 2 {
+		t.Errorf("listing[0].Hand = %d, want 2", l.Hand)
+	}
+
+	// Listing 2: Mazda 3
+	l = listings[1]
+	if l.Token != "67890" {
+		t.Errorf("listing[1].Token = %q, want 67890", l.Token)
+	}
+	if l.Year != 2021 {
+		t.Errorf("listing[1].Year = %d, want 2021", l.Year)
+	}
+	if l.Price != 125000 {
+		t.Errorf("listing[1].Price = %d, want 125000", l.Price)
+	}
+	if l.Km != 60000 {
+		t.Errorf("listing[1].Km = %d, want 60000", l.Km)
+	}
+	if l.Hand != 1 {
+		t.Errorf("listing[1].Hand = %d, want 1", l.Hand)
+	}
+
+	// Listing 3: Hyundai Tucson
+	l = listings[2]
+	if l.Token != "11223" {
+		t.Errorf("listing[2].Token = %q, want 11223", l.Token)
+	}
+	if l.Year != 2023 {
+		t.Errorf("listing[2].Year = %d, want 2023", l.Year)
+	}
+	if l.Price != 189000 {
+		t.Errorf("listing[2].Price = %d, want 189000", l.Price)
+	}
+	if l.Km != 20000 {
+		t.Errorf("listing[2].Km = %d, want 20000", l.Km)
+	}
+	if l.Hand != 1 {
+		t.Errorf("listing[2].Hand = %d, want 1", l.Hand)
+	}
+
+	// Verify page links are fully resolved
+	for i, ll := range listings {
+		if !strings.HasPrefix(ll.PageLink, "https://www.winwin.co.il/") {
+			t.Errorf("listing[%d].PageLink = %q, want https://www.winwin.co.il/ prefix", i, ll.PageLink)
+		}
+	}
+}
+
+func TestParseListingsPage_CardClassScope(t *testing.T) {
+	// Verify that the parser uses class-based card detection when available.
+	// The anchor is deeply nested (>6 levels), but the card class is at level 3.
+	html := `<!DOCTYPE html><html><body>
+<div class="page">
+  <div class="results">
+    <div class="listing-card">
+      <div class="inner">
+        <div class="wrap">
+          <div class="deep1">
+            <div class="deep2">
+              <div class="deep3">
+                <a href="/vehicles/private/99999">סובארו XV 2020</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <span>95,000 ₪</span>
+        <span>80,000 קמ</span>
+      </div>
+    </div>
+  </div>
+</div>
+</body></html>`
+
+	listings, err := ParseListingsPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("want 1 listing, got %d", len(listings))
+	}
+	l := listings[0]
+	if l.Price != 95000 {
+		t.Errorf("Price = %d, want 95000 (card scope should include price)", l.Price)
+	}
+	if l.Km != 80000 {
+		t.Errorf("Km = %d, want 80000 (card scope should include km)", l.Km)
+	}
+}
+
+func TestExtractCityHeuristic_Separators(t *testing.T) {
+	tests := []struct {
+		name string
+		blob string
+		want string
+	}{
+		{name: "bullet", blob: "some text • תל אביב", want: "תל אביב"},
+		{name: "pipe", blob: "some text | חיפה", want: "חיפה"},
+		{name: "middle_dot", blob: "some text · ירושלים", want: "ירושלים"},
+		{name: "dash", blob: "some text - באר שבע", want: "באר שבע"},
+		{name: "comma", blob: "some text, נתניה", want: "נתניה"},
+		{name: "no_separator", blob: "some text without city", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractCityHeuristic(tt.blob)
+			if got != tt.want {
+				t.Errorf("extractCityHeuristic(%q) = %q, want %q", tt.blob, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetch_ZeroResultsWarning(t *testing.T) {
+	// Return a large HTML body with no vehicle links — should log a warning but not error.
+	bigBody := "<html><body>" + strings.Repeat("<p>filler content</p>", 200) + "</body></html>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(bigBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := &WinWinFetcher{
+		userAgents: []string{"TestAgent/1.0"},
+		baseURL:    srv.URL,
+		logger:     logger,
+	}
+	var err error
+	f.client, err = NewClient([]string{"TestAgent/1.0"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listings, err := f.Fetch(context.Background(), model.SourceParams{})
+	if err != nil {
+		t.Fatalf("Fetch should not error on zero results: %v", err)
+	}
+	if len(listings) != 0 {
+		t.Fatalf("expected 0 listings, got %d", len(listings))
+	}
+}

--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -47,9 +47,10 @@ type FitnessDim struct {
 
 type Listing struct {
 	RawListing
-	SearchName       string
-	DealScore        *ScoreInfo
-	FitnessScore     float64
-	FitnessBreakdown []FitnessDim
-	BasePrice        *int
+	SearchName         string
+	DealScore          *ScoreInfo
+	FitnessScore       float64
+	FitnessBreakdown   []FitnessDim
+	BasePrice          *int
+	SuspiciousReasons  []string `json:"suspicious_reasons,omitempty"`
 }

--- a/internal/model/listing.go
+++ b/internal/model/listing.go
@@ -47,10 +47,10 @@ type FitnessDim struct {
 
 type Listing struct {
 	RawListing
-	SearchName         string
-	DealScore          *ScoreInfo
-	FitnessScore       float64
-	FitnessBreakdown   []FitnessDim
-	BasePrice          *int
-	SuspiciousReasons  []string `json:"suspicious_reasons,omitempty"`
+	SearchName        string
+	DealScore         *ScoreInfo
+	FitnessScore      float64
+	FitnessBreakdown  []FitnessDim
+	BasePrice         *int
+	SuspiciousReasons []string `json:"suspicious_reasons,omitempty"`
 }

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -81,6 +81,7 @@ func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawLis
 			MedianKm:    medianKm,
 			CohortSize:  cohort,
 		}
+		listing.SuspiciousReasons = scoring.DetectSuspicious(l, medianPrice)
 	}
 	return listing
 }

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -303,6 +303,10 @@ func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (in
 	return 0, nil
 }
 
+func (m *mockListingStore) SearchStats(_ context.Context, _ int64, _ int64) (*storage.SearchStats, error) {
+	return &storage.SearchStats{}, nil
+}
+
 func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
 }

--- a/internal/scoring/suspicious.go
+++ b/internal/scoring/suspicious.go
@@ -1,0 +1,21 @@
+package scoring
+
+import "github.com/dsionov/carwatch/internal/model"
+
+// DetectSuspicious returns a list of reason codes if the listing looks suspicious.
+// An empty/nil slice means no suspicion was detected.
+func DetectSuspicious(listing model.RawListing, medianPrice int) []string {
+	var reasons []string
+
+	// Price dramatically below market (< 50% of median).
+	if medianPrice > 0 && listing.Price > 0 && listing.Price < medianPrice/2 {
+		reasons = append(reasons, "price_below_market")
+	}
+
+	// No photos with very low price (< 70% of median).
+	if listing.ImageURL == "" && medianPrice > 0 && listing.Price > 0 && listing.Price < medianPrice*70/100 {
+		reasons = append(reasons, "no_photo_low_price")
+	}
+
+	return reasons
+}

--- a/internal/scoring/suspicious_test.go
+++ b/internal/scoring/suspicious_test.go
@@ -1,0 +1,80 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/model"
+)
+
+func TestDetectSuspicious_NoMedianPrice(t *testing.T) {
+	listing := model.RawListing{Price: 30000}
+	reasons := DetectSuspicious(listing, 0)
+	if len(reasons) != 0 {
+		t.Errorf("expected no reasons with zero median, got %v", reasons)
+	}
+}
+
+func TestDetectSuspicious_ZeroListingPrice(t *testing.T) {
+	reasons := DetectSuspicious(model.RawListing{Price: 0}, 100000)
+	if len(reasons) != 0 {
+		t.Errorf("expected no reasons with zero listing price, got %v", reasons)
+	}
+}
+
+func TestDetectSuspicious_PriceBelowMarket(t *testing.T) {
+	listing := model.RawListing{Price: 40000, ImageURL: "http://example.com/img.jpg"}
+	reasons := DetectSuspicious(listing, 100000)
+	if len(reasons) != 1 || reasons[0] != "price_below_market" {
+		t.Errorf("expected [price_below_market], got %v", reasons)
+	}
+}
+
+func TestDetectSuspicious_NoPhotoLowPrice(t *testing.T) {
+	// 65000 < 100000*70/100 = 70000, but 65000 >= 100000/2 = 50000
+	listing := model.RawListing{Price: 65000, ImageURL: ""}
+	reasons := DetectSuspicious(listing, 100000)
+	if len(reasons) != 1 || reasons[0] != "no_photo_low_price" {
+		t.Errorf("expected [no_photo_low_price], got %v", reasons)
+	}
+}
+
+func TestDetectSuspicious_BothReasons(t *testing.T) {
+	// 30000 < 50000 (median/2) AND no photo + 30000 < 70000 (median*70/100)
+	listing := model.RawListing{Price: 30000, ImageURL: ""}
+	reasons := DetectSuspicious(listing, 100000)
+	if len(reasons) != 2 {
+		t.Fatalf("expected 2 reasons, got %v", reasons)
+	}
+	if reasons[0] != "price_below_market" {
+		t.Errorf("first reason should be price_below_market, got %s", reasons[0])
+	}
+	if reasons[1] != "no_photo_low_price" {
+		t.Errorf("second reason should be no_photo_low_price, got %s", reasons[1])
+	}
+}
+
+func TestDetectSuspicious_NormalPrice(t *testing.T) {
+	listing := model.RawListing{Price: 90000, ImageURL: "http://example.com/img.jpg"}
+	reasons := DetectSuspicious(listing, 100000)
+	if len(reasons) != 0 {
+		t.Errorf("expected no reasons for normal listing, got %v", reasons)
+	}
+}
+
+func TestDetectSuspicious_ExactlyAtHalfMedian(t *testing.T) {
+	// Price == median/2 is NOT below market (strictly less than)
+	listing := model.RawListing{Price: 50000, ImageURL: "http://example.com/img.jpg"}
+	reasons := DetectSuspicious(listing, 100000)
+	if len(reasons) != 0 {
+		t.Errorf("price at exactly half median should not trigger, got %v", reasons)
+	}
+}
+
+func TestDetectSuspicious_NoPhotoNormalPrice(t *testing.T) {
+	// No photo but price is at 80% of median (not below 70%)
+	listing := model.RawListing{Price: 80000, ImageURL: ""}
+	reasons := DetectSuspicious(listing, 100000)
+	if len(reasons) != 0 {
+		t.Errorf("no photo but normal price should not trigger, got %v", reasons)
+	}
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -223,6 +223,15 @@ type ListingFilter struct {
 	PhotoOnly  bool
 }
 
+// SearchStats holds aggregate market stats for a single search.
+type SearchStats struct {
+	Total    int64   `json:"total"`
+	New24h   int64   `json:"new_24h"`
+	AvgPrice float64 `json:"avg_price"`
+	MinPrice int     `json:"min_price"`
+	MaxPrice int     `json:"max_price"`
+}
+
 type ListingStore interface {
 	SaveListing(ctx context.Context, r ListingRecord) error
 	SaveListings(ctx context.Context, records []ListingRecord) error
@@ -236,6 +245,7 @@ type ListingStore interface {
 	// CountSearchListingsForChat returns listing counts per search_id for chatID,
 	// applying each search row's price/year/km/hand constraints like CountSearchListings.
 	CountSearchListingsForChat(ctx context.Context, chatID int64) (map[int64]int64, error)
+	SearchStats(ctx context.Context, chatID int64, searchID int64) (*SearchStats, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -161,6 +161,9 @@ type ListingRecord struct {
 	DealScore    *int
 	BasePrice    *int
 	FirstSeenAt  time.Time
+	// RemovedAt: non-nil when the listing disappeared from the source but was
+	// preserved because it is bookmarked ("likely sold").
+	RemovedAt *time.Time
 }
 
 type PricePoint struct {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -110,7 +110,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 			FROM listing_history
 			WHERE search_id = $1
 			ORDER BY first_seen_at DESC
@@ -120,7 +120,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT $1 OFFSET $2`, limit, offset)
@@ -135,12 +135,13 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		var r storage.ListingRecord
 		var fs sql.NullFloat64
 		var ic, mp, cs, ds, bp sql.NullInt64
+		var removedAt sql.NullTime
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
 			&r.Manufacturer, &r.Model, &r.SubModel, &r.SubModelID, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&ic, &fs, &mp, &cs, &ds, &bp, &r.FirstSeenAt,
+			&ic, &fs, &mp, &cs, &ds, &bp, &r.FirstSeenAt, &removedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
@@ -163,6 +164,9 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		if bp.Valid {
 			v := int(bp.Int64)
 			r.BasePrice = &v
+		}
+		if removedAt.Valid {
+			r.RemovedAt = &removedAt.Time
 		}
 		items = append(items, r)
 	}

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -64,7 +64,8 @@ const upsertListingSQL = `
 		median_price = COALESCE(EXCLUDED.median_price, listing_history.median_price),
 		cohort_size = COALESCE(EXCLUDED.cohort_size, listing_history.cohort_size),
 		deal_score = COALESCE(EXCLUDED.deal_score, listing_history.deal_score),
-		base_price = COALESCE(EXCLUDED.base_price, listing_history.base_price)`
+		base_price = COALESCE(EXCLUDED.base_price, listing_history.base_price),
+		removed_at = NULL`
 
 type listingScanner interface {
 	Scan(dest ...any) error
@@ -74,10 +75,11 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
 	var ic, mp, cs, ds, bp sql.NullInt64
+	var removedAt sql.NullTime
 	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel, &l.SubModelID,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt); err != nil {
+		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt, &removedAt); err != nil {
 		return l, err
 	}
 	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
@@ -99,6 +101,9 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	if bp.Valid {
 		v := int(bp.Int64)
 		l.BasePrice = &v
+	}
+	if removedAt.Valid {
+		l.RemovedAt = &removedAt.Time
 	}
 	return l, nil
 }
@@ -233,7 +238,7 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		WHERE chat_id = $1 AND token = $2
 		ORDER BY first_seen_at DESC
@@ -253,7 +258,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		WHERE chat_id = $1
 		ORDER BY first_seen_at DESC, token DESC
@@ -286,7 +291,7 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		ORDER BY first_seen_at DESC
 		LIMIT $1`, limit)
@@ -393,7 +398,7 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		WHERE chat_id = $1 AND search_id = $2%s
 		ORDER BY %s
@@ -474,44 +479,64 @@ func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64) (
 }
 
 func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
-	if len(keepTokens) == 0 {
-		result, err := s.db.ExecContext(ctx, `
-			DELETE FROM listing_history
-			WHERE chat_id = $1 AND search_id = $2
-			  AND NOT EXISTS (
-			    SELECT 1 FROM saved_listings
-			    WHERE saved_listings.token = listing_history.token
-			      AND saved_listings.chat_id = listing_history.chat_id
-			  )`, chatID, searchID)
-		if err != nil {
-			return 0, err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("delete stale begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var staleFilter string
+	args := []interface{}{chatID, searchID}
+	if len(keepTokens) > 0 {
+		placeholders := make([]string, len(keepTokens))
+		for i, t := range keepTokens {
+			placeholders[i] = fmt.Sprintf("$%d", i+3)
+			args = append(args, t)
 		}
-		return result.RowsAffected()
+		staleFilter = fmt.Sprintf(" AND token NOT IN (%s)", strings.Join(placeholders, ","))
 	}
 
-	args := make([]interface{}, 0, 2+len(keepTokens))
-	args = append(args, chatID, searchID)
-	placeholders := make([]string, len(keepTokens))
-	for i, t := range keepTokens {
-		placeholders[i] = fmt.Sprintf("$%d", i+3)
-		args = append(args, t)
+	// Mark bookmarked stale listings as removed_at (likely sold).
+	markArgs := make([]interface{}, len(args))
+	copy(markArgs, args)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE listing_history
+		SET removed_at = NOW()
+		WHERE chat_id = $1 AND search_id = $2%s
+		  AND removed_at IS NULL
+		  AND EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, staleFilter), markArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("mark removed_at: %w", err)
 	}
 
-	query := fmt.Sprintf(`
+	// Delete non-bookmarked stale listings.
+	deleteArgs := make([]interface{}, len(args))
+	copy(deleteArgs, args)
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		DELETE FROM listing_history
-		WHERE chat_id = $1 AND search_id = $2
-		  AND token NOT IN (%s)
+		WHERE chat_id = $1 AND search_id = $2%s
 		  AND NOT EXISTS (
 		    SELECT 1 FROM saved_listings
 		    WHERE saved_listings.token = listing_history.token
 		      AND saved_listings.chat_id = listing_history.chat_id
-		  )`, strings.Join(placeholders, ","))
+		  )`, staleFilter), deleteArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("delete stale: %w", err)
+	}
 
-	result, err := s.db.ExecContext(ctx, query, args...)
+	removed, err := result.RowsAffected()
 	if err != nil {
 		return 0, err
 	}
-	return result.RowsAffected()
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("delete stale commit: %w", err)
+	}
+	return removed, nil
 }
 
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
@@ -552,7 +577,7 @@ func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) 
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = $1

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -445,6 +445,34 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 	return out, rows.Err()
 }
 
+func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64) (*storage.SearchStats, error) {
+	var st storage.SearchStats
+	var avgPrice, minPrice, maxPrice sql.NullFloat64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) AS total,
+			COUNT(CASE WHEN first_seen_at > NOW() - INTERVAL '1 day' THEN 1 END) AS new_24h,
+			AVG(CASE WHEN price > 0 THEN price END) AS avg_price,
+			MIN(CASE WHEN price > 0 THEN price END) AS min_price,
+			MAX(CASE WHEN price > 0 THEN price END) AS max_price
+		FROM listing_history
+		WHERE search_id = $1 AND chat_id = $2`, searchID, chatID).
+		Scan(&st.Total, &st.New24h, &avgPrice, &minPrice, &maxPrice)
+	if err != nil {
+		return nil, fmt.Errorf("search stats: %w", err)
+	}
+	if avgPrice.Valid {
+		st.AvgPrice = avgPrice.Float64
+	}
+	if minPrice.Valid {
+		st.MinPrice = int(minPrice.Float64)
+	}
+	if maxPrice.Valid {
+		st.MaxPrice = int(maxPrice.Float64)
+	}
+	return &st, nil
+}
+
 func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
 	if len(keepTokens) == 0 {
 		result, err := s.db.ExecContext(ctx, `

--- a/internal/storage/postgres/notifications_center.go
+++ b/internal/storage/postgres/notifications_center.go
@@ -13,7 +13,7 @@ func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.T
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history lh
 		WHERE lh.chat_id = $1 AND lh.first_seen_at > $2
 		AND NOT EXISTS (

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -1,0 +1,1516 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// testStore returns a *Store connected to a real Postgres instance.
+// Skips the test when TEST_POSTGRES_DSN is not set.
+func testStore(t *testing.T) *Store {
+	t.Helper()
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_DSN not set; skipping Postgres integration test")
+	}
+	migrationsPath := os.Getenv("TEST_POSTGRES_MIGRATIONS")
+	if migrationsPath == "" {
+		migrationsPath = "../../../migrations"
+	}
+	store, err := New(dsn, migrationsPath)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	t.Cleanup(func() {
+		db := store.DB()
+		// Clean up in dependency order.
+		db.Exec("DELETE FROM listing_user_seen")
+		db.Exec("DELETE FROM pending_digest")
+		db.Exec("DELETE FROM pending_notifications")
+		db.Exec("DELETE FROM saved_listings")
+		db.Exec("DELETE FROM hidden_listings")
+		db.Exec("DELETE FROM listing_history")
+		db.Exec("DELETE FROM seen_listings")
+		db.Exec("DELETE FROM price_history")
+		db.Exec("DELETE FROM link_tokens")
+		db.Exec("DELETE FROM daily_digest")
+		db.Exec("DELETE FROM searches")
+		db.Exec("DELETE FROM price_list_cache")
+		db.Exec("DELETE FROM users")
+		store.Close()
+	})
+	return store
+}
+
+func seedPgUser(t *testing.T, store *Store, chatID int64) {
+	t.Helper()
+	if err := store.UpsertUser(context.Background(), chatID, "testuser"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+}
+
+func ptrBoolPg(b bool) *bool { return &b }
+
+// ---------------------------------------------------------------------------
+// User CRUD
+// ---------------------------------------------------------------------------
+
+func TestPostgres_UserCRUD(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Create
+	if err := store.UpsertUser(ctx, 100, "alice"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	u, err := store.GetUser(ctx, 100)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if u == nil {
+		t.Fatal("user should exist")
+	}
+	if u.Username != "alice" || u.State != "idle" || !u.Active {
+		t.Errorf("user = %+v", u)
+	}
+
+	// Upsert updates username
+	if err := store.UpsertUser(ctx, 100, "alice_new"); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	u, _ = store.GetUser(ctx, 100)
+	if u.Username != "alice_new" {
+		t.Errorf("username should update on upsert, got %q", u.Username)
+	}
+
+	// GetUser not found
+	u, err = store.GetUser(ctx, 999)
+	if err != nil {
+		t.Fatalf("get nonexistent: %v", err)
+	}
+	if u != nil {
+		t.Error("expected nil for nonexistent user")
+	}
+
+	// SetUserActive
+	seedPgUser(t, store, 200)
+	if err := store.SetUserActive(ctx, 200, false); err != nil {
+		t.Fatalf("set inactive: %v", err)
+	}
+	users, err := store.ListActiveUsers(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(users) != 1 || users[0].ChatID != 100 {
+		t.Errorf("expected 1 active user (100), got %d", len(users))
+	}
+
+	// CountUsers counts only active
+	count, err := store.CountUsers(ctx)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+
+	// UpsertUser reactivates inactive user
+	if err := store.UpsertUser(ctx, 200, "reactivated"); err != nil {
+		t.Fatalf("upsert reactivate: %v", err)
+	}
+	u, _ = store.GetUser(ctx, 200)
+	if !u.Active {
+		t.Error("UpsertUser should reactivate an inactive user")
+	}
+
+	// SetUserLanguage
+	if err := store.SetUserLanguage(ctx, 100, "en"); err != nil {
+		t.Fatalf("SetUserLanguage: %v", err)
+	}
+	u, _ = store.GetUser(ctx, 100)
+	if u.Language != "en" {
+		t.Errorf("language = %q, want en", u.Language)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Search CRUD
+// ---------------------------------------------------------------------------
+
+func TestPostgres_SearchCRUD(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	// Create
+	id, err := store.CreateSearch(ctx, storage.Search{
+		ChatID:       100,
+		Name:         "mazda3-2.0",
+		Manufacturer: 27,
+		Model:        10332,
+		YearMin:      2018,
+		YearMax:      2024,
+		PriceMax:     150000,
+		EngineMinCC:  1800,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+	if id == 0 {
+		t.Error("expected non-zero search ID")
+	}
+
+	// List
+	searches, err := store.ListSearches(ctx, 100)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(searches) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(searches))
+	}
+	s := searches[0]
+	if s.Name != "mazda3-2.0" || s.Manufacturer != 27 || s.PriceMax != 150000 {
+		t.Errorf("search = %+v", s)
+	}
+
+	// GetSearch
+	s2, err := store.GetSearch(ctx, id, 100)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if s2 == nil || s2.Name != "mazda3-2.0" {
+		t.Errorf("search = %+v", s2)
+	}
+
+	// GetSearch wrong owner
+	s2, err = store.GetSearch(ctx, id, 999)
+	if err != nil {
+		t.Fatalf("get wrong owner: %v", err)
+	}
+	if s2 != nil {
+		t.Error("expected nil when chatID does not match")
+	}
+
+	// UpdateSearch
+	err = store.UpdateSearch(ctx, storage.Search{
+		ID: id, ChatID: 100, Name: "updated", Source: "yad2",
+		Manufacturer: 27, Model: 10332, YearMin: 2020, YearMax: 2025, PriceMax: 180000,
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	s3, _ := store.GetSearch(ctx, id, 100)
+	if s3.Name != "updated" || s3.PriceMax != 180000 {
+		t.Errorf("after update: name=%q price_max=%d", s3.Name, s3.PriceMax)
+	}
+
+	// UpdateSearch not found
+	err = store.UpdateSearch(ctx, storage.Search{ID: 999, ChatID: 100, Name: "x"})
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+
+	// SetSearchActive
+	if err := store.SetSearchActive(ctx, id, 100, false); err != nil {
+		t.Fatalf("set inactive: %v", err)
+	}
+	s4, _ := store.GetSearch(ctx, id, 100)
+	if s4.Active {
+		t.Error("search should be inactive")
+	}
+	if err := store.SetSearchActive(ctx, id, 100, true); err != nil {
+		t.Fatalf("set active: %v", err)
+	}
+	s4, _ = store.GetSearch(ctx, id, 100)
+	if !s4.Active {
+		t.Error("search should be active again")
+	}
+
+	// SetSearchActive wrong owner
+	if err := store.SetSearchActive(ctx, id, 999, false); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for wrong owner, got: %v", err)
+	}
+
+	// Delete
+	if err := store.DeleteSearch(ctx, id, 100); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	searches, _ = store.ListSearches(ctx, 100)
+	if len(searches) != 0 {
+		t.Error("search should be deleted")
+	}
+
+	// Delete wrong owner
+	seedPgUser(t, store, 300)
+	id2, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "owned", Manufacturer: 1, Model: 1})
+	if err := store.DeleteSearch(ctx, id2, 300); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for wrong-owner delete, got: %v", err)
+	}
+}
+
+func TestPostgres_SearchUserSeq(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	id1, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "first", Manufacturer: 1, Model: 1})
+	id2, _ := store.CreateSearch(ctx, storage.Search{ChatID: 100, Name: "second", Manufacturer: 2, Model: 2})
+	id3, _ := store.CreateSearch(ctx, storage.Search{ChatID: 200, Name: "other-user", Manufacturer: 1, Model: 1})
+
+	s1, _ := store.GetSearch(ctx, id1, 100)
+	s2, _ := store.GetSearch(ctx, id2, 100)
+	s3, _ := store.GetSearch(ctx, id3, 200)
+
+	if s1.UserSeq != 1 {
+		t.Errorf("first search UserSeq = %d, want 1", s1.UserSeq)
+	}
+	if s2.UserSeq != 2 {
+		t.Errorf("second search UserSeq = %d, want 2", s2.UserSeq)
+	}
+	if s3.UserSeq != 1 {
+		t.Errorf("other user's first search UserSeq = %d, want 1", s3.UserSeq)
+	}
+
+	// GetSearchBySeq
+	s, err := store.GetSearchBySeq(ctx, 100, 2)
+	if err != nil {
+		t.Fatalf("get by seq: %v", err)
+	}
+	if s == nil || s.Name != "second" {
+		t.Errorf("expected 'second', got %+v", s)
+	}
+
+	s, err = store.GetSearchBySeq(ctx, 100, 99)
+	if err != nil {
+		t.Fatalf("get nonexistent seq: %v", err)
+	}
+	if s != nil {
+		t.Error("expected nil for nonexistent seq")
+	}
+}
+
+func TestPostgres_SearchShareToken(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	id, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "shared", Source: "yad2",
+		Manufacturer: 27, Model: 10332,
+	})
+
+	search, _ := store.GetSearch(ctx, id, 100)
+	if search.ShareToken == "" {
+		t.Fatal("expected non-empty share token")
+	}
+
+	found, err := store.GetSearchByShareToken(ctx, search.ShareToken)
+	if err != nil {
+		t.Fatalf("GetSearchByShareToken: %v", err)
+	}
+	if found == nil || found.ID != id {
+		t.Errorf("expected ID %d, got %+v", id, found)
+	}
+
+	// Not found
+	found, err = store.GetSearchByShareToken(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetSearchByShareToken nonexistent: %v", err)
+	}
+	if found != nil {
+		t.Error("expected nil for nonexistent token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Listing save, query, pagination
+// ---------------------------------------------------------------------------
+
+func TestPostgres_ListingSaveAndQuery(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "mazda3", Source: "yad2",
+		Manufacturer: 8, Model: 10061,
+	})
+
+	// SaveListing
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-1", ChatID: 100, SearchID: searchID, SearchName: "mazda3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
+		Km: 50000, Hand: 2, City: "Tel Aviv",
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// GetListing
+	l, err := store.GetListing(ctx, 100, "tok-1")
+	if err != nil {
+		t.Fatalf("get listing: %v", err)
+	}
+	if l == nil || l.Manufacturer != "Mazda" || l.Price != 95000 {
+		t.Errorf("listing = %+v", l)
+	}
+
+	// GetListing not found
+	l, _ = store.GetListing(ctx, 100, "nonexistent")
+	if l != nil {
+		t.Error("expected nil for nonexistent token")
+	}
+
+	// GetListing wrong owner
+	seedPgUser(t, store, 200)
+	l, _ = store.GetListing(ctx, 200, "tok-1")
+	if l != nil {
+		t.Error("expected nil for wrong owner")
+	}
+
+	// SaveListings batch
+	records := []storage.ListingRecord{
+		{Token: "batch-1", ChatID: 100, SearchID: searchID, SearchName: "mazda3", Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000},
+		{Token: "batch-2", ChatID: 100, SearchID: searchID, SearchName: "mazda3", Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 100000},
+	}
+	if err := store.SaveListings(ctx, records); err != nil {
+		t.Fatalf("batch save: %v", err)
+	}
+
+	// Empty batch should be no-op
+	if err := store.SaveListings(ctx, nil); err != nil {
+		t.Fatalf("empty batch: %v", err)
+	}
+
+	// CountUserListings
+	count, err := store.CountUserListings(ctx, 100)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3, got %d", count)
+	}
+
+	// ListUserListings pagination
+	page1, _ := store.ListUserListings(ctx, 100, 2, 0)
+	if len(page1) != 2 {
+		t.Errorf("page 1: expected 2, got %d", len(page1))
+	}
+	page2, _ := store.ListUserListings(ctx, 100, 2, 2)
+	if len(page2) != 1 {
+		t.Errorf("page 2: expected 1, got %d", len(page2))
+	}
+
+	// ListSearchListings
+	listings, err := store.ListSearchListings(ctx, 100, searchID, storage.ListingFilter{}, 20, 0, "newest")
+	if err != nil {
+		t.Fatalf("ListSearchListings: %v", err)
+	}
+	if len(listings) != 3 {
+		t.Errorf("expected 3, got %d", len(listings))
+	}
+
+	// CountSearchListings
+	cnt, err := store.CountSearchListings(ctx, 100, searchID, storage.ListingFilter{})
+	if err != nil {
+		t.Fatalf("CountSearchListings: %v", err)
+	}
+	if cnt != 3 {
+		t.Errorf("expected 3, got %d", cnt)
+	}
+
+	// Upsert conflict
+	if err := store.SaveListings(ctx, []storage.ListingRecord{
+		{Token: "batch-1", ChatID: 100, SearchID: searchID, SearchName: "mazda3", Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000, Km: 60000},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	l, _ = store.GetListing(ctx, 100, "batch-1")
+	if l.Price != 80000 || l.Km != 60000 {
+		t.Errorf("after upsert: price=%d km=%d", l.Price, l.Km)
+	}
+	// Should still be 3 listings total
+	count, _ = store.CountUserListings(ctx, 100)
+	if count != 3 {
+		t.Errorf("upsert should not create duplicate, got %d", count)
+	}
+}
+
+func TestPostgres_ListSearchListings_Filters(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Source: "yad2",
+		Manufacturer: 8, Model: 10061,
+	})
+
+	// lsl-1: Year=2021, Price=120000, Km=50000, Hand=2, Commercial
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "lsl-1", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 120000, Km: 50000, Hand: 2,
+		IsCommercial: ptrBoolPg(true),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// lsl-2: Year=2022, Price=90000, Km=30000, Hand=1, Private
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "lsl-2", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2022, Price: 90000, Km: 30000, Hand: 1,
+		IsCommercial: ptrBoolPg(false),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		filter storage.ListingFilter
+		want   int
+	}{
+		{"no filter", storage.ListingFilter{}, 2},
+		{"price_max excludes expensive", storage.ListingFilter{PriceMax: 100000}, 1},
+		{"year_min", storage.ListingFilter{YearMin: 2022}, 1},
+		{"year_max", storage.ListingFilter{YearMax: 2021}, 1},
+		{"max_km", storage.ListingFilter{MaxKm: 40000}, 1},
+		{"max_hand", storage.ListingFilter{MaxHand: 1}, 1},
+		{"combined", storage.ListingFilter{PriceMax: 100000, YearMin: 2022}, 1},
+		{"all filtered out", storage.ListingFilter{PriceMax: 50000}, 0},
+		{"commercial only", storage.ListingFilter{Commercial: ptrBoolPg(true)}, 1},
+		{"private only", storage.ListingFilter{Commercial: ptrBoolPg(false)}, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := store.ListSearchListings(ctx, 100, searchID, tc.filter, 20, 0, "newest")
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(got) != tc.want {
+				t.Errorf("got %d rows, want %d", len(got), tc.want)
+			}
+			cnt, err := store.CountSearchListings(ctx, 100, searchID, tc.filter)
+			if err != nil {
+				t.Fatalf("count: %v", err)
+			}
+			if int(cnt) != tc.want {
+				t.Errorf("count = %d, want %d", cnt, tc.want)
+			}
+		})
+	}
+
+	// Sort orders
+	t.Run("sort price_asc", func(t *testing.T) {
+		listings, _ := store.ListSearchListings(ctx, 100, searchID, storage.ListingFilter{}, 20, 0, "price_asc")
+		if listings[0].Price != 90000 {
+			t.Errorf("expected 90000 first, got %d", listings[0].Price)
+		}
+	})
+	t.Run("sort price_desc", func(t *testing.T) {
+		listings, _ := store.ListSearchListings(ctx, 100, searchID, storage.ListingFilter{}, 20, 0, "price_desc")
+		if listings[0].Price != 120000 {
+			t.Errorf("expected 120000 first, got %d", listings[0].Price)
+		}
+	})
+	t.Run("sort year", func(t *testing.T) {
+		listings, _ := store.ListSearchListings(ctx, 100, searchID, storage.ListingFilter{}, 20, 0, "year")
+		if listings[0].Year != 2022 {
+			t.Errorf("expected 2022 first, got %d", listings[0].Year)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Dedup
+// ---------------------------------------------------------------------------
+
+func TestPostgres_Dedup(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	// First claim succeeds
+	isNew, err := store.ClaimNew(ctx, "token1", 100, 1)
+	if err != nil || !isNew {
+		t.Fatalf("first claim: new=%v, err=%v", isNew, err)
+	}
+
+	// Duplicate claim fails
+	isNew, err = store.ClaimNew(ctx, "token1", 100, 1)
+	if err != nil || isNew {
+		t.Error("duplicate claim for same user should return false")
+	}
+
+	// Different user can claim same token
+	isNew, err = store.ClaimNew(ctx, "token1", 200, 1)
+	if err != nil || !isNew {
+		t.Error("same token for different user should be new")
+	}
+
+	// ReleaseClaim allows reclaim
+	if err := store.ReleaseClaim(ctx, "token1", 100); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	isNew, _ = store.ClaimNew(ctx, "token1", 100, 1)
+	if !isNew {
+		t.Error("released token should be claimable again")
+	}
+
+	// User 200's claim should be unaffected
+	isNew, _ = store.ClaimNew(ctx, "token1", 200, 1)
+	if isNew {
+		t.Error("user 200's claim should be unaffected by user 100's release")
+	}
+
+	// Prune
+	_, _ = store.ClaimNew(ctx, "prune-tok", 100, 1)
+	pruned, err := store.Prune(ctx, 0)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned < 1 {
+		t.Errorf("expected at least 1 pruned, got %d", pruned)
+	}
+
+	// Prune keeps recent
+	_, _ = store.ClaimNew(ctx, "recent-tok", 100, 1)
+	pruned, err = store.Prune(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune recent: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned (recent), got %d", pruned)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bookmarks
+// ---------------------------------------------------------------------------
+
+func TestPostgres_Bookmarks(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	// Save listing first (needed for ListSaved join)
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// SaveBookmark
+	if err := store.SaveBookmark(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
+	count, _ := store.CountSaved(ctx, 100)
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+
+	// Duplicate bookmark is idempotent
+	if err := store.SaveBookmark(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("duplicate: %v", err)
+	}
+	count, _ = store.CountSaved(ctx, 100)
+	if count != 1 {
+		t.Errorf("duplicate should not increase count, got %d", count)
+	}
+
+	// IsSaved
+	saved, _ := store.IsSaved(ctx, 100, "tok1")
+	if !saved {
+		t.Error("tok1 should be saved")
+	}
+	saved, _ = store.IsSaved(ctx, 100, "nonexistent")
+	if saved {
+		t.Error("nonexistent should not be saved")
+	}
+
+	// ListSaved
+	listings, err := store.ListSaved(ctx, 100, 10, 0)
+	if err != nil {
+		t.Fatalf("ListSaved: %v", err)
+	}
+	if len(listings) != 1 || listings[0].Manufacturer != "Mazda" {
+		t.Errorf("ListSaved = %+v", listings)
+	}
+
+	// Cross-user isolation
+	_ = store.SaveBookmark(ctx, 200, "tok2")
+	count1, _ := store.CountSaved(ctx, 100)
+	count2, _ := store.CountSaved(ctx, 200)
+	if count1 != 1 || count2 != 1 {
+		t.Errorf("counts: user100=%d user200=%d", count1, count2)
+	}
+
+	// SavedAmong
+	_ = store.SaveBookmark(ctx, 100, "tok-a")
+	m, err := store.SavedAmong(ctx, 100, []string{"tok1", "tok-a", "tok-missing"})
+	if err != nil {
+		t.Fatalf("SavedAmong: %v", err)
+	}
+	if !m["tok1"] || !m["tok-a"] || m["tok-missing"] {
+		t.Errorf("SavedAmong = %v", m)
+	}
+
+	// RemoveBookmark
+	if err := store.RemoveBookmark(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("RemoveBookmark: %v", err)
+	}
+	count, _ = store.CountSaved(ctx, 100)
+	if count != 1 { // tok-a remains
+		t.Errorf("after remove: count = %d, want 1", count)
+	}
+
+	// RemoveBookmark nonexistent is silent
+	if err := store.RemoveBookmark(ctx, 100, "nonexistent"); err != nil {
+		t.Fatalf("remove nonexistent: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hidden
+// ---------------------------------------------------------------------------
+
+func TestPostgres_Hidden(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	// HideListing
+	if err := store.HideListing(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("HideListing: %v", err)
+	}
+	hidden, _ := store.IsHidden(ctx, 100, "tok1")
+	if !hidden {
+		t.Error("tok1 should be hidden")
+	}
+
+	// Duplicate is idempotent
+	if err := store.HideListing(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("duplicate: %v", err)
+	}
+	count, _ := store.CountHidden(ctx, 100)
+	if count != 1 {
+		t.Errorf("duplicate should not increase count, got %d", count)
+	}
+
+	// Cross-user isolation
+	hidden200, _ := store.IsHidden(ctx, 200, "tok1")
+	if hidden200 {
+		t.Error("user 200 should NOT see tok1 as hidden")
+	}
+
+	// ListHiddenTokens
+	_ = store.HideListing(ctx, 100, "tok2")
+	tokens, err := store.ListHiddenTokens(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListHiddenTokens: %v", err)
+	}
+	if len(tokens) != 2 || !tokens["tok1"] || !tokens["tok2"] {
+		t.Errorf("tokens = %v", tokens)
+	}
+
+	// CountHidden cross-user
+	_ = store.HideListing(ctx, 200, "tok3")
+	c1, _ := store.CountHidden(ctx, 100)
+	c2, _ := store.CountHidden(ctx, 200)
+	if c1 != 2 || c2 != 1 {
+		t.Errorf("counts: user100=%d user200=%d", c1, c2)
+	}
+
+	// ListHidden pagination
+	for i := 0; i < 3; i++ {
+		_ = store.HideListing(ctx, 100, "extra-"+string(rune('a'+i)))
+	}
+	page1, _ := store.ListHidden(ctx, 100, 2, 0)
+	if len(page1) != 2 {
+		t.Errorf("page 1: expected 2, got %d", len(page1))
+	}
+
+	// UnhideListing
+	if err := store.UnhideListing(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("UnhideListing: %v", err)
+	}
+	hidden, _ = store.IsHidden(ctx, 100, "tok1")
+	if hidden {
+		t.Error("tok1 should no longer be hidden")
+	}
+	// tok2 still hidden
+	hidden, _ = store.IsHidden(ctx, 100, "tok2")
+	if !hidden {
+		t.Error("tok2 should still be hidden")
+	}
+
+	// UnhideListing nonexistent is silent
+	if err := store.UnhideListing(ctx, 100, "nonexistent"); err != nil {
+		t.Fatalf("unhide nonexistent: %v", err)
+	}
+
+	// ClearHidden
+	if err := store.ClearHidden(ctx, 100); err != nil {
+		t.Fatalf("ClearHidden: %v", err)
+	}
+	c1, _ = store.CountHidden(ctx, 100)
+	c2, _ = store.CountHidden(ctx, 200)
+	if c1 != 0 {
+		t.Errorf("user 100 should have 0 hidden after clear, got %d", c1)
+	}
+	if c2 != 1 {
+		t.Errorf("user 200 should still have 1, got %d", c2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Price tracking
+// ---------------------------------------------------------------------------
+
+func TestPostgres_PriceTracking(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// First record: not a change
+	_, changed, err := store.RecordPrice(ctx, "token1", 100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("first price should not be a change")
+	}
+
+	// Price drop
+	oldPrice, changed, err := store.RecordPrice(ctx, "token1", 90000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("price drop should be detected")
+	}
+	if oldPrice != 100000 {
+		t.Errorf("old price = %d, want 100000", oldPrice)
+	}
+
+	// Price increase
+	oldPrice, changed, err = store.RecordPrice(ctx, "token1", 95000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("price increase should be detected")
+	}
+	if oldPrice != 90000 {
+		t.Errorf("old price = %d, want 90000", oldPrice)
+	}
+
+	// Same price is not a change
+	oldPrice, changed, err = store.RecordPrice(ctx, "token1", 95000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("same price should not be a change")
+	}
+	if oldPrice != 95000 {
+		t.Errorf("old price = %d, want 95000", oldPrice)
+	}
+
+	// GetPriceHistory
+	points, err := store.GetPriceHistory(ctx, "token1")
+	if err != nil {
+		t.Fatalf("GetPriceHistory: %v", err)
+	}
+	if len(points) != 3 {
+		t.Fatalf("expected 3 price points, got %d", len(points))
+	}
+	// Most recent first
+	if points[0].Price != 95000 {
+		t.Errorf("most recent = %d, want 95000", points[0].Price)
+	}
+	if points[2].Price != 100000 {
+		t.Errorf("oldest = %d, want 100000", points[2].Price)
+	}
+
+	// GetPriceHistory empty
+	points, _ = store.GetPriceHistory(ctx, "nonexistent")
+	if len(points) != 0 {
+		t.Errorf("expected 0, got %d", len(points))
+	}
+
+	// PrunePrices keeps recent
+	pruned, _ := store.PrunePrices(ctx, 24*time.Hour)
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned (recent), got %d", pruned)
+	}
+
+	// PrunePrices removes all with zero duration
+	pruned, err = store.PrunePrices(ctx, 0)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 3 {
+		t.Errorf("expected 3 pruned, got %d", pruned)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Market listings
+// ---------------------------------------------------------------------------
+
+func TestPostgres_MarketListings(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	now := time.Now().UTC()
+
+	// Insert listings for two users with same token
+	for _, chatID := range []int64{100, 200} {
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: "tok1", ChatID: chatID, SearchName: "toyota",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
+			Price: 100000, FirstSeenAt: now,
+		})
+	}
+	// Another unique token
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok2", ChatID: 100, SearchName: "toyota",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021,
+		Price: 110000, FirstSeenAt: now,
+	})
+	// Empty manufacturer should be excluded
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok3", ChatID: 100, SearchName: "test",
+		Manufacturer: "", Model: "X", Year: 2020,
+		Price: 50000, FirstSeenAt: now,
+	})
+
+	listings, err := store.MarketListings(ctx)
+	if err != nil {
+		t.Fatalf("MarketListings: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Errorf("expected 2 deduplicated listings, got %d", len(listings))
+	}
+
+	// Verify latest by first_seen_at is returned
+	t.Run("selects latest first_seen_at", func(t *testing.T) {
+		older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		newer := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: "tok-parity", ChatID: 100, SearchName: "test",
+			Manufacturer: "Honda", Model: "Civic", Year: 2021,
+			Price: 90000, FirstSeenAt: newer,
+		})
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: "tok-parity", ChatID: 200, SearchName: "test",
+			Manufacturer: "Honda", Model: "Civic", Year: 2021,
+			Price: 100000, FirstSeenAt: older,
+		})
+
+		all, _ := store.MarketListings(ctx)
+		for _, l := range all {
+			if l.Manufacturer == "Honda" && l.Model == "Civic" {
+				if l.Price != 90000 {
+					t.Errorf("expected price 90000 (newer), got %d", l.Price)
+				}
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Link tokens
+// ---------------------------------------------------------------------------
+
+func TestPostgres_LinkTokens(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	// Create web user for linking
+	webID, err := store.UpsertWebUser(ctx, "firebase-uid-1", "test@example.com")
+	if err != nil {
+		t.Fatalf("create web user: %v", err)
+	}
+
+	// CreateLinkToken
+	token, err := store.CreateLinkToken(ctx, webID)
+	if err != nil {
+		t.Fatalf("CreateLinkToken: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	// ConsumeLinkToken success
+	gotID, err := store.ConsumeLinkToken(ctx, token)
+	if err != nil {
+		t.Fatalf("ConsumeLinkToken: %v", err)
+	}
+	if gotID != webID {
+		t.Errorf("got webChatID %d, want %d", gotID, webID)
+	}
+
+	// ConsumeLinkToken already used
+	_, err = store.ConsumeLinkToken(ctx, token)
+	if !errors.Is(err, storage.ErrLinkTokenUsed) {
+		t.Errorf("expected ErrLinkTokenUsed, got %v", err)
+	}
+
+	// ConsumeLinkToken not found
+	_, err = store.ConsumeLinkToken(ctx, "nonexistent-token")
+	if !errors.Is(err, storage.ErrLinkTokenNotFound) {
+		t.Errorf("expected ErrLinkTokenNotFound, got %v", err)
+	}
+
+	// Expired token: insert with past expiry directly
+	expiredToken := "expired-test-token"
+	_, _ = store.DB().ExecContext(ctx, `
+		INSERT INTO link_tokens (token, web_chat_id, expires_at, used)
+		VALUES ($1, $2, $3, FALSE)`,
+		expiredToken, webID, time.Now().UTC().Add(-1*time.Hour))
+	_, err = store.ConsumeLinkToken(ctx, expiredToken)
+	if !errors.Is(err, storage.ErrLinkTokenExpired) {
+		t.Errorf("expected ErrLinkTokenExpired, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+func TestPostgres_Notifications(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Enqueue
+	_ = store.EnqueueNotification(ctx, "100", "search1", "hello")
+	_ = store.EnqueueNotification(ctx, "200", "search2", "world")
+
+	// Pending
+	pending, err := store.PendingNotifications(ctx)
+	if err != nil {
+		t.Fatalf("PendingNotifications: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("expected 2, got %d", len(pending))
+	}
+
+	// Ack
+	_ = store.AckNotification(ctx, pending[0].ID)
+	remaining, _ := store.PendingNotifications(ctx)
+	if len(remaining) != 1 {
+		t.Errorf("expected 1 remaining, got %d", len(remaining))
+	}
+
+	// PruneNotifications keeps recent
+	_ = store.EnqueueNotification(ctx, "300", "search3", "fresh")
+	pruned, _ := store.PruneNotifications(ctx, 24*time.Hour)
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned (recent), got %d", pruned)
+	}
+
+	// PruneNotifications removes all with zero duration
+	pruned, err = store.PruneNotifications(ctx, 0)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned < 1 {
+		t.Errorf("expected at least 1 pruned, got %d", pruned)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delete search cascade
+// ---------------------------------------------------------------------------
+
+func TestPostgres_DeleteSearchCascade(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	id1, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "mazda-3", Manufacturer: 27, Model: 10332,
+	})
+	id2, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 200, Name: "mazda-3", Manufacturer: 27, Model: 10332,
+	})
+
+	// Seed seen_listings
+	_, _ = store.ClaimNew(ctx, "tok1", 100, id1)
+	_, _ = store.ClaimNew(ctx, "tok1", 200, id2)
+
+	// Seed listing_history
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 100, SearchID: id1, SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 200, SearchID: id2, SearchName: "mazda-3",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
+	})
+
+	// Seed notifications
+	_ = store.EnqueueNotification(ctx, "100", "mazda-3", "payload1")
+	_ = store.EnqueueNotification(ctx, "200", "mazda-3", "payload2")
+
+	// Delete user 100's search
+	if err := store.DeleteSearch(ctx, id1, 100); err != nil {
+		t.Fatalf("delete search: %v", err)
+	}
+
+	// Search gone
+	s, _ := store.GetSearch(ctx, id1, 100)
+	if s != nil {
+		t.Error("search should be deleted")
+	}
+
+	// seen_listings for user 100 cleaned up
+	isNew, _ := store.ClaimNew(ctx, "tok1", 100, id1)
+	if !isNew {
+		t.Error("tok1 claim for user 100 should be released")
+	}
+
+	// User 200's claim untouched
+	isNew, _ = store.ClaimNew(ctx, "tok1", 200, id2)
+	if isNew {
+		t.Error("user 200's claim should NOT be affected")
+	}
+
+	// listing_history for user 100 cleaned up
+	count100, _ := store.CountSearchListings(ctx, 100, id1, storage.ListingFilter{})
+	if count100 != 0 {
+		t.Errorf("expected 0 listings for user 100, got %d", count100)
+	}
+
+	// User 200's listing_history untouched
+	count200, _ := store.CountSearchListings(ctx, 200, id2, storage.ListingFilter{})
+	if count200 != 1 {
+		t.Errorf("expected 1 listing for user 200, got %d", count200)
+	}
+
+	// Pending notifications for user 100 cleaned
+	pending, _ := store.PendingNotifications(ctx)
+	for _, p := range pending {
+		if p.Recipient == "100" && p.SearchName == "mazda-3" {
+			t.Error("notification for user 100 should have been deleted")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Prune & delete stale listings
+// ---------------------------------------------------------------------------
+
+func TestPostgres_PruneListings(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	old := time.Now().Add(-100 * 24 * time.Hour)
+	recent := time.Now().Add(-10 * 24 * time.Hour)
+
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-1", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000, FirstSeenAt: old,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "recent-1", ChatID: 100, SearchName: "test",
+		Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 95000, FirstSeenAt: recent,
+	})
+
+	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("PruneListings: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned, got %d", pruned)
+	}
+
+	count, _ := store.CountUserListings(ctx, 100)
+	if count != 1 {
+		t.Errorf("expected 1 remaining, got %d", count)
+	}
+}
+
+func TestPostgres_PruneListingsPreservesSaved(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	old := time.Now().Add(-100 * 24 * time.Hour)
+
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-saved", ChatID: 100, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000, FirstSeenAt: old,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-unsaved", ChatID: 100, SearchName: "test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000, FirstSeenAt: old,
+	})
+	_ = store.SaveBookmark(ctx, 100, "old-saved")
+
+	pruned, _ := store.PruneListings(ctx, 90*24*time.Hour)
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned (unsaved only), got %d", pruned)
+	}
+
+	saved, _ := store.GetListing(ctx, 100, "old-saved")
+	if saved == nil {
+		t.Error("saved listing should survive pruning")
+	}
+}
+
+func TestPostgres_DeleteStaleListings(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
+	})
+
+	for _, tok := range []string{"a", "b", "c", "d"} {
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, ChatID: 100, SearchID: searchID, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		})
+	}
+
+	removed, err := store.DeleteStaleListings(ctx, 100, searchID, []string{"a", "c"})
+	if err != nil {
+		t.Fatalf("DeleteStaleListings: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 removed, got %d", removed)
+	}
+
+	// Kept tokens still exist
+	for _, tok := range []string{"a", "c"} {
+		l, _ := store.GetListing(ctx, 100, tok)
+		if l == nil {
+			t.Errorf("listing %q should still exist", tok)
+		}
+	}
+	// Removed tokens gone
+	for _, tok := range []string{"b", "d"} {
+		l, _ := store.GetListing(ctx, 100, tok)
+		if l != nil {
+			t.Errorf("listing %q should be deleted", tok)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PriceList
+// ---------------------------------------------------------------------------
+
+func TestPostgres_PriceList(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Not found
+	e, err := store.GetPriceListEntry(ctx, 12345, 2022)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if e != nil {
+		t.Error("expected nil for nonexistent entry")
+	}
+
+	// Set
+	if err := store.SetPriceListEntry(ctx, storage.PriceListEntry{
+		SubModelID: 12345, Year: 2022, BasePrice: 150000, Title: "Mazda 3 Sedan",
+	}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// Get
+	e, err = store.GetPriceListEntry(ctx, 12345, 2022)
+	if err != nil {
+		t.Fatalf("get after set: %v", err)
+	}
+	if e == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if e.BasePrice != 150000 || e.Title != "Mazda 3 Sedan" {
+		t.Errorf("entry = %+v", e)
+	}
+
+	// Upsert updates
+	if err := store.SetPriceListEntry(ctx, storage.PriceListEntry{
+		SubModelID: 12345, Year: 2022, BasePrice: 145000, Title: "Mazda 3 Sedan",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	e, _ = store.GetPriceListEntry(ctx, 12345, 2022)
+	if e.BasePrice != 145000 {
+		t.Errorf("after upsert: base_price = %d, want 145000", e.BasePrice)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Notification center (NewListingsSince, MarkListingUserSeen)
+// ---------------------------------------------------------------------------
+
+func TestPostgres_NotificationCenter(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "new-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: now,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "new-2", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+		FirstSeenAt: now,
+	})
+
+	// NewListingsSince
+	listings, err := store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if err != nil {
+		t.Fatalf("NewListingsSince: %v", err)
+	}
+	if len(listings) != 2 {
+		t.Fatalf("expected 2, got %d", len(listings))
+	}
+
+	// CountNewListingsSince
+	count, _ := store.CountNewListingsSince(ctx, 100, cutoff)
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+
+	// MarkListingUserSeen excludes from results
+	if err := store.MarkListingUserSeen(ctx, 100, "new-1"); err != nil {
+		t.Fatal(err)
+	}
+	listings, _ = store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if len(listings) != 1 {
+		t.Errorf("after mark seen: expected 1, got %d", len(listings))
+	}
+	count, _ = store.CountNewListingsSince(ctx, 100, cutoff)
+	if count != 1 {
+		t.Errorf("after mark seen: count = %d, want 1", count)
+	}
+
+	// UnmarkListingUserSeen brings it back
+	if err := store.UnmarkListingUserSeen(ctx, 100, "new-1"); err != nil {
+		t.Fatal(err)
+	}
+	listings, _ = store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if len(listings) != 2 {
+		t.Errorf("after unmark: expected 2, got %d", len(listings))
+	}
+
+	// Wrong user sees nothing
+	listings, _ = store.NewListingsSince(ctx, 200, cutoff, 20, 0)
+	if len(listings) != 0 {
+		t.Errorf("wrong user: expected 0, got %d", len(listings))
+	}
+
+	// Future cutoff returns nothing
+	listings, _ = store.NewListingsSince(ctx, 100, time.Now().Add(time.Hour), 20, 0)
+	if len(listings) != 0 {
+		t.Errorf("future cutoff: expected 0, got %d", len(listings))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WhatsApp / Web user channels
+// ---------------------------------------------------------------------------
+
+func TestPostgres_ChannelUsers(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// WhatsApp user
+	waID1, err := store.UpsertWhatsAppUser(ctx, "+972501234567")
+	if err != nil {
+		t.Fatalf("create whatsapp: %v", err)
+	}
+	if waID1 < 1_000_000_000_000 {
+		t.Errorf("WhatsApp ID = %d, want >= 1T", waID1)
+	}
+
+	// Idempotent
+	waID2, _ := store.UpsertWhatsAppUser(ctx, "+972501234567")
+	if waID2 != waID1 {
+		t.Errorf("idempotent: %d vs %d", waID2, waID1)
+	}
+
+	// Different phone
+	waID3, _ := store.UpsertWhatsAppUser(ctx, "+972509876543")
+	if waID3 == waID1 {
+		t.Error("different phone numbers should get different IDs")
+	}
+
+	// Channel fields
+	u, _ := store.GetUser(ctx, waID1)
+	if u.Channel != "whatsapp" || u.ChannelID != "+972501234567" {
+		t.Errorf("channel=%q channelID=%q", u.Channel, u.ChannelID)
+	}
+
+	// Web user
+	webID1, err := store.UpsertWebUser(ctx, "firebase-uid-1", "a@example.com")
+	if err != nil {
+		t.Fatalf("create web: %v", err)
+	}
+	if webID1 < 2_000_000_000_000 {
+		t.Errorf("Web ID = %d, want >= 2T", webID1)
+	}
+
+	webU, _ := store.GetUser(ctx, webID1)
+	if webU.Channel != "web" || webU.ChannelID != "firebase-uid-1" || webU.Username != "a@example.com" {
+		t.Errorf("web user = %+v", webU)
+	}
+
+	// GetUserByChannelID
+	found, _ := store.GetUserByChannelID(ctx, "whatsapp", "+972501234567")
+	if found == nil || found.ChatID != waID1 {
+		t.Errorf("GetUserByChannelID = %+v", found)
+	}
+	notFound, _ := store.GetUserByChannelID(ctx, "whatsapp", "+000000000")
+	if notFound != nil {
+		t.Error("expected nil for unknown phone")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CountSearchListingsForChat
+// ---------------------------------------------------------------------------
+
+func TestPostgres_CountSearchListingsForChat(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	idCapped, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "capped", Source: "yad2",
+		Manufacturer: 8, Model: 10061, PriceMax: 100000,
+	})
+	idOpen, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "open", Source: "yad2",
+		Manufacturer: 9, Model: 10062,
+	})
+
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "cfc-1", ChatID: 100, SearchID: idCapped, SearchName: "capped",
+		Manufacturer: "Mazda", Model: "3", Year: 2022, Price: 90000, Km: 30000, Hand: 1,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "cfc-2", ChatID: 100, SearchID: idCapped, SearchName: "capped",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 120000, Km: 50000, Hand: 2,
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "cfc-3", ChatID: 100, SearchID: idOpen, SearchName: "open",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 80000, Km: 70000, Hand: 3,
+	})
+
+	got, err := store.CountSearchListingsForChat(ctx, 100)
+	if err != nil {
+		t.Fatalf("CountSearchListingsForChat: %v", err)
+	}
+
+	// capped search has PriceMax=100000, so only cfc-1 (90000) qualifies
+	if got[idCapped] != 1 {
+		t.Errorf("capped search: got %d, want 1", got[idCapped])
+	}
+	if got[idOpen] != 1 {
+		t.Errorf("open search: got %d, want 1", got[idOpen])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Admin
+// ---------------------------------------------------------------------------
+
+func TestPostgres_Admin(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	// DBSizeBytes
+	size, err := store.DBSizeBytes()
+	if err != nil {
+		t.Fatalf("DBSizeBytes: %v", err)
+	}
+	if size <= 0 {
+		t.Errorf("expected positive size, got %d", size)
+	}
+
+	// CountAllListings (empty)
+	cnt, _ := store.CountAllListings(ctx)
+	if cnt != 0 {
+		t.Errorf("expected 0, got %d", cnt)
+	}
+
+	// Insert listings
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "admin-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000,
+		FirstSeenAt: time.Now(),
+	})
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "admin-2", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Honda", Model: "Civic", Year: 2021, Price: 90000,
+		FirstSeenAt: time.Now(),
+	})
+
+	cnt, _ = store.CountAllListings(ctx)
+	if cnt != 2 {
+		t.Errorf("expected 2, got %d", cnt)
+	}
+
+	// TableSizes
+	sizes, err := store.TableSizes(ctx)
+	if err != nil {
+		t.Fatalf("TableSizes: %v", err)
+	}
+	if sizes["users"] != 1 {
+		t.Errorf("users count = %d, want 1", sizes["users"])
+	}
+
+	// AdminListListings
+	items, total, err := store.AdminListListings(ctx, 1, 0, 0)
+	if err != nil {
+		t.Fatalf("AdminListListings: %v", err)
+	}
+	if total != 2 || len(items) != 1 {
+		t.Errorf("total=%d items=%d", total, len(items))
+	}
+
+	// AdminDeleteListing
+	if err := store.AdminDeleteListing(ctx, "admin-1", 100); err != nil {
+		t.Fatalf("AdminDeleteListing: %v", err)
+	}
+	l, _ := store.GetListing(ctx, 100, "admin-1")
+	if l != nil {
+		t.Error("listing should be deleted")
+	}
+
+	// DBPoolStats
+	stats := store.DBPoolStats()
+	if stats == nil {
+		t.Error("expected non-nil pool stats")
+	}
+}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -28,21 +28,16 @@ func testStore(t *testing.T) *Store {
 	}
 	t.Cleanup(func() {
 		db := store.DB()
-		// Clean up in dependency order.
-		db.Exec("DELETE FROM listing_user_seen")
-		db.Exec("DELETE FROM pending_digest")
-		db.Exec("DELETE FROM pending_notifications")
-		db.Exec("DELETE FROM saved_listings")
-		db.Exec("DELETE FROM hidden_listings")
-		db.Exec("DELETE FROM listing_history")
-		db.Exec("DELETE FROM seen_listings")
-		db.Exec("DELETE FROM price_history")
-		db.Exec("DELETE FROM link_tokens")
-		db.Exec("DELETE FROM daily_digest")
-		db.Exec("DELETE FROM searches")
-		db.Exec("DELETE FROM price_list_cache")
-		db.Exec("DELETE FROM users")
-		store.Close()
+		tables := []string{
+			"listing_user_seen", "pending_digest", "pending_notifications",
+			"saved_listings", "hidden_listings", "listing_history",
+			"seen_listings", "price_history", "link_tokens",
+			"daily_digest", "searches", "price_list_cache", "users",
+		}
+		for _, tbl := range tables {
+			_, _ = db.Exec("DELETE FROM " + tbl)
+		}
+		_ = store.Close()
 	})
 	return store
 }

--- a/internal/storage/sqlite/admin.go
+++ b/internal/storage/sqlite/admin.go
@@ -110,7 +110,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 			FROM listing_history
 			WHERE search_id = ?
 			ORDER BY first_seen_at DESC
@@ -120,7 +120,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT ? OFFSET ?`, limit, offset)
@@ -137,12 +137,13 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		var ic sql.NullInt64
 		var mp, cs, ds, bp sql.NullInt64
 		var firstSeen string
+		var removedAt sql.NullString
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
 			&r.Manufacturer, &r.Model, &r.SubModel, &r.SubModelID, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&ic, &score, &mp, &cs, &ds, &bp, &firstSeen,
+			&ic, &score, &mp, &cs, &ds, &bp, &firstSeen, &removedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
@@ -169,6 +170,11 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			return nil, 0, fmt.Errorf("parse first_seen_at %q for token %s: %w", firstSeen, r.Token, parseErr)
 		}
 		r.FirstSeenAt = parsed
+		if removedAt.Valid && removedAt.String != "" {
+			if t, err := parseFlexibleTime(removedAt.String); err == nil {
+				r.RemovedAt = &t
+			}
+		}
 		items = append(items, r)
 	}
 	return items, total, rows.Err()

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -41,7 +41,8 @@ const upsertListingSQL = `
 		median_price = COALESCE(excluded.median_price, listing_history.median_price),
 		cohort_size = COALESCE(excluded.cohort_size, listing_history.cohort_size),
 		deal_score = COALESCE(excluded.deal_score, listing_history.deal_score),
-		base_price = COALESCE(excluded.base_price, listing_history.base_price)`
+		base_price = COALESCE(excluded.base_price, listing_history.base_price),
+		removed_at = NULL`
 
 type listingScanner interface {
 	Scan(dest ...any) error
@@ -51,10 +52,11 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
 	var ic, mp, cs, ds, bp sql.NullInt64
+	var removedAt sql.NullTime
 	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel, &l.SubModelID,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt); err != nil {
+		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt, &removedAt); err != nil {
 		return l, err
 	}
 	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
@@ -76,6 +78,9 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	if bp.Valid {
 		v := int(bp.Int64)
 		l.BasePrice = &v
+	}
+	if removedAt.Valid {
+		l.RemovedAt = &removedAt.Time
 	}
 	return l, nil
 }
@@ -214,7 +219,7 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		WHERE chat_id = ? AND token = ?
 		ORDER BY rowid DESC LIMIT 1`, chatID, token)
@@ -233,7 +238,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		WHERE chat_id = ?
 		ORDER BY first_seen_at DESC, token DESC
@@ -266,7 +271,7 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price, lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
 		FROM listing_history lh
 		INNER JOIN (
 			SELECT token, MAX(first_seen_at) AS max_seen
@@ -366,7 +371,7 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
 		WHERE chat_id = ? AND search_id = ?%s
 		ORDER BY %s
@@ -485,44 +490,64 @@ func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int
 }
 
 func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
-	if len(keepTokens) == 0 {
-		result, err := s.db.ExecContext(ctx, `
-			DELETE FROM listing_history
-			WHERE chat_id = ? AND search_id = ?
-			  AND NOT EXISTS (
-			    SELECT 1 FROM saved_listings
-			    WHERE saved_listings.token = listing_history.token
-			      AND saved_listings.chat_id = listing_history.chat_id
-			  )`, chatID, searchID)
-		if err != nil {
-			return 0, err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("delete stale begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var staleFilter string
+	args := []interface{}{chatID, searchID}
+	if len(keepTokens) > 0 {
+		placeholders := make([]string, len(keepTokens))
+		for i, t := range keepTokens {
+			placeholders[i] = "?"
+			args = append(args, t)
 		}
-		return result.RowsAffected()
+		staleFilter = fmt.Sprintf(" AND token NOT IN (%s)", strings.Join(placeholders, ","))
 	}
 
-	placeholders := make([]string, len(keepTokens))
-	args := make([]interface{}, 0, 2+len(keepTokens))
-	args = append(args, chatID, searchID)
-	for i, t := range keepTokens {
-		placeholders[i] = "?"
-		args = append(args, t)
+	// Mark bookmarked stale listings as removed_at (likely sold).
+	markArgs := make([]interface{}, len(args))
+	copy(markArgs, args)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE listing_history
+		SET removed_at = CURRENT_TIMESTAMP
+		WHERE chat_id = ? AND search_id = ?%s
+		  AND removed_at IS NULL
+		  AND EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, staleFilter), markArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("mark removed_at: %w", err)
 	}
 
-	query := fmt.Sprintf(`
+	// Delete non-bookmarked stale listings.
+	deleteArgs := make([]interface{}, len(args))
+	copy(deleteArgs, args)
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		DELETE FROM listing_history
-		WHERE chat_id = ? AND search_id = ?
-		  AND token NOT IN (%s)
+		WHERE chat_id = ? AND search_id = ?%s
 		  AND NOT EXISTS (
 		    SELECT 1 FROM saved_listings
 		    WHERE saved_listings.token = listing_history.token
 		      AND saved_listings.chat_id = listing_history.chat_id
-		  )`, strings.Join(placeholders, ","))
+		  )`, staleFilter), deleteArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("delete stale: %w", err)
+	}
 
-	result, err := s.db.ExecContext(ctx, query, args...)
+	removed, err := result.RowsAffected()
 	if err != nil {
 		return 0, err
 	}
-	return result.RowsAffected()
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("delete stale commit: %w", err)
+	}
+	return removed, nil
 }
 
 func (s *Store) SaveBookmark(ctx context.Context, chatID int64, token string) error {
@@ -544,7 +569,7 @@ func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) 
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = ?

--- a/internal/storage/sqlite/listings.go
+++ b/internal/storage/sqlite/listings.go
@@ -439,6 +439,34 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 	return out, rows.Err()
 }
 
+func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64) (*storage.SearchStats, error) {
+	var st storage.SearchStats
+	var avgPrice, minPrice, maxPrice sql.NullFloat64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) AS total,
+			COUNT(CASE WHEN first_seen_at > datetime('now', '-1 day') THEN 1 END) AS new_24h,
+			AVG(CASE WHEN price > 0 THEN price END) AS avg_price,
+			MIN(CASE WHEN price > 0 THEN price END) AS min_price,
+			MAX(CASE WHEN price > 0 THEN price END) AS max_price
+		FROM listing_history
+		WHERE search_id = ? AND chat_id = ?`, searchID, chatID).
+		Scan(&st.Total, &st.New24h, &avgPrice, &minPrice, &maxPrice)
+	if err != nil {
+		return nil, fmt.Errorf("search stats: %w", err)
+	}
+	if avgPrice.Valid {
+		st.AvgPrice = avgPrice.Float64
+	}
+	if minPrice.Valid {
+		st.MinPrice = int(minPrice.Float64)
+	}
+	if maxPrice.Valid {
+		st.MaxPrice = int(maxPrice.Float64)
+	}
+	return &st, nil
+}
+
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, `

--- a/internal/storage/sqlite/migrate.go
+++ b/internal/storage/sqlite/migrate.go
@@ -48,6 +48,7 @@ func migrate(db *sql.DB) error {
 		migrateListingUserSeen,
 		migrateSearchPricePhotoFilters,
 		migrateSearchPriceMinAndGearBox,
+		migrateListingRemovedAt,
 	}
 	for _, step := range steps {
 		if err := step(db); err != nil {

--- a/internal/storage/sqlite/migrate_steps.go
+++ b/internal/storage/sqlite/migrate_steps.go
@@ -828,3 +828,18 @@ func migrateListingUserSeen(db *sql.DB) error {
 	}
 	return nil
 }
+
+func migrateListingRemovedAt(db *sql.DB) error {
+	var exists int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('listing_history') WHERE name = 'removed_at'",
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("check listing_history removed_at: %w", err)
+	}
+	if exists == 0 {
+		if _, err := db.Exec("ALTER TABLE listing_history ADD COLUMN removed_at TIMESTAMP"); err != nil {
+			return fmt.Errorf("add removed_at column: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/storage/sqlite/notifications_center.go
+++ b/internal/storage/sqlite/notifications_center.go
@@ -13,7 +13,7 @@ func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.T
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history lh
 		WHERE lh.chat_id = ? AND lh.first_seen_at > ?
 		AND NOT EXISTS (

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -3491,3 +3491,120 @@ func TestSyncUserActiveStatus(t *testing.T) {
 		t.Error("user 300 should be inactive (only paused search)")
 	}
 }
+
+// --- SearchStats Tests ---
+
+func TestSearchStats_Basic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "mazda-3", Source: "yad2",
+		Manufacturer: 27, Model: 10332,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	for i, price := range []int{80000, 90000, 100000, 0} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: fmt.Sprintf("ss-tok%d", i), ChatID: 100, SearchID: searchID,
+			SearchName: "mazda-3", Manufacturer: "Mazda", Model: "3",
+			Year: 2021, Price: price, FirstSeenAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("SaveListing %d: %v", i, err)
+		}
+	}
+
+	stats, err := store.SearchStats(ctx, 100, searchID)
+	if err != nil {
+		t.Fatalf("SearchStats: %v", err)
+	}
+	if stats.Total != 4 {
+		t.Errorf("Total = %d, want 4", stats.Total)
+	}
+	if stats.New24h != 4 {
+		t.Errorf("New24h = %d, want 4", stats.New24h)
+	}
+	if stats.MinPrice != 80000 {
+		t.Errorf("MinPrice = %d, want 80000", stats.MinPrice)
+	}
+	if stats.MaxPrice != 100000 {
+		t.Errorf("MaxPrice = %d, want 100000", stats.MaxPrice)
+	}
+	// avg of 80000,90000,100000 (excluding price=0) = 90000
+	if stats.AvgPrice != 90000 {
+		t.Errorf("AvgPrice = %f, want 90000", stats.AvgPrice)
+	}
+}
+
+func TestSearchStats_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "empty", Source: "yad2",
+		Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	stats, err := store.SearchStats(ctx, 100, searchID)
+	if err != nil {
+		t.Fatalf("SearchStats: %v", err)
+	}
+	if stats.Total != 0 {
+		t.Errorf("Total = %d, want 0", stats.Total)
+	}
+	if stats.AvgPrice != 0 {
+		t.Errorf("AvgPrice = %f, want 0", stats.AvgPrice)
+	}
+	if stats.MinPrice != 0 {
+		t.Errorf("MinPrice = %d, want 0", stats.MinPrice)
+	}
+	if stats.MaxPrice != 0 {
+		t.Errorf("MaxPrice = %d, want 0", stats.MaxPrice)
+	}
+}
+
+func TestSearchStats_CrossUserIsolation(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	seedUser(t, store, 200)
+
+	searchID1, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "user100", Source: "yad2",
+		Manufacturer: 1, Model: 1,
+	})
+	searchID2, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 200, Name: "user200", Source: "yad2",
+		Manufacturer: 1, Model: 1,
+	})
+
+	for i := range 3 {
+		_ = store.SaveListing(ctx, storage.ListingRecord{
+			Token: fmt.Sprintf("iso-1-%d", i), ChatID: 100, SearchID: searchID1,
+			SearchName: "user100", Manufacturer: "Test", Model: "Car",
+			Year: 2021, Price: 100000, FirstSeenAt: time.Now(),
+		})
+	}
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "iso-2-0", ChatID: 200, SearchID: searchID2,
+		SearchName: "user200", Manufacturer: "Test", Model: "Car",
+		Year: 2021, Price: 50000, FirstSeenAt: time.Now(),
+	})
+
+	stats1, _ := store.SearchStats(ctx, 100, searchID1)
+	stats2, _ := store.SearchStats(ctx, 200, searchID2)
+
+	if stats1.Total != 3 {
+		t.Errorf("user 100 Total = %d, want 3", stats1.Total)
+	}
+	if stats2.Total != 1 {
+		t.Errorf("user 200 Total = %d, want 1", stats2.Total)
+	}
+}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -3384,6 +3384,115 @@ func TestDeleteStaleListings_EmptyKeepTokens(t *testing.T) {
 	}
 }
 
+func TestDeleteStaleListings_SetsRemovedAtOnBookmarked(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	for _, tok := range []string{"keep", "stale-saved", "stale-unsaved"} {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: tok, ChatID: 100, SearchID: searchID, SearchName: "test",
+			Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		}); err != nil {
+			t.Fatalf("SaveListing %s: %v", tok, err)
+		}
+	}
+
+	if err := store.SaveBookmark(ctx, 100, "stale-saved"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
+
+	removed, err := store.DeleteStaleListings(ctx, 100, searchID, []string{"keep"})
+	if err != nil {
+		t.Fatalf("DeleteStaleListings: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed (only unsaved stale), got %d", removed)
+	}
+
+	// Bookmarked stale listing should have removed_at set.
+	saved, err := store.GetListing(ctx, 100, "stale-saved")
+	if err != nil {
+		t.Fatalf("GetListing stale-saved: %v", err)
+	}
+	if saved == nil {
+		t.Fatal("bookmarked listing should survive deletion")
+	}
+	if saved.RemovedAt == nil {
+		t.Error("bookmarked stale listing should have removed_at set")
+	}
+
+	// Kept listing should not have removed_at set.
+	kept, err := store.GetListing(ctx, 100, "keep")
+	if err != nil {
+		t.Fatalf("GetListing keep: %v", err)
+	}
+	if kept == nil {
+		t.Fatal("kept listing should still exist")
+	}
+	if kept.RemovedAt != nil {
+		t.Error("kept listing should not have removed_at set")
+	}
+}
+
+func TestDeleteStaleListings_RemovedAtClearedOnReInsert(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateSearch: %v", err)
+	}
+
+	// Save and bookmark a listing.
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+	}); err != nil {
+		t.Fatalf("SaveListing: %v", err)
+	}
+	if err := store.SaveBookmark(ctx, 100, "tok1"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
+
+	// Delete stale listings - tok1 should get removed_at.
+	if _, err := store.DeleteStaleListings(ctx, 100, searchID, nil); err != nil {
+		t.Fatalf("DeleteStaleListings: %v", err)
+	}
+	l, _ := store.GetListing(ctx, 100, "tok1")
+	if l == nil || l.RemovedAt == nil {
+		t.Fatal("expected removed_at to be set after stale deletion")
+	}
+
+	// Re-save the listing (listing reappeared) - removed_at should be cleared.
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok1", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 85000,
+	}); err != nil {
+		t.Fatalf("SaveListing re-insert: %v", err)
+	}
+	l, _ = store.GetListing(ctx, 100, "tok1")
+	if l == nil {
+		t.Fatal("listing should exist after re-insert")
+	}
+	if l.RemovedAt != nil {
+		t.Error("removed_at should be cleared after re-insert (listing reappeared)")
+	}
+	if l.Price != 85000 {
+		t.Errorf("price should be updated to 85000, got %d", l.Price)
+	}
+}
+
 func TestUpsertUser_ReactivatesInactiveUser(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/migrations/000009_listing_removed_at.down.sql
+++ b/migrations/000009_listing_removed_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE listing_history DROP COLUMN removed_at;

--- a/migrations/000009_listing_removed_at.up.sql
+++ b/migrations/000009_listing_removed_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE listing_history ADD COLUMN removed_at TIMESTAMP;

--- a/testdata/winwin_page.html
+++ b/testdata/winwin_page.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <title>רכבים למכירה - WinWin</title>
+</head>
+<body>
+  <div id="main-content">
+    <div class="search-results">
+
+      <!-- Listing 1: Toyota Corolla -->
+      <div class="vehicle-card" data-id="12345">
+        <div class="card-image">
+          <img src="/images/vehicles/12345.jpg" alt="טויוטה קורולה 2022">
+        </div>
+        <div class="card-body">
+          <a href="/vehicles/private/12345">טויוטה קורולה 2022</a>
+          <div class="card-details">
+            <span class="price">149,000 ₪</span>
+            <span class="km">45,000 ק״מ</span>
+            <span class="hand">יד 2</span>
+            <span class="location">• תל אביב</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Listing 2: Mazda 3 -->
+      <div class="vehicle-card" data-id="67890">
+        <div class="card-image">
+          <img src="/images/vehicles/67890.jpg" alt="מאזדה 3 2021">
+        </div>
+        <div class="card-body">
+          <a href="/vehicles/private/67890">מאזדה 3 2021</a>
+          <div class="card-details">
+            <span class="price">125,000 ₪</span>
+            <span class="km">60,000 ק״מ</span>
+            <span class="hand">יד 1</span>
+            <span class="location">• חיפה</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Listing 3: Hyundai Tucson -->
+      <div class="vehicle-card" data-id="11223">
+        <div class="card-image">
+          <img src="/images/vehicles/11223.jpg" alt="יונדאי טוסון 2023">
+        </div>
+        <div class="card-body">
+          <a href="/vehicles/private/11223">יונדאי טוסון 2023</a>
+          <div class="card-details">
+            <span class="price">189,000 ₪</span>
+            <span class="km">20,000 ק״מ</span>
+            <span class="hand">יד 1</span>
+            <span class="location">• ירושלים</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Listing 4: duplicate of listing 1, should be de-duplicated -->
+      <div class="vehicle-card" data-id="12345">
+        <div class="card-body">
+          <a href="/vehicles/private/12345">טויוטה קורולה 2022</a>
+          <span class="price">149,000 ₪</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,8 +1,13 @@
 {
   "name": "CarWatch",
   "short_name": "CarWatch",
+  "description": "מעקב חכם אחרי מודעות רכב מיד2 ו-WinWin. התראות מיידיות, ניתוח מחירים וציון התאמה אוטומטי.",
+  "lang": "he",
+  "dir": "rtl",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
+  "orientation": "portrait",
   "background_color": "#0B0D14",
   "theme_color": "#0B0D14",
   "icons": [

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'carwatch-v1';
+const STATIC_ASSETS = ['/', '/manifest.json'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith('/api/')) {
+    // Network-first for API calls
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(event.request))
+    );
+    return;
+  }
+  // Cache-first for static assets
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
+  );
+});

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useState, useEffect } from "react";
-import { Bookmark } from "lucide-react";
+import { Bookmark, AlertTriangle } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, cn, marketComparison } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
@@ -65,7 +65,18 @@ export function ListingCardBody({
         </div>
       )}
 
-      <div className="p-4">
+      <div className={cn("p-4", listing.removed_at && "opacity-60")}>
+        {listing.removed_at ? (
+          <div className="mb-2 flex items-center gap-1.5 rounded-lg bg-muted/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
+            {"נמכר כנראה"}
+          </div>
+        ) : null}
+        {listing.suspicious_reasons && listing.suspicious_reasons.length > 0 ? (
+          <div className="mb-2 flex items-center gap-1.5 rounded-lg bg-amber-500/10 px-2.5 py-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            {"זהירות"}
+          </div>
+        ) : null}
         <div className="mb-2 flex items-start gap-3">
           {logoSrc ? (
             <img

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -14,6 +14,7 @@ import {
   manufacturerLogoSrc,
   manufacturerLogoSrcFromCatalogId,
 } from "@/lib/manufacturerLogo";
+import { useSearchStats } from "@/hooks/useSearchStats";
 
 export type SearchCardProps = {
   search: Search;
@@ -37,6 +38,7 @@ export function SearchCard({
   const navigate = useNavigate();
   const isActive = search.active;
   const listingsPath = `/searches/${search.id}/listings`;
+  const { data: stats } = useSearchStats(search.id);
 
   const mfrLogo =
     manufacturerLogoSrcFromCatalogId(search.manufacturer_id) ??
@@ -187,6 +189,24 @@ export function SearchCard({
           </div>
         </Link>
       ) : null}
+
+      {stats && stats.total > 0 && (
+        <div className="mb-3 text-xs text-muted-foreground">
+          <span>{stats.total} {"מודעות"}</span>
+          {stats.new_24h > 0 && (
+            <>
+              <span className="mx-1.5">&middot;</span>
+              <span>{stats.new_24h} {"חדשות היום"}</span>
+            </>
+          )}
+          {stats.avg_price > 0 && (
+            <>
+              <span className="mx-1.5">&middot;</span>
+              <span>{"ממוצע"} {formatPrice(Math.round(stats.avg_price))}</span>
+            </>
+          )}
+        </div>
+      )}
 
       <Link
         to={listingsPath}

--- a/web/src/hooks/useSearchStats.test.ts
+++ b/web/src/hooks/useSearchStats.test.ts
@@ -1,0 +1,76 @@
+import React, { type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import { useSearchStats } from "./useSearchStats";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...mod,
+    api: {
+      ...mod.api,
+      searches: {
+        ...mod.api.searches,
+        stats: vi.fn(),
+      },
+    },
+  };
+});
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function withProviders(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe("useSearchStats", () => {
+  const mockedSearches = vi.mocked(api.searches);
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("fetches stats for a valid search ID", async () => {
+    const mockStats = {
+      total: 42,
+      new_24h: 5,
+      avg_price: 95000,
+      min_price: 70000,
+      max_price: 130000,
+    };
+    mockedSearches.stats.mockResolvedValue(mockStats);
+
+    const { result } = renderHook(() => useSearchStats(1), {
+      wrapper: withProviders(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockStats);
+    expect(mockedSearches.stats).toHaveBeenCalledWith(1);
+  });
+
+  it("does not fetch for invalid search ID", () => {
+    const { result } = renderHook(() => useSearchStats(0), {
+      wrapper: withProviders(queryClient),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(mockedSearches.stats).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useSearchStats.ts
+++ b/web/src/hooks/useSearchStats.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export function useSearchStats(searchId: number) {
+  return useQuery({
+    queryKey: ["search-stats", searchId],
+    queryFn: () => api.searches.stats(searchId),
+    enabled: searchId > 0,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -138,6 +138,10 @@ export interface Listing {
   seen?: boolean;
   /** From Yad2 bucket: true = dealer/commercial, false = private, absent when unknown. */
   is_commercial?: boolean | null;
+  /** Set when the listing disappeared from the source but is bookmarked (likely sold). */
+  removed_at?: string;
+  /** Reasons the listing was flagged as suspicious. */
+  suspicious_reasons?: string[];
 }
 
 export interface SearchStatsResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -140,6 +140,14 @@ export interface Listing {
   is_commercial?: boolean | null;
 }
 
+export interface SearchStatsResponse {
+  total: number;
+  new_24h: number;
+  avg_price: number;
+  min_price: number;
+  max_price: number;
+}
+
 export interface ListingsResponse {
   items: Listing[];
   total: number;
@@ -189,6 +197,8 @@ export const api = {
       fetchAPI<void>(`/searches/${id}/pause`, { method: "POST" }),
     resume: (id: number) =>
       fetchAPI<void>(`/searches/${id}/resume`, { method: "POST" }),
+    stats: (id: number) =>
+      fetchAPI<SearchStatsResponse>(`/searches/${id}/stats`),
   },
   listing: (token: string) => fetchAPI<Listing>(`/listings/${encodeURIComponent(token)}`),
   markListingSeen: (token: string) =>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,12 @@ import { ToastProvider, showGlobalToast } from "./components/ui/Toast";
 import { errorToHebrew } from "./lib/error-messages";
 import "./index.css";
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {});
+  });
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   Zap,
   Eye,
   EyeOff,
+  AlertTriangle,
 } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, safeHref, marketComparison, cn } from "@/lib/utils";
 import { api, ApiError } from "@/lib/api";
@@ -166,6 +167,32 @@ function ListingDetailContent({
   return (
     <div className="space-y-6">
       {backButton}
+
+      {listing.removed_at ? (
+        <div className="rounded-2xl border border-border/50 bg-muted/50 p-4 text-sm text-muted-foreground">
+          {"המודעה הוסרה מהאתר — ככל הנראה הרכב נמכר."}
+        </div>
+      ) : null}
+
+      {listing.suspicious_reasons && listing.suspicious_reasons.length > 0 ? (
+        <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 space-y-1.5">
+          <div className="flex items-center gap-2 text-sm font-semibold text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="h-4 w-4" />
+            {"מודעה חשודה"}
+          </div>
+          <ul className="list-disc list-inside text-xs text-amber-700/80 dark:text-amber-400/80 space-y-0.5">
+            {listing.suspicious_reasons.map((reason) => (
+              <li key={reason}>
+                {reason === "price_below_market"
+                  ? "המחיר נמוך משמעותית ממחיר השוק"
+                  : reason === "no_photo_low_price"
+                    ? "אין תמונה והמחיר נמוך"
+                    : reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       {/* Hero image */}
       {listing.image_url ? (

--- a/web/src/pages/NewSearchPage.test.tsx
+++ b/web/src/pages/NewSearchPage.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NewSearchPage } from "./NewSearchPage";
+import { ToastProvider } from "@/components/ui/Toast";
+
+vi.mock("@/hooks/useCatalog", () => ({
+  useManufacturers: () => ({ data: [] }),
+  useModels: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useSearches", () => ({
+  useCreateSearch: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ToastProvider>
+          <NewSearchPage />
+        </ToastProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("NewSearchPage presets", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders preset cards in initial state", () => {
+    renderPage();
+    expect(screen.getByText("רכב משפחתי")).toBeInTheDocument();
+    expect(screen.getByText("רכב ראשון")).toBeInTheDocument();
+    expect(screen.getByText("SUV")).toBeInTheDocument();
+    expect(screen.getByText("היברידי / חשמלי")).toBeInTheDocument();
+  });
+
+  it("hides presets after clicking one", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const presetBtn = screen.getByText("רכב ראשון").closest("button")!;
+    await user.click(presetBtn);
+    expect(screen.queryByText("התחל מתבנית")).not.toBeInTheDocument();
+  });
+
+  it("fills priceMax when 'רכב ראשון' preset is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const presetBtn = screen.getByText("רכב ראשון").closest("button")!;
+    await user.click(presetBtn);
+    const priceMaxInput = screen.getByLabelText(/מחיר מקסימום/) as HTMLInputElement;
+    expect(priceMaxInput.value).toBe("80000");
+  });
+
+  it("fills yearMin when 'SUV' preset is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const presetBtn = screen.getByText("SUV").closest("button")!;
+    await user.click(presetBtn);
+    const yearMinInput = screen.getByLabelText(/שנה מ-/) as HTMLInputElement;
+    const expectedYear = new Date().getFullYear() - 5;
+    expect(yearMinInput.value).toBe(String(expectedYear));
+  });
+});

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate, Link } from "react-router";
-import { Search, Loader2 } from "lucide-react";
+import { Search, Loader2, Car, Zap, Trees, UserRound } from "lucide-react";
 import { useManufacturers, useModels } from "@/hooks/useCatalog";
 import { useCreateSearch } from "@/hooks/useSearches";
 import { formatPrice } from "@/lib/utils";
@@ -52,6 +52,48 @@ const SOURCE_OPTIONS = [
 
 const HAND_OPTIONS = [0, 1, 2, 3, 4];
 
+interface SearchPreset {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof Car;
+  values: Partial<FormData>;
+}
+
+function getPresets(): SearchPreset[] {
+  const currentYear = new Date().getFullYear();
+  return [
+    {
+      id: "family",
+      title: "רכב משפחתי",
+      description: "עד 6 שנים, עד 150,000 ₪",
+      icon: Car,
+      values: { yearMin: currentYear - 6, priceMax: 150_000 },
+    },
+    {
+      id: "first",
+      title: "רכב ראשון",
+      description: "עד 80,000 ₪",
+      icon: UserRound,
+      values: { priceMax: 80_000 },
+    },
+    {
+      id: "suv",
+      title: "SUV",
+      description: "עד 5 שנים, עד 200,000 ₪",
+      icon: Trees,
+      values: { yearMin: currentYear - 5, priceMax: 200_000 },
+    },
+    {
+      id: "hybrid",
+      title: "היברידי / חשמלי",
+      description: "עד 4 שנים",
+      icon: Zap,
+      values: { yearMin: currentYear - 4 },
+    },
+  ];
+}
+
 function formatKmLabel(value: number): string {
   if (value === 0) return "ללא הגבלה";
   return `${value.toLocaleString("he-IL")} ק"מ`;
@@ -82,11 +124,20 @@ export function NewSearchPage() {
     photoOnly: false,
   });
 
+  const [presetsHidden, setPresetsHidden] = useState(false);
+  const presets = useMemo(() => getPresets(), []);
+  const showPresets = !presetsHidden && form.manufacturer === 0;
+
   const { data: manufacturers } = useManufacturers();
   const { data: models } = useModels(form.manufacturer);
 
   const set = <K extends keyof FormData>(key: K, val: FormData[K]) =>
     setForm((prev) => ({ ...prev, [key]: val }));
+
+  function applyPreset(preset: SearchPreset) {
+    setForm((prev) => ({ ...prev, ...preset.values }));
+    setPresetsHidden(true);
+  }
 
   const validYear = (y: number) => y === 0 || y >= 1990;
   const canSubmit =
@@ -148,6 +199,29 @@ export function NewSearchPage() {
         >
           {error}
         </div>
+      )}
+
+      {showPresets && (
+        <section aria-label="תבניות חיפוש מוכנות">
+          <h2 className="text-sm font-semibold text-foreground mb-3">התחל מתבנית</h2>
+          <div className="flex gap-3 overflow-x-auto pb-2 sm:grid sm:grid-cols-2 sm:overflow-visible sm:pb-0 snap-x snap-mandatory">
+            {presets.map((preset) => {
+              const Icon = preset.icon;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => applyPreset(preset)}
+                  className="flex-shrink-0 w-40 sm:w-auto snap-start rounded-2xl border border-border/50 bg-card p-4 text-start transition-colors hover:border-primary/40 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  <Icon className="h-5 w-5 text-primary mb-2" />
+                  <p className="text-sm font-semibold text-foreground">{preset.title}</p>
+                  <p className="text-xs text-muted-foreground mt-1">{preset.description}</p>
+                </button>
+              );
+            })}
+          </div>
+        </section>
       )}
 
       <form onSubmit={handleFormSubmit} className="contents">


### PR DESCRIPTION
## Summary

Final batch of audit fixes: 7 issues resolved across features, testing, and reliability. 39 files changed, 2,840 additions.

### New Features
- **PWA service worker (#746)**: Cache-first for static assets, network-first for API, enriched manifest with Hebrew/RTL metadata
- **Search presets (#748)**: 4 Hebrew preset cards (Family car, First car, SUV, Hybrid/Electric) on NewSearchPage with auto-fill
- **Market trends dashboard (#750)**: `GET /api/v1/searches/{id}/stats` endpoint + per-search stats row on SearchCard (total, new/24h, avg price)
- **Suspicious listing detection (#751)**: Below-market and no-photo+low-price flags with yellow warning badges
- **Likely sold tracking (#751)**: `removed_at` timestamp on bookmarked stale listings with gray "נמכר כנראה" badge

### Testing
- **Postgres integration tests (#723)**: 20 test functions (1,510 lines) covering all CRUD, dedup, bookmarks, prices, cascade deletes. CI Postgres service container added.

### Reliability
- **WinWin parser robustness (#728)**: Resilient parent-walking with class-pattern matching, zero-result detection warnings, real testdata fixture, expanded separator support

## Metrics
- Go coverage: 65.5%
- Frontend tests: 135 (up from 129)
- Lint: 0 issues
- E2E: all pass

## Test plan
- [x] All Go packages pass
- [x] 135 frontend tests pass
- [x] TypeScript compiles cleanly
- [x] golangci-lint: 0 issues
- [x] E2E tests pass
- [ ] Manual: verify PWA installability on Android Chrome
- [ ] Manual: verify search presets on mobile
- [ ] Manual: verify suspicious listing badges
- [ ] Manual: verify market stats on search cards

Closes #723
Closes #728
Closes #746
Closes #748
Closes #750
Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)