### PR TITLE
fix: resolve stale chunk errors after deploy

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'carwatch-v2';
+const CACHE_NAME = 'carwatch-v3';
 const STATIC_ASSETS = ['/manifest.json'];
 
 self.addEventListener('install', (event) => {
@@ -20,14 +20,20 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Only handle same-origin requests — let cross-origin (fonts, images,
-  // Firebase, Google APIs) pass through to the browser's default handler
-  // so they are not blocked by CSP connect-src restrictions.
   if (url.origin !== self.location.origin) {
     return;
   }
 
   if (url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // Navigation requests and hashed assets (e.g. /assets/Foo-abc123.js):
+  // always go network-first so deploys take effect immediately.
+  if (event.request.mode === 'navigate' || url.pathname.startsWith('/assets/')) {
     event.respondWith(
       fetch(event.request).catch(() => caches.match(event.request))
     );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -87,10 +87,10 @@ export default function App() {
   return (
     <Suspense fallback={<PageFallback />}>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/signup" element={<SignupPage />} />
-        <Route path="/try" element={<Suspense fallback={<PageFallback />}><TrySearchPage /></Suspense>} />
+        <Route path="/" element={<RouteGuard><LandingPage /></RouteGuard>} />
+        <Route path="/login" element={<RouteGuard><LoginPage /></RouteGuard>} />
+        <Route path="/signup" element={<RouteGuard><SignupPage /></RouteGuard>} />
+        <Route path="/try" element={<RouteGuard><Suspense fallback={<PageFallback />}><TrySearchPage /></Suspense></RouteGuard>} />
         <Route element={<ProtectedRoute />}>
           <Route element={<Shell />}>
             <Route path="/dashboard" element={<RouteGuard><SearchesPage /></RouteGuard>} />
@@ -105,7 +105,7 @@ export default function App() {
             <Route path="/notifications" element={<RouteGuard><NotificationsPage /></RouteGuard>} />
           </Route>
         </Route>
-        <Route path="*" element={<NotFoundPage />} />
+        <Route path="*" element={<RouteGuard><NotFoundPage /></RouteGuard>} />
       </Routes>
     </Suspense>
   );


### PR DESCRIPTION
## Summary

Fixes the remaining stale chunk errors that #770 didn't fully resolve:

- **SW served cached old chunks** — `/assets/*` used cache-first, so after deploy the service worker returned deleted hashed JS files. Switched to network-first for navigation and `/assets/*` requests.
- **Public routes had no ErrorBoundary** — `/`, `/login`, `/signup`, `/try`, `*` weren't wrapped in `RouteGuard`, so the auto-reload logic never triggered for those pages (exactly the `LandingPage` failure seen in production).
- Bumped SW cache to `v3` to purge stale caches on existing clients.

## Test plan

- [ ] Deploy and verify landing page loads without chunk errors
- [ ] Hard-refresh with DevTools open → no 404s on `/assets/*`
- [ ] Simulate stale chunk (rename a built asset on server) → page auto-reloads

closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across all application routes with consistent error boundaries.

* **Performance**
  * Updated service worker caching strategy to prioritize network-first approach for navigation and asset requests, ensuring faster content delivery and fresher updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->