### PR TITLE
refactor: extract shared buildFilterCriteria into model package

### DIFF
--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -1077,7 +1078,7 @@ func TestBuildFilterCriteriaFromSearch(t *testing.T) {
 		Keywords:    "automatic, sunroof",
 		ExcludeKeys: "salvage",
 	}
-	fc := buildFilterCriteriaFromSearch(sr)
+	fc := model.FilterCriteriaFromSearch(sr)
 
 	if fc.ModelID != 10226 {
 		t.Errorf("ModelID = %d, want 10226", fc.ModelID)

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -155,7 +155,7 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 
 	s.refreshMu.Store(cooldownKey, time.Now())
 
-	criteria := buildFilterCriteriaFromSearch(sr)
+	criteria := model.FilterCriteriaFromSearch(sr)
 	filtered := filter.Apply(criteria, allRaw)
 
 	freshTokens := make([]string, len(filtered))
@@ -240,38 +240,6 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 		Total:   total,
 		Removed: removed,
 	})
-}
-
-func buildFilterCriteriaFromSearch(sr *storage.Search) model.FilterCriteria {
-	criteria := model.FilterCriteria{
-		ModelID:     sr.Model,
-		YearMin:     sr.YearMin,
-		YearMax:     sr.YearMax,
-		PriceMin:    sr.PriceMin,
-		PriceMax:    sr.PriceMax,
-		EngineMinCC: float64(sr.EngineMinCC),
-		MaxKm:       sr.MaxKm,
-		MaxHand:     sr.MaxHand,
-		GearBox:     sr.GearBox,
-		PriceOnly:   sr.PriceOnly,
-		PhotoOnly:   sr.PhotoOnly,
-	}
-
-	if sr.Keywords != "" {
-		for _, kw := range strings.Split(sr.Keywords, ",") {
-			if kw = strings.TrimSpace(kw); kw != "" {
-				criteria.Keywords = append(criteria.Keywords, kw)
-			}
-		}
-	}
-	if sr.ExcludeKeys != "" {
-		for _, ex := range strings.Split(sr.ExcludeKeys, ",") {
-			if ex = strings.TrimSpace(ex); ex != "" {
-				criteria.ExcludeKeys = append(criteria.ExcludeKeys, ex)
-			}
-		}
-	}
-	return criteria
 }
 
 func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -1,5 +1,48 @@
 package model
 
+import (
+	"strings"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// FilterCriteriaFromSearch converts a storage.Search into the FilterCriteria
+// used by the post-fetch filter pipeline. Both the API refresh handler and the
+// scheduler were carrying identical copies of this logic; this single function
+// replaces both.
+func FilterCriteriaFromSearch(s *storage.Search) FilterCriteria {
+	criteria := FilterCriteria{
+		ModelID:     s.Model,
+		YearMin:     s.YearMin,
+		YearMax:     s.YearMax,
+		PriceMin:    s.PriceMin,
+		PriceMax:    s.PriceMax,
+		EngineMinCC: float64(s.EngineMinCC),
+		MaxKm:       s.MaxKm,
+		MaxHand:     s.MaxHand,
+		GearBox:     s.GearBox,
+		PriceOnly:   s.PriceOnly,
+		PhotoOnly:   s.PhotoOnly,
+	}
+
+	if s.Keywords != "" {
+		for _, kw := range strings.Split(s.Keywords, ",") {
+			if kw = strings.TrimSpace(kw); kw != "" {
+				criteria.Keywords = append(criteria.Keywords, kw)
+			}
+		}
+	}
+	if s.ExcludeKeys != "" {
+		for _, ek := range strings.Split(s.ExcludeKeys, ",") {
+			if ek = strings.TrimSpace(ek); ek != "" {
+				criteria.ExcludeKeys = append(criteria.ExcludeKeys, ek)
+			}
+		}
+	}
+
+	return criteria
+}
+
 // SourceParams defines the search parameters sent to listing sources.
 type SourceParams struct {
 	Manufacturer int

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/locale"
@@ -313,37 +312,4 @@ func filterHiddenListings(filtered []model.RawListing, hidden map[string]bool) [
 		}
 	}
 	return out
-}
-
-func buildFilterCriteria(search storage.Search) model.FilterCriteria {
-	criteria := model.FilterCriteria{
-		ModelID:     search.Model,
-		YearMin:     search.YearMin,
-		YearMax:     search.YearMax,
-		PriceMin:    search.PriceMin,
-		PriceMax:    search.PriceMax,
-		EngineMinCC: float64(search.EngineMinCC),
-		MaxKm:       search.MaxKm,
-		MaxHand:     search.MaxHand,
-		GearBox:     search.GearBox,
-		PriceOnly:   search.PriceOnly,
-		PhotoOnly:   search.PhotoOnly,
-	}
-
-	if search.Keywords != "" {
-		for _, kw := range strings.Split(search.Keywords, ",") {
-			if kw = strings.TrimSpace(kw); kw != "" {
-				criteria.Keywords = append(criteria.Keywords, kw)
-			}
-		}
-	}
-	if search.ExcludeKeys != "" {
-		for _, kw := range strings.Split(search.ExcludeKeys, ",") {
-			if kw = strings.TrimSpace(kw); kw != "" {
-				criteria.ExcludeKeys = append(criteria.ExcludeKeys, kw)
-			}
-		}
-	}
-
-	return criteria
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -691,7 +691,7 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 			"search_name", search.Name,
 		)
 
-		filtered := filter.Apply(buildFilterCriteria(search), raw)
+		filtered := filter.Apply(model.FilterCriteriaFromSearch(&search), raw)
 		searchLog.Debug("search filter applied",
 			"total_raw", len(raw),
 			"after_filter", len(filtered),


### PR DESCRIPTION
## Summary

- Extracted the duplicated `buildFilterCriteria` / `buildFilterCriteriaFromSearch` functions into a single `model.FilterCriteriaFromSearch` in `internal/model/params.go`
- Updated both call sites (API refresh handler and scheduler) to use the shared function
- Removed the old duplicated functions from `internal/api/listings.go` and `internal/scheduler/processing.go`

The same Search-to-FilterCriteria conversion existed in both packages with identical logic. This prevents divergence when filter fields are added in the future.

closes #830

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/api/ -run TestBuildFilterCriteriaFromSearch` passes
- [x] `go test ./internal/scheduler/` passes
- [x] `golangci-lint run ./...` passes with 0 issues