### PR TITLE
fix: apply search filters (km, seller type) to notification queries

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1252,9 +1252,21 @@ func setLastSeenAt(t *testing.T, store *sqlite.Store, chatID int64, when time.Ti
 	}
 }
 
+func seedNotifSearch(t *testing.T, store *sqlite.Store, chatID int64) int64 {
+	t.Helper()
+	id, err := store.CreateSearch(context.Background(), storage.Search{
+		ChatID: chatID, Name: "notif-test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("seed notif search: %v", err)
+	}
+	return id
+}
+
 func TestNotificationCount(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
+	searchID := seedNotifSearch(t, store, 999)
 
 	// Set last_seen_at to now so no listings are new
 	if err := store.UpdateLastSeenAt(ctx, 999); err != nil {
@@ -1274,7 +1286,7 @@ func TestNotificationCount(t *testing.T) {
 	}
 
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "notif-1", ChatID: 999, SearchName: "s1",
+		Token: "notif-1", ChatID: 999, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: time.Now().UTC(),
 	}); err != nil {
@@ -1291,11 +1303,12 @@ func TestNotificationCount(t *testing.T) {
 func TestNotificationsList(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
+	searchID := seedNotifSearch(t, store, 999)
 
 	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "notif-list-1", ChatID: 999, SearchName: "s1",
+		Token: "notif-list-1", ChatID: 999, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: time.Now().UTC(),
 	}); err != nil {
@@ -1319,11 +1332,12 @@ func TestNotificationsList(t *testing.T) {
 func TestNotificationsMarkSeen(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
+	searchID := seedNotifSearch(t, store, 999)
 
 	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "notif-seen-1", ChatID: 999, SearchName: "s1",
+		Token: "notif-seen-1", ChatID: 999, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: time.Now().UTC(),
 	}); err != nil {
@@ -1419,11 +1433,12 @@ func TestHideListing_LimitEnforced(t *testing.T) {
 func TestMarkListingUserSeen(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
+	searchID := seedNotifSearch(t, store, 999)
 
 	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "seen-token-1", ChatID: 999, SearchName: "s1",
+		Token: "seen-token-1", ChatID: 999, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: time.Now().UTC(),
 	}); err != nil {

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -465,11 +465,18 @@ func TestNotificationsList_Pagination(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
 
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 999, Name: "notif-test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	setLastSeenAt(t, store, 999, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	for i := range 5 {
 		if err := store.SaveListing(ctx, storage.ListingRecord{
-			Token: fmt.Sprintf("notif-pg-%d", i), ChatID: 999, SearchName: "s1",
+			Token: fmt.Sprintf("notif-pg-%d", i), ChatID: 999, SearchID: searchID, SearchName: "s1",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000 + i*1000,
 			FirstSeenAt: time.Now().UTC(),
 		}); err != nil {

--- a/internal/storage/postgres/notifications_center.go
+++ b/internal/storage/postgres/notifications_center.go
@@ -19,8 +19,8 @@ const notifFilterSQL = `
 	AND (s.year_min = 0 OR lh.year >= s.year_min)
 	AND (s.year_max = 0 OR lh.year <= s.year_max)
 	AND (s.seller_filter = '' OR s.seller_filter = 'any'
-		OR (s.seller_filter = 'private' AND lh.is_commercial = false)
-		OR (s.seller_filter = 'commercial' AND lh.is_commercial = true))`
+		OR (s.seller_filter = 'private' AND lh.is_commercial = 0)
+		OR (s.seller_filter = 'commercial' AND lh.is_commercial = 1))`
 
 func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/internal/storage/postgres/notifications_center.go
+++ b/internal/storage/postgres/notifications_center.go
@@ -8,18 +8,33 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
+// notifFilterSQL applies each listing's parent search criteria so that
+// notifications respect the user's current search settings (MaxKm,
+// seller_filter, etc.) even if they were changed after the listing was saved.
+const notifFilterSQL = `
+	AND (s.max_km = 0 OR lh.km <= s.max_km OR lh.km = 0)
+	AND (s.max_hand = 0 OR lh.hand <= s.max_hand)
+	AND (s.price_min = 0 OR lh.price >= s.price_min OR lh.price = 0)
+	AND (s.price_max = 0 OR lh.price <= s.price_max)
+	AND (s.year_min = 0 OR lh.year >= s.year_min)
+	AND (s.year_max = 0 OR lh.year <= s.year_max)
+	AND (s.seller_filter = '' OR s.seller_filter = 'any'
+		OR (s.seller_filter = 'private' AND lh.is_commercial = false)
+		OR (s.seller_filter = 'commercial' AND lh.is_commercial = true))`
+
 func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
-			km, hand, city, page_link, image_url,
-			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
+			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
+			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
 		FROM listing_history lh
+		JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 		WHERE lh.chat_id = $1 AND lh.first_seen_at > $2
 		AND NOT EXISTS (
 			SELECT 1 FROM listing_user_seen u
 			WHERE u.chat_id = lh.chat_id AND u.token = lh.token
-		)
+		)`+notifFilterSQL+`
 		ORDER BY lh.first_seen_at DESC, lh.token DESC
 		LIMIT $3 OFFSET $4`,
 		chatID, since, limit, offset)
@@ -46,11 +61,12 @@ func (s *Store) CountNewListingsSince(ctx context.Context, chatID int64, since t
 	var count int64
 	err := s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM listing_history lh
+		JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 		WHERE lh.chat_id = $1 AND lh.first_seen_at > $2
 		AND NOT EXISTS (
 			SELECT 1 FROM listing_user_seen u
 			WHERE u.chat_id = lh.chat_id AND u.token = lh.token
-		)`,
+		)`+notifFilterSQL,
 		chatID, since).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("count new listings since: %w", err)

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -1266,16 +1266,23 @@ func TestPostgres_NotificationCenter(t *testing.T) {
 	ctx := context.Background()
 	seedPgUser(t, store, 100)
 
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "notif-test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
 	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Now().UTC()
 
 	_ = store.SaveListing(ctx, storage.ListingRecord{
-		Token: "new-1", ChatID: 100, SearchName: "s1",
+		Token: "new-1", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: now,
 	})
 	_ = store.SaveListing(ctx, storage.ListingRecord{
-		Token: "new-2", ChatID: 100, SearchName: "s1",
+		Token: "new-2", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
 		FirstSeenAt: now,
 	})

--- a/internal/storage/sqlite/coverage_test.go
+++ b/internal/storage/sqlite/coverage_test.go
@@ -578,11 +578,12 @@ func TestNewListingsSince_Offset(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	seedUser(t, store, 100)
+	searchID := seedSearchForNotif(t, store, 100)
 
 	since := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	for i := range 5 {
 		if err := store.SaveListing(ctx, storage.ListingRecord{
-			Token: "nls-" + string(rune('a'+i)), ChatID: 100, SearchName: "s1",
+			Token: "nls-" + string(rune('a'+i)), ChatID: 100, SearchID: searchID, SearchName: "s1",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 			FirstSeenAt: time.Now().UTC(),
 		}); err != nil {

--- a/internal/storage/sqlite/notifications_center.go
+++ b/internal/storage/sqlite/notifications_center.go
@@ -8,18 +8,33 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
+// notifFilterSQL applies each listing's parent search criteria so that
+// notifications respect the user's current search settings (MaxKm,
+// seller_filter, etc.) even if they were changed after the listing was saved.
+const notifFilterSQL = `
+	AND (s.max_km = 0 OR lh.km <= s.max_km OR lh.km = 0)
+	AND (s.max_hand = 0 OR lh.hand <= s.max_hand)
+	AND (s.price_min = 0 OR lh.price >= s.price_min OR lh.price = 0)
+	AND (s.price_max = 0 OR lh.price <= s.price_max)
+	AND (s.year_min = 0 OR lh.year >= s.year_min)
+	AND (s.year_max = 0 OR lh.year <= s.year_max)
+	AND (s.seller_filter = '' OR s.seller_filter = 'any'
+		OR (s.seller_filter = 'private' AND lh.is_commercial = 0)
+		OR (s.seller_filter = 'commercial' AND lh.is_commercial = 1))`
+
 func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.Time, limit, offset int) ([]storage.ListingRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
-			km, hand, city, page_link, image_url,
-			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
+			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
+			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
 		FROM listing_history lh
+		JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 		WHERE lh.chat_id = ? AND lh.first_seen_at > ?
 		AND NOT EXISTS (
 			SELECT 1 FROM listing_user_seen u
 			WHERE u.chat_id = lh.chat_id AND u.token = lh.token
-		)
+		)`+notifFilterSQL+`
 		ORDER BY lh.first_seen_at DESC, lh.token DESC
 		LIMIT ? OFFSET ?`, chatID, since, limit, offset)
 	if err != nil {
@@ -42,11 +57,12 @@ func (s *Store) CountNewListingsSince(ctx context.Context, chatID int64, since t
 	var count int64
 	err := s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM listing_history lh
+		JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 		WHERE lh.chat_id = ? AND lh.first_seen_at > ?
 		AND NOT EXISTS (
 			SELECT 1 FROM listing_user_seen u
 			WHERE u.chat_id = lh.chat_id AND u.token = lh.token
-		)`,
+		)`+notifFilterSQL,
 		chatID, since).Scan(&count)
 	return count, err
 }

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2686,24 +2686,35 @@ func TestNew_CreatesDirectory(t *testing.T) {
 
 // --- Notification Center Tests ---
 
+func seedSearchForNotif(t *testing.T, store *Store, chatID int64) int64 {
+	t.Helper()
+	id, err := store.CreateSearch(context.Background(), storage.Search{
+		ChatID: chatID, Name: "notif-test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("seed search: %v", err)
+	}
+	return id
+}
+
 func TestNewListingsSince(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	seedUser(t, store, 100)
+	searchID := seedSearchForNotif(t, store, 100)
 
-	// Use a cutoff well in the past so all inserts are after it
 	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	now := time.Now().UTC()
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "new-1", ChatID: 100, SearchName: "s1",
+		Token: "new-1", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: now,
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "new-2", ChatID: 100, SearchName: "s1",
+		Token: "new-2", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
 		FirstSeenAt: now,
 	}); err != nil {
@@ -2748,11 +2759,12 @@ func TestCountNewListingsSince(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	seedUser(t, store, 100)
+	searchID := seedSearchForNotif(t, store, 100)
 
 	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "cnt-1", ChatID: 100, SearchName: "s1",
+		Token: "cnt-1", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: time.Now().UTC(),
 	}); err != nil {
@@ -2780,11 +2792,12 @@ func TestNewListingsSince_RespectsListingUserSeen(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	seedUser(t, store, 100)
+	searchID := seedSearchForNotif(t, store, 100)
 
 	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	if err := store.SaveListing(ctx, storage.ListingRecord{
-		Token: "lus-1", ChatID: 100, SearchName: "s1",
+		Token: "lus-1", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: time.Now().UTC(),
 	}); err != nil {
@@ -2808,6 +2821,76 @@ func TestNewListingsSince_RespectsListingUserSeen(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("expected count 0, got %d", count)
+	}
+}
+
+func TestNewListingsSince_FiltersKmAndSellerType(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "filtered-search", Manufacturer: 1, Model: 1,
+		MaxKm: 100000, SellerFilter: "private",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+
+	commercial := true
+	private := false
+
+	for _, rec := range []storage.ListingRecord{
+		{Token: "ok-1", ChatID: 100, SearchID: searchID, SearchName: "filtered-search",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+			Km: 80000, IsCommercial: &private, FirstSeenAt: now},
+		{Token: "km-over", ChatID: 100, SearchID: searchID, SearchName: "filtered-search",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+			Km: 150000, IsCommercial: &private, FirstSeenAt: now},
+		{Token: "commercial", ChatID: 100, SearchID: searchID, SearchName: "filtered-search",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+			Km: 50000, IsCommercial: &commercial, FirstSeenAt: now},
+		{Token: "km-zero", ChatID: 100, SearchID: searchID, SearchName: "filtered-search",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+			Km: 0, IsCommercial: &private, FirstSeenAt: now},
+	} {
+		if err := store.SaveListing(ctx, rec); err != nil {
+			t.Fatalf("save %s: %v", rec.Token, err)
+		}
+	}
+
+	listings, err := store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if err != nil {
+		t.Fatalf("NewListingsSince: %v", err)
+	}
+
+	tokens := make(map[string]bool)
+	for _, l := range listings {
+		tokens[l.Token] = true
+	}
+
+	if !tokens["ok-1"] {
+		t.Error("expected ok-1 (km within range, private) to be present")
+	}
+	if !tokens["km-zero"] {
+		t.Error("expected km-zero (unknown km, private) to be present")
+	}
+	if tokens["km-over"] {
+		t.Error("expected km-over (km exceeds max) to be filtered out")
+	}
+	if tokens["commercial"] {
+		t.Error("expected commercial (seller type mismatch) to be filtered out")
+	}
+
+	count, err := store.CountNewListingsSince(ctx, 100, cutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("count: expected 2, got %d", count)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Notification queries (`NewListingsSince`, `CountNewListingsSince`) were returning **all** listings for a user since their last-seen timestamp, ignoring per-search filter criteria
- This caused the dashboard notifications page to show:
  - Listings with **km exceeding** the configured `max_km`
  - Listings from **commercial sellers** when the search was set to private-only
- Fix: JOIN `listing_history` with the `searches` table and enforce the search's current `max_km`, `max_hand`, price range, year range, and `seller_filter` in both SQLite and Postgres implementations

## Test plan

- [x] New test `TestNewListingsSince_FiltersKmAndSellerType` verifies km-over and commercial listings are excluded
- [x] Existing notification tests updated to use proper search associations (required by the new JOIN)
- [x] Full test suite passes (`make test`)
- [x] `go vet` clean

closes #849

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Notifications now properly respect your saved search filter settings (distance, price range, year range, and seller preferences) when displaying new listings.

* **Tests**
  * Added verification tests to ensure notification filtering works correctly with various search criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->