### PR TITLE
fix: add per-chat send delay and cap digest pending items

### DIFF
--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
@@ -25,8 +26,12 @@ const (
 	telegramListingSeparatorLine = "━━━━━━━━━━━━━━━━━━━━"
 
 	// defaultSendDelay is the minimum pause between consecutive Telegram
-	// API calls to avoid hitting rate limits.
+	// API calls within a single split message to avoid hitting rate limits.
 	defaultSendDelay = 50 * time.Millisecond
+
+	// defaultChatDelay is the minimum pause between separate deliveries
+	// to the same chat to avoid per-chat Telegram rate limiting.
+	defaultChatDelay = 100 * time.Millisecond
 
 	// telegramMaxRetries is the maximum number of extra attempts after a
 	// rate-limited (HTTP 429) sendMessage/sendPhoto failure.
@@ -42,9 +47,11 @@ const (
 )
 
 type Notifier struct {
-	bot       *tgbot.Bot
-	logger    *slog.Logger
-	sendDelay time.Duration
+	bot          *tgbot.Bot
+	logger       *slog.Logger
+	sendDelay    time.Duration
+	chatDelay    time.Duration
+	lastSendTime sync.Map // chatID string -> time.Time
 }
 
 func New(token string, logger *slog.Logger, opts ...tgbot.Option) (*Notifier, error) {
@@ -56,7 +63,7 @@ func New(token string, logger *slog.Logger, opts ...tgbot.Option) (*Notifier, er
 	if err != nil {
 		return nil, fmt.Errorf("create telegram bot: %w", err)
 	}
-	return &Notifier{bot: b, logger: logger, sendDelay: defaultSendDelay}, nil
+	return &Notifier{bot: b, logger: logger, sendDelay: defaultSendDelay, chatDelay: defaultChatDelay}, nil
 }
 
 func (n *Notifier) Bot() *tgbot.Bot {
@@ -72,7 +79,26 @@ func (n *Notifier) Connect(ctx context.Context) error {
 	return nil
 }
 
+// enforcePerChatDelay sleeps if necessary to maintain at least chatDelay
+// between consecutive API calls targeting the same chat, preventing per-chat
+// rate limiting when multiple searches deliver results in quick succession.
+func (n *Notifier) enforcePerChatDelay(chatID string) {
+	if n.chatDelay <= 0 {
+		return
+	}
+	now := time.Now()
+	if v, ok := n.lastSendTime.Load(chatID); ok {
+		if last, ok := v.(time.Time); ok {
+			if elapsed := now.Sub(last); elapsed < n.chatDelay {
+				time.Sleep(n.chatDelay - elapsed)
+			}
+		}
+	}
+	n.lastSendTime.Store(chatID, time.Now())
+}
+
 func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.Listing, lang locale.Lang) error {
+	n.enforcePerChatDelay(chatID)
 	if len(listings) == 1 && listings[0].ImageURL != "" {
 		return n.sendListingWithPhoto(ctx, chatID, listings[0], lang)
 	}
@@ -81,6 +107,7 @@ func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.L
 }
 
 func (n *Notifier) NotifyRaw(ctx context.Context, chatID string, message string) error {
+	n.enforcePerChatDelay(chatID)
 	n.logger.Debug("notifyRaw",
 		"chat_id", chatID,
 		"msg_len", len(message),

--- a/internal/notifier/telegram/telegram_test.go
+++ b/internal/notifier/telegram/telegram_test.go
@@ -68,8 +68,9 @@ func newTestNotifier(t *testing.T, handler http.Handler) *Notifier {
 	if err != nil {
 		t.Fatalf("create notifier: %v", err)
 	}
-	// Disable send delay in tests to avoid sleeping.
+	// Disable delays in tests to avoid sleeping.
 	n.sendDelay = 0
+	n.chatDelay = 0
 	return n
 }
 
@@ -777,5 +778,56 @@ func TestNotifyRaw_AllowsValidMessage(t *testing.T) {
 	}
 	if called.Load() == 0 {
 		t.Error("API should have been called for valid message")
+	}
+}
+
+// --- Per-chat throttle tests ---
+
+func TestEnforcePerChatDelay_SameChatIsThrottled(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(sendMessageOK)
+	}))
+	n.chatDelay = 50 * time.Millisecond
+
+	start := time.Now()
+	_ = n.NotifyRaw(context.Background(), "123", "first valid notification message")
+	_ = n.NotifyRaw(context.Background(), "123", "second valid notification message")
+	elapsed := time.Since(start)
+
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("two sends to same chat took %v, expected >= 50ms", elapsed)
+	}
+}
+
+func TestEnforcePerChatDelay_DifferentChatsNotThrottled(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(sendMessageOK)
+	}))
+	n.chatDelay = 200 * time.Millisecond
+
+	start := time.Now()
+	_ = n.NotifyRaw(context.Background(), "100", "message for chat 100 here")
+	_ = n.NotifyRaw(context.Background(), "200", "message for chat 200 here")
+	elapsed := time.Since(start)
+
+	if elapsed >= 200*time.Millisecond {
+		t.Errorf("different chats should not be throttled, took %v", elapsed)
+	}
+}
+
+func TestEnforcePerChatDelay_DisabledWhenZero(t *testing.T) {
+	n := newTestNotifier(t, routingHandler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(sendMessageOK)
+	}))
+	n.chatDelay = 0
+
+	start := time.Now()
+	for i := 0; i < 5; i++ {
+		_ = n.NotifyRaw(context.Background(), "123", "rapid fire notification message")
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("5 sends with zero chatDelay took %v, expected near-instant", elapsed)
 	}
 }

