### PR TITLE
fix: add per-chat send rate limiter and digest flush retry mechanism

### DIFF
--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
@@ -25,8 +26,13 @@ const (
 	telegramListingSeparatorLine = "━━━━━━━━━━━━━━━━━━━━"
 
 	// defaultSendDelay is the minimum pause between consecutive Telegram
-	// API calls to avoid hitting rate limits.
+	// API calls within a single split message to avoid hitting rate limits.
 	defaultSendDelay = 50 * time.Millisecond
+
+	// defaultChatDelay is the minimum pause between separate deliveries
+	// to the same chat (across different searches) to avoid per-chat
+	// Telegram rate limiting.
+	defaultChatDelay = 100 * time.Millisecond
 
 	// telegramMaxRetries is the maximum number of extra attempts after a
 	// rate-limited (HTTP 429) sendMessage/sendPhoto failure.
@@ -42,9 +48,11 @@ const (
 )
 
 type Notifier struct {
-	bot       *tgbot.Bot
-	logger    *slog.Logger
-	sendDelay time.Duration
+	bot          *tgbot.Bot
+	logger       *slog.Logger
+	sendDelay    time.Duration
+	chatDelay    time.Duration
+	lastSendTime sync.Map // chatID string -> time.Time
 }
 
 func New(token string, logger *slog.Logger, opts ...tgbot.Option) (*Notifier, error) {
@@ -56,7 +64,7 @@ func New(token string, logger *slog.Logger, opts ...tgbot.Option) (*Notifier, er
 	if err != nil {
 		return nil, fmt.Errorf("create telegram bot: %w", err)
 	}
-	return &Notifier{bot: b, logger: logger, sendDelay: defaultSendDelay}, nil
+	return &Notifier{bot: b, logger: logger, sendDelay: defaultSendDelay, chatDelay: defaultChatDelay}, nil
 }
 
 func (n *Notifier) Bot() *tgbot.Bot {
@@ -73,6 +81,7 @@ func (n *Notifier) Connect(ctx context.Context) error {
 }
 
 func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.Listing, lang locale.Lang) error {
+	n.throttleChat(chatID)
 	if len(listings) == 1 && listings[0].ImageURL != "" {
 		return n.sendListingWithPhoto(ctx, chatID, listings[0], lang)
 	}
@@ -81,6 +90,7 @@ func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.L
 }
 
 func (n *Notifier) NotifyRaw(ctx context.Context, chatID string, message string) error {
+	n.throttleChat(chatID)
 	n.logger.Debug("notifyRaw",
 		"chat_id", chatID,
 		"msg_len", len(message),
@@ -91,6 +101,24 @@ func (n *Notifier) NotifyRaw(ctx context.Context, chatID string, message string)
 
 func (n *Notifier) Disconnect() error {
 	return nil
+}
+
+// throttleChat enforces a minimum delay between API calls targeting the same
+// chat. This prevents per-chat rate limiting when multiple searches deliver
+// results to the same user in quick succession.
+func (n *Notifier) throttleChat(chatID string) {
+	if n.chatDelay <= 0 {
+		return
+	}
+	now := time.Now()
+	if v, ok := n.lastSendTime.Load(chatID); ok {
+		if last, ok := v.(time.Time); ok {
+			if wait := n.chatDelay - now.Sub(last); wait > 0 {
+				time.Sleep(wait)
+			}
+		}
+	}
+	n.lastSendTime.Store(chatID, time.Now())
 }
 
 func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, listing model.Listing, lang locale.Lang) error {

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -68,8 +68,9 @@ func newTestNotifier(t *testing.T, handler http.Handler) *Notifier {
 	if err != nil {
 		t.Fatalf("create notifier: %v", err)
 	}
-	// Disable send delay in tests to avoid sleeping.
+	// Disable send delays in tests to avoid sleeping.
 	n.sendDelay = 0
+	n.chatDelay = 0
 	return n
 }
 
@@ -777,5 +778,47 @@ func TestNotifyRaw_AllowsValidMessage(t *testing.T) {
 	}
 	if called.Load() == 0 {
 		t.Error("API should have been called for valid message")
+	}
+}
+
+// --- Per-chat throttle tests ---
+
+func TestThrottleChat_EnforcesMinimumDelay(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(sendMessageOK)
+	}))
+	n.chatDelay = 50 * time.Millisecond
+	start := time.Now()
+	_ = n.NotifyRaw(context.Background(), "123", "first valid notification message")
+	_ = n.NotifyRaw(context.Background(), "123", "second valid notification message")
+	if time.Since(start) < 50*time.Millisecond {
+		t.Errorf("two sends to same chat took %v, expected >= 50ms", time.Since(start))
+	}
+}
+
+func TestThrottleChat_NoCrossChatDelay(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(sendMessageOK)
+	}))
+	n.chatDelay = 200 * time.Millisecond
+	start := time.Now()
+	_ = n.NotifyRaw(context.Background(), "100", "message for chat 100 here")
+	_ = n.NotifyRaw(context.Background(), "200", "message for chat 200 here")
+	if time.Since(start) >= 200*time.Millisecond {
+		t.Errorf("different chats took %v, expected < 200ms", time.Since(start))
+	}
+}
+
+func TestThrottleChat_DisabledWhenZero(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(sendMessageOK)
+	}))
+	n.chatDelay = 0
+	start := time.Now()
+	for i := 0; i < 5; i++ {
+		_ = n.NotifyRaw(context.Background(), "123", "rapid fire notification message")
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Errorf("5 sends with zero chatDelay took %v, expected near-instant", time.Since(start))
 	}
 }

