### PR TITLE
feat: add guest instant search for unauthenticated car search demo

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -58,6 +58,7 @@ type Server struct {
 	startTime        time.Time
 	rl               *rateLimiter
 	ipRL             *ipRateLimiter
+	guestRL          *ipRateLimiter
 	vacuumMu         sync.Mutex
 	fetchers         *fetcher.Factory
 	priceListSvc     *pricelist.Service
@@ -82,6 +83,9 @@ func (s *Server) Shutdown() {
 	}
 	if s.ipRL != nil {
 		s.ipRL.stop()
+	}
+	if s.guestRL != nil {
+		s.guestRL.stop()
 	}
 }
 
@@ -127,6 +131,7 @@ func New(c Config) *Server {
 		startTime:    time.Now(),
 		rl:           newRateLimiter(60, time.Second/60),
 		ipRL:         newIPRateLimiter(20, time.Second/10, c.API.TrustForwardedFor),
+		guestRL:      newIPRateLimiter(5, 12*time.Minute, c.API.TrustForwardedFor),
 		fetchers:     c.Fetchers,
 		priceListSvc: c.PriceListSvc,
 	}
@@ -158,77 +163,95 @@ func securityHeaders(next http.Handler) http.Handler {
 }
 
 func (s *Server) Routes() http.Handler {
-	mux := http.NewServeMux()
+	// --- Auth routes (existing, unchanged) ---
+	authMux := http.NewServeMux()
 
-	mux.HandleFunc("GET /api/v1/catalog/manufacturers", s.listManufacturers)
-	mux.HandleFunc("GET /api/v1/catalog/manufacturers/{id}/models", s.listModels)
+	authMux.HandleFunc("GET /api/v1/catalog/manufacturers", s.listManufacturers)
+	authMux.HandleFunc("GET /api/v1/catalog/manufacturers/{id}/models", s.listModels)
 
-	mux.HandleFunc("GET /api/v1/me", s.getMe)
+	authMux.HandleFunc("GET /api/v1/me", s.getMe)
 
-	mux.HandleFunc("GET /api/v1/searches", s.listSearches)
-	mux.HandleFunc("POST /api/v1/searches", s.createSearch)
-	mux.HandleFunc("GET /api/v1/searches/{id}", s.getSearch)
-	mux.HandleFunc("PUT /api/v1/searches/{id}", s.updateSearch)
-	mux.HandleFunc("DELETE /api/v1/searches/{id}", s.deleteSearch)
-	mux.HandleFunc("POST /api/v1/searches/{id}/pause", s.pauseSearch)
-	mux.HandleFunc("POST /api/v1/searches/{id}/resume", s.resumeSearch)
+	authMux.HandleFunc("GET /api/v1/searches", s.listSearches)
+	authMux.HandleFunc("POST /api/v1/searches", s.createSearch)
+	authMux.HandleFunc("GET /api/v1/searches/{id}", s.getSearch)
+	authMux.HandleFunc("PUT /api/v1/searches/{id}", s.updateSearch)
+	authMux.HandleFunc("DELETE /api/v1/searches/{id}", s.deleteSearch)
+	authMux.HandleFunc("POST /api/v1/searches/{id}/pause", s.pauseSearch)
+	authMux.HandleFunc("POST /api/v1/searches/{id}/resume", s.resumeSearch)
 
-	mux.HandleFunc("GET /api/v1/searches/{id}/stats", s.searchStats)
-	mux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
-	mux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
-	mux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
+	authMux.HandleFunc("GET /api/v1/searches/{id}/stats", s.searchStats)
+	authMux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
+	authMux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
+	authMux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
 
 	if s.admin != nil {
-		mux.HandleFunc("GET /api/v1/admin/stats", s.requireAdmin(s.adminStats))
-		mux.HandleFunc("GET /api/v1/admin/listings", s.requireAdmin(s.adminListListings))
-		mux.HandleFunc("DELETE /api/v1/admin/listings/{token}", s.requireAdmin(s.adminDeleteListing))
-		mux.HandleFunc("GET /api/v1/admin/searches", s.requireAdmin(s.adminListSearches))
-		mux.HandleFunc("DELETE /api/v1/admin/searches/{id}", s.requireAdmin(s.adminDeleteSearch))
-		mux.HandleFunc("GET /api/v1/admin/users", s.requireAdmin(s.adminListUsers))
-		mux.HandleFunc("PATCH /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminSetUserActive))
-		mux.HandleFunc("DELETE /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminDeleteUser))
-		mux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
-		mux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))
-		mux.HandleFunc("POST /api/v1/admin/sync-user-status", s.requireAdmin(s.adminSyncUserStatus))
-		mux.HandleFunc("GET /api/v1/admin/price-history", s.requireAdmin(s.adminListPriceHistory))
-		mux.HandleFunc("GET /api/v1/admin/seen-listings", s.requireAdmin(s.adminListSeenListings))
-		mux.HandleFunc("GET /api/v1/admin/activity", s.requireAdmin(s.adminActivity))
+		authMux.HandleFunc("GET /api/v1/admin/stats", s.requireAdmin(s.adminStats))
+		authMux.HandleFunc("GET /api/v1/admin/listings", s.requireAdmin(s.adminListListings))
+		authMux.HandleFunc("DELETE /api/v1/admin/listings/{token}", s.requireAdmin(s.adminDeleteListing))
+		authMux.HandleFunc("GET /api/v1/admin/searches", s.requireAdmin(s.adminListSearches))
+		authMux.HandleFunc("DELETE /api/v1/admin/searches/{id}", s.requireAdmin(s.adminDeleteSearch))
+		authMux.HandleFunc("GET /api/v1/admin/users", s.requireAdmin(s.adminListUsers))
+		authMux.HandleFunc("PATCH /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminSetUserActive))
+		authMux.HandleFunc("DELETE /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminDeleteUser))
+		authMux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
+		authMux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))
+		authMux.HandleFunc("POST /api/v1/admin/sync-user-status", s.requireAdmin(s.adminSyncUserStatus))
+		authMux.HandleFunc("GET /api/v1/admin/price-history", s.requireAdmin(s.adminListPriceHistory))
+		authMux.HandleFunc("GET /api/v1/admin/seen-listings", s.requireAdmin(s.adminListSeenListings))
+		authMux.HandleFunc("GET /api/v1/admin/activity", s.requireAdmin(s.adminActivity))
 		if s.logHub != nil {
-			mux.HandleFunc("GET /api/v1/admin/logs", s.requireAdmin(s.adminLogs))
-			mux.HandleFunc("GET /api/v1/admin/logs/stream", s.requireAdmin(s.adminLogStream))
+			authMux.HandleFunc("GET /api/v1/admin/logs", s.requireAdmin(s.adminLogs))
+			authMux.HandleFunc("GET /api/v1/admin/logs/stream", s.requireAdmin(s.adminLogStream))
 		}
 		if s.logLevel != nil {
-			mux.HandleFunc("GET /api/v1/admin/logs/level", s.requireAdmin(s.adminGetLogLevel))
-			mux.HandleFunc("PUT /api/v1/admin/logs/level", s.requireAdmin(s.adminSetLogLevel))
+			authMux.HandleFunc("GET /api/v1/admin/logs/level", s.requireAdmin(s.adminGetLogLevel))
+			authMux.HandleFunc("PUT /api/v1/admin/logs/level", s.requireAdmin(s.adminSetLogLevel))
 		}
 	}
 
 	if s.notifs != nil {
-		mux.HandleFunc("GET /api/v1/notifications", s.listNotifications)
-		mux.HandleFunc("GET /api/v1/notifications/count", s.notificationCount)
-		mux.HandleFunc("POST /api/v1/notifications/seen", s.markNotificationsSeen)
-		mux.HandleFunc("POST /api/v1/listings/{token}/seen", s.markListingSeen)
-		mux.HandleFunc("DELETE /api/v1/listings/{token}/seen", s.unmarkListingSeen)
+		authMux.HandleFunc("GET /api/v1/notifications", s.listNotifications)
+		authMux.HandleFunc("GET /api/v1/notifications/count", s.notificationCount)
+		authMux.HandleFunc("POST /api/v1/notifications/seen", s.markNotificationsSeen)
+		authMux.HandleFunc("POST /api/v1/listings/{token}/seen", s.markListingSeen)
+		authMux.HandleFunc("DELETE /api/v1/listings/{token}/seen", s.unmarkListingSeen)
 	}
 
-	mux.HandleFunc("GET /api/v1/telegram/status", s.getTelegramStatus)
+	authMux.HandleFunc("GET /api/v1/telegram/status", s.getTelegramStatus)
 	if s.linkTokens != nil {
-		mux.HandleFunc("POST /api/v1/telegram/link", s.postTelegramLink)
+		authMux.HandleFunc("POST /api/v1/telegram/link", s.postTelegramLink)
 	}
 
 	if s.saved != nil && s.hidden != nil {
-		mux.HandleFunc("GET /api/v1/saved", s.listSaved)
-		mux.HandleFunc("POST /api/v1/listings/{token}/save", s.saveListing)
-		mux.HandleFunc("DELETE /api/v1/listings/{token}/save", s.unsaveListing)
-		mux.HandleFunc("POST /api/v1/listings/{token}/hide", s.hideListing)
-		mux.HandleFunc("DELETE /api/v1/listings/{token}/hide", s.unhideListing)
-		mux.HandleFunc("GET /api/v1/history", s.listHistory)
+		authMux.HandleFunc("GET /api/v1/saved", s.listSaved)
+		authMux.HandleFunc("POST /api/v1/listings/{token}/save", s.saveListing)
+		authMux.HandleFunc("DELETE /api/v1/listings/{token}/save", s.unsaveListing)
+		authMux.HandleFunc("POST /api/v1/listings/{token}/hide", s.hideListing)
+		authMux.HandleFunc("DELETE /api/v1/listings/{token}/hide", s.unhideListing)
+		authMux.HandleFunc("GET /api/v1/history", s.listHistory)
 	}
 
-	chain := s.withMaxBody(mux)
-	chain = s.withRateLimit(chain)
-	chain = s.authMiddleware(chain)
-	chain = s.withIPRateLimit(chain)
+	authChain := s.withMaxBody(authMux)
+	authChain = s.withRateLimit(authChain)
+	authChain = s.authMiddleware(authChain)
+
+	// --- Guest routes (no auth) ---
+	guestMux := http.NewServeMux()
+	guestMux.HandleFunc("POST /api/v1/guest/instant-search", s.instantSearch)
+	guestMux.HandleFunc("GET /api/v1/catalog/manufacturers", s.listManufacturers)
+	guestMux.HandleFunc("GET /api/v1/catalog/manufacturers/{id}/models", s.listModels)
+
+	guestChain := s.withMaxBody(guestMux)
+	guestChain = s.withGuestRateLimit(guestChain)
+
+	// --- Top-level router ---
+	top := http.NewServeMux()
+	top.Handle("/api/v1/guest/", guestChain)
+	top.Handle("/api/v1/catalog/", guestChain)
+	top.Handle("/", authChain)
+
+	// Shared outer middleware: requestID → accessLog → securityHeaders → CORS → ipRL
+	chain := s.withIPRateLimit(top)
 	chain = s.corsMiddleware(chain)
 	chain = securityHeaders(chain)
 	chain = s.withAccessLog(chain)

--- a/internal/api/instant_search.go
+++ b/internal/api/instant_search.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/filter"
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/scoring"
+)
+
+type instantSearchRequest struct {
+	Source       string `json:"source"`
+	Manufacturer int    `json:"manufacturer"`
+	Model        int    `json:"model"`
+	YearMin      int    `json:"year_min"`
+	YearMax      int    `json:"year_max"`
+	PriceMin     int    `json:"price_min"`
+	PriceMax     int    `json:"price_max"`
+	MaxKm        int    `json:"max_km"`
+	MaxHand      int    `json:"max_hand"`
+	EngineMinCC  int    `json:"engine_min_cc"`
+	GearBox      string `json:"gear_box,omitempty"`
+	PriceOnly    bool   `json:"price_only,omitempty"`
+	PhotoOnly    bool   `json:"photo_only,omitempty"`
+}
+
+type instantSearchResponse struct {
+	Items []listingResponse `json:"items"`
+	Total int               `json:"total"`
+}
+
+const instantSearchMaxResults = 30
+
+func (s *Server) instantSearch(w http.ResponseWriter, r *http.Request) {
+	if s.fetchers == nil {
+		writeError(w, http.StatusServiceUnavailable, "search not available")
+		return
+	}
+
+	var req instantSearchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Manufacturer <= 0 {
+		writeError(w, http.StatusBadRequest, "manufacturer is required")
+		return
+	}
+
+	if req.Source == "" {
+		req.Source = "yad2"
+	}
+	if !isValidSource(req.Source) {
+		writeError(w, http.StatusBadRequest, "invalid source")
+		return
+	}
+
+	if msg := validateSearchRanges(req.YearMin, req.YearMax, req.PriceMin, req.PriceMax, req.MaxKm, req.MaxHand, req.EngineMinCC); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	log := s.handlerLogger(r, "op", "instant_search")
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	sources := strings.Split(req.Source, ",")
+	var allRaw []model.RawListing
+	for _, src := range sources {
+		src = strings.TrimSpace(src)
+		f, ok := s.fetchers.Get(src)
+		if !ok {
+			continue
+		}
+		params := model.SourceParams{
+			Manufacturer: req.Manufacturer,
+			Model:        req.Model,
+			YearMin:      req.YearMin,
+			YearMax:      req.YearMax,
+			PriceMin:     req.PriceMin,
+			PriceMax:     req.PriceMax,
+			MaxKm:        req.MaxKm,
+			MaxHand:      req.MaxHand,
+			EngineMinCC:  req.EngineMinCC,
+		}
+
+		var raw []model.RawListing
+		var fetchErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			raw, fetchErr = f.Fetch(ctx, params)
+			if fetchErr == nil {
+				break
+			}
+			log.Warn("fetch attempt failed", "source", src,
+				"attempt", fmt.Sprintf("%d/3", attempt+1), "error", fetchErr)
+			if attempt < 2 {
+				delay := time.Duration(1<<attempt) * time.Second
+				select {
+				case <-ctx.Done():
+					break
+				case <-time.After(delay):
+				}
+			}
+		}
+		if fetchErr != nil {
+			continue
+		}
+		allRaw = append(allRaw, raw...)
+	}
+
+	criteria := model.FilterCriteria{
+		ModelID:     req.Model,
+		YearMin:     req.YearMin,
+		YearMax:     req.YearMax,
+		PriceMin:    req.PriceMin,
+		PriceMax:    req.PriceMax,
+		EngineMinCC: float64(req.EngineMinCC),
+		MaxKm:       req.MaxKm,
+		MaxHand:     req.MaxHand,
+		GearBox:     req.GearBox,
+		PriceOnly:   req.PriceOnly,
+		PhotoOnly:   req.PhotoOnly,
+	}
+	filtered := filter.Apply(criteria, allRaw)
+
+	type scoredListing struct {
+		listing model.RawListing
+		fitness float64
+	}
+	scored := make([]scoredListing, 0, len(filtered))
+	for _, l := range filtered {
+		fp := scoring.FitnessParams{
+			Price:        l.Price,
+			Km:           l.Km,
+			Hand:         l.Hand,
+			Year:         l.Year,
+			EngineVolume: l.EngineVolume,
+			PriceMax:     req.PriceMax,
+			MaxKm:        req.MaxKm,
+			MaxHand:      req.MaxHand,
+			YearMin:      req.YearMin,
+			YearMax:      req.YearMax,
+			EngineMinCC:  req.EngineMinCC,
+		}
+		result := scoring.FitnessScoreDetailed(fp)
+		scored = append(scored, scoredListing{listing: l, fitness: result.Total})
+	}
+
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].fitness > scored[j].fitness
+	})
+
+	if len(scored) > instantSearchMaxResults {
+		scored = scored[:instantSearchMaxResults]
+	}
+
+	items := make([]listingResponse, 0, len(scored))
+	for _, sl := range scored {
+		l := sl.listing
+		fs := sl.fitness
+		resp := listingResponse{
+			Token:        l.Token,
+			Manufacturer: l.Manufacturer,
+			Model:        l.Model,
+			SubModel:     l.SubModel,
+			Year:         l.Year,
+			Price:        l.Price,
+			Km:           l.Km,
+			Hand:         l.Hand,
+			City:         l.City,
+			PageLink:     l.PageLink,
+			ImageURL:     l.ImageURL,
+			EngineVolume: l.EngineVolume,
+			HorsePower:   l.HorsePower,
+			EngineType:   l.EngineType,
+			GearBox:      l.GearBox,
+			Description:  l.Description,
+			FitnessScore: &fs,
+			FirstSeenAt:  l.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			IsCommercial: l.Commercial,
+		}
+		items = append(items, resp)
+	}
+
+	log.Info("instant search complete",
+		"fetched", len(allRaw), "filtered", len(filtered), "returned", len(items))
+
+	writeJSON(w, http.StatusOK, instantSearchResponse{
+		Items: items,
+		Total: len(items),
+	})
+}

