### PR TITLE
fix: add image URL fallbacks and redesign search forms with premium SectionCard layout

### DIFF
--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -103,9 +103,11 @@ func parseItemNextData(data []byte) (ItemDetails, error) {
 }
 
 type itemPageData struct {
-	Km         int    `json:"km"`
-	Kilometer  int    `json:"kilometer"`
-	CoverImage string `json:"coverImage"`
+	Km         int      `json:"km"`
+	Kilometer  int      `json:"kilometer"`
+	CoverImage string   `json:"coverImage"`
+	CoverImg   string   `json:"cover_image"`
+	Images     []string `json:"images"`
 	Address    struct {
 		City struct {
 			Text    string `json:"text"`
@@ -121,11 +123,26 @@ type itemPageData struct {
 func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 	details := ItemDetails{
 		Km:       effectiveKm(d),
-		ImageURL: d.CoverImage,
+		ImageURL: resolveItemImageURL(d),
 		City:     firstNonEmpty(d.Address.City.TextEng, d.Address.City.Text),
 		Area:     firstNonEmpty(d.Address.Area.TextEng, d.Address.Area.Text),
 	}
 	return details, details.Km > 0 || details.ImageURL != "" || details.City != "" || details.Area != ""
+}
+
+// resolveItemImageURL checks multiple image field locations in the item page
+// data, returning the first non-empty URL found.
+func resolveItemImageURL(d itemPageData) string {
+	if d.CoverImage != "" {
+		return d.CoverImage
+	}
+	if d.CoverImg != "" {
+		return d.CoverImg
+	}
+	if len(d.Images) > 0 && d.Images[0] != "" {
+		return d.Images[0]
+	}
+	return ""
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/fetcher/yad2/item_parser_test.go
+++ b/internal/fetcher/yad2/item_parser_test.go
@@ -122,3 +122,39 @@ func TestParseItemPage_NoKm(t *testing.T) {
 		t.Fatal("expected error when km is 0")
 	}
 }
+
+func TestParseItemPage_CoverImgSnakeCase(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 50000,
+  "cover_image": "https://img.yad2.co.il/snake.jpg"
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.ImageURL != "https://img.yad2.co.il/snake.jpg" {
+		t.Errorf("ImageURL = %q, want cover_image fallback", details.ImageURL)
+	}
+}
+
+func TestParseItemPage_ImagesArrayFallback(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 75000,
+  "images": ["https://img.yad2.co.il/arr1.jpg", "https://img.yad2.co.il/arr2.jpg"]
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.ImageURL != "https://img.yad2.co.il/arr1.jpg" {
+		t.Errorf("ImageURL = %q, want first from images array", details.ImageURL)
+	}
+}

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -70,7 +70,7 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 	seen := make(map[string]struct{}, len(items))
 	skipped := 0
 	for _, tagged := range items {
-		l, err := itemToListing(tagged.raw, tagged.commercial)
+		l, err := itemToListing(tagged.raw, tagged.commercial, logger)
 		if err != nil {
 			skipped++
 			if logger != nil {
@@ -171,7 +171,7 @@ func extractItems(nd nextDataEnvelope) ([]feedTaggedItem, error) {
 	return nil, fmt.Errorf("no feed items found in __NEXT_DATA__")
 }
 
-func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, error) {
+func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (model.RawListing, error) {
 	var item feedItem
 	if err := json.Unmarshal(raw, &item); err != nil {
 		return model.RawListing{}, err
@@ -187,6 +187,15 @@ func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, err
 	engineVol := item.EngineVolume
 	if engineVol == 0 {
 		engineVol = item.EngineVolumeNew
+	}
+
+	imgURL := resolveImageURL(item)
+	if imgURL == "" && logger != nil {
+		logger.Warn("feed item has no image URL",
+			"token", item.Token,
+			"manufacturer", textFromField(item.Manufacturer),
+			"model", textFromField(item.Model),
+		)
 	}
 
 	listing := model.RawListing{
@@ -209,7 +218,7 @@ func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, err
 		Hand:               parseHand(item.Hand),
 		Price:              item.Price,
 		Description:        item.MetaData.Description,
-		ImageURL:           item.MetaData.CoverImage,
+		ImageURL:           imgURL,
 		PageLink:           fmt.Sprintf("https://www.yad2.co.il/vehicles/item/%s", item.Token),
 	}
 
@@ -236,6 +245,28 @@ func itemToListing(raw json.RawMessage, commercial *bool) (model.RawListing, err
 	}
 	listing.Commercial = commercial
 	return listing, nil
+}
+
+// resolveImageURL checks multiple image field locations in the feed item,
+// returning the first non-empty URL found. This handles Yad2 API format
+// changes where the image may appear in different fields.
+func resolveImageURL(item feedItem) string {
+	if item.MetaData.CoverImage != "" {
+		return item.MetaData.CoverImage
+	}
+	if item.MetaData.CoverImg != "" {
+		return item.MetaData.CoverImg
+	}
+	if item.CoverImageTop != "" {
+		return item.CoverImageTop
+	}
+	if item.CoverImgTop != "" {
+		return item.CoverImgTop
+	}
+	if len(item.Images) > 0 && item.Images[0] != "" {
+		return item.Images[0]
+	}
+	return ""
 }
 
 func parseHand(raw json.RawMessage) int {
@@ -300,9 +331,14 @@ type feedItem struct {
 	} `json:"address"`
 	MetaData struct {
 		CoverImage  string `json:"coverImage"`
+		CoverImg    string `json:"cover_image"`
 		Description string `json:"description"`
 	} `json:"metaData"`
-	Dates struct {
+	// Top-level image fields as fallback when metaData.coverImage is absent.
+	Images        []string `json:"images"`
+	CoverImageTop string   `json:"coverImage"`
+	CoverImgTop   string   `json:"cover_image"`
+	Dates         struct {
 		CreatedAt string `json:"createdAt"`
 		UpdatedAt string `json:"updatedAt"`
 	} `json:"dates"`

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -377,3 +377,147 @@ func TestParseNextData_DeduplicatesAcrossBuckets(t *testing.T) {
 		tokens[l.Token] = true
 	}
 }
+
+func TestResolveImageURL_MetaDataCoverImage(t *testing.T) {
+	item := feedItem{
+		MetaData: struct {
+			CoverImage  string `json:"coverImage"`
+			CoverImg    string `json:"cover_image"`
+			Description string `json:"description"`
+		}{CoverImage: "https://img.yad2.co.il/primary.jpg"},
+	}
+	got := resolveImageURL(item)
+	if got != "https://img.yad2.co.il/primary.jpg" {
+		t.Errorf("resolveImageURL = %q, want primary coverImage", got)
+	}
+}
+
+func TestResolveImageURL_MetaDataCoverImg(t *testing.T) {
+	item := feedItem{
+		MetaData: struct {
+			CoverImage  string `json:"coverImage"`
+			CoverImg    string `json:"cover_image"`
+			Description string `json:"description"`
+		}{CoverImg: "https://img.yad2.co.il/alt.jpg"},
+	}
+	got := resolveImageURL(item)
+	if got != "https://img.yad2.co.il/alt.jpg" {
+		t.Errorf("resolveImageURL = %q, want cover_image fallback", got)
+	}
+}
+
+func TestResolveImageURL_TopLevelCoverImage(t *testing.T) {
+	item := feedItem{
+		CoverImageTop: "https://img.yad2.co.il/top.jpg",
+	}
+	got := resolveImageURL(item)
+	if got != "https://img.yad2.co.il/top.jpg" {
+		t.Errorf("resolveImageURL = %q, want top-level coverImage", got)
+	}
+}
+
+func TestResolveImageURL_TopLevelCoverImgSnake(t *testing.T) {
+	item := feedItem{
+		CoverImgTop: "https://img.yad2.co.il/top_snake.jpg",
+	}
+	got := resolveImageURL(item)
+	if got != "https://img.yad2.co.il/top_snake.jpg" {
+		t.Errorf("resolveImageURL = %q, want top-level cover_image", got)
+	}
+}
+
+func TestResolveImageURL_ImagesArray(t *testing.T) {
+	item := feedItem{
+		Images: []string{"https://img.yad2.co.il/first.jpg", "https://img.yad2.co.il/second.jpg"},
+	}
+	got := resolveImageURL(item)
+	if got != "https://img.yad2.co.il/first.jpg" {
+		t.Errorf("resolveImageURL = %q, want first from images array", got)
+	}
+}
+
+func TestResolveImageURL_Empty(t *testing.T) {
+	item := feedItem{}
+	got := resolveImageURL(item)
+	if got != "" {
+		t.Errorf("resolveImageURL = %q, want empty", got)
+	}
+}
+
+func TestParseNextData_ImageFallbackCoverImg(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "img-alt-1",
+				 "manufacturer": {"text": "Toyota"},
+				 "model": {"text": "Corolla"},
+				 "price": 70000,
+				 "hand": 1,
+				 "metaData": {"cover_image": "https://img.yad2.co.il/snake.jpg", "description": "test"}}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].ImageURL != "https://img.yad2.co.il/snake.jpg" {
+		t.Errorf("ImageURL = %q, want cover_image fallback", listings[0].ImageURL)
+	}
+}
+
+func TestParseNextData_ImageFallbackTopLevel(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "img-top-1",
+				 "manufacturer": {"text": "Toyota"},
+				 "model": {"text": "Corolla"},
+				 "price": 70000,
+				 "hand": 1,
+				 "coverImage": "https://img.yad2.co.il/top.jpg"}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].ImageURL != "https://img.yad2.co.il/top.jpg" {
+		t.Errorf("ImageURL = %q, want top-level coverImage", listings[0].ImageURL)
+	}
+}
+
+func TestParseNextData_ImageFallbackImagesArray(t *testing.T) {
+	data := []byte(`{
+		"props": {"pageProps": {"dehydratedState": {"queries": [{"state": {"data": {
+			"private": [
+				{"token": "img-arr-1",
+				 "manufacturer": {"text": "Toyota"},
+				 "model": {"text": "Corolla"},
+				 "price": 70000,
+				 "hand": 1,
+				 "images": ["https://img.yad2.co.il/arr1.jpg", "https://img.yad2.co.il/arr2.jpg"]}
+			]
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].ImageURL != "https://img.yad2.co.il/arr1.jpg" {
+		t.Errorf("ImageURL = %q, want first from images array", listings[0].ImageURL)
+	}
+}

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -6,7 +6,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
 };
 
 const inputStyles =
-  "w-full bg-card border rounded-xl px-4 py-3 text-sm outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 placeholder:text-muted-foreground transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed";
+  "w-full bg-background border rounded-xl px-4 py-2.5 text-sm outline-none focus:border-primary focus:ring-2 focus:ring-ring placeholder:text-muted-foreground transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed";
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, error, ...props }, ref) => (

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -7,7 +7,7 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
 };
 
 const selectStyles =
-  "w-full bg-card border rounded-xl py-3 ps-10 pe-4 text-sm outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed appearance-none cursor-pointer";
+  "w-full bg-background border rounded-xl py-2.5 ps-10 pe-4 text-sm outline-none focus:border-primary focus:ring-2 focus:ring-ring transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed appearance-none cursor-pointer";
 
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, error, children, ...props }, ref) => (

--- a/web/src/pages/EditSearchPage.tsx
+++ b/web/src/pages/EditSearchPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useParams, Link } from "react-router";
-import { Save, Loader2 } from "lucide-react";
+import { Save, Loader2, ArrowRight } from "lucide-react";
 import { useSearch, useUpdateSearch } from "@/hooks/useSearches";
 import { formatPrice } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
@@ -8,7 +8,6 @@ import { ChipButton } from "@/components/ui/ChipButton";
 import { Input } from "@/components/ui/Input";
 import { RangeSlider } from "@/components/ui/RangeSlider";
 import { FormField } from "@/components/ui/FormField";
-import { PageHeader } from "@/components/ui/PageHeader";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useToast } from "@/components/ui/Toast";
@@ -42,6 +41,17 @@ function normalizeSellerFilter(v: string | undefined): "any" | "private" | "comm
 function formatKmLabel(value: number): string {
   if (value === 0) return "ללא הגבלה";
   return `${value.toLocaleString("he-IL")} ק"מ`;
+}
+
+function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-card border border-border rounded-2xl overflow-hidden">
+      <div className="px-6 py-3.5 border-b border-border bg-secondary/30">
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{title}</h2>
+      </div>
+      <div className="p-6 space-y-4">{children}</div>
+    </div>
+  );
 }
 
 export function EditSearchPage() {
@@ -136,7 +146,7 @@ export function EditSearchPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6 pb-24 md:pb-8">
+      <div className="space-y-5 pb-24 md:pb-8 dir-rtl">
         <Skeleton className="h-8 w-48 rounded-lg" />
         <Skeleton className="h-64 rounded-2xl" />
         <Skeleton className="h-48 rounded-2xl" />
@@ -160,98 +170,148 @@ export function EditSearchPage() {
   }
 
   return (
-    <div className="space-y-6 pb-24 md:pb-8">
-      <PageHeader
-        title={`עריכת ${search.manufacturer_name} ${search.model_name}`}
-        subtitle={`מקור: ${search.source}`}
-        backTo="/dashboard"
-        backLabel="חזרה"
-      />
+    <div className="space-y-5 pb-24 md:pb-8 dir-rtl">
+      {/* Header */}
+      <header className="flex flex-col gap-1 pb-2">
+        <Link
+          to="/dashboard"
+          className="mb-2 inline-flex items-center gap-1.5 rounded-xl bg-secondary/60 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground w-fit"
+        >
+          <span>חזרה</span>
+          <ArrowRight className="h-4 w-4 shrink-0" aria-hidden />
+        </Link>
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          עריכת {search.manufacturer_name} {search.model_name}
+        </h1>
+        <p className="text-sm text-muted-foreground">מקור: {search.source}</p>
+      </header>
 
       {error && (
         <div
-          className="rounded-xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive"
+          className="rounded-2xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive"
           role="alert"
         >
           {error}
         </div>
       )}
 
-      <form onSubmit={handleFormSubmit} className="contents">
-      <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-5">
-        <h2 className="text-sm font-semibold text-foreground">טווח שנים</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FormField
-            label="שנה מ-"
-            htmlFor="yearMin"
-            error={
-              form.yearMin > form.yearMax
-                ? "שנה מינימלית חייבת להיות קטנה מהמקסימלית"
-                : undefined
-            }
-          >
-            <Input
-              id="yearMin"
-              type="number"
-              value={form.yearMin}
-              onChange={(e) => set("yearMin", Number(e.target.value))}
-              min={1990}
-              max={2030}
-              error={form.yearMin > form.yearMax}
-              className="tabular-nums"
-            />
+      <form onSubmit={handleFormSubmit} className="space-y-5">
+        {/* Vehicle Details (year range) */}
+        <SectionCard title="סינון לפי רכב">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              label="שנה מ-"
+              htmlFor="yearMin"
+              error={
+                form.yearMin > form.yearMax
+                  ? "שנה מינימלית חייבת להיות קטנה מהמקסימלית"
+                  : undefined
+              }
+            >
+              <Input
+                id="yearMin"
+                type="number"
+                value={form.yearMin}
+                onChange={(e) => set("yearMin", Number(e.target.value))}
+                min={1990}
+                max={2030}
+                error={form.yearMin > form.yearMax}
+                className="tabular-nums"
+              />
+            </FormField>
+
+            <FormField label="שנה עד" htmlFor="yearMax">
+              <Input
+                id="yearMax"
+                type="number"
+                value={form.yearMax}
+                onChange={(e) => set("yearMax", Number(e.target.value))}
+                min={1990}
+                max={2030}
+                className="tabular-nums"
+              />
+            </FormField>
+          </div>
+        </SectionCard>
+
+        {/* Price & Mileage */}
+        <SectionCard title='מחיר וק"מ'>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              label="מחיר מינימום (₪)"
+              htmlFor="priceMin"
+              hint={form.priceMin > 0 ? formatPrice(form.priceMin) : undefined}
+            >
+              <Input
+                id="priceMin"
+                type="number"
+                value={form.priceMin || ""}
+                onChange={(e) => set("priceMin", Number(e.target.value))}
+                placeholder="ללא הגבלה"
+                className="tabular-nums"
+              />
+            </FormField>
+
+            <FormField
+              label="מחיר מקסימום (₪)"
+              htmlFor="priceMax"
+              hint={form.priceMax > 0 ? formatPrice(form.priceMax) : undefined}
+            >
+              <Input
+                id="priceMax"
+                type="number"
+                value={form.priceMax || ""}
+                onChange={(e) => set("priceMax", Number(e.target.value))}
+                placeholder="ללא הגבלה"
+                className="tabular-nums"
+              />
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label='ק"מ מקסימלי'>
+              <RangeSlider
+                min={0}
+                max={400_000}
+                step={10_000}
+                value={form.maxKm}
+                onChange={(v) => set("maxKm", v)}
+                formatLabel={formatKmLabel}
+              />
+            </FormField>
+
+            <FormField label="יד מקסימלית">
+              <div className="flex flex-wrap gap-2">
+                {HAND_OPTIONS.map((h) => (
+                  <ChipButton
+                    key={h}
+                    selected={form.maxHand === h}
+                    onClick={() => set("maxHand", h)}
+                  >
+                    {h === 0 ? "כל היידות" : `יד ${h}`}
+                  </ChipButton>
+                ))}
+              </div>
+            </FormField>
+          </div>
+        </SectionCard>
+
+        {/* Advanced Filters */}
+        <SectionCard title="פילטרים נוספים">
+          <FormField label="תיבת הילוכים">
+            <div className="flex flex-wrap gap-2">
+              {GEARBOX_OPTIONS.map((opt) => (
+                <ChipButton
+                  key={opt.value}
+                  selected={form.gearBox === opt.value}
+                  onClick={() => set("gearBox", opt.value)}
+                >
+                  {opt.label}
+                </ChipButton>
+              ))}
+            </div>
           </FormField>
 
-          <FormField label="שנה עד" htmlFor="yearMax">
-            <Input
-              id="yearMax"
-              type="number"
-              value={form.yearMax}
-              onChange={(e) => set("yearMax", Number(e.target.value))}
-              min={1990}
-              max={2030}
-              className="tabular-nums"
-            />
-          </FormField>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-5">
-        <h2 className="text-sm font-semibold text-foreground">מחיר וק&quot;מ</h2>
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FormField
-            label="מחיר מינימום (₪)"
-            htmlFor="priceMin"
-            hint={form.priceMin > 0 ? formatPrice(form.priceMin) : undefined}
-          >
-            <Input
-              id="priceMin"
-              type="number"
-              value={form.priceMin || ""}
-              onChange={(e) => set("priceMin", Number(e.target.value))}
-              placeholder="ללא הגבלה"
-              className="tabular-nums"
-            />
-          </FormField>
-
-          <FormField
-            label="מחיר מקסימום (₪)"
-            htmlFor="priceMax"
-            hint={form.priceMax > 0 ? formatPrice(form.priceMax) : undefined}
-          >
-            <Input
-              id="priceMax"
-              type="number"
-              value={form.priceMax || ""}
-              onChange={(e) => set("priceMax", Number(e.target.value))}
-              placeholder="ללא הגבלה"
-              className="tabular-nums"
-            />
-          </FormField>
-        </div>
-
-        <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             label='נפח מנוע מינימלי (סמ"ק)'
             htmlFor="engineMinCC"
@@ -267,133 +327,96 @@ export function EditSearchPage() {
             />
           </FormField>
 
-          <FormField label="תיבת הילוכים" htmlFor="gearBox">
+          <div className="space-y-1">
+            <span className="text-sm font-medium text-foreground">סוג מוכר</span>
+            <p className="text-xs text-muted-foreground">
+              מסנן לפי מודעות ממוכר פרטי או ממוסך/סוכנות.
+            </p>
             <div className="flex flex-wrap gap-2">
-              {GEARBOX_OPTIONS.map((opt) => (
+              {SELLER_FILTER_OPTIONS.map((opt) => (
                 <ChipButton
                   key={opt.value}
-                  selected={form.gearBox === opt.value}
-                  onClick={() => set("gearBox", opt.value)}
+                  selected={form.sellerFilter === opt.value}
+                  onClick={() => set("sellerFilter", opt.value)}
                 >
                   {opt.label}
                 </ChipButton>
               ))}
             </div>
+          </div>
+
+          <div className="space-y-1">
+            <span className="text-sm font-medium text-foreground">סינון מודעות</span>
+            <p className="text-xs text-muted-foreground">
+              הצג רק מודעות שעומדות בתנאים הבאים.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <ChipButton
+                selected={form.priceOnly}
+                onClick={() => set("priceOnly", !form.priceOnly)}
+              >
+                עם מחיר בלבד
+              </ChipButton>
+              <ChipButton
+                selected={form.photoOnly}
+                onClick={() => set("photoOnly", !form.photoOnly)}
+              >
+                עם תמונה בלבד
+              </ChipButton>
+            </div>
+          </div>
+
+          <FormField
+            label="כלול מילים"
+            htmlFor="keywords"
+            hint="הפרד מילים בפסיקים"
+          >
+            <Input
+              id="keywords"
+              value={form.keywords}
+              onChange={(e) => set("keywords", e.target.value)}
+              placeholder='לדוגמה: אוטומט, היברידי, לא פגע...'
+            />
           </FormField>
-        </div>
 
-        <FormField label='ק"מ מקסימלי'>
-          <RangeSlider
-            min={0}
-            max={400_000}
-            step={10_000}
-            value={form.maxKm}
-            onChange={(v) => set("maxKm", v)}
-            formatLabel={formatKmLabel}
-          />
-        </FormField>
+          <FormField
+            label="סנן מילים"
+            htmlFor="excludeKeys"
+            hint="מודעות שמכילות מילים אלה לא יוצגו"
+          >
+            <Input
+              id="excludeKeys"
+              value={form.excludeKeys}
+              onChange={(e) => set("excludeKeys", e.target.value)}
+              placeholder='לדוגמה: חירום, תאונה'
+            />
+          </FormField>
+        </SectionCard>
 
-        <FormField label="יד מקסימלית">
-          <div className="flex flex-wrap gap-2">
-            {HAND_OPTIONS.map((h) => (
-              <ChipButton
-                key={h}
-                selected={form.maxHand === h}
-                onClick={() => set("maxHand", h)}
-              >
-                {h === 0 ? "כל היידות" : `יד ${h}`}
-              </ChipButton>
-            ))}
-          </div>
-        </FormField>
-
-        <div className="space-y-3">
-          <h3 className="text-xs font-medium text-muted-foreground">סוג מוכר</h3>
-          <p className="text-xs text-muted-foreground">
-            מסנן לפי מודעות ממוכר פרטי או ממוסך/סוכנות.
-          </p>
-          <div className="flex flex-wrap gap-2">
-            {SELLER_FILTER_OPTIONS.map((opt) => (
-              <ChipButton
-                key={opt.value}
-                selected={form.sellerFilter === opt.value}
-                onClick={() => set("sellerFilter", opt.value)}
-              >
-                {opt.label}
-              </ChipButton>
-            ))}
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <h3 className="text-xs font-medium text-muted-foreground">סינון מודעות</h3>
-          <p className="text-xs text-muted-foreground">
-            הצג רק מודעות שעומדות בתנאים הבאים.
-          </p>
-          <div className="flex flex-wrap gap-2">
-            <ChipButton
-              selected={form.priceOnly}
-              onClick={() => set("priceOnly", !form.priceOnly)}
+        {/* Action buttons */}
+        <div className="sticky bottom-[calc(4rem+env(safe-area-inset-bottom,0px))] landscape:bottom-14 md:bottom-0 z-40 -mx-4 px-4 py-3 bg-background/90 backdrop-blur-xl border-t border-border/30 md:static md:mx-0 md:px-0 md:py-0 md:bg-transparent md:backdrop-blur-none md:border-0">
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="flex-1 md:flex-none inline-flex items-center justify-center gap-2 bg-primary rounded-2xl px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:-translate-y-px hover:shadow-xl hover:shadow-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-lg"
             >
-              עם מחיר בלבד
-            </ChipButton>
-            <ChipButton
-              selected={form.photoOnly}
-              onClick={() => set("photoOnly", !form.photoOnly)}
+              {updateSearch.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4" />
+              )}
+              שמור שינויים
+            </button>
+            <Link
+              to="/dashboard"
+              className="inline-flex items-center justify-center rounded-2xl border border-border px-6 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary md:flex-none"
             >
-              עם תמונה בלבד
-            </ChipButton>
+              ביטול
+            </Link>
           </div>
         </div>
-      </section>
-
-      <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-5">
-        <h2 className="text-sm font-semibold text-foreground">מילות מפתח</h2>
-
-        <FormField
-          label="כלול מילים"
-          htmlFor="keywords"
-          hint="הפרד מילים בפסיקים"
-        >
-          <Input
-            id="keywords"
-            value={form.keywords}
-            onChange={(e) => set("keywords", e.target.value)}
-            placeholder='לדוגמה: אוטומט, היברידי, לא פגע...'
-          />
-        </FormField>
-
-        <FormField
-          label="סנן מילים"
-          htmlFor="excludeKeys"
-          hint="מודעות שמכילות מילים אלה לא יוצגו"
-        >
-          <Input
-            id="excludeKeys"
-            value={form.excludeKeys}
-            onChange={(e) => set("excludeKeys", e.target.value)}
-            placeholder='לדוגמה: חירום, תאונה'
-          />
-        </FormField>
-      </section>
-
-      <div className="sticky bottom-[calc(4rem+env(safe-area-inset-bottom,0px))] landscape:bottom-14 md:bottom-0 z-40 -mx-4 px-4 py-3 bg-background/90 backdrop-blur-xl border-t border-border/30 md:static md:mx-0 md:px-0 md:py-0 md:bg-transparent md:backdrop-blur-none md:border-0">
-        <div className="flex items-center gap-3">
-          <Button type="submit" disabled={!canSubmit} size="lg" className="flex-1 md:flex-none">
-            {updateSearch.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Save className="h-4 w-4" />
-            )}
-            שמור שינויים
-          </Button>
-          <Button variant="secondary" size="lg" asChild className="md:flex-none">
-            <Link to="/dashboard">ביטול</Link>
-          </Button>
-        </div>
-      </div>
       </form>
     </div>
   );
 }
-

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -208,7 +208,7 @@ export function ListingsPage() {
 
       {/* Grid */}
       {showSkeletons ? (
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-5 sm:gap-4 sm:grid-cols-2">
           {Array.from({ length: 6 }).map((_, i) => (
             <motion.div
               key={`skel-${i}`}
@@ -233,7 +233,7 @@ export function ListingsPage() {
         />
       ) : (
         <>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-5 sm:gap-4 sm:grid-cols-2">
             <AnimatePresence mode="popLayout">
               {data.items.map((listing, i) => (
                 <motion.div
@@ -308,7 +308,7 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
           navigate(`/listings/${listing.token}`, { state: { listing } });
         }
       }}
-      className="group block cursor-pointer rounded-2xl border border-border/50 bg-card overflow-hidden transition-all duration-300 hover:border-border hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)] hover:-translate-y-0.5 dir-rtl"
+      className="group block cursor-pointer rounded-2xl border border-border/50 bg-card overflow-hidden shadow-sm transition-all duration-300 hover:border-border hover:shadow-[0_12px_40px_rgba(0,0,0,0.45)] hover:-translate-y-1 dir-rtl"
     >
       <ListingCardBody
         listing={listing}

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -1,16 +1,14 @@
 import { useState, useMemo } from "react";
 import { useNavigate, Link } from "react-router";
-import { Search, Loader2, Car, Zap, Trees, UserRound } from "lucide-react";
+import { Search, Loader2, Car, Zap, Trees, UserRound, ArrowRight } from "lucide-react";
 import { useManufacturers, useModels } from "@/hooks/useCatalog";
 import { useCreateSearch } from "@/hooks/useSearches";
 import { formatPrice } from "@/lib/utils";
-import { Button } from "@/components/ui/Button";
 import { ChipButton } from "@/components/ui/ChipButton";
 import { Input } from "@/components/ui/Input";
 import { RangeSlider } from "@/components/ui/RangeSlider";
 import { Select } from "@/components/ui/Select";
 import { FormField } from "@/components/ui/FormField";
-import { PageHeader } from "@/components/ui/PageHeader";
 import { useToast } from "@/components/ui/Toast";
 
 interface FormData {
@@ -99,6 +97,17 @@ function formatKmLabel(value: number): string {
   return `${value.toLocaleString("he-IL")} ק"מ`;
 }
 
+function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-card border border-border rounded-2xl overflow-hidden">
+      <div className="px-6 py-3.5 border-b border-border bg-secondary/30">
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{title}</h2>
+      </div>
+      <div className="p-6 space-y-4">{children}</div>
+    </div>
+  );
+}
+
 export function NewSearchPage() {
   const navigate = useNavigate();
   const createSearch = useCreateSearch();
@@ -184,17 +193,23 @@ export function NewSearchPage() {
   }
 
   return (
-    <div className="space-y-6 landscape:space-y-4 pb-24 md:pb-8">
-      <PageHeader
-        title="חיפוש חדש"
-        subtitle="הגדר פילטרים למעקב אחר מודעות"
-        backTo="/dashboard"
-        backLabel="חזרה"
-      />
+    <div className="space-y-5 pb-24 md:pb-8 dir-rtl">
+      {/* Header */}
+      <header className="flex flex-col gap-1 pb-2">
+        <Link
+          to="/dashboard"
+          className="mb-2 inline-flex items-center gap-1.5 rounded-xl bg-secondary/60 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground w-fit"
+        >
+          <span>חזרה</span>
+          <ArrowRight className="h-4 w-4 shrink-0" aria-hidden />
+        </Link>
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">חיפוש חדש</h1>
+        <p className="text-sm text-muted-foreground">הגדר פילטרים למעקב מודעות</p>
+      </header>
 
       {error && (
         <div
-          className="rounded-xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive"
+          className="rounded-2xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive"
           role="alert"
         >
           {error}
@@ -212,7 +227,7 @@ export function NewSearchPage() {
                   key={preset.id}
                   type="button"
                   onClick={() => applyPreset(preset)}
-                  className="flex-shrink-0 w-40 sm:w-auto snap-start rounded-2xl border border-border/50 bg-card p-4 text-start transition-colors hover:border-primary/40 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  className="flex-shrink-0 w-40 sm:w-auto snap-start rounded-2xl border border-border/50 bg-card p-4 text-start transition-all hover:border-primary/40 hover:bg-primary/5 hover:shadow-md hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 >
                   <Icon className="h-5 w-5 text-primary mb-2" />
                   <p className="text-sm font-semibold text-foreground">{preset.title}</p>
@@ -224,194 +239,192 @@ export function NewSearchPage() {
         </section>
       )}
 
-      <form onSubmit={handleFormSubmit} className="contents">
-      {/* Section: Search Name */}
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <FormField
-          label="שם החיפוש"
-          htmlFor="searchName"
-          hint="אופציונלי — ייווצר אוטומטית מהיצרן והדגם"
-        >
-          <Input
-            id="searchName"
-            value={form.name}
-            onChange={(e) => set("name", e.target.value)}
-            placeholder='לדוגמה: "טויוטה קורולה ידנית"'
-          />
-        </FormField>
-      </section>
-
-      {/* Section: Source */}
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">מקור</h2>
-        <div className="flex flex-wrap gap-2">
-          {SOURCE_OPTIONS.map((src) => (
-            <ChipButton
-              key={src.value}
-              selected={form.source === src.value}
-              onClick={() => set("source", src.value)}
-            >
-              {src.label}
-            </ChipButton>
-          ))}
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">סוג מוכר</h2>
-        <p className="text-xs text-muted-foreground">
-          מסנן לפי מודעות ממוכר פרטי או ממוסך/סוכנות (כשהמקור זיהוי זאת במודעה).
-        </p>
-        <div className="flex flex-wrap gap-2">
-          {SELLER_FILTER_OPTIONS.map((opt) => (
-            <ChipButton
-              key={opt.value}
-              selected={form.sellerFilter === opt.value}
-              onClick={() => set("sellerFilter", opt.value)}
-            >
-              {opt.label}
-            </ChipButton>
-          ))}
-        </div>
-      </section>
-
-      {/* Section: Listing quality filters */}
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">סינון מודעות</h2>
-        <p className="text-xs text-muted-foreground">
-          הצג רק מודעות שעומדות בתנאים הבאים.
-        </p>
-        <div className="flex flex-wrap gap-2">
-          <ChipButton
-            selected={form.priceOnly}
-            onClick={() => set("priceOnly", !form.priceOnly)}
+      <form onSubmit={handleFormSubmit} className="space-y-5">
+        {/* Search Name */}
+        <SectionCard title="שם החיפוש">
+          <FormField
+            label="שם החיפוש"
+            htmlFor="searchName"
+            hint="אופציונלי — ייווצר אוטומטית מהיצרן והדגם"
           >
-            עם מחיר בלבד
-          </ChipButton>
-          <ChipButton
-            selected={form.photoOnly}
-            onClick={() => set("photoOnly", !form.photoOnly)}
-          >
-            עם תמונה בלבד
-          </ChipButton>
-        </div>
-      </section>
+            <Input
+              id="searchName"
+              value={form.name}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder='לדוגמה: "טויוטה קורולה ידנית"'
+            />
+          </FormField>
+        </SectionCard>
 
-      {/* Section: Vehicle filter */}
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">סינון לפי רכב</h2>
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FormField label="יצרן" htmlFor="mfr">
-            <Select
-              id="mfr"
-              value={form.manufacturer}
-              onChange={(e) => {
-                set("manufacturer", Number(e.target.value));
-                set("model", 0);
-              }}
-            >
-              <option value={0}>כל היצרנים</option>
-              {manufacturers?.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}
-                </option>
+        {/* Vehicle Filter */}
+        <SectionCard title="סינון לפי רכב">
+          <div className="space-y-1">
+            <span className="text-sm font-medium text-foreground">מקור</span>
+            <div className="flex flex-wrap gap-2">
+              {SOURCE_OPTIONS.map((src) => (
+                <ChipButton
+                  key={src.value}
+                  selected={form.source === src.value}
+                  onClick={() => set("source", src.value)}
+                >
+                  {src.label}
+                </ChipButton>
               ))}
-            </Select>
-          </FormField>
+            </div>
+          </div>
 
-          <FormField label="דגם" htmlFor="mdl">
-            <Select
-              id="mdl"
-              value={form.model}
-              disabled={form.manufacturer === 0}
-              onChange={(e) => set("model", Number(e.target.value))}
-            >
-              <option value={0}>
-                {form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים"}
-              </option>
-              {models?.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label="יצרן" htmlFor="mfr">
+              <Select
+                id="mfr"
+                value={form.manufacturer}
+                onChange={(e) => {
+                  set("manufacturer", Number(e.target.value));
+                  set("model", 0);
+                }}
+              >
+                <option value={0}>כל היצרנים</option>
+                {manufacturers?.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+
+            <FormField label="דגם" htmlFor="mdl">
+              <Select
+                id="mdl"
+                value={form.model}
+                disabled={form.manufacturer === 0}
+                onChange={(e) => set("model", Number(e.target.value))}
+              >
+                <option value={0}>
+                  {form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים"}
                 </option>
+                {models?.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              label="שנה מ-"
+              htmlFor="yearMin"
+              error={
+                form.yearMin > form.yearMax
+                  ? "שנה מינימלית חייבת להיות קטנה מהמקסימלית"
+                  : undefined
+              }
+            >
+              <Input
+                id="yearMin"
+                type="number"
+                value={form.yearMin}
+                onChange={(e) => set("yearMin", Number(e.target.value))}
+                min={1990}
+                max={2030}
+                error={form.yearMin > form.yearMax}
+                className="tabular-nums"
+              />
+            </FormField>
+
+            <FormField label="שנה עד" htmlFor="yearMax">
+              <Input
+                id="yearMax"
+                type="number"
+                value={form.yearMax}
+                onChange={(e) => set("yearMax", Number(e.target.value))}
+                min={1990}
+                max={2030}
+                className="tabular-nums"
+              />
+            </FormField>
+          </div>
+        </SectionCard>
+
+        {/* Price & Mileage */}
+        <SectionCard title='מחיר וק"מ'>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              label="מחיר מינימום (₪)"
+              htmlFor="priceMin"
+              hint={form.priceMin > 0 ? formatPrice(form.priceMin) : undefined}
+            >
+              <Input
+                id="priceMin"
+                type="number"
+                value={form.priceMin || ""}
+                onChange={(e) => set("priceMin", Number(e.target.value))}
+                placeholder="ללא הגבלה"
+                className="tabular-nums"
+              />
+            </FormField>
+
+            <FormField
+              label="מחיר מקסימום (₪)"
+              htmlFor="priceMax"
+              hint={form.priceMax > 0 ? formatPrice(form.priceMax) : undefined}
+            >
+              <Input
+                id="priceMax"
+                type="number"
+                value={form.priceMax || ""}
+                onChange={(e) => set("priceMax", Number(e.target.value))}
+                placeholder="ללא הגבלה"
+                className="tabular-nums"
+              />
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label='ק"מ מקסימלי'>
+              <RangeSlider
+                min={0}
+                max={400_000}
+                step={10_000}
+                value={form.maxKm}
+                onChange={(v) => set("maxKm", v)}
+                formatLabel={formatKmLabel}
+              />
+            </FormField>
+
+            <FormField label="יד מקסימלית">
+              <div className="flex flex-wrap gap-2">
+                {HAND_OPTIONS.map((h) => (
+                  <ChipButton
+                    key={h}
+                    selected={form.maxHand === h}
+                    onClick={() => set("maxHand", h)}
+                  >
+                    {h === 0 ? "כל היידות" : `יד ${h}`}
+                  </ChipButton>
+                ))}
+              </div>
+            </FormField>
+          </div>
+        </SectionCard>
+
+        {/* Advanced Filters */}
+        <SectionCard title="פילטרים נוספים">
+          <FormField label="תיבת הילוכים">
+            <div className="flex flex-wrap gap-2">
+              {GEARBOX_OPTIONS.map((opt) => (
+                <ChipButton
+                  key={opt.value}
+                  selected={form.gearBox === opt.value}
+                  onClick={() => set("gearBox", opt.value)}
+                >
+                  {opt.label}
+                </ChipButton>
               ))}
-            </Select>
-          </FormField>
-        </div>
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FormField
-            label="שנה מ-"
-            htmlFor="yearMin"
-            error={
-              form.yearMin > form.yearMax
-                ? "שנה מינימלית חייבת להיות קטנה מהמקסימלית"
-                : undefined
-            }
-          >
-            <Input
-              id="yearMin"
-              type="number"
-              value={form.yearMin}
-              onChange={(e) => set("yearMin", Number(e.target.value))}
-              min={1990}
-              max={2030}
-              error={form.yearMin > form.yearMax}
-              className="tabular-nums"
-            />
+            </div>
           </FormField>
 
-          <FormField label="שנה עד" htmlFor="yearMax">
-            <Input
-              id="yearMax"
-              type="number"
-              value={form.yearMax}
-              onChange={(e) => set("yearMax", Number(e.target.value))}
-              min={1990}
-              max={2030}
-              className="tabular-nums"
-            />
-          </FormField>
-        </div>
-      </section>
-
-      {/* Section: Price & KM */}
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">מחיר וק&quot;מ</h2>
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          <FormField
-            label="מחיר מינימום (₪)"
-            htmlFor="priceMin"
-            hint={form.priceMin > 0 ? formatPrice(form.priceMin) : undefined}
-          >
-            <Input
-              id="priceMin"
-              type="number"
-              value={form.priceMin || ""}
-              onChange={(e) => set("priceMin", Number(e.target.value))}
-              placeholder="ללא הגבלה"
-              className="tabular-nums"
-            />
-          </FormField>
-
-          <FormField
-            label="מחיר מקסימום (₪)"
-            htmlFor="priceMax"
-            hint={form.priceMax > 0 ? formatPrice(form.priceMax) : undefined}
-          >
-            <Input
-              id="priceMax"
-              type="number"
-              value={form.priceMax || ""}
-              onChange={(e) => set("priceMax", Number(e.target.value))}
-              placeholder="ללא הגבלה"
-              className="tabular-nums"
-            />
-          </FormField>
-        </div>
-
-        <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             label='נפח מנוע מינימלי (סמ"ק)'
             htmlFor="engineMinCC"
@@ -427,96 +440,90 @@ export function NewSearchPage() {
             />
           </FormField>
 
-          <FormField label="תיבת הילוכים" htmlFor="gearBox">
+          <div className="space-y-1">
+            <span className="text-sm font-medium text-foreground">סוג מוכר</span>
             <div className="flex flex-wrap gap-2">
-              {GEARBOX_OPTIONS.map((opt) => (
+              {SELLER_FILTER_OPTIONS.map((opt) => (
                 <ChipButton
                   key={opt.value}
-                  selected={form.gearBox === opt.value}
-                  onClick={() => set("gearBox", opt.value)}
+                  selected={form.sellerFilter === opt.value}
+                  onClick={() => set("sellerFilter", opt.value)}
                 >
                   {opt.label}
                 </ChipButton>
               ))}
             </div>
-          </FormField>
-        </div>
-
-        <FormField label='ק"מ מקסימלי'>
-          <RangeSlider
-            min={0}
-            max={400_000}
-            step={10_000}
-            value={form.maxKm}
-            onChange={(v) => set("maxKm", v)}
-            formatLabel={formatKmLabel}
-          />
-        </FormField>
-
-        <FormField label="יד מקסימלית">
-          <div className="flex flex-wrap gap-2">
-            {HAND_OPTIONS.map((h) => (
-              <ChipButton
-                key={h}
-                selected={form.maxHand === h}
-                onClick={() => set("maxHand", h)}
-              >
-                {h === 0 ? "כל היידות" : `יד ${h}`}
-              </ChipButton>
-            ))}
           </div>
-        </FormField>
-      </section>
 
-      {/* Section: Keywords */}
-      <section className="rounded-2xl border border-border/50 bg-card p-5 landscape:p-4 space-y-5 landscape:space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">מילות מפתח</h2>
+          <div className="space-y-1">
+            <span className="text-sm font-medium text-foreground">סינון מודעות</span>
+            <div className="flex flex-wrap gap-2">
+              <ChipButton
+                selected={form.priceOnly}
+                onClick={() => set("priceOnly", !form.priceOnly)}
+              >
+                עם מחיר בלבד
+              </ChipButton>
+              <ChipButton
+                selected={form.photoOnly}
+                onClick={() => set("photoOnly", !form.photoOnly)}
+              >
+                עם תמונה בלבד
+              </ChipButton>
+            </div>
+          </div>
 
-        <FormField
-          label="כלול מילים"
-          htmlFor="keywords"
-          hint="הפרד מילים בפסיקים"
-        >
-          <Input
-            id="keywords"
-            value={form.keywords}
-            onChange={(e) => set("keywords", e.target.value)}
-            placeholder='לדוגמה: אוטומט, היברידי, לא פגע...'
-          />
-        </FormField>
+          <FormField
+            label="כלול מילים"
+            htmlFor="keywords"
+            hint="הפרד מילים בפסיקים"
+          >
+            <Input
+              id="keywords"
+              value={form.keywords}
+              onChange={(e) => set("keywords", e.target.value)}
+              placeholder='לדוגמה: אוטומט, היברידי, לא פגע...'
+            />
+          </FormField>
 
-        <FormField
-          label="סנן מילים"
-          htmlFor="excludeKeys"
-          hint="מודעות שמכילות מילים אלה לא יוצגו"
-        >
-          <Input
-            id="excludeKeys"
-            value={form.excludeKeys}
-            onChange={(e) => set("excludeKeys", e.target.value)}
-            placeholder='לדוגמה: חירום, תאונה'
-          />
-        </FormField>
-      </section>
+          <FormField
+            label="סנן מילים"
+            htmlFor="excludeKeys"
+            hint="מודעות שמכילות מילים אלה לא יוצגו"
+          >
+            <Input
+              id="excludeKeys"
+              value={form.excludeKeys}
+              onChange={(e) => set("excludeKeys", e.target.value)}
+              placeholder='לדוגמה: חירום, תאונה'
+            />
+          </FormField>
+        </SectionCard>
 
-      {/* Actions — sticky on mobile */}
-      <div className="sticky bottom-[calc(4rem+env(safe-area-inset-bottom,0px))] landscape:bottom-14 md:bottom-0 z-40 -mx-4 px-4 py-3 bg-background/90 backdrop-blur-xl border-t border-border/30 md:static md:mx-0 md:px-0 md:py-0 md:bg-transparent md:backdrop-blur-none md:border-0">
-        <div className="flex items-center gap-3">
-          <Button type="submit" disabled={!canSubmit} size="lg" className="flex-1 md:flex-none">
-            {createSearch.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Search className="h-4 w-4" />
-            )}
-            צור חיפוש
-          </Button>
-          <Button variant="secondary" size="lg" asChild className="md:flex-none">
-            <Link to="/dashboard">ביטול</Link>
-          </Button>
+        {/* Action buttons */}
+        <div className="sticky bottom-[calc(4rem+env(safe-area-inset-bottom,0px))] landscape:bottom-14 md:bottom-0 z-40 -mx-4 px-4 py-3 bg-background/90 backdrop-blur-xl border-t border-border/30 md:static md:mx-0 md:px-0 md:py-0 md:bg-transparent md:backdrop-blur-none md:border-0">
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="flex-1 md:flex-none inline-flex items-center justify-center gap-2 bg-primary rounded-2xl px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:-translate-y-px hover:shadow-xl hover:shadow-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-lg"
+            >
+              {createSearch.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Search className="h-4 w-4" />
+              )}
+              צור חיפוש
+            </button>
+            <Link
+              to="/dashboard"
+              className="inline-flex items-center justify-center rounded-2xl border border-border px-6 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary md:flex-none"
+            >
+              ביטול
+            </Link>
+          </div>
         </div>
-      </div>
       </form>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

Two changes: fixing the image regression and redesigning the search forms for a premium feel.

### Image URL Fallbacks
Yad2 may have changed their feed format — `coverImage` in `metaData` is sometimes empty. Added fallback resolution chain:
1. `metaData.coverImage` (original)
2. `metaData.cover_image` (snake_case variant)
3. Top-level `coverImage` / `cover_image`
4. `images[0]` array fallback

Added WARN log when a listing has no image URL for production diagnostics. Same fallbacks added to item detail page parser. 11 new parser tests.

### Premium UI Redesign
Redesigned NewSearchPage and EditSearchPage with SectionCard layout:
- Bordered `rounded-2xl` cards with secondary-tinted headers
- Logical section grouping: Vehicle Filter, Price & Mileage, Advanced Filters
- 2-column grids for related field pairs
- Styled back button, submit with shadow+lift, cancel with border
- Updated Input/Select components: `rounded-xl`, `bg-background`, `focus:ring-ring`
- Listing cards: stronger shadow, hover elevation, wider mobile gaps

## Test plan
- [x] All Go tests pass (65.6% coverage)
- [x] 135 frontend tests pass
- [x] TypeScript compiles cleanly
- [x] golangci-lint: 0 issues
- [ ] Manual: verify images appear on listing cards after deploy
- [ ] Manual: verify new search form design on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated Input and Select components with refined focus ring colors and improved spacing
  * Redesigned search form pages with new card-based layouts and reorganized filter sections
  * Optimized grid spacing in listings display for improved visual consistency

* **Improvements**
  * Enhanced image loading with robust fallback logic to improve display coverage across various sources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/764)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->