### PR TITLE
fix: repair refreshListings context cancellation and warn on dev auth in production

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -298,6 +298,7 @@ func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 		LogLevel:     logLevel,
 		Fetchers:     fetchers,
 		PriceListSvc: plSvc,
+		Bind:         cfg.HTTP.Bind,
 	})
 
 	return apiServer, nil

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -108,9 +108,18 @@ type Config struct {
 	BotUsername  string
 	Fetchers     *fetcher.Factory
 	PriceListSvc *pricelist.Service
+	Bind         string
 }
 
 func New(c Config) *Server {
+	if c.FirebaseAuth == nil {
+		bind := c.Bind
+		if bind != "" && !strings.HasPrefix(bind, "127.0.0.1") && !strings.HasPrefix(bind, "localhost") {
+			c.Logger.Warn("firebase auth not configured — using dev auth mode on non-localhost bind address",
+				"bind", bind)
+		}
+	}
+
 	return &Server{
 		catalog:      c.Catalog,
 		searches:     c.Searches,

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -131,6 +131,7 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 
 		var raw []model.RawListing
 		var fetchErr error
+	retryLoop:
 		for attempt := 0; attempt < 3; attempt++ {
 			raw, fetchErr = f.Fetch(r.Context(), params)
 			if fetchErr == nil {
@@ -142,7 +143,8 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 				delay := time.Duration(1<<attempt) * time.Second
 				select {
 				case <-r.Context().Done():
-					break
+					fetchErr = r.Context().Err()
+					break retryLoop
 				case <-time.After(delay):
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes two API-layer issues:

- **refreshListings retry loop context cancellation (#825):** The `break` inside the `select` on context cancellation only exited the `select` statement, not the enclosing `for` retry loop. This caused one additional stale fetch attempt after the client disconnected. Fixed by adding a `retryLoop:` label and using `break retryLoop` to exit both the select and the for loop. The context error is also propagated to `fetchErr` so the source is properly skipped.

- **Dev auth mode startup warning (#834):** When Firebase auth is not configured (`firebaseAuth == nil`), the server falls back to a static bearer token with a hardcoded dev chat ID. If this is accidentally left enabled on a non-localhost bind address, it could be a security concern. Added a `Warn`-level log at startup when the bind address is not `127.0.0.1` or `localhost` and Firebase auth is nil, making the dev auth mode visible in production logs.

## Changes

- `internal/api/listings.go` — Added `retryLoop:` label and `break retryLoop` in the context cancellation branch; set `fetchErr = r.Context().Err()` before breaking
- `internal/api/api.go` — Added `Bind` field to `Config` struct; added startup warning in `New()` when Firebase auth is nil and bind is non-localhost
- `cmd/bot/main.go` — Passed `cfg.HTTP.Bind` to the new `api.Config.Bind` field

## Test plan

- [x] `go build ./internal/api/...` passes
- [x] `go test ./internal/api/...` passes
- [x] `golangci-lint run ./internal/api/...` passes (0 issues)
- [ ] Manual: start server with no Firebase config on `0.0.0.0:8080` and verify warning is logged
- [ ] Manual: cancel a refresh request mid-retry and verify no extra fetch attempt occurs

closes #825, closes #834