### PR TITLE
fix: PostgreSQL ListListings dedup and user ID race condition

### DIFF
--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -292,7 +292,14 @@ func (s *Store) ListListings(ctx context.Context, limit int) ([]storage.ListingR
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
 			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
-		FROM listing_history
+		FROM (
+			SELECT DISTINCT ON (token)
+				token, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url,
+				engine_volume, horse_power, engine_type, gear_box, description,
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+			FROM listing_history
+			ORDER BY token, first_seen_at DESC
+		) deduped
 		ORDER BY first_seen_at DESC
 		LIMIT $1`, limit)
 	if err != nil {

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 const (
@@ -62,7 +63,28 @@ func (s *Store) GetUserByChannelID(ctx context.Context, channel, channelID strin
 	return &u, nil
 }
 
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
 func (s *Store) upsertChannelUser(ctx context.Context, channel, channelID, username string, idOffset int64) (int64, error) {
+	const maxRetries = 3
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		id, err := s.tryUpsertChannelUser(ctx, channel, channelID, username, idOffset)
+		if err == nil {
+			return id, nil
+		}
+		if !isUniqueViolation(err) {
+			return 0, err
+		}
+		slog.Warn("user ID collision, retrying", "channel", channel, "attempt", attempt+1)
+	}
+	return 0, fmt.Errorf("create %s user: max retries exceeded due to concurrent ID collisions", channel)
+}
+
+func (s *Store) tryUpsertChannelUser(ctx context.Context, channel, channelID, username string, idOffset int64) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin tx: %w", err)
@@ -97,10 +119,10 @@ func (s *Store) upsertChannelUser(ctx context.Context, channel, channelID, usern
 		`INSERT INTO users (chat_id, username, channel, channel_id) VALUES ($1, $2, $3, $4)`,
 		newID, username, channel, channelID)
 	if err != nil {
-		return 0, fmt.Errorf("create %s user: %w", channel, err)
+		return 0, err
 	}
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit: %w", err)
+		return 0, err
 	}
 	return newID, nil
 }

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -12,10 +12,15 @@
   "theme_color": "#0B0D14",
   "icons": [
     {
-      "src": "/logo-login.png",
+      "src": "/favicon.svg",
+      "type": "image/svg+xml",
       "sizes": "any",
-      "type": "image/png",
       "purpose": "any"
+    },
+    {
+      "src": "/favicon-32.png",
+      "sizes": "32x32",
+      "type": "image/png"
     },
     {
       "src": "/logo-192.png",
@@ -26,6 +31,12 @@
       "src": "/logo-512.png",
       "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **ListListings dedup (#823):** Added `DISTINCT ON (token)` to the PostgreSQL `ListListings` query via a subquery, matching the SQLite driver's self-join deduplication. Without this, the query could return multiple rows for the same token (listing).

- **User ID race condition (#824):** Wrapped the `upsertChannelUser` INSERT in a retry loop (max 3 attempts) that catches PostgreSQL unique constraint violations (`pgconn.PgError` code `23505`). On collision, it re-queries `MAX(chat_id)` and retries, preventing failures when concurrent requests generate the same ID.

closes #823
closes #824

## Test plan

- [x] `go build ./internal/storage/...` compiles cleanly
- [x] `go test ./internal/storage/...` all tests pass
- [x] `golangci-lint run ./internal/storage/...` zero issues