### PR TITLE
fix: replace fake landing page stats with honest feature highlights

### DIFF
--- a/web/src/components/landing/StatsSection.tsx
+++ b/web/src/components/landing/StatsSection.tsx
@@ -1,92 +1,35 @@
 import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 import { motion } from "motion/react";
-import { Activity, Clock, Search, Sparkles } from "lucide-react";
+import { Bell, Clock, Search, Shield } from "lucide-react";
 import { useInView } from "@/hooks/useInView";
 
-/** Illustrative counters for marketing; replace when real metrics exist. */
-const stats: {
-  value: number;
-  suffix: string;
+const features: {
   label: string;
-  decimals: number;
+  description: string;
   icon: LucideIcon;
 }[] = [
   {
-    value: 12000,
-    suffix: "+",
-    label: "מודעות נסרקות מדי יום",
-    decimals: 0,
+    label: "סריקה רציפה",
+    description: "Yad2 ו-WinWin נסרקים כל 30 דקות, אוטומטית",
     icon: Search,
   },
   {
-    value: 98,
-    suffix: "%",
-    label: "מהמשתמשים מוצאים רכב תוך שבועיים",
-    decimals: 0,
-    icon: Sparkles,
+    label: "התראה מיידית",
+    description: "מודעה חדשה? תקבל התראה בטלגרם תוך דקות",
+    icon: Bell,
   },
   {
-    value: 3.5,
-    suffix: "K",
-    label: "חיפושים שמורים פעילים",
-    decimals: 1,
-    icon: Activity,
-  },
-  {
-    value: 4,
-    suffix: " דק׳",
-    label: "זמן ממוצע מפרסום לקבלת התראה",
-    decimals: 0,
+    label: "הגדרה ב-2 דקות",
+    description: "בחר יצרן, דגם, תקציב — והמערכת עובדת בשבילך",
     icon: Clock,
   },
+  {
+    label: "ציון התאמה חכם",
+    description: "כל מודעה מקבלת ציון 0-10 לפי הקריטריונים שלך",
+    icon: Shield,
+  },
 ];
-
-function Counter({
-  target,
-  suffix,
-  decimals,
-  active,
-}: {
-  target: number;
-  suffix: string;
-  decimals: number;
-  active: boolean;
-}) {
-  const [val, setVal] = useState(0);
-  const rafRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!active) return;
-    const duration = 1800;
-    const start = performance.now();
-    const tick = (now: number) => {
-      const elapsed = now - start;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = 1 - Math.pow(1 - progress, 3);
-      setVal(eased * target);
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(tick);
-      }
-    };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => {
-      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
-    };
-  }, [active, target]);
-
-  const display =
-    decimals > 0
-      ? val.toFixed(decimals)
-      : Math.floor(val).toLocaleString("he-IL");
-  return (
-    <span>
-      {display}
-      {suffix}
-    </span>
-  );
-}
 
 function FadeUp({
   children,
@@ -109,54 +52,42 @@ function FadeUp({
 }
 
 export function StatsSection() {
-  const { ref, inView } = useInView(0.3);
-
   return (
     <section
       id="stats"
-      ref={ref}
       className="scroll-mt-28 px-4 py-24 sm:px-6"
     >
       <div className="relative mx-auto max-w-5xl">
         <div className="pointer-events-none absolute -top-24 start-1/2 h-64 w-[min(90%,28rem)] -translate-x-1/2 rounded-full bg-primary/8 blur-[100px]" />
-        <div className="pointer-events-none absolute -bottom-16 -start-20 h-40 w-40 rounded-full bg-purple-500/10 blur-[80px]" />
 
         <FadeUp>
           <div className="mb-14 text-center">
             <span className="mb-3 block text-xs font-semibold tracking-widest text-primary uppercase">
-              במספרים
+              איך זה עובד
             </span>
             <h2 className="text-3xl font-bold text-foreground md:text-4xl">
-              בנוי לקצב השוק המקומי
+              מעקב אוטומטי, תוצאות מיידיות
             </h2>
             <p className="mx-auto mt-3 max-w-lg text-sm text-muted-foreground md:text-base">
-              נתונים להמחשה — בקרוב נחבר מדדים חיים כשיהיו זמינים במוצר.
+              המערכת עובדת ברקע — אתה מקבל רק את מה שרלוונטי לך
             </p>
           </div>
         </FadeUp>
 
         <div className="relative grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
-          {stats.map((s, i) => {
-            const Icon = s.icon;
+          {features.map((f, i) => {
+            const Icon = f.icon;
             return (
-              <FadeUp key={s.label} delay={i * 0.1}>
-                <div className="group card-hover relative overflow-hidden rounded-2xl border border-border/80 bg-card p-5 text-center shadow-[0_1px_0_0_rgba(255,255,255,0.04)_inset] dark:shadow-[0_1px_0_0_rgba(255,255,255,0.06)_inset]">
-                  <div className="pointer-events-none absolute -end-6 -top-6 h-24 w-24 rounded-full bg-primary/10 opacity-70 blur-2xl transition-opacity group-hover:opacity-100" />
+              <FadeUp key={f.label} delay={i * 0.1}>
+                <div className="group card-hover relative overflow-hidden rounded-2xl border border-border/80 bg-card p-5 text-center">
                   <div className="relative mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-border/50 bg-secondary/50">
                     <Icon className="h-[18px] w-[18px] text-primary" aria-hidden />
                   </div>
-                  <div className="relative mb-2 text-2xl font-bold tabular-nums md:text-3xl">
-                    <span className="gradient-text">
-                      <Counter
-                        target={s.value}
-                        suffix={s.suffix}
-                        decimals={s.decimals}
-                        active={inView}
-                      />
-                    </span>
-                  </div>
-                  <p className="relative text-[11px] leading-snug text-muted-foreground sm:text-xs">
-                    {s.label}
+                  <p className="relative mb-1.5 text-sm font-semibold text-foreground">
+                    {f.label}
+                  </p>
+                  <p className="relative text-xs leading-relaxed text-muted-foreground">
+                    {f.description}
                   </p>
                 </div>
               </FadeUp>


### PR DESCRIPTION
## Summary

Removed fabricated statistics from the landing page StatsSection that were explicitly marked as "marketing placeholders" in code comments. Fake numbers like "12,000+ listings scanned daily" and "98% success rate" undermine user trust when they're not grounded in reality.

**Before:** 4 animated counters with fake numbers
**After:** 4 feature highlight cards with truthful descriptions of what the product actually does

- Continuous scanning (every 30 min)
- Instant Telegram alerts
- 2-minute setup
- Smart 0-10 match scoring

Also removed ~70 lines of Counter animation code that was only used for the fake stats.

closes #782

## Test plan

- [x] TypeScript compiles clean
- [x] All 135 tests pass
- [ ] Visual: Stats section shows feature cards instead of animated counters
- [ ] Visual: No fabricated numbers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)