### PR TITLE
feat: redesign app shell with grouped sidebar and 5-item mobile nav

### DIFF
--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -25,30 +25,137 @@ interface NavItem {
   path: string;
   label: string;
   icon: typeof LayoutDashboard;
-  mobile: boolean;
   badge?: boolean;
   adminOnly?: boolean;
 }
 
-const navItems: NavItem[] = [
-  { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard, mobile: true },
-  { path: "/searches/new", label: "חיפוש חדש", icon: Plus, mobile: true },
-  { path: "/saved", label: "מועדפים", icon: Bookmark, mobile: true },
-  { path: "/history", label: "היסטוריה", icon: History, mobile: true },
-  {
-    path: "/notifications",
-    label: "התראות",
-    icon: Bell,
-    badge: true,
-    mobile: true,
-  },
-  { path: "/settings", label: "הגדרות", icon: Settings, mobile: true },
-  { path: "/admin", label: "ניהול", icon: Wrench, mobile: false, adminOnly: true },
+const mainNav: NavItem[] = [
+  { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard },
+  { path: "/searches/new", label: "חיפוש חדש", icon: Plus },
+];
+
+const libraryNav: NavItem[] = [
+  { path: "/saved", label: "מועדפים", icon: Bookmark },
+  { path: "/history", label: "היסטוריה", icon: History },
+  { path: "/notifications", label: "התראות", icon: Bell, badge: true },
+];
+
+const systemNav: NavItem[] = [
+  { path: "/settings", label: "הגדרות", icon: Settings },
+  { path: "/admin", label: "ניהול", icon: Wrench, adminOnly: true },
+];
+
+interface MobileNavItem {
+  path: string;
+  label: string;
+  icon: typeof LayoutDashboard;
+  badge?: boolean;
+  fab?: boolean;
+}
+
+const mobileNav: MobileNavItem[] = [
+  { path: "/dashboard", label: "ראשי", icon: LayoutDashboard },
+  { path: "/saved", label: "מועדפים", icon: Bookmark },
+  { path: "/searches/new", label: "חדש", icon: Plus, fab: true },
+  { path: "/notifications", label: "התראות", icon: Bell, badge: true },
+  { path: "/settings", label: "הגדרות", icon: Settings },
 ];
 
 function isNavActive(pathname: string, path: string): boolean {
   if (path === "/dashboard") return pathname === "/dashboard";
   return pathname === path || pathname.startsWith(`${path}/`);
+}
+
+function SidebarNavItem({
+  item,
+  active,
+  unread,
+}: {
+  item: NavItem;
+  active: boolean;
+  unread: number;
+}) {
+  const Icon = item.icon;
+  const showBadge = item.badge && unread > 0;
+
+  return (
+    <Link
+      to={item.path}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "group relative flex items-center gap-3 rounded-lg py-2 pe-3 ps-4 text-sm font-medium outline-none transition-all duration-150",
+        "focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+        active
+          ? "bg-sidebar-active-fade text-primary dark:text-white"
+          : "text-sidebar-foreground hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white",
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full transition-all duration-150",
+          active
+            ? "bg-primary shadow-[0_0_10px_var(--color-glow-primary)]"
+            : "bg-transparent group-hover:bg-primary/40",
+        )}
+        aria-hidden
+      />
+      <Icon
+        size={17}
+        className={cn(
+          "relative z-[1] shrink-0 transition-colors duration-150",
+          active
+            ? "text-primary"
+            : "text-sidebar-muted group-hover:text-primary",
+        )}
+      />
+      <span className="relative z-[1]">
+        {item.label}
+        {showBadge ? (
+          <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
+            {unread > 99 ? "99+" : unread}
+          </span>
+        ) : null}
+      </span>
+      {active ? (
+        <div className="relative z-[1] mr-auto h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_8px_2px_var(--color-glow-primary)]" />
+      ) : null}
+    </Link>
+  );
+}
+
+function SidebarSection({
+  label,
+  items,
+  pathname,
+  unread,
+  isAdmin,
+}: {
+  label: string;
+  items: NavItem[];
+  pathname: string;
+  unread: number;
+  isAdmin: boolean;
+}) {
+  const visibleItems = items.filter((item) => !item.adminOnly || isAdmin);
+  if (visibleItems.length === 0) return null;
+
+  return (
+    <div>
+      <p className="mb-1 px-4 text-[11px] font-semibold tracking-wide text-sidebar-muted uppercase">
+        {label}
+      </p>
+      <div className="space-y-0.5">
+        {visibleItems.map((item) => (
+          <SidebarNavItem
+            key={item.path}
+            item={item}
+            active={isNavActive(pathname, item.path)}
+            unread={unread}
+          />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export function Shell() {
@@ -61,28 +168,28 @@ export function Shell() {
   const connectionStatus = useHealthCheck();
   const { data: me } = useMe();
   const isAdmin = me?.is_admin ?? false;
-  const visibleNavItems = navItems.filter(
-    (item) => !item.adminOnly || isAdmin,
-  );
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
 
   return (
     <div className="min-h-screen bg-background">
       <ConnectionBanner status={connectionStatus} />
+
+      {/* ── Desktop Sidebar ── */}
       <aside
         aria-label="ניווט ראשי"
-        className="fixed inset-y-0 right-0 z-40 hidden h-full w-64 flex-col border-l border-sidebar-border bg-sidebar md:flex"
+        className="fixed inset-y-0 right-0 z-40 hidden h-full w-60 flex-col border-l border-sidebar-border bg-sidebar md:flex"
       >
-        <div className="flex items-center gap-3 border-b border-sidebar-border px-5 py-5">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-primary/80 text-white shadow-md">
-            <Car className="h-5 w-5 text-white drop-shadow-sm" />
+        {/* Brand */}
+        <div className="flex items-center gap-3 border-b border-sidebar-border px-4 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-primary/80 text-white shadow-sm">
+            <Car className="h-4.5 w-4.5 text-white" />
           </div>
           <div className="min-w-0 flex-1">
-            <h1 className="text-base leading-none font-bold tracking-tight text-foreground dark:text-white">
+            <h1 className="text-sm leading-none font-bold tracking-tight text-foreground dark:text-white">
               CarWatch
             </h1>
-            <p className="mt-0.5 text-xs text-sidebar-muted">
+            <p className="mt-0.5 text-[11px] text-sidebar-muted">
               מעקב רכבים חכם
             </p>
           </div>
@@ -90,78 +197,33 @@ export function Shell() {
             type="button"
             onClick={toggleTheme}
             aria-label={theme === "dark" ? "הפעל מצב בהיר" : "הפעל מצב כהה"}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.96] motion-reduce:active:scale-100"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-sidebar-accent text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.96] motion-reduce:active:scale-100"
             title={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
           >
-            {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
+            {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
           </button>
         </div>
 
-        <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-4">
-          {visibleNavItems.map((item) => {
-            const Icon = item.icon;
-            const active = isNavActive(location.pathname, item.path);
-            const showBadge = item.badge && unread > 0;
-
-            return (
-              <Link
-                key={item.path}
-                to={item.path}
-                aria-current={active ? "page" : undefined}
-                className={cn(
-                  "group relative flex items-center gap-3 rounded-lg py-2 pe-3 ps-4 text-sm font-medium outline-none transition-all duration-150",
-                  "focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
-                  active
-                    ? "bg-sidebar-active-fade text-primary dark:text-white"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white",
-                )}
-              >
-                <span
-                  className={cn(
-                    "pointer-events-none absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full transition-all duration-150",
-                    active
-                      ? "bg-primary shadow-[0_0_10px_var(--color-glow-primary)]"
-                      : "bg-transparent group-hover:bg-primary/40",
-                  )}
-                  aria-hidden
-                />
-                <Icon
-                  size={17}
-                  className={cn(
-                    "relative z-[1] shrink-0 transition-colors duration-150",
-                    active
-                      ? "text-primary"
-                      : "text-sidebar-muted group-hover:text-primary",
-                  )}
-                />
-                <span className="relative z-[1]">
-                  {item.label}
-                  {showBadge ? (
-                    <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
-                      {unread > 99 ? "99+" : unread}
-                    </span>
-                  ) : null}
-                </span>
-                {active ? (
-                  <div className="relative z-[1] mr-auto h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_8px_2px_var(--color-glow-primary)]" />
-                ) : null}
-              </Link>
-            );
-          })}
+        {/* Navigation */}
+        <nav className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4">
+          <SidebarSection label="ראשי" items={mainNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
+          <SidebarSection label="ספריה" items={libraryNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
+          <SidebarSection label="מערכת" items={systemNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
         </nav>
 
+        {/* Notification Banner */}
         {unread > 0 ? (
-          <div className="border-t border-sidebar-border px-3 py-4">
+          <div className="border-t border-sidebar-border px-3 py-3">
             <Link
               to="/notifications"
-              className="flex items-center gap-2.5 rounded-lg border border-sidebar-active-edge bg-sidebar-active-fade px-3 py-2.5 transition-all duration-150 hover:bg-primary/10"
+              className="flex items-center gap-2.5 rounded-lg border border-sidebar-active-edge bg-sidebar-active-fade px-3 py-2 transition-all duration-150 hover:bg-primary/10"
             >
               <div className="relative shrink-0">
                 <Bell className="h-4 w-4 text-primary" />
                 <span className="absolute -top-1 -right-1 h-2 w-2 animate-pulse-glow rounded-full bg-primary" />
               </div>
               <span className="text-xs font-medium text-primary">
-                התראות פעילות
+                התראות חדשות
               </span>
               <span className="mr-auto flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1 text-xs font-bold text-white shadow-sm">
                 {unread > 99 ? "99+" : unread}
@@ -170,9 +232,10 @@ export function Shell() {
           </div>
         ) : null}
 
-        <div className="shrink-0 border-t border-sidebar-border p-4">
-          <div className="mb-3 flex items-center gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-sm font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
+        {/* User */}
+        <div className="shrink-0 border-t border-sidebar-border p-3">
+          <div className="mb-2.5 flex items-center gap-2.5">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-xs font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
               {emailInitial}
             </div>
             <p
@@ -185,14 +248,14 @@ export function Shell() {
           <button
             type="button"
             onClick={() => void signOut()}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2.5 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
           >
-            <LogOut className="h-4 w-4" aria-hidden />
+            <LogOut className="h-3.5 w-3.5" aria-hidden />
             התנתק
           </button>
           {appVersion ? (
             <p
-              className="mt-2 text-center text-[11px] text-sidebar-muted/60 tabular-nums"
+              className="mt-1.5 text-center text-[10px] text-sidebar-muted/50 tabular-nums"
               title={`v${appVersion}`}
             >
               v{appVersion}
@@ -201,7 +264,8 @@ export function Shell() {
         </div>
       </aside>
 
-      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[calc(4rem+env(safe-area-inset-bottom,0px))] landscape:pb-16 md:mr-64 md:pb-0">
+      {/* ── Main Content ── */}
+      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[calc(4.5rem+env(safe-area-inset-bottom,0px))] landscape:pb-16 md:mr-60 md:pb-0">
         <div className="mx-auto max-w-5xl px-4 py-6 landscape:py-4 sm:px-6 md:py-8 lg:px-8">
           <div key={location.pathname} className="animate-fade-in">
             <Outlet />
@@ -209,15 +273,34 @@ export function Shell() {
         </div>
       </main>
 
+      {/* ── Mobile Bottom Nav ── */}
       <nav
         aria-label="ניווט"
-        className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/90 shadow-[0_-2px_16px_-6px_rgba(0,0,0,0.1)] dark:shadow-[0_-8px_32px_-8px_rgba(0,0,0,0.4)] backdrop-blur-xl backdrop-saturate-150 pb-[env(safe-area-inset-bottom,0px)] md:hidden"
+        className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/90 shadow-[0_-2px_16px_-6px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_24px_-8px_rgba(0,0,0,0.4)] backdrop-blur-xl backdrop-saturate-150 pb-[env(safe-area-inset-bottom,0px)] md:hidden"
       >
-        <div className="flex justify-around px-1 py-2 landscape:py-1.5">
-          {visibleNavItems.filter((item) => item.mobile).map((item) => {
+        <div className="flex items-end justify-around px-2 py-1.5 landscape:py-1">
+          {mobileNav.map((item) => {
             const Icon = item.icon;
             const isActive = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;
+
+            if (item.fab) {
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  aria-label={item.label}
+                  className="group relative -mt-4 flex flex-col items-center"
+                >
+                  <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-white shadow-[0_4px_14px_-2px_var(--color-glow-primary)] transition-all duration-150 active:scale-[0.92] motion-reduce:active:scale-100">
+                    <Plus className="h-5.5 w-5.5" />
+                  </span>
+                  <span className="mt-0.5 text-[10px] font-medium text-primary landscape:hidden">
+                    {item.label}
+                  </span>
+                </Link>
+              );
+            }
 
             return (
               <Link
@@ -225,28 +308,26 @@ export function Shell() {
                 to={item.path}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
-                  "group flex min-w-0 flex-1 flex-col items-center gap-1 landscape:gap-0.5 px-2 py-2 landscape:py-0.5 text-[11px] font-medium transition-all duration-150",
+                  "group flex min-w-0 flex-1 flex-col items-center gap-0.5 px-1 py-1.5 landscape:py-0.5 text-[10px] font-medium transition-all duration-150",
                   "active:scale-[0.94] motion-reduce:active:scale-100",
                   isActive ? "text-primary" : "text-muted-foreground",
                 )}
               >
-                <span className="flex flex-col items-center gap-1 landscape:gap-0">
-                  <span className="relative">
-                    <Icon className="h-5 w-5 landscape:h-4 landscape:w-4 transition-transform duration-150 group-active:scale-90" />
-                    {showBadge && (
-                      <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-white animate-pulse-soft">
-                        {unread > 99 ? "99+" : unread}
-                      </span>
-                    )}
-                  </span>
-                  {isActive && (
-                    <span
-                      className="h-1.5 w-1.5 landscape:h-1 landscape:w-1 rounded-full bg-primary shadow-[0_0_8px_2px_var(--color-glow-primary)]"
-                      aria-hidden
-                    />
+                <span className="relative">
+                  <Icon className="h-5 w-5 landscape:h-4 landscape:w-4 transition-transform duration-150 group-active:scale-90" />
+                  {showBadge && (
+                    <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-white animate-pulse-soft">
+                      {unread > 99 ? "99+" : unread}
+                    </span>
                   )}
                 </span>
-                <span className="line-clamp-1 text-center leading-tight landscape:text-[10px]">
+                {isActive && (
+                  <span
+                    className="h-1 w-1 rounded-full bg-primary shadow-[0_0_6px_1px_var(--color-glow-primary)]"
+                    aria-hidden
+                  />
+                )}
+                <span className="line-clamp-1 text-center leading-tight landscape:text-[9px]">
                   {item.label}
                 </span>
               </Link>


### PR DESCRIPTION
## Summary

- **Desktop sidebar**: Narrowed from 64rem to 60rem. Navigation grouped into labeled sections ("ראשי", "ספריה", "מערכת") for clearer mental model. Extracted `SidebarNavItem` and `SidebarSection` components.
- **Mobile bottom nav**: Reduced from 7 items to 5 with a prominent center floating action button (FAB) for "New Search" — the primary user action. History moved to desktop-only.
- **FAB design**: Elevated circle with primary color and glow shadow, floats above the nav bar, unmissable for the most important action.
- **Tighter spacing**: Compact brand area, smaller user section, standardized paddings.

> **Note**: This PR includes the design system changes from #794. Merge #794 first, then this PR will show only the shell-specific diff.

Addresses: #772

## Test plan

- [x] TypeScript compiles clean
- [x] All 135 frontend tests pass
- [ ] Visual: Desktop sidebar shows 3 grouped sections with labels
- [ ] Visual: Mobile bottom nav has 5 items with center FAB
- [ ] Visual: FAB for "New Search" is visually prominent and elevated
- [ ] Visual: History is accessible from desktop sidebar but not mobile nav
- [ ] Visual: Notification badge shows on mobile bell icon
- [ ] Visual: Works correctly in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)