--- a/internal/api/instant_search_test.go
+++ b/internal/api/instant_search_test.go
@@ -1,0 +1,260 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/catalog"
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage/sqlite"
+)
+
+// fakeFetcher returns canned listings for testing.
+type fakeFetcher struct {
+	listings []model.RawListing
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, _ model.SourceParams) ([]model.RawListing, error) {
+	return f.listings, nil
+}
+
+func setupGuestTestServer(t *testing.T, listings []model.RawListing) *Server {
+	t.Helper()
+	store, err := sqlite.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cat := catalog.NewDynamic(slog.Default())
+	cat.Load(context.Background())
+	cat.Ingest(context.Background(), catalog.IngestEntry{
+		ManufacturerID: 19, ManufacturerName: "Toyota",
+		ManufacturerNameHe: "טויוטה",
+		ModelID:            10226, ModelName: "Corolla", ModelNameHe: "קורולה",
+	})
+
+	factory := fetcher.NewFactory()
+	factory.Register("yad2", &fakeFetcher{listings: listings})
+
+	srv := New(Config{
+		Catalog:  cat,
+		Searches: store,
+		Listings: store,
+		Users:    store,
+		Prices:   store,
+		Logger:   slog.Default(),
+		Fetchers: factory,
+		API: config.APIConfig{
+			CORSOrigins: []string{"http://localhost:5173"},
+			DevChatID:   999,
+		},
+	})
+
+	if err := store.UpsertUser(context.Background(), 999, "testuser"); err != nil {
+		t.Fatal(err)
+	}
+
+	return srv
+}
+
+func doGuestRequest(t *testing.T, srv *Server, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reqBody *bytes.Buffer
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request body: %v", err)
+		}
+		reqBody = bytes.NewBuffer(b)
+	} else {
+		reqBody = &bytes.Buffer{}
+	}
+
+	req := httptest.NewRequest(method, path, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization header — guest request.
+
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+	return w
+}
+
+func makeTestListings(n int) []model.RawListing {
+	listings := make([]model.RawListing, n)
+	for i := range n {
+		listings[i] = model.RawListing{
+			Token:          "tok-" + itoa(int64(i)),
+			Manufacturer:   "Toyota",
+			ManufacturerID: 19,
+			Model:          "Corolla",
+			ModelID:        10226,
+			Year:           2020,
+			Price:          100000 + i*1000,
+			Km:             50000 + i*1000,
+			Hand:           1,
+			City:           "Tel Aviv",
+			PageLink:       "https://yad2.co.il/item/tok-" + itoa(int64(i)),
+		}
+	}
+	return listings
+}
+
+func TestInstantSearch_HappyPath(t *testing.T) {
+	listings := makeTestListings(5)
+	srv := setupGuestTestServer(t, listings)
+
+	req := instantSearchRequest{
+		Source:       "yad2",
+		Manufacturer: 19,
+		Model:        10226,
+		YearMin:      2018,
+		YearMax:      2024,
+		PriceMax:     200000,
+	}
+
+	w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp instantSearchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 5 {
+		t.Fatalf("expected total 5, got %d", resp.Total)
+	}
+	if len(resp.Items) != 5 {
+		t.Fatalf("expected 5 items, got %d", len(resp.Items))
+	}
+
+	// Verify fitness_score is present on each item.
+	for i, item := range resp.Items {
+		if item.FitnessScore == nil {
+			t.Errorf("item[%d] missing fitness_score", i)
+		}
+	}
+
+	// Verify sorted by fitness score descending.
+	for i := 1; i < len(resp.Items); i++ {
+		if *resp.Items[i].FitnessScore > *resp.Items[i-1].FitnessScore {
+			t.Errorf("items not sorted by fitness_score desc: [%d]=%v > [%d]=%v",
+				i, *resp.Items[i].FitnessScore, i-1, *resp.Items[i-1].FitnessScore)
+		}
+	}
+}
+
+func TestInstantSearch_MissingManufacturer(t *testing.T) {
+	srv := setupGuestTestServer(t, nil)
+
+	req := instantSearchRequest{
+		Source: "yad2",
+		Model:  10226,
+	}
+
+	w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing manufacturer, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestInstantSearch_InvalidYearRange(t *testing.T) {
+	srv := setupGuestTestServer(t, nil)
+
+	req := instantSearchRequest{
+		Source:       "yad2",
+		Manufacturer: 19,
+		YearMin:      2025,
+		YearMax:      2020,
+	}
+
+	w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid year range, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestInstantSearch_CappedAt30(t *testing.T) {
+	listings := makeTestListings(50)
+	srv := setupGuestTestServer(t, listings)
+
+	req := instantSearchRequest{
+		Source:       "yad2",
+		Manufacturer: 19,
+		YearMin:      2018,
+		YearMax:      2024,
+		PriceMax:     999999,
+	}
+
+	w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp instantSearchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 30 {
+		t.Fatalf("expected total capped at 30, got %d", resp.Total)
+	}
+	if len(resp.Items) != 30 {
+		t.Fatalf("expected 30 items, got %d", len(resp.Items))
+	}
+}
+
+func TestInstantSearch_RateLimited(t *testing.T) {
+	listings := makeTestListings(1)
+	srv := setupGuestTestServer(t, listings)
+
+	req := instantSearchRequest{
+		Source:       "yad2",
+		Manufacturer: 19,
+		YearMin:      2018,
+		YearMax:      2024,
+		PriceMax:     200000,
+	}
+
+	// Exhaust the guest rate limit (burst=5).
+	for i := 0; i < 5; i++ {
+		w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d: %s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	// 6th request should be rate limited.
+	w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("6th request: expected 429, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestInstantSearch_NoAuthRequired(t *testing.T) {
+	// Verify that the guest endpoint works without any auth,
+	// and that auth-only endpoints still require auth.
+	srv := setupGuestTestServer(t, makeTestListings(1))
+
+	// Guest endpoint should work without auth.
+	req := instantSearchRequest{
+		Source:       "yad2",
+		Manufacturer: 19,
+		YearMin:      2018,
+		YearMax:      2024,
+		PriceMax:     200000,
+	}
+	w := doGuestRequest(t, srv, "POST", "/api/v1/guest/instant-search", req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("guest endpoint should work without auth, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Catalog endpoints should also work without auth via guest chain.
+	w = doGuestRequest(t, srv, "GET", "/api/v1/catalog/manufacturers", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("catalog should work without auth, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -233,6 +233,17 @@ func (s *Server) withIPRateLimit(next http.Handler) http.Handler {
 	})
 }
 
+func (s *Server) withGuestRateLimit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := extractIP(r, s.guestRL.trustProxy)
+		if !s.guestRL.allow(ip) {
+			writeError(w, http.StatusTooManyRequests, "guest rate limit exceeded")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func (rl *rateLimiter) cleanup(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ const EditSearchPage = lazy(() =>
     default: m.EditSearchPage,
   })),
 );
+const TrySearchPage = lazy(() => import("./pages/TrySearchPage"));
 const NotFoundPage = lazy(() =>
   import("./pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })),
 );
@@ -89,6 +90,7 @@ export default function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/try" element={<Suspense fallback={<PageFallback />}><TrySearchPage /></Suspense>} />
         <Route element={<ProtectedRoute />}>
           <Route element={<Shell />}>
             <Route path="/dashboard" element={<RouteGuard><SearchesPage /></RouteGuard>} />

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -99,6 +99,12 @@ export function HeroSection() {
             התחל לעקוב עכשיו
             <ArrowLeft size={18} />
           </Link>
+          <Link
+            to="/try"
+            className="flex items-center gap-2 rounded-2xl border border-primary/30 bg-primary/5 px-6 py-3.5 text-sm font-medium text-primary transition-colors hover:border-primary/50 hover:bg-primary/10"
+          >
+            נסה חיפוש חינם
+          </Link>
           <a
             href="#how"
             className="flex items-center gap-2 rounded-2xl border border-border px-6 py-3.5 text-sm font-medium text-muted-foreground transition-colors hover:border-border/80 hover:bg-secondary/50 hover:text-foreground"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -520,4 +520,56 @@ export const telegramApi = {
     fetchAPI<TelegramLinkResponse>("/telegram/link", { method: "POST" }),
 };
 
+async function fetchGuestAPI<T>(path: string, options?: RequestInit): Promise<T> {
+  const headers = new Headers(options?.headers);
+  if (!headers.has("Content-Type") && options?.body) {
+    headers.set("Content-Type", "application/json");
+  }
+  const res = await fetch(`${BASE_URL}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: "Unknown error" }));
+    throw new ApiError(res.status, body.error);
+  }
+  return res.json();
+}
+
+export interface InstantSearchRequest {
+  source: string;
+  manufacturer: number;
+  model: number;
+  year_min?: number;
+  year_max?: number;
+  price_min?: number;
+  price_max?: number;
+  max_km?: number;
+  max_hand?: number;
+  engine_min_cc?: number;
+  gear_box?: string;
+  price_only?: boolean;
+  photo_only?: boolean;
+}
+
+export interface InstantSearchResponse {
+  items: Listing[];
+  total: number;
+}
+
+export const guestApi = {
+  instantSearch: (data: InstantSearchRequest) =>
+    fetchGuestAPI<InstantSearchResponse>("/guest/instant-search", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  catalog: {
+    manufacturers: (q?: string) =>
+      fetchGuestAPI<Manufacturer[]>(
+        `/catalog/manufacturers${q ? `?q=${encodeURIComponent(q)}` : ""}`,
+      ),
+    models: (mfrId: number, q?: string) =>
+      fetchGuestAPI<Model[]>(
+        `/catalog/manufacturers/${mfrId}/models${q ? `?q=${encodeURIComponent(q)}` : ""}`,
+      ),
+  },
+};
+
 export { ApiError };

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -1,0 +1,412 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { Search, Loader2, SearchX, ShieldAlert } from "lucide-react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import {
+  guestApi,
+  ApiError,
+  type Listing,
+  type Manufacturer,
+  type Model,
+} from "@/lib/api";
+import { formatPrice } from "@/lib/utils";
+import { ChipButton } from "@/components/ui/ChipButton";
+import { Input } from "@/components/ui/Input";
+import { RangeSlider } from "@/components/ui/RangeSlider";
+import { Select } from "@/components/ui/Select";
+import { FormField } from "@/components/ui/FormField";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ListingCardBody } from "@/components/ListingCardBody";
+import { ListingCardSkeleton } from "@/components/ListingCardSkeleton";
+
+/* ------------------------------------------------------------------ */
+/*  SectionCard — mirrors the pattern from NewSearchPage               */
+/* ------------------------------------------------------------------ */
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-card border border-border rounded-2xl overflow-hidden">
+      <div className="px-6 py-3.5 border-b border-border bg-secondary/30">
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          {title}
+        </h2>
+      </div>
+      <div className="p-6 space-y-4">{children}</div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const HAND_OPTIONS = [0, 1, 2, 3, 4];
+
+function formatKmLabel(value: number): string {
+  if (value === 0) return "ללא הגבלה";
+  return `${value.toLocaleString("he-IL")} ק"מ`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Form state                                                         */
+/* ------------------------------------------------------------------ */
+
+interface GuestFormData {
+  manufacturer: number;
+  model: number;
+  yearMin: number;
+  yearMax: number;
+  priceMin: number;
+  priceMax: number;
+  maxKm: number;
+  maxHand: number;
+}
+
+const INITIAL_FORM: GuestFormData = {
+  manufacturer: 0,
+  model: 0,
+  yearMin: 2018,
+  yearMax: new Date().getFullYear(),
+  priceMin: 0,
+  priceMax: 0,
+  maxKm: 0,
+  maxHand: 0,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default function TrySearchPage() {
+  const [form, setForm] = useState<GuestFormData>(INITIAL_FORM);
+  const [rateLimited, setRateLimited] = useState(false);
+
+  const set = <K extends keyof GuestFormData>(key: K, val: GuestFormData[K]) =>
+    setForm((prev) => ({ ...prev, [key]: val }));
+
+  /* -- Guest catalog queries -- */
+  const { data: manufacturers } = useQuery<Manufacturer[]>({
+    queryKey: ["guest-manufacturers"],
+    queryFn: () => guestApi.catalog.manufacturers(),
+    staleTime: 5 * 60_000,
+  });
+
+  const { data: models } = useQuery<Model[]>({
+    queryKey: ["guest-models", form.manufacturer],
+    queryFn: () => guestApi.catalog.models(form.manufacturer),
+    enabled: form.manufacturer > 0,
+    staleTime: 5 * 60_000,
+  });
+
+  /* -- Instant search mutation -- */
+  const search = useMutation({
+    mutationFn: () => {
+      setRateLimited(false);
+      return guestApi.instantSearch({
+        source: "yad2",
+        manufacturer: form.manufacturer,
+        model: form.model,
+        year_min: form.yearMin || undefined,
+        year_max: form.yearMax || undefined,
+        price_min: form.priceMin || undefined,
+        price_max: form.priceMax || undefined,
+        max_km: form.maxKm || undefined,
+        max_hand: form.maxHand || undefined,
+      });
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 429) {
+        setRateLimited(true);
+      }
+    },
+  });
+
+  const results: Listing[] | undefined = search.data?.items;
+  const total = search.data?.total ?? 0;
+
+  const validYear = (y: number) => y === 0 || y >= 1990;
+  const canSubmit =
+    validYear(form.yearMin) &&
+    validYear(form.yearMax) &&
+    (form.yearMin === 0 ||
+      form.yearMax === 0 ||
+      form.yearMin <= form.yearMax) &&
+    !search.isPending;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    search.mutate();
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 dir-rtl">
+      {/* Header */}
+      <header className="mb-8 text-center">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+          נסה חיפוש חינם
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          מצא רכב במחיר הטוב ביותר — ללא הרשמה
+        </p>
+      </header>
+
+      {/* Rate limit banner */}
+      {rateLimited && (
+        <div
+          className="mb-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-center text-sm text-amber-700 dark:text-amber-400"
+          role="alert"
+        >
+          <ShieldAlert className="mx-auto mb-1 h-5 w-5" aria-hidden />
+          הגעת למגבלת חיפושים. הירשם לחיפושים ללא הגבלה
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Vehicle filter */}
+        <SectionCard title="סינון לפי רכב">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label="יצרן" htmlFor="guest-mfr">
+              <Select
+                id="guest-mfr"
+                value={form.manufacturer}
+                onChange={(e) => {
+                  set("manufacturer", Number(e.target.value));
+                  set("model", 0);
+                }}
+              >
+                <option value={0}>כל היצרנים</option>
+                {manufacturers?.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name_he && m.name_he !== m.name
+                      ? `${m.name_he} (${m.name})`
+                      : m.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+
+            <FormField label="דגם" htmlFor="guest-mdl">
+              <Select
+                id="guest-mdl"
+                value={form.model}
+                disabled={form.manufacturer === 0}
+                onChange={(e) => set("model", Number(e.target.value))}
+              >
+                <option value={0}>
+                  {form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים"}
+                </option>
+                {models?.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name_he && m.name_he !== m.name
+                      ? `${m.name_he} (${m.name})`
+                      : m.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              label="שנה מ-"
+              htmlFor="guest-yearMin"
+              error={
+                form.yearMin > form.yearMax
+                  ? "שנה מינימלית חייבת להיות קטנה מהמקסימלית"
+                  : undefined
+              }
+            >
+              <Input
+                id="guest-yearMin"
+                type="number"
+                value={form.yearMin}
+                onChange={(e) => set("yearMin", Number(e.target.value))}
+                min={1990}
+                max={2030}
+                error={form.yearMin > form.yearMax}
+                className="tabular-nums"
+              />
+            </FormField>
+
+            <FormField label="שנה עד" htmlFor="guest-yearMax">
+              <Input
+                id="guest-yearMax"
+                type="number"
+                value={form.yearMax}
+                onChange={(e) => set("yearMax", Number(e.target.value))}
+                min={1990}
+                max={2030}
+                className="tabular-nums"
+              />
+            </FormField>
+          </div>
+        </SectionCard>
+
+        {/* Price & km */}
+        <SectionCard title='מחיר וק"מ'>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              label="מחיר מינימום (₪)"
+              htmlFor="guest-priceMin"
+              hint={form.priceMin > 0 ? formatPrice(form.priceMin) : undefined}
+            >
+              <Input
+                id="guest-priceMin"
+                type="number"
+                value={form.priceMin || ""}
+                onChange={(e) => set("priceMin", Number(e.target.value))}
+                placeholder="ללא הגבלה"
+                className="tabular-nums"
+              />
+            </FormField>
+
+            <FormField
+              label="מחיר מקסימום (₪)"
+              htmlFor="guest-priceMax"
+              hint={form.priceMax > 0 ? formatPrice(form.priceMax) : undefined}
+            >
+              <Input
+                id="guest-priceMax"
+                type="number"
+                value={form.priceMax || ""}
+                onChange={(e) => set("priceMax", Number(e.target.value))}
+                placeholder="ללא הגבלה"
+                className="tabular-nums"
+              />
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label='ק"מ מקסימלי'>
+              <RangeSlider
+                min={0}
+                max={400_000}
+                step={10_000}
+                value={form.maxKm}
+                onChange={(v) => set("maxKm", v)}
+                formatLabel={formatKmLabel}
+              />
+            </FormField>
+
+            <FormField label="יד מקסימלית">
+              <div className="flex flex-wrap gap-2">
+                {HAND_OPTIONS.map((h) => (
+                  <ChipButton
+                    key={h}
+                    selected={form.maxHand === h}
+                    onClick={() => set("maxHand", h)}
+                  >
+                    {h === 0 ? "כל היידות" : `יד ${h}`}
+                  </ChipButton>
+                ))}
+              </div>
+            </FormField>
+          </div>
+        </SectionCard>
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full inline-flex items-center justify-center gap-2 bg-primary rounded-2xl px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:-translate-y-px hover:shadow-xl hover:shadow-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-lg"
+        >
+          {search.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Search className="h-4 w-4" />
+          )}
+          חפש עכשיו
+        </button>
+      </form>
+
+      {/* ------------------------------------------------------------ */}
+      {/*  Results                                                       */}
+      {/* ------------------------------------------------------------ */}
+
+      {/* Loading skeletons */}
+      {search.isPending && (
+        <div className="mt-10">
+          <div className="mb-4 h-5 w-32 rounded shimmer-skeleton" />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <ListingCardSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Error (non-rate-limit) */}
+      {search.isError && !rateLimited && (
+        <div
+          className="mt-10 rounded-2xl border border-destructive/20 bg-destructive/5 p-4 text-center text-sm text-destructive"
+          role="alert"
+        >
+          שגיאה בביצוע החיפוש, נסה שוב
+        </div>
+      )}
+
+      {/* No results */}
+      {search.isSuccess && results?.length === 0 && (
+        <div className="mt-10">
+          <EmptyState
+            icon={SearchX}
+            title="לא נמצאו תוצאות"
+            description="נסה לשנות את הפילטרים"
+          />
+        </div>
+      )}
+
+      {/* Results grid */}
+      {search.isSuccess && results && results.length > 0 && (
+        <div className="mt-10">
+          <h2 className="mb-4 text-sm font-semibold text-muted-foreground">
+            נמצאו {total.toLocaleString("he-IL")} תוצאות
+          </h2>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            {results.map((listing) => (
+              <a
+                key={listing.token}
+                href={listing.page_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group rounded-2xl border border-border/50 bg-card overflow-hidden transition-all hover:border-primary/30 hover:shadow-lg"
+              >
+                <ListingCardBody listing={listing} hoverScale />
+              </a>
+            ))}
+          </div>
+
+          {/* CTA banner */}
+          <div className="mt-8 rounded-2xl border border-primary/20 bg-primary/5 p-6 text-center">
+            <h3 className="text-lg font-bold mb-2">אהבת את התוצאות?</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              הירשם בחינם וקבל: התראות בזמן אמת &bull; מעקב ירידות מחיר &bull;
+              שמירת מודעות &bull; ניקוד עסקאות
+            </p>
+            <div className="flex gap-3 justify-center">
+              <Link
+                to="/signup"
+                className="rounded-xl bg-primary px-6 py-2.5 text-sm font-semibold text-white shadow-lg"
+              >
+                הירשם בחינם
+              </Link>
+              <Link
+                to="/login"
+                className="rounded-xl border border-border px-6 py-2.5 text-sm font-medium"
+              >
+                התחבר
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a guest/demo instant search feature that lets visitors search for cars **without registration**. Visitors can experience the core value (live listings with fitness scores) in seconds, driving signup conversion.

### How it works
1. User visits \`/try\` (linked from landing page CTA)
2. Selects manufacturer, model, and filters
3. Clicks "חפש עכשיו" (Search now)
4. Gets real-time listings from Yad2/WinWin with fitness scores in 3-8 seconds
5. CTA banner drives signup: "אהבת את התוצאות? הירשם בחינם"

### Backend
- **New endpoint**: \`POST /api/v1/guest/instant-search\` — no auth required
- **Route splitting**: Guest routes (\`/api/v1/guest/*\`, \`/api/v1/catalog/*\`) skip auth middleware; auth routes unchanged
- **Guest rate limiter**: 5 searches/hour/IP (strict, separate from regular API limits)
- **Handler**: Fetches from sources, applies filters, scores with \`FitnessScoreDetailed\`, returns top 30 sorted by score
- **Safety**: Manufacturer required (no wildcard searches), 30-second timeout, 3-retry with backoff

### Frontend
- **New page**: \`/try\` route with SectionCard form + inline results
- **Guest API**: \`guestApi\` client with no auth token
- **Results**: \`ListingCardBody\` cards with external links (no bookmark/seen)
- **CTA**: Signup/login banner after results
- **Landing page**: "נסה חיפוש חינם" button added to hero section

### What guests see vs registered users
| Feature | Guest | Registered |
|---------|-------|------------|
| Live listings + images | ✓ | ✓ |
| Fitness Score | ✓ | ✓ |
| Deal Score / Market comparison | ✗ | ✓ |
| Bookmarks / Alerts | ✗ | ✓ |
| Price drop tracking | ✗ | ✓ |

## Test plan
- [x] All Go tests pass (65.7% coverage)
- [x] 135 frontend tests pass
- [x] TypeScript compiles
- [x] golangci-lint: 0 issues
- [ ] Manual: visit /try → search → see listings in seconds
- [ ] Manual: 6th search from same IP → 429 rate limit
- [ ] Manual: catalog dropdowns work without auth
- [ ] Manual: CTA links to /signup and /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a free "Try Search" page allowing unauthenticated users to discover vehicles with filtering and instant search functionality.
  * Added a "Try Search" call-to-action button on the landing page.
  * Enabled guest access to catalog data (manufacturers and models) without requiring authentication.

* **Bug Fixes**
  * Implemented separate rate limiting for guest/unauthenticated traffic to improve service stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->