### PR TITLE
fix: expand log capture to all components for admin log viewer

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -73,7 +73,11 @@ func run(configPath string, logger *slog.Logger) error {
 	logLevelVar.Set(logLevel)
 	logHub := logstream.NewHub(2000)
 	baseHandler := newLogHandler(cfg.LogFormat, &logLevelVar)
-	teeHandler := logstream.NewTeeHandler(baseHandler, logHub, "yad2", "winwin", "scheduler", "enricher")
+	teeHandler := logstream.NewTeeHandler(baseHandler, logHub,
+		"yad2", "winwin", "scheduler", "enricher",
+		"api-pricelist", "bot", "telegram", "notifier",
+		"circuit_breaker",
+	)
 	logger = slog.New(teeHandler)
 	slog.SetDefault(logger)
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)

--- a/web/src/components/admin/LogsTab.tsx
+++ b/web/src/components/admin/LogsTab.tsx
@@ -24,7 +24,11 @@ const LEVEL_STYLES: Record<
   ERROR: { bg: "bg-destructive/10", text: "text-destructive", label: "ERR" },
 };
 
-const ALL_COMPONENTS = ["yad2", "winwin", "scheduler", "enricher"] as const;
+const ALL_COMPONENTS = [
+  "scheduler", "yad2", "winwin", "enricher",
+  "bot", "telegram", "notifier",
+  "api-pricelist", "circuit_breaker",
+] as const;
 const ALL_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR"] as const;
 
 function LogLine({


### PR DESCRIPTION
## Summary

The admin log viewer only showed logs from 4 components (yad2, winwin, scheduler, enricher). Logs from bot, telegram, notifier, api-pricelist, and circuit_breaker were invisible — never captured by the TeeHandler.

## Root Cause

`cmd/bot/main.go:76` — TeeHandler was initialized with only 4 component names. The frontend `LogsTab.tsx:27` also hardcoded the same 4 in its filter chips.

## Fix

Expanded both to 9 components:
- `scheduler`, `yad2`, `winwin`, `enricher` (existing)
- `bot`, `telegram`, `notifier`, `api-pricelist`, `circuit_breaker` (added)

All scheduler logs already include `search_id`, `chat_id`, `search_name` context — they just weren't being captured.

## Test plan
- [x] Build + lint pass
- [x] TypeScript compiles
- [ ] Manual: verify admin logs show bot/telegram/notifier entries after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)