### PR TITLE
fix: service worker blocks cross-origin requests via CSP

### DIFF
--- a/internal/spa/spa.go
+++ b/internal/spa/spa.go
@@ -24,8 +24,10 @@ func Handler(distFS fs.FS) http.Handler {
 				"img-src 'self' data: https: blob:; "+
 				"connect-src 'self' https://*.googleapis.com https://accounts.google.com "+
 				"https://securetoken.googleapis.com https://identitytoolkit.googleapis.com https://www.googleapis.com "+
-				"https://www.gstatic.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com; "+
+				"https://www.gstatic.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com "+
+				"https://fonts.gstatic.com https://fonts.googleapis.com https://img.yad2.co.il https://apis.google.com; "+
 				"frame-src https://accounts.google.com https://*.firebaseapp.com https://carwatch-5cabf.firebaseapp.com; "+
+				"worker-src 'self'; "+
 				"frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'")
 
 		path := strings.TrimPrefix(r.URL.Path, "/")

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -19,14 +19,21 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
+
+  // Only handle same-origin requests — let cross-origin (fonts, images,
+  // Firebase, Google APIs) pass through to the browser's default handler
+  // so they are not blocked by CSP connect-src restrictions.
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
   if (url.pathname.startsWith('/api/')) {
-    // Network-first for API calls
     event.respondWith(
       fetch(event.request).catch(() => caches.match(event.request))
     );
     return;
   }
-  // Cache-first for static assets
+
   event.respondWith(
     caches.match(event.request).then((cached) => cached || fetch(event.request))
   );


### PR DESCRIPTION
## Summary

The service worker was intercepting ALL fetch requests including cross-origin ones (Google Fonts, Yad2 image CDN, Firebase APIs). These cross-origin fetches violated the CSP `connect-src` directive, causing:

- **Images not loading** (`img.yad2.co.il` blocked)
- **Fonts not loading** (`fonts.gstatic.com` blocked)
- **Firebase auth failing** (`apis.google.com` blocked)

## Root Cause

`sw.js` fetch handler had no origin check — it called `fetch()` for every request, including cross-origin ones. The browser's CSP policy only allows `connect-src` to listed domains, and the SW's `fetch()` call is subject to CSP.

## Fix

1. **Service worker**: Skip cross-origin requests entirely — only handle same-origin (`url.origin !== self.location.origin` → return without `event.respondWith`)
2. **CSP**: Added `fonts.gstatic.com`, `fonts.googleapis.com`, `img.yad2.co.il`, `apis.google.com` to `connect-src` as defense-in-depth
3. **CSP**: Added `worker-src 'self'` for the service worker itself

## Test plan
- [x] All Go tests pass
- [x] golangci-lint: 0 issues
- [ ] Manual: verify images load on listing cards after deploy
- [ ] Manual: verify Hebrew font (Heebo) loads
- [ ] Manual: verify Firebase login works
- [ ] Manual: verify no CSP errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service worker now properly handles cross-origin requests by blocking them.
  * Updated security policy configuration to strengthen application protection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/765)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->