--- a/internal/scheduler/digest.go
+++ b/internal/scheduler/digest.go
@@ -10,6 +10,18 @@ import (
 	"github.com/dsionov/carwatch/internal/notifier"
 )
 
+const (
+	// digestRetryInterval is the shorter flush interval used after a
+	// delivery failure, so retries happen sooner than the next full
+	// digest interval.
+	digestRetryInterval = 2 * time.Minute
+
+	// maxDigestPending is the maximum number of items allowed to
+	// accumulate in a digest queue. When exceeded, the oldest items
+	// are acked (discarded) to prevent unbounded growth.
+	maxDigestPending = 100
+)
+
 func (s *Scheduler) processDigests(ctx context.Context) {
 	if s.stores.Digests == nil {
 		return
@@ -43,6 +55,11 @@ func (s *Scheduler) processDigests(ctx context.Context) {
 			interval = 6 * time.Hour
 		}
 
+		// If a previous flush failed, use a shorter retry interval.
+		if _, failed := s.digestFailures.Load(chatID); failed {
+			interval = digestRetryInterval
+		}
+
 		lastFlushed, err := s.stores.Digests.DigestLastFlushed(ctx, chatID)
 		if err != nil {
 			s.logger.Error("get last flushed failed", "chat_id", chatID, "error", err)
@@ -65,6 +82,18 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 		return
 	}
 
+	// Cap accumulated items to prevent unbounded growth.
+	if len(payloads) > maxDigestPending {
+		overflow := len(payloads) - maxDigestPending
+		s.logger.Warn("digest queue exceeded max pending items, discarding oldest",
+			"chat_id", chatID,
+			"total", len(payloads),
+			"discarding", overflow,
+			"max", maxDigestPending,
+		)
+		payloads = payloads[overflow:]
+	}
+
 	chatIDStr := fmt.Sprintf("%d", chatID)
 	lang := s.userLang(ctx, chatID)
 	header := locale.Tf(lang, "fmt_digest_header", len(payloads))
@@ -76,8 +105,13 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 			"items", len(payloads),
 			"error", err,
 		)
+		// Record the failure so processDigests uses a shorter retry interval.
+		s.digestFailures.Store(chatID, time.Now())
 		return
 	}
