### PR TITLE
fix: auto-reload on stale chunk errors after deploy

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,5 +1,5 @@
-const CACHE_NAME = 'carwatch-v1';
-const STATIC_ASSETS = ['/', '/manifest.json'];
+const CACHE_NAME = 'carwatch-v2';
+const STATIC_ASSETS = ['/manifest.json'];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -31,6 +31,22 @@ export class ErrorBoundary extends Component<Props, State> {
       "\nComponent stack:",
       info.componentStack,
     );
+
+    // Auto-reload on stale chunk errors (happens after deploy when
+    // the browser has cached index.html referencing old asset hashes).
+    if (
+      error.message?.includes("Failed to fetch dynamically imported module") ||
+      error.message?.includes("Loading chunk") ||
+      error.message?.includes("Loading CSS chunk")
+    ) {
+      const key = "carwatch_chunk_reload";
+      const last = sessionStorage.getItem(key);
+      if (!last || Date.now() - Number(last) > 10_000) {
+        sessionStorage.setItem(key, String(Date.now()));
+        window.location.reload();
+        return;
+      }
+    }
   }
 
   private handleRetry = () => {


### PR DESCRIPTION
## Summary

After each deploy, users with cached `index.html` try to load old chunk filenames (e.g., `LandingPage-eTJxsk2p.js`) that no longer exist, causing "Failed to fetch dynamically imported module" errors.

## Fix

1. **ErrorBoundary auto-reload**: Detects chunk-loading errors and auto-reloads once (10-second debounce via sessionStorage prevents loops)
2. **Service worker v2**: Bumped cache version to force old SWs to update. Removed `/` from static cache so `index.html` is always fetched fresh from the server.

## Test plan
- [x] 135 frontend tests pass
- [x] TypeScript compiles
- [ ] Manual: deploy → visit site with old cache → should auto-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)