### PR TITLE
feat: upgrade listing detail page with sticky actions, spec pills, and trust signals

### DIFF
--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -1,18 +1,37 @@
 import type { ReactNode } from "react";
 import { useState, useEffect } from "react";
-import { Bookmark, AlertTriangle } from "lucide-react";
+import { Bookmark, AlertTriangle, ExternalLink } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, cn, marketComparison } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
 import { scoreHsl, scoreLabel } from "@/lib/scoringAlgorithm";
 import { manufacturerLogoSrc } from "@/lib/manufacturerLogo";
 
-/**
- * Shared card body for listing display. When `hoverScale` is true the image
- * zooms on hover via `group-hover:scale-105` -- the caller must wrap this
- * component in an element with the Tailwind `group` class for the effect to
- * work.
- */
+function listingSource(pageLink: string): "Yad2" | "WinWin" | null {
+  if (!pageLink) return null;
+  if (pageLink.includes("yad2")) return "Yad2";
+  if (pageLink.includes("winwin")) return "WinWin";
+  return null;
+}
+
+function dealBadge(listing: Listing): {
+  label: string;
+  className: string;
+} | null {
+  const mc = marketComparison(listing.price, listing.median_price, listing.base_price);
+  if (!mc) return null;
+  if (mc.diffPercent > 10) {
+    return { label: "עסקה מעולה", className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 ring-emerald-500/20" };
+  }
+  if (mc.diffPercent > 5) {
+    return { label: "מחיר טוב", className: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 ring-emerald-500/15" };
+  }
+  if (mc.diffPercent < -10) {
+    return { label: "מעל השוק", className: "bg-red-500/10 text-red-600 dark:text-red-400 ring-red-500/15" };
+  }
+  return null;
+}
+
 export function ListingCardBody({
   listing,
   actions,
@@ -22,7 +41,6 @@ export function ListingCardBody({
   listing: Listing;
   actions?: ReactNode;
   hoverScale?: boolean;
-  /** When true, show a bookmark icon on the image (e.g. saved listing). */
   showBookmarkOverlay?: boolean;
 }) {
   const [descExpanded, setDescExpanded] = useState(false);
@@ -35,19 +53,15 @@ export function ListingCardBody({
   }, [listing.token]);
 
   const logoSrc = manufacturerLogoSrc(listing.manufacturer);
+  const source = listingSource(listing.page_link);
+  const deal = dealBadge(listing);
+  const isNew = listing.seen === false;
 
   return (
     <>
-      {listing.image_url ? (
-        <div className="relative aspect-video w-full overflow-hidden bg-secondary">
-          {showBookmarkOverlay ? (
-            <div
-              className="absolute top-2 start-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-background/85 shadow-sm ring-1 ring-border/60 backdrop-blur-[2px]"
-              aria-hidden
-            >
-              <Bookmark className="h-4 w-4 fill-amber-500 text-amber-600 dark:text-amber-400 dark:fill-amber-400" />
-            </div>
-          ) : null}
+      {/* Image */}
+      <div className="relative aspect-video w-full overflow-hidden bg-secondary">
+        {listing.image_url ? (
           <img
             src={listing.image_url}
             alt={`${listing.manufacturer} ${listing.model}`}
@@ -58,99 +72,143 @@ export function ListingCardBody({
             )}
             loading="lazy"
           />
-        </div>
-      ) : (
-        <div className="aspect-video w-full bg-secondary flex items-center justify-center">
-          <span className="text-4xl opacity-20">🚗</span>
-        </div>
-      )}
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <span className="text-4xl opacity-15">🚗</span>
+          </div>
+        )}
 
+        {/* Image overlays */}
+        <div className="absolute inset-x-0 top-0 flex items-start justify-between p-2.5">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {deal ? (
+              <span className={cn("rounded-md px-2 py-0.5 text-[11px] font-semibold ring-1 ring-inset backdrop-blur-sm", deal.className)}>
+                {deal.label}
+              </span>
+            ) : null}
+            {listing.suspicious_reasons && listing.suspicious_reasons.length > 0 ? (
+              <span className="flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-0.5 text-[11px] font-semibold text-amber-600 ring-1 ring-inset ring-amber-500/20 backdrop-blur-sm dark:text-amber-400">
+                <AlertTriangle className="h-3 w-3" />
+                זהירות
+              </span>
+            ) : null}
+            {listing.removed_at ? (
+              <span className="rounded-md bg-muted/80 px-2 py-0.5 text-[11px] font-medium text-muted-foreground ring-1 ring-inset ring-border/50 backdrop-blur-sm">
+                נמכר כנראה
+              </span>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-1.5">
+            {showBookmarkOverlay ? (
+              <div
+                className="flex h-7 w-7 items-center justify-center rounded-full bg-background/80 shadow-sm ring-1 ring-border/40 backdrop-blur-sm"
+                aria-hidden
+              >
+                <Bookmark className="h-3.5 w-3.5 fill-amber-500 text-amber-600 dark:text-amber-400 dark:fill-amber-400" />
+              </div>
+            ) : null}
+            {source ? (
+              <span className="rounded-md bg-background/80 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground ring-1 ring-border/40 backdrop-blur-sm">
+                {source}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        {/* New indicator glow */}
+        {isNew ? (
+          <div className="pointer-events-none absolute inset-0 ring-2 ring-inset ring-primary/40" aria-hidden />
+        ) : null}
+      </div>
+
+      {/* Content */}
       <div className={cn("p-4", listing.removed_at && "opacity-60")}>
-        {listing.removed_at ? (
-          <div className="mb-2 flex items-center gap-1.5 rounded-lg bg-muted/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
-            {"נמכר כנראה"}
-          </div>
-        ) : null}
-        {listing.suspicious_reasons && listing.suspicious_reasons.length > 0 ? (
-          <div className="mb-2 flex items-center gap-1.5 rounded-lg bg-amber-500/10 px-2.5 py-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
-            <AlertTriangle className="h-3.5 w-3.5" />
-            {"זהירות"}
-          </div>
-        ) : null}
-        <div className="mb-2 flex items-start gap-3">
+        {/* Title row: logo + name + score + price */}
+        <div className="mb-2.5 flex items-start gap-3">
           {logoSrc ? (
             <img
               src={logoSrc}
               alt=""
-              className="h-10 w-10 shrink-0 object-contain"
+              className="h-9 w-9 shrink-0 object-contain"
               loading="lazy"
               decoding="async"
             />
           ) : null}
-          {listing.fitness_score != null ? (
-            <MatchScoreBox score={listing.fitness_score} size="md" />
-          ) : (
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted text-xs text-muted-foreground">—</div>
-          )}
           <div className="min-w-0 flex-1">
-            <h3 className="font-semibold text-card-foreground">
-              {listing.manufacturer} {listing.model}
-            </h3>
-            <p className="mt-0.5 text-xs text-muted-foreground">{listing.year}</p>
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold leading-tight text-card-foreground">
+                {listing.manufacturer} {listing.model}
+              </h3>
+              {isNew ? (
+                <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-bold text-primary">
+                  חדש
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {listing.year}
+              {listing.fitness_score != null ? (
+                <span className="mx-1.5 text-border">·</span>
+              ) : null}
+              {listing.fitness_score != null ? (
+                <span className="font-medium" style={{ color: scoreHsl(listing.fitness_score) }}>
+                  {scoreLabel(listing.fitness_score)}
+                </span>
+              ) : null}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-start gap-2">
             {listing.fitness_score != null ? (
-              <p
-                className="mt-0.5 text-xs font-medium"
-                style={{ color: scoreHsl(listing.fitness_score) }}
-              >
-                {scoreLabel(listing.fitness_score)}
-              </p>
+              <MatchScoreBox score={listing.fitness_score} size="sm" />
             ) : null}
-          </div>
-          <div className="shrink-0 text-end">
-            <span className="text-lg font-bold tabular-nums text-primary">
-              {formatPrice(listing.price)}
-            </span>
-            {(() => {
-              const mc = marketComparison(
-                listing.price,
-                listing.median_price,
-                listing.base_price,
-              );
-              if (mc) {
-                return (
-                  <p className={cn("text-[11px] font-medium mt-0.5", mc.color)}>
-                    {mc.label}
-                  </p>
-                );
-              }
-              if (listing.price > 0 && !listing.base_price && !listing.median_price) {
-                return (
-                  <span className="text-[11px] text-muted-foreground mt-0.5">אין מידע</span>
-                );
-              }
-              return null;
-            })()}
+            <div className="text-end">
+              <span className="text-lg font-bold tabular-nums text-primary leading-tight">
+                {formatPrice(listing.price)}
+              </span>
+              {(() => {
+                const mc = marketComparison(listing.price, listing.median_price, listing.base_price);
+                if (mc) {
+                  return (
+                    <p className={cn("text-[11px] font-medium mt-0.5", mc.color)}>
+                      {mc.label}
+                    </p>
+                  );
+                }
+                return null;
+              })()}
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground mb-3">
+        {/* Meta pills */}
+        <div className="mb-3 flex flex-wrap gap-1.5">
           {listing.km > 0 ? (
-            <span className="tabular-nums">{formatKm(listing.km)}</span>
-          ) : (
-            <span className="text-muted-foreground">לא ידוע</span>
-          )}
-          <span className="text-border">·</span>
-          <span>יד {listing.hand > 0 ? listing.hand : "—"}</span>
-          <span className="text-border">·</span>
-          <span>{listing.city || "—"}</span>
+            <span className="rounded-md bg-secondary px-2 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+              {formatKm(listing.km)}
+            </span>
+          ) : null}
+          <span className="rounded-md bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground">
+            יד {listing.hand > 0 ? listing.hand : "—"}
+          </span>
+          {listing.city ? (
+            <span className="rounded-md bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground">
+              {listing.city}
+            </span>
+          ) : null}
+          {listing.gear_box ? (
+            <span className="rounded-md bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground">
+              {listing.gear_box}
+            </span>
+          ) : null}
         </div>
 
+        {/* Description */}
         {rawDesc ? (
           <div className="mb-3 min-w-0">
             <p
               className={cn(
                 "text-xs text-muted-foreground leading-relaxed break-words whitespace-pre-line",
-                !descExpanded && descLong && "line-clamp-3",
+                !descExpanded && descLong && "line-clamp-2",
               )}
             >
               {rawDesc}
@@ -170,11 +228,24 @@ export function ListingCardBody({
           </div>
         ) : null}
 
+        {/* Footer: time + actions */}
         <div className="flex items-center gap-2">
-          <span className="me-auto text-xs text-muted-foreground">
+          <span className="me-auto text-[11px] font-medium text-muted-foreground">
             {relativeTime(listing.first_seen_at)}
           </span>
           {actions}
+          {listing.page_link ? (
+            <a
+              href={listing.page_link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              aria-label="צפה במודעה המקורית"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          ) : null}
         </div>
       </div>
     </>

--- a/web/src/components/ListingCardSkeleton.tsx
+++ b/web/src/components/ListingCardSkeleton.tsx
@@ -8,37 +8,38 @@ export function ListingCardSkeleton({ className }: { className?: string }) {
         className,
       )}
     >
-      {/* Image area */}
+      {/* Image */}
       <div className="aspect-video w-full shimmer-skeleton" />
 
       <div className="p-4">
-        {/* Title row: logo + score + name/year + price */}
-        <div className="mb-2 flex items-start gap-3">
-          <div className="h-10 w-10 shrink-0 rounded-lg shimmer-skeleton" />
-          <div className="h-10 w-10 shrink-0 rounded-xl shimmer-skeleton" />
+        {/* Title row: logo + name + score + price */}
+        <div className="mb-2.5 flex items-start gap-3">
+          <div className="h-9 w-9 shrink-0 rounded-lg shimmer-skeleton" />
           <div className="min-w-0 flex-1 space-y-1.5">
             <div className="h-4 w-3/4 rounded shimmer-skeleton" />
-            <div className="h-3 w-12 rounded shimmer-skeleton" />
+            <div className="h-3 w-20 rounded shimmer-skeleton" />
           </div>
-          <div className="shrink-0 space-y-1.5 text-end">
-            <div className="h-5 w-20 rounded shimmer-skeleton ms-auto" />
-            <div className="h-3 w-14 rounded shimmer-skeleton ms-auto" />
+          <div className="flex items-start gap-2">
+            <div className="h-9 w-9 shrink-0 rounded-lg shimmer-skeleton" />
+            <div className="space-y-1.5">
+              <div className="h-5 w-20 rounded shimmer-skeleton" />
+              <div className="h-3 w-14 rounded shimmer-skeleton" />
+            </div>
           </div>
         </div>
 
-        {/* Meta line: km · hand · city */}
-        <div className="flex gap-3 mb-3">
-          <div className="h-3.5 w-16 rounded shimmer-skeleton" />
-          <div className="h-3.5 w-10 rounded shimmer-skeleton" />
-          <div className="h-3.5 w-14 rounded shimmer-skeleton" />
+        {/* Meta pills */}
+        <div className="flex gap-1.5 mb-3">
+          <div className="h-5 w-16 rounded-md shimmer-skeleton" />
+          <div className="h-5 w-12 rounded-md shimmer-skeleton" />
+          <div className="h-5 w-14 rounded-md shimmer-skeleton" />
         </div>
 
-        {/* Footer: time + action buttons */}
+        {/* Footer */}
         <div className="flex items-center gap-2">
-          <div className="h-3 w-20 rounded shimmer-skeleton me-auto" />
-          <div className="h-7 w-7 rounded-lg shimmer-skeleton" />
-          <div className="h-7 w-7 rounded-lg shimmer-skeleton" />
-          <div className="h-7 w-7 rounded-lg shimmer-skeleton" />
+          <div className="h-3 w-16 rounded shimmer-skeleton me-auto" />
+          <div className="h-7 w-7 rounded-md shimmer-skeleton" />
+          <div className="h-7 w-7 rounded-md shimmer-skeleton" />
         </div>
       </div>
     </div>

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -25,30 +25,137 @@ interface NavItem {
   path: string;
   label: string;
   icon: typeof LayoutDashboard;
-  mobile: boolean;
   badge?: boolean;
   adminOnly?: boolean;
 }
 
-const navItems: NavItem[] = [
-  { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard, mobile: true },
-  { path: "/searches/new", label: "חיפוש חדש", icon: Plus, mobile: true },
-  { path: "/saved", label: "מועדפים", icon: Bookmark, mobile: true },
-  { path: "/history", label: "היסטוריה", icon: History, mobile: true },
-  {
-    path: "/notifications",
-    label: "התראות",
-    icon: Bell,
-    badge: true,
-    mobile: true,
-  },
-  { path: "/settings", label: "הגדרות", icon: Settings, mobile: true },
-  { path: "/admin", label: "ניהול", icon: Wrench, mobile: false, adminOnly: true },
+const mainNav: NavItem[] = [
+  { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard },
+  { path: "/searches/new", label: "חיפוש חדש", icon: Plus },
+];
+
+const libraryNav: NavItem[] = [
+  { path: "/saved", label: "מועדפים", icon: Bookmark },
+  { path: "/history", label: "היסטוריה", icon: History },
+  { path: "/notifications", label: "התראות", icon: Bell, badge: true },
+];
+
+const systemNav: NavItem[] = [
+  { path: "/settings", label: "הגדרות", icon: Settings },
+  { path: "/admin", label: "ניהול", icon: Wrench, adminOnly: true },
+];
+
+interface MobileNavItem {
+  path: string;
+  label: string;
+  icon: typeof LayoutDashboard;
+  badge?: boolean;
+  fab?: boolean;
+}
+
+const mobileNav: MobileNavItem[] = [
+  { path: "/dashboard", label: "ראשי", icon: LayoutDashboard },
+  { path: "/saved", label: "מועדפים", icon: Bookmark },
+  { path: "/searches/new", label: "חדש", icon: Plus, fab: true },
+  { path: "/notifications", label: "התראות", icon: Bell, badge: true },
+  { path: "/settings", label: "הגדרות", icon: Settings },
 ];
 
 function isNavActive(pathname: string, path: string): boolean {
   if (path === "/dashboard") return pathname === "/dashboard";
   return pathname === path || pathname.startsWith(`${path}/`);
+}
+
+function SidebarNavItem({
+  item,
+  active,
+  unread,
+}: {
+  item: NavItem;
+  active: boolean;
+  unread: number;
+}) {
+  const Icon = item.icon;
+  const showBadge = item.badge && unread > 0;
+
+  return (
+    <Link
+      to={item.path}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "group relative flex items-center gap-3 rounded-lg py-2 pe-3 ps-4 text-sm font-medium outline-none transition-all duration-150",
+        "focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
+        active
+          ? "bg-sidebar-active-fade text-primary dark:text-white"
+          : "text-sidebar-foreground hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white",
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full transition-all duration-150",
+          active
+            ? "bg-primary shadow-[0_0_10px_var(--color-glow-primary)]"
+            : "bg-transparent group-hover:bg-primary/40",
+        )}
+        aria-hidden
+      />
+      <Icon
+        size={17}
+        className={cn(
+          "relative z-[1] shrink-0 transition-colors duration-150",
+          active
+            ? "text-primary"
+            : "text-sidebar-muted group-hover:text-primary",
+        )}
+      />
+      <span className="relative z-[1]">
+        {item.label}
+        {showBadge ? (
+          <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
+            {unread > 99 ? "99+" : unread}
+          </span>
+        ) : null}
+      </span>
+      {active ? (
+        <div className="relative z-[1] mr-auto h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_8px_2px_var(--color-glow-primary)]" />
+      ) : null}
+    </Link>
+  );
+}
+
+function SidebarSection({
+  label,
+  items,
+  pathname,
+  unread,
+  isAdmin,
+}: {
+  label: string;
+  items: NavItem[];
+  pathname: string;
+  unread: number;
+  isAdmin: boolean;
+}) {
+  const visibleItems = items.filter((item) => !item.adminOnly || isAdmin);
+  if (visibleItems.length === 0) return null;
+
+  return (
+    <div>
+      <p className="mb-1 px-4 text-[11px] font-semibold tracking-wide text-sidebar-muted uppercase">
+        {label}
+      </p>
+      <div className="space-y-0.5">
+        {visibleItems.map((item) => (
+          <SidebarNavItem
+            key={item.path}
+            item={item}
+            active={isNavActive(pathname, item.path)}
+            unread={unread}
+          />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export function Shell() {
@@ -61,28 +168,28 @@ export function Shell() {
   const connectionStatus = useHealthCheck();
   const { data: me } = useMe();
   const isAdmin = me?.is_admin ?? false;
-  const visibleNavItems = navItems.filter(
-    (item) => !item.adminOnly || isAdmin,
-  );
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
 
   return (
     <div className="min-h-screen bg-background">
       <ConnectionBanner status={connectionStatus} />
+
+      {/* ── Desktop Sidebar ── */}
       <aside
         aria-label="ניווט ראשי"
-        className="fixed inset-y-0 right-0 z-40 hidden h-full w-64 flex-col border-l border-sidebar-border bg-sidebar md:flex"
+        className="fixed inset-y-0 right-0 z-40 hidden h-full w-60 flex-col border-l border-sidebar-border bg-sidebar md:flex"
       >
-        <div className="flex items-center gap-3 border-b border-sidebar-border px-5 py-5">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-primary/80 text-white shadow-md">
-            <Car className="h-5 w-5 text-white drop-shadow-sm" />
+        {/* Brand */}
+        <div className="flex items-center gap-3 border-b border-sidebar-border px-4 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-primary/80 text-white shadow-sm">
+            <Car className="h-4.5 w-4.5 text-white" />
           </div>
           <div className="min-w-0 flex-1">
-            <h1 className="text-base leading-none font-bold tracking-tight text-foreground dark:text-white">
+            <h1 className="text-sm leading-none font-bold tracking-tight text-foreground dark:text-white">
               CarWatch
             </h1>
-            <p className="mt-0.5 text-xs text-sidebar-muted">
+            <p className="mt-0.5 text-[11px] text-sidebar-muted">
               מעקב רכבים חכם
             </p>
           </div>
@@ -90,78 +197,33 @@ export function Shell() {
             type="button"
             onClick={toggleTheme}
             aria-label={theme === "dark" ? "הפעל מצב בהיר" : "הפעל מצב כהה"}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.96] motion-reduce:active:scale-100"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-sidebar-accent text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.96] motion-reduce:active:scale-100"
             title={theme === "dark" ? "מצב בהיר" : "מצב כהה"}
           >
-            {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
+            {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
           </button>
         </div>
 
-        <nav className="flex-1 space-y-0.5 overflow-y-auto px-3 py-4">
-          {visibleNavItems.map((item) => {
-            const Icon = item.icon;
-            const active = isNavActive(location.pathname, item.path);
-            const showBadge = item.badge && unread > 0;
-
-            return (
-              <Link
-                key={item.path}
-                to={item.path}
-                aria-current={active ? "page" : undefined}
-                className={cn(
-                  "group relative flex items-center gap-3 rounded-lg py-2 pe-3 ps-4 text-sm font-medium outline-none transition-all duration-150",
-                  "focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar",
-                  active
-                    ? "bg-sidebar-active-fade text-primary dark:text-white"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white",
-                )}
-              >
-                <span
-                  className={cn(
-                    "pointer-events-none absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full transition-all duration-150",
-                    active
-                      ? "bg-primary shadow-[0_0_10px_var(--color-glow-primary)]"
-                      : "bg-transparent group-hover:bg-primary/40",
-                  )}
-                  aria-hidden
-                />
-                <Icon
-                  size={17}
-                  className={cn(
-                    "relative z-[1] shrink-0 transition-colors duration-150",
-                    active
-                      ? "text-primary"
-                      : "text-sidebar-muted group-hover:text-primary",
-                  )}
-                />
-                <span className="relative z-[1]">
-                  {item.label}
-                  {showBadge ? (
-                    <span className="absolute -top-1.5 -right-4 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-white animate-pulse-soft">
-                      {unread > 99 ? "99+" : unread}
-                    </span>
-                  ) : null}
-                </span>
-                {active ? (
-                  <div className="relative z-[1] mr-auto h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_8px_2px_var(--color-glow-primary)]" />
-                ) : null}
-              </Link>
-            );
-          })}
+        {/* Navigation */}
+        <nav className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4">
+          <SidebarSection label="ראשי" items={mainNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
+          <SidebarSection label="ספריה" items={libraryNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
+          <SidebarSection label="מערכת" items={systemNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
         </nav>
 
+        {/* Notification Banner */}
         {unread > 0 ? (
-          <div className="border-t border-sidebar-border px-3 py-4">
+          <div className="border-t border-sidebar-border px-3 py-3">
             <Link
               to="/notifications"
-              className="flex items-center gap-2.5 rounded-lg border border-sidebar-active-edge bg-sidebar-active-fade px-3 py-2.5 transition-all duration-150 hover:bg-primary/10"
+              className="flex items-center gap-2.5 rounded-lg border border-sidebar-active-edge bg-sidebar-active-fade px-3 py-2 transition-all duration-150 hover:bg-primary/10"
             >
               <div className="relative shrink-0">
                 <Bell className="h-4 w-4 text-primary" />
                 <span className="absolute -top-1 -right-1 h-2 w-2 animate-pulse-glow rounded-full bg-primary" />
               </div>
               <span className="text-xs font-medium text-primary">
-                התראות פעילות
+                התראות חדשות
               </span>
               <span className="mr-auto flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1 text-xs font-bold text-white shadow-sm">
                 {unread > 99 ? "99+" : unread}
@@ -170,9 +232,10 @@ export function Shell() {
           </div>
         ) : null}
 
-        <div className="shrink-0 border-t border-sidebar-border p-4">
-          <div className="mb-3 flex items-center gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-sm font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
+        {/* User */}
+        <div className="shrink-0 border-t border-sidebar-border p-3">
+          <div className="mb-2.5 flex items-center gap-2.5">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-xs font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
               {emailInitial}
             </div>
             <p
@@ -185,14 +248,14 @@ export function Shell() {
           <button
             type="button"
             onClick={() => void signOut()}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2.5 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
           >
-            <LogOut className="h-4 w-4" aria-hidden />
+            <LogOut className="h-3.5 w-3.5" aria-hidden />
             התנתק
           </button>
           {appVersion ? (
             <p
-              className="mt-2 text-center text-[11px] text-sidebar-muted/60 tabular-nums"
+              className="mt-1.5 text-center text-[10px] text-sidebar-muted/50 tabular-nums"
               title={`v${appVersion}`}
             >
               v{appVersion}
@@ -201,7 +264,8 @@ export function Shell() {
         </div>
       </aside>
 
-      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[calc(4rem+env(safe-area-inset-bottom,0px))] landscape:pb-16 md:mr-64 md:pb-0">
+      {/* ── Main Content ── */}
+      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[calc(4.5rem+env(safe-area-inset-bottom,0px))] landscape:pb-16 md:mr-60 md:pb-0">
         <div className="mx-auto max-w-5xl px-4 py-6 landscape:py-4 sm:px-6 md:py-8 lg:px-8">
           <div key={location.pathname} className="animate-fade-in">
             <Outlet />
@@ -209,15 +273,34 @@ export function Shell() {
         </div>
       </main>
 
+      {/* ── Mobile Bottom Nav ── */}
       <nav
         aria-label="ניווט"
-        className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/90 shadow-[0_-2px_16px_-6px_rgba(0,0,0,0.1)] dark:shadow-[0_-8px_32px_-8px_rgba(0,0,0,0.4)] backdrop-blur-xl backdrop-saturate-150 pb-[env(safe-area-inset-bottom,0px)] md:hidden"
+        className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/90 shadow-[0_-2px_16px_-6px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_24px_-8px_rgba(0,0,0,0.4)] backdrop-blur-xl backdrop-saturate-150 pb-[env(safe-area-inset-bottom,0px)] md:hidden"
       >
-        <div className="flex justify-around px-1 py-2 landscape:py-1.5">
-          {visibleNavItems.filter((item) => item.mobile).map((item) => {
+        <div className="flex items-end justify-around px-2 py-1.5 landscape:py-1">
+          {mobileNav.map((item) => {
             const Icon = item.icon;
             const isActive = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;
+
+            if (item.fab) {
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  aria-label={item.label}
+                  className="group relative -mt-4 flex flex-col items-center"
+                >
+                  <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-white shadow-[0_4px_14px_-2px_var(--color-glow-primary)] transition-all duration-150 active:scale-[0.92] motion-reduce:active:scale-100">
+                    <Plus className="h-5.5 w-5.5" />
+                  </span>
+                  <span className="mt-0.5 text-[10px] font-medium text-primary landscape:hidden">
+                    {item.label}
+                  </span>
+                </Link>
+              );
+            }
 
             return (
               <Link
@@ -225,28 +308,26 @@ export function Shell() {
                 to={item.path}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
-                  "group flex min-w-0 flex-1 flex-col items-center gap-1 landscape:gap-0.5 px-2 py-2 landscape:py-0.5 text-[11px] font-medium transition-all duration-150",
+                  "group flex min-w-0 flex-1 flex-col items-center gap-0.5 px-1 py-1.5 landscape:py-0.5 text-[10px] font-medium transition-all duration-150",
                   "active:scale-[0.94] motion-reduce:active:scale-100",
                   isActive ? "text-primary" : "text-muted-foreground",
                 )}
               >
-                <span className="flex flex-col items-center gap-1 landscape:gap-0">
-                  <span className="relative">
-                    <Icon className="h-5 w-5 landscape:h-4 landscape:w-4 transition-transform duration-150 group-active:scale-90" />
-                    {showBadge && (
-                      <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-white animate-pulse-soft">
-                        {unread > 99 ? "99+" : unread}
-                      </span>
-                    )}
-                  </span>
-                  {isActive && (
-                    <span
-                      className="h-1.5 w-1.5 landscape:h-1 landscape:w-1 rounded-full bg-primary shadow-[0_0_8px_2px_var(--color-glow-primary)]"
-                      aria-hidden
-                    />
+                <span className="relative">
+                  <Icon className="h-5 w-5 landscape:h-4 landscape:w-4 transition-transform duration-150 group-active:scale-90" />
+                  {showBadge && (
+                    <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-white animate-pulse-soft">
+                      {unread > 99 ? "99+" : unread}
+                    </span>
                   )}
                 </span>
-                <span className="line-clamp-1 text-center leading-tight landscape:text-[10px]">
+                {isActive && (
+                  <span
+                    className="h-1 w-1 rounded-full bg-primary shadow-[0_0_6px_1px_var(--color-glow-primary)]"
+                    aria-hidden
+                  />
+                )}
+                <span className="line-clamp-1 text-center leading-tight landscape:text-[9px]">
                   {item.label}
                 </span>
               </Link>

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -1,7 +1,6 @@
 import { useLocation, Link, useNavigate, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useState, useEffect, type ReactNode } from "react";
-import type { ComponentType } from "react";
 import {
   ArrowRight,
   ExternalLink,
@@ -17,6 +16,11 @@ import {
   Eye,
   EyeOff,
   AlertTriangle,
+  Bookmark,
+  BookmarkCheck,
+  Shield,
+  Store,
+  User,
 } from "lucide-react";
 import { formatPrice, formatKm, relativeTime, safeHref, marketComparison, cn } from "@/lib/utils";
 import { api, ApiError } from "@/lib/api";
@@ -25,10 +29,18 @@ import { Button } from "@/components/ui/Button";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
 import { scoreHsl, scoreLabel } from "@/lib/scoringAlgorithm";
 import { useMarkListingSeen, useUnmarkListingSeen } from "@/hooks/useListingSeen";
+import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
 import { manufacturerLogoSrc } from "@/lib/manufacturerLogo";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { PriceHistoryChart } from "@/components/PriceHistoryChart";
+
+function listingSource(pageLink: string): string | null {
+  if (!pageLink) return null;
+  if (pageLink.includes("yad2")) return "Yad2";
+  if (pageLink.includes("winwin")) return "WinWin";
+  return null;
+}
 
 export function ListingDetailPage() {
   const location = useLocation();
@@ -82,7 +94,7 @@ export function ListingDetailPage() {
         <Skeleton className="h-12 w-60 rounded-lg" />
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[1, 2, 3, 4].map((i) => (
-            <Skeleton key={i} className="h-24 rounded-2xl" />
+            <Skeleton key={i} className="h-20 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -153,29 +165,33 @@ function ListingDetailContent({
 }) {
   const markSeen = useMarkListingSeen();
   const unmarkSeen = useUnmarkListingSeen();
+  const saveBookmark = useSaveBookmark();
+  const removeBookmark = useRemoveBookmark();
   const [seen, setSeen] = useState(() => listing.seen ?? false);
+  const [saved, setSaved] = useState(() => listing.saved ?? false);
 
   useEffect(() => {
     setSeen(listing.seen ?? false);
-  }, [listing.token, listing.seen]);
-
-  const hasVehicleSpecs =
-    listing.engine_volume || listing.horse_power || listing.engine_type || listing.gear_box;
+    setSaved(listing.saved ?? false);
+  }, [listing.token, listing.seen, listing.saved]);
 
   const detailLogoSrc = manufacturerLogoSrc(listing.manufacturer);
+  const source = listingSource(listing.page_link);
+  const mc = marketComparison(listing.price, listing.median_price, listing.base_price);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5 pb-24 md:pb-8">
       {backButton}
 
+      {/* Removed / Suspicious banners */}
       {listing.removed_at ? (
-        <div className="rounded-2xl border border-border/50 bg-muted/50 p-4 text-sm text-muted-foreground">
+        <div className="rounded-xl border border-border/50 bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
           {"המודעה הוסרה מהאתר — ככל הנראה הרכב נמכר."}
         </div>
       ) : null}
 
       {listing.suspicious_reasons && listing.suspicious_reasons.length > 0 ? (
-        <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 space-y-1.5">
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 space-y-1.5">
           <div className="flex items-center gap-2 text-sm font-semibold text-amber-700 dark:text-amber-400">
             <AlertTriangle className="h-4 w-4" />
             {"מודעה חשודה"}
@@ -210,13 +226,13 @@ function ListingDetailContent({
         </div>
       )}
 
-      {/* Title + score + Price */}
+      {/* Title + Score + Price */}
       <div className="flex items-start gap-4">
         {detailLogoSrc ? (
           <img
             src={detailLogoSrc}
             alt=""
-            className="mt-1 h-12 w-12 shrink-0 object-contain"
+            className="mt-1 h-11 w-11 shrink-0 object-contain"
             loading="lazy"
             decoding="async"
           />
@@ -225,7 +241,7 @@ function ListingDetailContent({
           <MatchScoreBox score={listing.fitness_score} size="lg" />
         ) : null}
         <div className="min-w-0 flex-1">
-          <h1 className="text-2xl font-bold tracking-tight">
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
             {listing.manufacturer} {listing.model}
           </h1>
           {listing.sub_model && (
@@ -235,7 +251,6 @@ function ListingDetailContent({
               {listing.horse_power ? ` (${listing.horse_power} כ"ס)` : ""}
             </p>
           )}
-          <p className="mt-0.5 text-muted-foreground">{listing.year}</p>
           {listing.fitness_score != null ? (
             <p
               className="mt-1 text-sm font-medium"
@@ -245,17 +260,28 @@ function ListingDetailContent({
             </p>
           ) : null}
         </div>
-        <span className="shrink-0 text-2xl font-bold tabular-nums text-primary">
-          {formatPrice(listing.price)}
-        </span>
+        <div className="shrink-0 text-end">
+          <span className="text-xl font-bold tabular-nums text-primary sm:text-2xl">
+            {formatPrice(listing.price)}
+          </span>
+          {mc ? (
+            <p className={cn("text-xs font-medium mt-0.5", mc.color)}>
+              {mc.label}
+            </p>
+          ) : null}
+        </div>
       </div>
 
-      {/* Primary specs grid */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <SpecCard icon={Calendar} label="שנה" value={String(listing.year)} />
-        <SpecCard icon={MapPin} label="עיר" value={listing.city || "—"} />
-        <SpecCard icon={Hand} label="יד" value={listing.hand > 0 ? String(listing.hand) : "—"} />
-        <SpecCard icon={Gauge} label='ק"מ' value={formatKm(listing.km)} />
+      {/* Spec pills */}
+      <div className="flex flex-wrap gap-2">
+        <SpecPill icon={Calendar} value={String(listing.year)} />
+        <SpecPill icon={Gauge} value={formatKm(listing.km)} />
+        <SpecPill icon={Hand} value={`יד ${listing.hand > 0 ? listing.hand : "—"}`} />
+        <SpecPill icon={MapPin} value={listing.city || "—"} />
+        {listing.gear_box ? <SpecPill icon={Cog} value={listing.gear_box} /> : null}
+        {listing.engine_type ? <SpecPill icon={Fuel} value={listing.engine_type} /> : null}
+        {listing.engine_volume ? <SpecPill icon={Fuel} value={`${listing.engine_volume} סמ"ק`} /> : null}
+        {listing.horse_power ? <SpecPill icon={Zap} value={`${listing.horse_power} כ"ס`} /> : null}
       </div>
 
       {/* Market value comparison */}
@@ -269,24 +295,6 @@ function ListingDetailContent({
       {/* Price history chart */}
       <PriceHistoryChart token={listing.token} currentPrice={listing.price} />
 
-      {/* Vehicle specs grid */}
-      {hasVehicleSpecs && (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {listing.engine_volume ? (
-            <SpecCard icon={Fuel} label="נפח מנוע" value={`${listing.engine_volume}`} />
-          ) : null}
-          {listing.horse_power ? (
-            <SpecCard icon={Zap} label='כ"ס' value={String(listing.horse_power)} />
-          ) : null}
-          {listing.engine_type ? (
-            <SpecCard icon={Fuel} label="סוג מנוע" value={listing.engine_type} />
-          ) : null}
-          {listing.gear_box ? (
-            <SpecCard icon={Cog} label="תיבת הילוכים" value={listing.gear_box} />
-          ) : null}
-        </div>
-      )}
-
       {/* Description */}
       {listing.description && (
         <div className="rounded-2xl border border-border/50 bg-card p-5">
@@ -297,12 +305,63 @@ function ListingDetailContent({
         </div>
       )}
 
-      <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-        <Clock className="h-4 w-4" />
-        {relativeTime(listing.first_seen_at)}
+      {/* Trust indicators */}
+      <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-3">
+        <h2 className="text-sm font-semibold text-foreground">פרטי מודעה</h2>
+        <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5" />
+            {relativeTime(listing.first_seen_at)}
+          </span>
+          {source ? (
+            <span className="flex items-center gap-1.5">
+              <Shield className="h-3.5 w-3.5" />
+              מקור: {source}
+            </span>
+          ) : null}
+          {listing.is_commercial != null ? (
+            <span className="flex items-center gap-1.5">
+              {listing.is_commercial ? (
+                <><Store className="h-3.5 w-3.5" />מסחרי</>
+              ) : (
+                <><User className="h-3.5 w-3.5" />פרטי</>
+              )}
+            </span>
+          ) : null}
+          {listing.image_url ? (
+            <span className="flex items-center gap-1.5">
+              <Eye className="h-3.5 w-3.5" />
+              כולל תמונה
+            </span>
+          ) : (
+            <span className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400">
+              <EyeOff className="h-3.5 w-3.5" />
+              ללא תמונה
+            </span>
+          )}
+        </div>
       </div>
 
-      <div className="flex flex-wrap gap-3">
+      {/* Desktop actions */}
+      <div className="hidden md:flex flex-wrap gap-3">
+        <Button
+          type="button"
+          variant={saved ? "secondary" : "primary"}
+          size="lg"
+          disabled={saved ? removeBookmark.isPending : saveBookmark.isPending}
+          onClick={() => {
+            const next = !saved;
+            setSaved(next);
+            const mutation = next ? saveBookmark : removeBookmark;
+            mutation.mutate(listing.token, { onError: () => setSaved(!next) });
+          }}
+        >
+          {saved ? (
+            <><BookmarkCheck className="h-4 w-4" />שמור</>
+          ) : (
+            <><Bookmark className="h-4 w-4" />שמור למועדפים</>
+          )}
+        </Button>
         <Button
           type="button"
           variant="secondary"
@@ -316,15 +375,9 @@ function ListingDetailContent({
           }}
         >
           {seen ? (
-            <>
-              <EyeOff className="h-4 w-4" />
-              החזר לחדשות
-            </>
+            <><EyeOff className="h-4 w-4" />החזר לחדשות</>
           ) : (
-            <>
-              <Eye className="h-4 w-4" />
-              סמן כנצפה
-            </>
+            <><Eye className="h-4 w-4" />סמן כנצפה</>
           )}
         </Button>
         {safeHref(listing.page_link) ? (
@@ -333,12 +386,64 @@ function ListingDetailContent({
             href={safeHref(listing.page_link)!}
             target="_blank"
             rel="noopener noreferrer"
+            variant="secondary"
             size="lg"
           >
             <ExternalLink className="h-4 w-4" />
-            צפה במודעה המקורית
+            צפה במודעה
           </Button>
         ) : null}
+      </div>
+
+      {/* Mobile sticky action bar */}
+      <div className="fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))] z-40 border-t border-border/50 bg-card/95 px-4 py-3 backdrop-blur-xl md:hidden">
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant={saved ? "secondary" : "primary"}
+            size="md"
+            className="flex-1"
+            disabled={saved ? removeBookmark.isPending : saveBookmark.isPending}
+            onClick={() => {
+              const next = !saved;
+              setSaved(next);
+              const mutation = next ? saveBookmark : removeBookmark;
+              mutation.mutate(listing.token, { onError: () => setSaved(!next) });
+            }}
+          >
+            {saved ? (
+              <><BookmarkCheck className="h-4 w-4" />שמור</>
+            ) : (
+              <><Bookmark className="h-4 w-4" />שמור</>
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="md"
+            disabled={seen ? unmarkSeen.isPending : markSeen.isPending}
+            onClick={() => {
+              const next = !seen;
+              setSeen(next);
+              const mutation = next ? markSeen : unmarkSeen;
+              mutation.mutate(listing.token, { onError: () => setSeen(!next) });
+            }}
+          >
+            {seen ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </Button>
+          {safeHref(listing.page_link) ? (
+            <Button
+              as="a"
+              href={safeHref(listing.page_link)!}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="secondary"
+              size="md"
+            >
+              <ExternalLink className="h-4 w-4" />
+            </Button>
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -409,7 +514,6 @@ function MarketValueCard({
         </span>
       </div>
 
-      {/* Visual bar — listing vs reference (Yad2 price list or cohort median) */}
       <div className="relative h-2 rounded-full bg-secondary overflow-hidden">
         <div
           className={cn("absolute inset-y-0 start-0 rounded-full transition-all", barTint)}
@@ -450,20 +554,17 @@ function MarketValueCard({
   );
 }
 
-function SpecCard({
+function SpecPill({
   icon: Icon,
-  label,
   value,
 }: {
-  icon: ComponentType<{ className?: string }>;
-  label: string;
+  icon: React.ComponentType<{ className?: string }>;
   value: string;
 }) {
   return (
-    <div className="rounded-2xl border border-border/50 bg-card p-4 text-center transition-colors duration-200 hover:border-border">
-      <Icon className="mx-auto h-5 w-5 text-muted-foreground mb-1.5" />
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <p className="text-sm font-semibold mt-0.5 tabular-nums">{value}</p>
-    </div>
+    <span className="inline-flex items-center gap-1.5 rounded-lg bg-secondary px-3 py-1.5 text-sm text-muted-foreground">
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="tabular-nums">{value}</span>
+    </span>
   );
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,40 +1,28 @@
 import { useState, useEffect, useCallback } from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import {
-  Bell,
-  Mail,
-  Clock,
-  Hash,
   Loader2,
   MessageCircle,
   ExternalLink,
   CheckCircle2,
   RefreshCw,
-  Info,
+  Sun,
+  Moon,
+  User,
+  LogOut,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
-import { ChipButton } from "@/components/ui/ChipButton";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { useToast } from "@/components/ui/Toast";
 import { telegramApi, type TelegramStatus } from "@/lib/api";
-
-const SCAN_FREQ_OPTIONS = [
-  { value: 15, label: "כל 15 דקות" },
-  { value: 30, label: "כל 30 דקות" },
-  { value: 60, label: "כל שעה" },
-  { value: 120, label: "כל שעתיים" },
-];
-
-const ALERT_COUNT_OPTIONS = [1, 3, 5, 10, 20];
+import { useAuth } from "@/contexts/AuthContext";
+import { useTheme } from "@/contexts/ThemeContext";
 
 export function SettingsPage() {
   usePageTitle("הגדרות");
   const { toast } = useToast();
-
-  const telegramEnabled = true;
-  const emailEnabled = false;
-  const scanFrequency = 30;
-  const alertCount = 5;
+  const { user, signOut } = useAuth();
+  const { theme, toggle: toggleTheme } = useTheme();
 
   const [tgStatus, setTgStatus] = useState<TelegramStatus | null>(null);
   const [tgLoading, setTgLoading] = useState(true);
@@ -72,7 +60,58 @@ export function SettingsPage() {
 
   return (
     <div className="space-y-6 pb-24 md:pb-8">
-      <PageHeader title="הגדרות" subtitle="התאם את חוויית השימוש שלך" />
+      <PageHeader title="הגדרות" subtitle="ניהול חשבון וחיבורים" />
+
+      {/* Account */}
+      <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <User className="h-4 w-4 text-primary" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-foreground">חשבון</h2>
+            <p className="text-xs text-muted-foreground truncate">
+              {user?.email ?? "—"}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Theme */}
+      <section className="rounded-2xl border border-border/50 bg-card p-5">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            {theme === "dark" ? (
+              <Moon className="h-4 w-4 text-primary" />
+            ) : (
+              <Sun className="h-4 w-4 text-primary" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-foreground">מראה</h2>
+            <p className="text-xs text-muted-foreground">
+              {theme === "dark" ? "מצב כהה" : "מצב בהיר"}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={theme === "dark"}
+            aria-label="מצב כהה"
+            onClick={toggleTheme}
+            dir="ltr"
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-150 ${
+              theme === "dark" ? "bg-primary" : "bg-muted"
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm ring-0 transition-transform duration-150 ${
+                theme === "dark" ? "translate-x-5" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
+      </section>
 
       {/* Telegram Connection */}
       <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-4">
@@ -82,10 +121,10 @@ export function SettingsPage() {
           </div>
           <div className="flex-1 min-w-0">
             <h2 className="text-sm font-semibold text-foreground">
-              חיבור Telegram
+              התראות Telegram
             </h2>
             <p className="text-xs text-muted-foreground">
-              חבר את חשבון הטלגרם שלך לקבלת התראות
+              קבל עדכונים על מודעות חדשות בטלגרם
             </p>
           </div>
           {!tgLoading && tgStatus?.connected && (
@@ -106,8 +145,8 @@ export function SettingsPage() {
             בודק חיבור...
           </div>
         ) : tgStatus?.connected ? (
-          <div className="flex items-center gap-3 rounded-xl bg-score-good/5 border border-score-good/20 p-3">
-            <CheckCircle2 className="h-5 w-5 text-score-good shrink-0" />
+          <div className="flex items-center gap-3 rounded-xl bg-success/5 border border-success/20 p-3">
+            <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-foreground">מחובר</p>
               {tgStatus.telegram_username && (
@@ -139,135 +178,17 @@ export function SettingsPage() {
         )}
       </section>
 
-      {/* Read-only notice */}
-      <div className="flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
-        <Info className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-        <p className="text-xs text-muted-foreground leading-relaxed">
-          ההגדרות הבאות הן לקריאה בלבד כרגע. ניתן לשנות את ההגדרות דרך פקודות הבוט בטלגרם.
-        </p>
-      </div>
-
-      {/* Notifications */}
-      <section inert aria-label="הגדרות התראות — בקרוב" className="rounded-2xl border border-border/50 bg-card p-5 space-y-5 opacity-60">
-        <h2 className="text-sm font-semibold text-foreground">התראות</h2>
-
-        <ToggleRow
-          icon={Bell}
-          label="התראות Telegram"
-          description="קבל עדכונים על מודעות חדשות בטלגרם"
-          enabled={telegramEnabled}
-          onToggle={() => {}}
-        />
-
-        <div className="border-t border-border/30" />
-
-        <ToggleRow
-          icon={Mail}
-          label="התראות אימייל"
-          description="קבל עדכונים על מודעות חדשות באימייל"
-          enabled={emailEnabled}
-          onToggle={() => {}}
-        />
+      {/* Sign Out */}
+      <section className="rounded-2xl border border-border/50 bg-card p-5">
+        <Button
+          variant="ghost"
+          onClick={() => void signOut()}
+          className="w-full text-destructive hover:bg-destructive/5 hover:text-destructive"
+        >
+          <LogOut className="h-4 w-4" />
+          התנתק מהחשבון
+        </Button>
       </section>
-
-      {/* Scan Frequency */}
-      <section inert aria-label="תדירות סריקה — בקרוב" className="rounded-2xl border border-border/50 bg-card p-5 space-y-4 opacity-60">
-        <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <Clock className="h-4 w-4 text-primary" />
-          </div>
-          <div>
-            <h2 className="text-sm font-semibold text-foreground">
-              תדירות סריקה
-            </h2>
-            <p className="text-xs text-muted-foreground">
-              כמה פעמים לסרוק מודעות חדשות
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {SCAN_FREQ_OPTIONS.map((opt) => (
-            <ChipButton
-              key={opt.value}
-              selected={scanFrequency === opt.value}
-              onClick={() => {}}
-            >
-              {opt.label}
-            </ChipButton>
-          ))}
-        </div>
-      </section>
-
-      {/* Alert Count */}
-      <section inert aria-label="מודעות בהתראה — בקרוב" className="rounded-2xl border border-border/50 bg-card p-5 space-y-4 opacity-60">
-        <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-score-good/10">
-            <Hash className="h-4 w-4 text-score-good" />
-          </div>
-          <div>
-            <h2 className="text-sm font-semibold text-foreground">
-              מודעות בהתראה
-            </h2>
-            <p className="text-xs text-muted-foreground">
-              כמה מודעות להציג בכל התראה
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {ALERT_COUNT_OPTIONS.map((count) => (
-            <ChipButton
-              key={count}
-              selected={alertCount === count}
-              onClick={() => {}}
-            >
-              {count}
-            </ChipButton>
-          ))}
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function ToggleRow({
-  icon: Icon,
-  label,
-  description,
-  enabled,
-  onToggle,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  description: string;
-  enabled: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="flex items-center gap-4">
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-        <Icon className="h-4 w-4 text-primary" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-foreground">{label}</p>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={enabled}
-        aria-label={label}
-        onClick={onToggle}
-        dir="ltr"
-        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 ${
-          enabled ? "bg-primary" : "bg-muted"
-        }`}
-      >
-        <span
-          className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm ring-0 transition-transform duration-200 ${
-            enabled ? "translate-x-5" : "translate-x-0.5"
-          }`}
-        />
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Mobile sticky action bar**: Save, Mark Seen, and External Link buttons fixed at bottom on mobile — always accessible without scrolling
- **Bookmark integration**: Save/unsave functionality with optimistic UI using existing `useSaveBookmark`/`useRemoveBookmark` hooks
- **Spec pills**: Replaced 4-column grid cards with inline pill badges for faster scanning (year, km, hand, city, gearbox, engine, horsepower)
- **Trust indicators**: New section showing listing age, source (Yad2/WinWin), seller type (private/commercial), photo availability
- **Market context in title**: Price comparison label shown directly under price

> **Note**: Stacked on previous redesign PRs. Merge in order.

Addresses: #789

## Test plan

- [x] TypeScript compiles clean
- [x] All 135 frontend tests pass
- [ ] Visual: Mobile sticky bar visible at bottom with Save, Seen, External buttons
- [ ] Visual: Spec pills display inline with icons
- [ ] Visual: Trust indicators section shows listing metadata
- [ ] Visual: Bookmark toggle works with optimistic update
- [ ] Visual: Works correctly in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)