+
+	// Delivery succeeded; clear the failure marker.
+	s.digestFailures.Delete(chatID)
 
 	if err := s.stores.Digests.AckDigest(ctx, chatID, cutoff); err != nil {
 		s.logger.Error("digest ack failed after successful send, items may be resent",

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -78,9 +78,10 @@ type Scheduler struct {
 	priceListSvc      *pricelist.Service
 	triggerCh         chan struct{}
 
-	langCache   sync.Map
-	digestCache sync.Map
-	cycleCount  uint64
+	langCache      sync.Map
+	digestCache    sync.Map
+	digestFailures sync.Map // chatID (int64) -> time.Time of last flush failure
+	cycleCount     uint64
 
 	marketCacheMu      sync.RWMutex
 	marketCache        *scoring.MarketCache

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -968,3 +968,87 @@ func TestRetryPending_PurgesMalformedPayloads(t *testing.T) {
 		t.Error("valid payload id=3 should be acked after send")
 	}
 }
+
+func TestFlushAndSendDigest_SendError_SetsRetryMarker(t *testing.T) {
+	n := &errNotifier{rawErr: errors.New("send failed")}
+	ds := newMockDigestStore()
+	ds.items[100] = digestItems("item1")
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.flushAndSendDigest(context.Background(), 100)
+	if _, ok := s.digestFailures.Load(int64(100)); !ok {
+		t.Error("expected digestFailures marker after send failure")
+	}
+}
+
+func TestFlushAndSendDigest_Success_ClearsRetryMarker(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newMockDigestStore()
+	ds.items[100] = digestItems("item1")
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.digestFailures.Store(int64(100), time.Now())
+	s.flushAndSendDigest(context.Background(), 100)
+	if _, ok := s.digestFailures.Load(int64(100)); ok {
+		t.Error("expected digestFailures marker cleared after success")
+	}
+}
+
+func TestProcessDigests_UsesRetryIntervalAfterFailure(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newMockDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "24h")
+	ds.items[100] = digestItems("item1")
+	ds.flushed[100] = time.Now().Add(-3 * time.Minute)
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.digestFailures.Store(int64(100), time.Now().Add(-3*time.Minute))
+	s.processDigests(context.Background())
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 1 {
+		t.Errorf("expected retry flush, got %d messages", len(n.rawMessages))
+	}
+}
+
+func TestProcessDigests_NoRetryWithoutFailureMarker(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newMockDigestStore()
+	_ = ds.SetDigestMode(context.Background(), 100, "digest", "24h")
+	ds.items[100] = digestItems("item1")
+	ds.flushed[100] = time.Now().Add(-3 * time.Minute)
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, testLogger(), Options{DigestStore: ds})
+	s.processDigests(context.Background())
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.rawMessages) != 0 {
+		t.Errorf("expected no flush without failure marker, got %d", len(n.rawMessages))
+	}
+}
+
+func TestFlushAndSendDigest_CapsOverflowItems(t *testing.T) {
+	n := &mockNotifier{}
+	ds := newMockDigestStore()
+	payloads := make([]string, maxDigestPending+20)
+	for i := range payloads {
+		payloads[i] = fmt.Sprintf("item-%d", i)
+	}
+	ds.items[100] = digestItems(payloads...)
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	s, _ := NewWithOptions(testConfig(), nil, nil, n, logger, Options{DigestStore: ds})
+	s.flushAndSendDigest(context.Background(), 100)
+	n.mu.Lock()
+	sentCount := len(n.rawMessages)
+	n.mu.Unlock()
+	if sentCount != 1 {
+		t.Fatalf("expected 1 message, got %d", sentCount)
+	}
+	msg := n.rawMessages[0].message
+	if strings.Contains(msg, "item-0") {
+		t.Error("oldest items should be discarded")
+	}
+	if !strings.Contains(msg, fmt.Sprintf("item-%d", maxDigestPending+19)) {
+		t.Error("newest items should be present")
+	}
+	if !strings.Contains(logBuf.String(), "digest queue exceeded max pending items") {
+		t.Error("expected overflow warning in log")
+	}
+}


### PR DESCRIPTION
## Summary

- **Per-chat rate limiter** (#821): Added `chatDelay` (100ms) to the Telegram notifier that enforces a minimum pause between separate deliveries to the same chat. A user with 3 active searches finding 5 listings each previously could trigger 15+ messages in under 2 seconds. The throttle uses a `sync.Map` to track the last send time per chat ID and sleeps if needed before each `Notify`/`NotifyRaw` call.

- **Digest flush retry** (#837): When `flushAndSendDigest` fails, the scheduler now records a failure marker per chat ID and uses a shorter retry interval (2 minutes instead of the full digest interval) on the next `processDigests` cycle. Additionally, a `maxDigestPending` cap of 100 items prevents unbounded accumulation -- when exceeded, the oldest items are discarded with a warning log.

## Test plan

- [x] `TestThrottleChat_EnforcesMinimumDelay` -- verifies same-chat sends are delayed
- [x] `TestThrottleChat_NoCrossChatDelay` -- verifies different chats are not delayed
- [x] `TestThrottleChat_DisabledWhenZero` -- verifies zero chatDelay skips throttle
- [x] `TestFlushAndSendDigest_SendError_SetsRetryMarker` -- verifies failure marker is set
- [x] `TestFlushAndSendDigest_Success_ClearsRetryMarker` -- verifies marker is cleared on success
- [x] `TestProcessDigests_UsesRetryIntervalAfterFailure` -- verifies shorter retry interval
- [x] `TestProcessDigests_NoRetryWithoutFailureMarker` -- verifies normal interval without marker
- [x] `TestFlushAndSendDigest_CapsOverflowItems` -- verifies cap with overflow log
- [x] All existing tests pass
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` passes (no new issues)

closes #821, closes #837