--- a/internal/scheduler/digest.go
+++ b/internal/scheduler/digest.go
@@ -10,6 +10,12 @@ import (
 	"github.com/dsionov/carwatch/internal/notifier"
 )
 
+// maxPendingDigestItems is the upper bound on buffered digest items per chat.
+// When a flush fails repeatedly the buffer grows without bound; once it exceeds
+// this limit the oldest items are acknowledged (dropped) to prevent unbounded
+// memory/storage growth.
+const maxPendingDigestItems = 100
+
 func (s *Scheduler) processDigests(ctx context.Context) {
 	if s.stores.Digests == nil {
 		return
@@ -63,6 +69,20 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 	}
 	if len(payloads) == 0 {
 		return
+	}
+
+	// Cap accumulated items to prevent unbounded growth after repeated
+	// flush failures. Drop the oldest items and ack them so they are not
+	// retried forever.
+	if len(payloads) > maxPendingDigestItems {
+		overflow := len(payloads) - maxPendingDigestItems
+		s.logger.Warn("digest queue exceeded max pending items, discarding oldest",
+			"chat_id", chatID,
+			"total", len(payloads),
+			"discarding", overflow,
+			"max", maxPendingDigestItems,
+		)
+		payloads = payloads[overflow:]
 	}
 
 	chatIDStr := fmt.Sprintf("%d", chatID)


### PR DESCRIPTION
## Summary

- **Per-chat rate limit protection (#821):** Added a 100ms minimum delay between consecutive Telegram API calls targeting the same chat. This prevents per-chat rate limiting when multiple searches deliver results to a single user in quick succession. The delay is enforced via a `sync.Map` tracking the last send time per chat ID, checked at the entry points (`Notify` and `NotifyRaw`). A new `chatDelay` field allows disabling the delay in tests.

- **Digest pending items cap (#837):** Added a hard cap of 100 pending digest items per chat. When flush failures cause items to accumulate beyond this limit, the oldest items are discarded with a warning log. This prevents unbounded storage/memory growth from repeated delivery failures.

closes #821
closes #837

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New tests verify per-chat throttle enforces delay for same chat
- [x] New tests verify different chats are not cross-throttled
- [x] New tests verify throttle is disabled when chatDelay is zero
- [ ] CI checks pass