### PR TITLE
fix: add lockChat to wizard handlers and per-handler context timeouts

### DIFF
--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -25,6 +25,9 @@ const (
 // --- Callback Handler ---
 
 func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	if update.CallbackQuery == nil {
 		b.logger.Debug("handleCallback: nil callback query")
 		return
@@ -163,11 +166,17 @@ func (b *Bot) onDigestInterval(ctx context.Context, chatID int64, data string) {
 }
 
 func (b *Bot) onCancelCallback(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	_ = b.users.UpdateUserState(ctx, chatID, StateIdle, "{}")
 	b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "cancel"))
 }
 
 func (b *Bot) onEditRestart(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	lang := b.getUserLang(ctx, chatID)
 	wd := b.loadWizardData(ctx, chatID)
 	newWd := WizardData{EditSearchID: wd.EditSearchID}
@@ -218,6 +227,9 @@ func (b *Bot) onQuickStart(ctx context.Context, chatID int64) {
 }
 
 func (b *Bot) onWatchFromCallback(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	lang := b.getUserLang(ctx, chatID)
 
 	if b.checkSearchLimit(ctx, chatID, lang, "watch_limit") {

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
@@ -18,6 +19,9 @@ import (
 // --- Command Handlers ---
 
 func (b *Bot) handleStart(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	username := update.Message.From.Username
 
@@ -52,6 +56,9 @@ func (b *Bot) handleStart(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 }
 
 func (b *Bot) handleShare(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
@@ -167,6 +174,9 @@ func (b *Bot) handleLinkStart(ctx context.Context, telegramChatID int64, param s
 }
 
 func (b *Bot) handleWatch(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.logger.Debug("/watch command", "chat_id", chatID, "username", update.Message.From.Username)
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
@@ -183,6 +193,9 @@ func (b *Bot) handleWatch(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 }
 
 func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
@@ -231,6 +244,9 @@ func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 }
 
 func (b *Bot) handleStop(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	lang := b.getUserLang(ctx, chatID)
 	parts := strings.Fields(update.Message.Text)
@@ -254,6 +270,9 @@ func (b *Bot) handleStop(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 }
 
 func (b *Bot) handlePause(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	lang := b.getUserLang(ctx, chatID)
 	parts := strings.Fields(update.Message.Text)
@@ -288,6 +307,9 @@ func (b *Bot) handlePause(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 }
 
 func (b *Bot) handleResume(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	lang := b.getUserLang(ctx, chatID)
 	parts := strings.Fields(update.Message.Text)
@@ -322,6 +344,9 @@ func (b *Bot) handleResume(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 }
 
 func (b *Bot) handleCancel(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	lang := b.getUserLang(ctx, chatID)
 	_ = b.users.UpdateUserState(ctx, chatID, StateIdle, "{}")
@@ -329,11 +354,17 @@ func (b *Bot) handleCancel(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 }
 
 func (b *Bot) handleHelp(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	lang := b.getUserLang(ctx, update.Message.Chat.ID)
 	b.sendMarkdown(ctx, update.Message.Chat.ID, locale.T(lang, "help"))
 }
 
 func (b *Bot) handleSettings(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
@@ -351,6 +382,9 @@ func (b *Bot) handleSettings(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 }
 
 func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	if chatID != b.adminChatID {
 		lang := b.getUserLang(ctx, chatID)
@@ -386,6 +420,9 @@ func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 }
 
 func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
@@ -447,6 +484,9 @@ func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 }
 
 func (b *Bot) handleLanguage(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
@@ -463,6 +503,9 @@ func (b *Bot) handleLanguage(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 }
 
 func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
@@ -516,6 +559,9 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 }
 
 func (b *Bot) handleUpgrade(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)

--- a/internal/bot/history.go
+++ b/internal/bot/history.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
@@ -16,6 +17,9 @@ import (
 const historyPageSize = 5
 
 func (b *Bot) handleHistory(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	b.sendHistoryPage(ctx, chatID, 0)
@@ -127,6 +131,9 @@ func (b *Bot) onHistoryPage(ctx context.Context, chatID int64, data string) {
 // --- /saved command ---
 
 func (b *Bot) handleSaved(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	b.sendSavedPage(ctx, chatID, 0)
@@ -225,6 +232,9 @@ func (b *Bot) onSavedPage(ctx context.Context, chatID int64, data string) {
 // --- /hidden command ---
 
 func (b *Bot) handleHidden(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	b.sendHiddenPage(ctx, chatID, 0)

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -81,12 +81,18 @@ func (b *Bot) onMfrPage(ctx context.Context, chatID int64, data string) {
 }
 
 func (b *Bot) onMfrSearch(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	wd := b.loadWizardData(ctx, chatID)
 	b.saveWizardState(ctx, chatID, StateSearchManufacturer, wd)
 	b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "wizard_mfr_search"))
 }
 
 func (b *Bot) onMdlPage(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	pageStr := strings.TrimPrefix(data, cbMdlPage)
 	page, err := strconv.Atoi(pageStr)
 	if err != nil {
@@ -102,6 +108,9 @@ func (b *Bot) onMdlPage(ctx context.Context, chatID int64, data string) {
 }
 
 func (b *Bot) onMdlSearch(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	wd := b.loadWizardData(ctx, chatID)
 	b.saveWizardState(ctx, chatID, StateSearchModel, wd)
 	lang := b.getUserLang(ctx, chatID)
@@ -109,6 +118,9 @@ func (b *Bot) onMdlSearch(ctx context.Context, chatID int64) {
 }
 
 func (b *Bot) onManufacturerSelected(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskManufacturer) {
 		return
 	}
@@ -150,6 +162,9 @@ func (b *Bot) onManufacturerSelected(ctx context.Context, chatID int64, data str
 }
 
 func (b *Bot) onModelSelected(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskModel) {
 		return
 	}
@@ -171,6 +186,9 @@ func (b *Bot) onModelSelected(ctx context.Context, chatID int64, data string) {
 }
 
 func (b *Bot) onEngineSelected(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskEngine) {
 		return
 	}
@@ -192,6 +210,9 @@ func (b *Bot) onEngineSelected(ctx context.Context, chatID int64, data string) {
 }
 
 func (b *Bot) onMaxKmSelected(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskMaxKm) {
 		return
 	}
@@ -211,6 +232,9 @@ func (b *Bot) onMaxKmSelected(ctx context.Context, chatID int64, data string) {
 }
 
 func (b *Bot) onMaxHandSelected(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskMaxHand) {
 		return
 	}
@@ -232,6 +256,9 @@ func (b *Bot) onMaxHandSelected(ctx context.Context, chatID int64, data string) 
 }
 
 func (b *Bot) onSkipKeywords(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskKeywords) {
 		return
 	}
@@ -246,6 +273,9 @@ func (b *Bot) onSkipKeywords(ctx context.Context, chatID int64) {
 }
 
 func (b *Bot) onSkipExcludeKeys(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskExcludeKeys) {
 		return
 	}
@@ -259,6 +289,9 @@ func (b *Bot) onSkipExcludeKeys(ctx context.Context, chatID int64) {
 }
 
 func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	user, err := b.users.GetUser(ctx, chatID)
 	if err != nil {
 		b.logger.Error("get user failed in onConfirm", "chat_id", chatID, "error", err)
@@ -369,12 +402,18 @@ func (b *Bot) onConfirm(ctx context.Context, chatID int64) {
 // --- Default Handler (free text during wizard) ---
 
 func (b *Bot) handleDefault(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Update) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	if update.Message == nil {
 		return
 	}
 
 	chatID := update.Message.Chat.ID
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
+
+	unlock := b.lockChat(chatID)
+	defer unlock()
 
 	user, err := b.users.GetUser(ctx, chatID)
 	if err != nil {
@@ -514,6 +553,9 @@ func (b *Bot) handlePriceMin(ctx context.Context, chatID int64, text string) {
 }
 
 func (b *Bot) onSkipPriceMin(ctx context.Context, chatID int64) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskPriceMin) {
 		return
 	}
@@ -526,6 +568,9 @@ func (b *Bot) onSkipPriceMin(ctx context.Context, chatID int64) {
 }
 
 func (b *Bot) onGearBoxSelected(ctx context.Context, chatID int64, data string) {
+	unlock := b.lockChat(chatID)
+	defer unlock()
+
 	if !b.expectState(ctx, chatID, StateAskGearBox) {
 		return
 	}


### PR DESCRIPTION
## Summary

Wizard state mutations were unprotected against concurrent callback handling, and bot command handlers had no timeout — a slow DB query could block all update processing for all users.

## Wizard race condition

Only 2 of 17 wizard-mutating handlers used `lockChat()`. Rapid button clicks could cause read-modify-write races on wizard state in the database. All wizard-mutating handlers now acquire the per-chat lock before touching state.

## Handler timeouts

All command and callback handlers now get a 30-second context timeout. Previously, a hung database query would block the go-telegram/bot update processing loop indefinitely, making the bot unresponsive to all users.

closes #817, closes #819

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus_4.6_(1M)](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)