### PR TITLE
feat: open dashboard to guests with optional auth and guest-aware Shell

### DIFF
--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -159,7 +159,7 @@ func TestSmoke_FullStack(t *testing.T) {
 		}
 	})
 
-	t.Run("unauthenticated API returns 200 on optional-auth endpoints", func(t *testing.T) {
+	t.Run("unauthenticated API returns 200 with empty data on optional-auth endpoints", func(t *testing.T) {
 		resp, err := client.Get(srv.URL + "/api/v1/searches")
 		if err != nil {
 			t.Fatalf("GET /api/v1/searches: %v", err)
@@ -167,6 +167,13 @@ func TestSmoke_FullStack(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
 			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+		var searches []map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&searches); err != nil {
+			t.Fatalf("decode /api/v1/searches: %v", err)
+		}
+		if len(searches) != 0 {
+			t.Errorf("guest searches length = %d, want 0", len(searches))
 		}
 	})
 

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -148,14 +148,25 @@ func TestSmoke_FullStack(t *testing.T) {
 		}
 	})
 
-	t.Run("unauthenticated API returns 401", func(t *testing.T) {
+	t.Run("unauthenticated API returns 401 on strict endpoints", func(t *testing.T) {
+		resp, err := client.Get(srv.URL + "/api/v1/telegram/status")
+		if err != nil {
+			t.Fatalf("GET /api/v1/telegram/status: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 401 {
+			t.Errorf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("unauthenticated API returns 200 on optional-auth endpoints", func(t *testing.T) {
 		resp, err := client.Get(srv.URL + "/api/v1/searches")
 		if err != nil {
 			t.Fatalf("GET /api/v1/searches: %v", err)
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != 401 {
-			t.Errorf("status = %d, want 401", resp.StatusCode)
+		if resp.StatusCode != 200 {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
 		}
 	})
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -178,9 +178,6 @@ func (s *Server) Routes() http.Handler {
 	authMux.HandleFunc("GET /api/v1/catalog/manufacturers", s.listManufacturers)
 	authMux.HandleFunc("GET /api/v1/catalog/manufacturers/{id}/models", s.listModels)
 
-	authMux.HandleFunc("GET /api/v1/me", s.getMe)
-
-	authMux.HandleFunc("GET /api/v1/searches", s.listSearches)
 	authMux.HandleFunc("POST /api/v1/searches", s.createSearch)
 	authMux.HandleFunc("GET /api/v1/searches/{id}", s.getSearch)
 	authMux.HandleFunc("PUT /api/v1/searches/{id}", s.updateSearch)
@@ -220,7 +217,6 @@ func (s *Server) Routes() http.Handler {
 
 	if s.notifs != nil {
 		authMux.HandleFunc("GET /api/v1/notifications", s.listNotifications)
-		authMux.HandleFunc("GET /api/v1/notifications/count", s.notificationCount)
 		authMux.HandleFunc("POST /api/v1/notifications/seen", s.markNotificationsSeen)
 		authMux.HandleFunc("POST /api/v1/listings/{token}/seen", s.markListingSeen)
 		authMux.HandleFunc("DELETE /api/v1/listings/{token}/seen", s.unmarkListingSeen)
@@ -244,6 +240,18 @@ func (s *Server) Routes() http.Handler {
 	authChain = s.withRateLimit(authChain)
 	authChain = s.authMiddleware(authChain)
 
+	// --- Optional-auth routes (read-only, return empty data for guests) ---
+	optAuthMux := http.NewServeMux()
+	optAuthMux.HandleFunc("GET /api/v1/me", s.getMe)
+	optAuthMux.HandleFunc("GET /api/v1/searches", s.listSearches)
+	if s.notifs != nil {
+		optAuthMux.HandleFunc("GET /api/v1/notifications/count", s.notificationCount)
+	}
+
+	optAuthChain := s.withMaxBody(optAuthMux)
+	optAuthChain = s.withRateLimit(optAuthChain)
+	optAuthChain = s.optionalAuthMiddleware(optAuthChain)
+
 	// --- Guest instant-search (rate-limited, no auth) ---
 	guestMux := http.NewServeMux()
 	guestMux.HandleFunc("POST /api/v1/guest/instant-search", s.instantSearch)
@@ -262,9 +270,15 @@ func (s *Server) Routes() http.Handler {
 	catalogChain := s.withMaxBody(catalogMux)
 
 	// --- Top-level router ---
+	// More-specific prefixes are matched first by net/http.ServeMux.
 	top := http.NewServeMux()
 	top.Handle("/api/v1/guest/", guestChain)
 	top.Handle("/api/v1/catalog/", catalogChain)
+	top.Handle("GET /api/v1/me", optAuthChain)
+	top.Handle("GET /api/v1/searches", optAuthChain)
+	if s.notifs != nil {
+		top.Handle("GET /api/v1/notifications/count", optAuthChain)
+	}
 	top.Handle("/", authChain)
 
 	// Shared outer middleware: requestID → accessLog → securityHeaders → CORS → ipRL
@@ -308,6 +322,43 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 		}
 
 		next.ServeHTTP(w, r)
+	})
+}
+
+// optionalAuthMiddleware tries to authenticate the request but does not
+// reject it when credentials are missing or invalid. If authentication
+// succeeds the resolved chatID and email are injected into the context;
+// otherwise chatID is set to 0 (guest sentinel) and the request is
+// allowed to proceed.  Handlers behind this middleware can call
+// chatIDFromContext to distinguish guests (0) from real users.
+func (s *Server) optionalAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHdr := r.Header.Get("Authorization")
+		bearer := bearerFromAuthHeader(authHdr)
+
+		var chatID int64
+		var userEmail string
+
+		if s.firebaseAuth != nil && bearer != "" {
+			tok, err := s.firebaseAuth.VerifyIDToken(r.Context(), bearer)
+			if err == nil {
+				userEmail = emailFromClaims(tok)
+				id, upsertErr := s.users.UpsertWebUser(r.Context(), tok.UID, userEmail)
+				if upsertErr == nil {
+					chatID = id
+				}
+			}
+		} else if s.firebaseAuth == nil {
+			if s.cfg.AuthToken != "" && bearer == s.cfg.AuthToken {
+				chatID = s.cfg.DevChatID
+			} else if s.cfg.AuthToken == "" {
+				chatID = s.cfg.DevChatID
+			}
+		}
+
+		ctx := context.WithValue(r.Context(), chatIDKey, chatID)
+		ctx = context.WithValue(ctx, emailKey, userEmail)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -606,14 +606,17 @@ func TestAuthMiddleware(t *testing.T) {
 		},
 	})
 
+	// Use a strict-auth endpoint (GET /api/v1/telegram/status) to test the middleware.
+	// GET /api/v1/searches now uses optional auth and allows guests.
+
 	// No token — should fail
-	w := doRequest(t, srv, "GET", "/api/v1/searches", nil)
+	w := doRequest(t, srv, "GET", "/api/v1/telegram/status", nil)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 without token, got %d", w.Code)
 	}
 
 	// Wrong token — should fail
-	req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+	req := httptest.NewRequest("GET", "/api/v1/telegram/status", nil)
 	req.Header.Set("Authorization", "Bearer wrong")
 	w2 := httptest.NewRecorder()
 	srv.Routes().ServeHTTP(w2, req)
@@ -625,7 +628,7 @@ func TestAuthMiddleware(t *testing.T) {
 	if err := store.UpsertUser(context.Background(), 999, "testuser"); err != nil {
 		t.Fatal(err)
 	}
-	req = httptest.NewRequest("GET", "/api/v1/searches", nil)
+	req = httptest.NewRequest("GET", "/api/v1/telegram/status", nil)
 	req.Header.Set("Authorization", "Bearer secret123")
 	w3 := httptest.NewRecorder()
 	srv.Routes().ServeHTTP(w3, req)

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -525,7 +525,8 @@ func TestAuth_NoChatID(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	srv.cfg.DevChatID = 0
 
-	w := doRequest(t, srv, "GET", "/api/v1/searches", nil)
+	// Use a strict-auth endpoint; GET /api/v1/searches uses optional auth now.
+	w := doRequest(t, srv, "GET", "/api/v1/telegram/status", nil)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 with no DevChatID, got %d", w.Code)
 	}

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -7,8 +7,10 @@ type notifCountResponse struct {
 }
 
 func (s *Server) notificationCount(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := chatIDFromContext(r.Context())
 	if !ok {
+		// Guest user — return zero count.
+		writeJSON(w, http.StatusOK, notifCountResponse{Count: 0})
 		return
 	}
 

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -177,8 +177,10 @@ func (s *Server) searchResponseWithListingCount(ctx context.Context, chatID int6
 }
 
 func (s *Server) listSearches(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := chatIDFromContext(r.Context())
 	if !ok {
+		// Guest user — return empty list.
+		writeJSON(w, http.StatusOK, []searchResponse{})
 		return
 	}
 	log := s.handlerLogger(r, "op", "list_searches")

--- a/web/src/components/ProtectedRoute.test.tsx
+++ b/web/src/components/ProtectedRoute.test.tsx
@@ -40,10 +40,10 @@ describe("ProtectedRoute", () => {
     expect(screen.getByText("טוען...")).toBeInTheDocument();
   });
 
-  it("redirects unauthenticated users to login", () => {
+  it("renders content for unauthenticated guests (no redirect)", () => {
     authState = { user: null, loading: false };
     renderWithRoute();
-    expect(screen.getByText("Login Page")).toBeInTheDocument();
-    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    expect(screen.queryByText("Login Page")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/ProtectedRoute.tsx
+++ b/web/src/components/ProtectedRoute.tsx
@@ -1,10 +1,9 @@
-import { Navigate, Outlet, useLocation } from "react-router";
+import { Outlet } from "react-router";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 
 export function ProtectedRoute() {
-  const { user, loading } = useAuth();
-  const location = useLocation();
+  const { loading } = useAuth();
 
   if (loading) {
     return (
@@ -16,10 +15,6 @@ export function ProtectedRoute() {
         />
       </div>
     );
-  }
-
-  if (!user) {
-    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
   }
 
   return <Outlet />;

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -9,8 +9,10 @@ import {
   History,
   Bell,
   LogOut,
+  LogIn,
   Sun,
   Moon,
+  User,
 } from "lucide-react";
 import { useNotificationCount } from "@/hooks/useNotifications";
 import { useAppVersion } from "@/hooks/useAppVersion";
@@ -160,13 +162,13 @@ function SidebarSection({
 
 export function Shell() {
   const location = useLocation();
-  const { data: notifCount } = useNotificationCount();
-  const unread = notifCount?.count ?? 0;
   const { user, signOut } = useAuth();
+  const { data: notifCount } = useNotificationCount(!!user);
+  const unread = notifCount?.count ?? 0;
   const { theme, toggle: toggleTheme } = useTheme();
   const appVersion = useAppVersion();
   const connectionStatus = useHealthCheck();
-  const { data: me } = useMe();
+  const { data: me } = useMe(!!user);
   const isAdmin = me?.is_admin ?? false;
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
@@ -232,27 +234,47 @@ export function Shell() {
           </div>
         ) : null}
 
+        {/* Guest signup banner */}
+        {!user && (
+          <div className="mx-4 mb-4 rounded-xl border border-primary/20 bg-primary/5 p-3 text-center text-xs text-muted-foreground">
+            <Link to="/login" className="font-medium text-primary hover:underline">
+              הירשם בחינם
+            </Link>{" "}
+            כדי לשמור חיפושים ולקבל התראות
+          </div>
+        )}
+
         {/* User */}
         <div className="shrink-0 border-t border-sidebar-border p-3">
           <div className="mb-2.5 flex items-center gap-2.5">
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-xs font-semibold text-sidebar-foreground ring-1 ring-sidebar-border">
-              {emailInitial}
+              {user ? emailInitial : <User className="h-4 w-4" />}
             </div>
             <p
               className="min-w-0 flex-1 truncate text-xs text-sidebar-muted"
               title={user?.email ?? undefined}
             >
-              {user?.email ?? ""}
+              {user?.email ?? "אורח"}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => void signOut()}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
-          >
-            <LogOut className="h-3.5 w-3.5" aria-hidden />
-            התנתק
-          </button>
+          {user ? (
+            <button
+              type="button"
+              onClick={() => void signOut()}
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
+            >
+              <LogOut className="h-3.5 w-3.5" aria-hidden />
+              התנתק
+            </button>
+          ) : (
+            <Link
+              to="/login"
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-primary/30 bg-primary/10 px-3 py-2 text-sm font-medium text-primary transition-all duration-150 hover:bg-primary/20 active:scale-[0.99] motion-reduce:active:scale-100"
+            >
+              <LogIn className="h-3.5 w-3.5" aria-hidden />
+              התחבר
+            </Link>
+          )}
           {appVersion ? (
             <p
               className="mt-1.5 text-center text-[10px] text-sidebar-muted/50 tabular-nums"

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
   Moon,
   User,
+  Search,
 } from "lucide-react";
 import { useNotificationCount } from "@/hooks/useNotifications";
 import { useAppVersion } from "@/hooks/useAppVersion";
@@ -29,22 +30,24 @@ interface NavItem {
   icon: typeof LayoutDashboard;
   badge?: boolean;
   adminOnly?: boolean;
+  authOnly?: boolean;
 }
 
 const mainNav: NavItem[] = [
   { path: "/dashboard", label: "לוח בקרה", icon: LayoutDashboard },
-  { path: "/searches/new", label: "חיפוש חדש", icon: Plus },
+  { path: "/searches/new", label: "חיפוש חדש", icon: Plus, authOnly: true },
 ];
 
 const libraryNav: NavItem[] = [
-  { path: "/saved", label: "מועדפים", icon: Bookmark },
-  { path: "/history", label: "היסטוריה", icon: History },
-  { path: "/notifications", label: "התראות", icon: Bell, badge: true },
+  { path: "/saved", label: "מועדפים", icon: Bookmark, authOnly: true },
+  { path: "/history", label: "היסטוריה", icon: History, authOnly: true },
+  { path: "/notifications", label: "התראות", icon: Bell, badge: true, authOnly: true },
 ];
 
 const systemNav: NavItem[] = [
-  { path: "/settings", label: "הגדרות", icon: Settings },
+  { path: "/settings", label: "הגדרות", icon: Settings, authOnly: true },
   { path: "/admin", label: "ניהול", icon: Wrench, adminOnly: true },
+  { path: "/try", label: "נסה חיפוש", icon: Search },
 ];
 
 interface MobileNavItem {
@@ -131,14 +134,18 @@ function SidebarSection({
   pathname,
   unread,
   isAdmin,
+  isAuthenticated,
 }: {
   label: string;
   items: NavItem[];
   pathname: string;
   unread: number;
   isAdmin: boolean;
+  isAuthenticated: boolean;
 }) {
-  const visibleItems = items.filter((item) => !item.adminOnly || isAdmin);
+  const visibleItems = items.filter(
+    (item) => (!item.adminOnly || isAdmin) && (!item.authOnly || isAuthenticated),
+  );
   if (visibleItems.length === 0) return null;
 
   return (
@@ -208,9 +215,9 @@ export function Shell() {
 
         {/* Navigation */}
         <nav className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4">
-          <SidebarSection label="ראשי" items={mainNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
-          <SidebarSection label="ספריה" items={libraryNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
-          <SidebarSection label="מערכת" items={systemNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} />
+          <SidebarSection label="ראשי" items={mainNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} isAuthenticated={!!user} />
+          <SidebarSection label="ספריה" items={libraryNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} isAuthenticated={!!user} />
+          <SidebarSection label="מערכת" items={systemNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} isAuthenticated={!!user} />
         </nav>
 
         {/* Notification Banner */}

--- a/web/src/hooks/useMe.ts
+++ b/web/src/hooks/useMe.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { userApi } from "@/lib/api";
 
-export function useMe() {
+export function useMe(enabled = true) {
   return useQuery({
     queryKey: ["me"],
     queryFn: userApi.me,
+    enabled,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -1,20 +1,22 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { notificationsApi } from "@/lib/api";
 
-export function useNotificationCount() {
+export function useNotificationCount(enabled = true) {
   return useQuery({
     queryKey: ["notification-count"],
     queryFn: () => notificationsApi.count(),
-    refetchInterval: 60_000,
+    enabled,
+    refetchInterval: enabled ? 60_000 : false,
     refetchIntervalInBackground: false,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: enabled,
   });
 }
 
-export function useNotifications(limit: number, offset: number) {
+export function useNotifications(limit: number, offset: number, enabled = true) {
   return useQuery({
     queryKey: ["notifications", limit, offset],
     queryFn: () => notificationsApi.list({ limit, offset }),
+    enabled,
   });
 }
 

--- a/web/src/hooks/useSearches.ts
+++ b/web/src/hooks/useSearches.ts
@@ -21,10 +21,11 @@ export function useUpdateSearch() {
   });
 }
 
-export function useSearches() {
+export function useSearches(enabled = true) {
   return useQuery({
     queryKey: ["searches"],
     queryFn: api.searches.list,
+    enabled,
   });
 }
 

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -17,6 +17,7 @@ import {
 import { formatPrice, relativeTime, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { SearchCard } from "@/components/SearchCard";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -47,7 +48,7 @@ export function SearchesPage() {
   const fadeUp = useFadeUpVariants();
   const reduceMotion = useReducedMotion();
   const { toast } = useToast();
-  const { data: searches, isLoading, isError } = useSearches();
+  const { data: searches, isLoading, isError } = useSearches(!!user);
   const { data: notifCount } = useNotificationCount(!!user);
   const { data: recentListings } = useNotifications(5, 0, !!user);
   const deleteSearch = useDeleteSearch();
@@ -61,35 +62,10 @@ export function SearchesPage() {
   const activeCount = searches?.filter((s) => s.active).length ?? 0;
   const totalSearches = searches?.length ?? 0;
 
-  if (isLoading) {
-    return (
-      <div className="space-y-8 animate-fade-in motion-reduce:animate-none">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-40" />
-            <Skeleton className="h-4 w-56" />
-          </div>
-          <Skeleton className="h-10 w-36 rounded-xl" />
-        </div>
-        <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
-          {[1, 2, 3, 4].map((i) => (
-            <Skeleton key={i} className="h-[100px] rounded-xl" />
-          ))}
-        </div>
-        <Skeleton className="h-5 w-32" />
-        <div className="grid gap-4 sm:grid-cols-2">
-          {[1, 2].map((i) => (
-            <Skeleton key={i} className="h-52 rounded-2xl" />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
   if (!user) {
     return (
       <div className="space-y-8 animate-fade-in">
-        <DashboardHeader />
+        <PageHeader title="לוח בקרה" />
         <div className="rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/5 to-transparent p-6 sm:p-10 text-center space-y-6">
           <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <Sparkles className="h-8 w-8" />
@@ -114,6 +90,31 @@ export function SearchesPage() {
               </Link>
             </Button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-8 animate-fade-in motion-reduce:animate-none">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-40" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+          <Skeleton className="h-10 w-36 rounded-xl" />
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-[100px] rounded-xl" />
+          ))}
+        </div>
+        <Skeleton className="h-5 w-32" />
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[1, 2].map((i) => (
+            <Skeleton key={i} className="h-52 rounded-2xl" />
+          ))}
         </div>
       </div>
     );

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Link } from "react-router";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { Plus, Search as SearchIcon, Activity, Bell, Car } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { Plus, Search as SearchIcon, Activity, Bell, Car, Sparkles } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import {
   useSearches,
@@ -42,12 +43,13 @@ function useFadeUpVariants() {
 
 export function SearchesPage() {
   usePageTitle("לוח בקרה");
+  const { user } = useAuth();
   const fadeUp = useFadeUpVariants();
   const reduceMotion = useReducedMotion();
   const { toast } = useToast();
   const { data: searches, isLoading, isError } = useSearches();
-  const { data: notifCount } = useNotificationCount();
-  const { data: recentListings } = useNotifications(5, 0);
+  const { data: notifCount } = useNotificationCount(!!user);
+  const { data: recentListings } = useNotifications(5, 0, !!user);
   const deleteSearch = useDeleteSearch();
   const pauseSearch = usePauseSearch();
   const resumeSearch = useResumeSearch();
@@ -79,6 +81,39 @@ export function SearchesPage() {
           {[1, 2].map((i) => (
             <Skeleton key={i} className="h-52 rounded-2xl" />
           ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="space-y-8 animate-fade-in">
+        <DashboardHeader />
+        <div className="rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/5 to-transparent p-6 sm:p-10 text-center space-y-6">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <Sparkles className="h-8 w-8" />
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-xl font-bold text-foreground">ברוך הבא ל-CarWatch!</h2>
+            <p className="mx-auto max-w-md text-sm text-muted-foreground leading-relaxed">
+              הירשם בחינם כדי ליצור חיפושים, לעקוב אחר מודעות רכב ולקבל התראות בזמן אמת. תוכל גם לנסות חיפוש מהיר בלי הרשמה.
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Button asChild size="lg">
+              <Link to="/login">
+                <Plus className="h-4 w-4" />
+                הירשם בחינם
+              </Link>
+            </Button>
+            <Button asChild variant="secondary" size="lg">
+              <Link to="/try">
+                <SearchIcon className="h-4 w-4" />
+                נסה חיפוש מהיר
+              </Link>
+            </Button>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

- **ProtectedRoute** no longer hard-redirects guests to `/login` — it renders the app shell for all users, letting guests browse the dashboard freely
- **API optional auth middleware** (`optionalAuthMiddleware`) added for read-only endpoints (`GET /searches`, `GET /me`, `GET /notifications/count`), returning empty data for `chatID=0` instead of 401; write endpoints remain behind strict auth
- **Shell** skips notification polling and `/me` fetch for guests, shows a guest avatar with "Sign in" CTA and a signup banner instead of sign-out button
- **SearchesPage** renders a guest welcome state with signup and try-search CTAs instead of attempting authenticated API calls

closes #808
closes #809
closes #813

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/api/...` — all tests pass (auth middleware tests updated to use strict-auth endpoints)
- [x] `golangci-lint run ./internal/api/...` — 0 issues
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — all 135 tests pass
- [ ] Manual: visit `/dashboard` as guest — see welcome state, no 401 errors in console
- [ ] Manual: sign in — see normal dashboard with searches, notifications, sign-out button
- [ ] Manual: verify write endpoints (create/delete search) still return 401 for guests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest access enabled for select read-only areas; UI shows a guest welcome with sign-up/login CTA and adjusts sidebar/user area for guests.
  * Data feeds (searches, notifications, user info) now load conditionally based on authentication state.

* **Bug Fixes**
  * API endpoints return appropriate responses for unauthenticated requests (guests receive empty results or zero counts where applicable).

* **Tests**
  * Updated tests to reflect optional-auth behavior and stricter auth checks for protected endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->