### PR TITLE
test: maximize backend and frontend test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ config.yaml
 coverage.out
 .idea/
 .coverage/
+web/coverage/
 web/node_modules/
 web/dist/
 

--- a/internal/api/phase2_coverage_test.go
+++ b/internal/api/phase2_coverage_test.go
@@ -89,7 +89,10 @@ func TestAdminLogLevel_GetAndSet(t *testing.T) {
 		t.Fatalf("PUT INVALID: expected 400, got %d", w.Code)
 	}
 
-	doRequest(t, srv, "PUT", "/api/v1/admin/logs/level", map[string]string{"level": "INFO"})
+	w = doRequest(t, srv, "PUT", "/api/v1/admin/logs/level", map[string]string{"level": "INFO"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT INFO reset: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
 }
 
 // --- adminListPriceHistory ---
@@ -120,9 +123,12 @@ func TestAdminListSeenListings(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
 
-	searchID, _ := store.CreateSearch(ctx, storage.Search{
+	searchID, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 999, Name: "seen-admin", Manufacturer: 1, Model: 1,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.ClaimNew(ctx, "admin-seen-tok", 999, searchID); err != nil {
 		t.Fatal(err)
 	}
@@ -155,12 +161,15 @@ func TestListingFilterFromSearch(t *testing.T) {
 	srv, store := setupTestServer(t)
 	ctx := context.Background()
 
-	searchID, _ := store.CreateSearch(ctx, storage.Search{
+	searchID, err := store.CreateSearch(ctx, storage.Search{
 		ChatID: 999, Name: "filter-test", Manufacturer: 19, Model: 10226,
 		YearMin: 2018, YearMax: 2024, PriceMax: 200000, MaxKm: 100000,
 		MaxHand: 3, SellerFilter: "private", GearBox: "automatic",
 		PriceOnly: true, PhotoOnly: true,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, rec := range []storage.ListingRecord{
 		{Token: "pass-1", ChatID: 999, SearchID: searchID, SearchName: "filter-test",

--- a/internal/api/phase2_coverage_test.go
+++ b/internal/api/phase2_coverage_test.go
@@ -1,0 +1,435 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// --- getMe ---
+
+func TestGetMe(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	w := doRequest(t, srv, "GET", "/api/v1/me", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp["is_admin"] != true {
+		t.Errorf("dev user 999 should be admin, got %v", resp)
+	}
+}
+
+// --- adminSetUserActive ---
+
+func TestAdminSetUserActive(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+	if err := store.UpsertUser(ctx, 200, "bob"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "PATCH", "/api/v1/admin/users/200", map[string]bool{"active": false})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	u, err := store.GetUser(ctx, 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u == nil || u.Active {
+		t.Error("user should be inactive after PATCH")
+	}
+}
+
+func TestAdminSetUserActive_BadID(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	w := doRequest(t, srv, "PATCH", "/api/v1/admin/users/abc", map[string]bool{"active": true})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- adminGetLogLevel / adminSetLogLevel ---
+
+func TestAdminLogLevel_GetAndSet(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	lvl := &slog.LevelVar{}
+	lvl.Set(slog.LevelInfo)
+	srv.logLevel = lvl
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/logs/level", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET: expected 200, got %d", w.Code)
+	}
+	var resp map[string]string
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp["level"] == "" {
+		t.Error("expected a level string")
+	}
+
+	w = doRequest(t, srv, "PUT", "/api/v1/admin/logs/level", map[string]string{"level": "WARN"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT WARN: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = doRequest(t, srv, "PUT", "/api/v1/admin/logs/level", map[string]string{"level": "INVALID"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("PUT INVALID: expected 400, got %d", w.Code)
+	}
+
+	doRequest(t, srv, "PUT", "/api/v1/admin/logs/level", map[string]string{"level": "INFO"})
+}
+
+// --- adminListPriceHistory ---
+
+func TestAdminListPriceHistory(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	db := store.DB()
+	if _, err := db.ExecContext(ctx, "INSERT INTO price_history (token, price) VALUES ('ph-1', 100000)"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/price-history", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp["total"].(float64) < 1 {
+		t.Error("expected at least 1 price record")
+	}
+}
+
+// --- adminListSeenListings ---
+
+func TestAdminListSeenListings(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 999, Name: "seen-admin", Manufacturer: 1, Model: 1,
+	})
+	if _, err := store.ClaimNew(ctx, "admin-seen-tok", 999, searchID); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/admin/seen-listings", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- adminActivity ---
+
+func TestAdminActivity(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	w := doRequest(t, srv, "GET", "/api/v1/admin/activity?days=7", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	items, ok := resp["items"].([]any)
+	if !ok || len(items) < 7 {
+		t.Errorf("expected at least 7 activity days, got %d", len(items))
+	}
+}
+
+// --- listingFilterFromSearch (all combos) ---
+
+func TestListingFilterFromSearch(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 999, Name: "filter-test", Manufacturer: 19, Model: 10226,
+		YearMin: 2018, YearMax: 2024, PriceMax: 200000, MaxKm: 100000,
+		MaxHand: 3, SellerFilter: "private", GearBox: "automatic",
+		PriceOnly: true, PhotoOnly: true,
+	})
+
+	for _, rec := range []storage.ListingRecord{
+		{Token: "pass-1", ChatID: 999, SearchID: searchID, SearchName: "filter-test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 150000,
+			Km: 80000, Hand: 2, GearBox: "automatic", ImageURL: "https://img.com/1.jpg",
+			IsCommercial: ptrBool(false), FirstSeenAt: time.Now().UTC()},
+		{Token: "fail-km", ChatID: 999, SearchID: searchID, SearchName: "filter-test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 150000,
+			Km: 200000, Hand: 2, GearBox: "automatic", ImageURL: "https://img.com/2.jpg",
+			IsCommercial: ptrBool(false), FirstSeenAt: time.Now().UTC()},
+		{Token: "fail-hand", ChatID: 999, SearchID: searchID, SearchName: "filter-test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 150000,
+			Km: 50000, Hand: 5, GearBox: "automatic", ImageURL: "https://img.com/3.jpg",
+			IsCommercial: ptrBool(false), FirstSeenAt: time.Now().UTC()},
+		{Token: "fail-seller", ChatID: 999, SearchID: searchID, SearchName: "filter-test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 150000,
+			Km: 50000, Hand: 2, GearBox: "automatic", ImageURL: "https://img.com/4.jpg",
+			IsCommercial: ptrBool(true), FirstSeenAt: time.Now().UTC()},
+		{Token: "fail-price", ChatID: 999, SearchID: searchID, SearchName: "filter-test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 0,
+			Km: 50000, Hand: 2, GearBox: "automatic", ImageURL: "https://img.com/5.jpg",
+			IsCommercial: ptrBool(false), FirstSeenAt: time.Now().UTC()},
+		{Token: "fail-photo", ChatID: 999, SearchID: searchID, SearchName: "filter-test",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 150000,
+			Km: 50000, Hand: 2, GearBox: "automatic", ImageURL: "",
+			IsCommercial: ptrBool(false), FirstSeenAt: time.Now().UTC()},
+	} {
+		if err := store.SaveListing(ctx, rec); err != nil {
+			t.Fatalf("save %s: %v", rec.Token, err)
+		}
+	}
+
+	w := doRequest(t, srv, "GET", fmt.Sprintf("/api/v1/searches/%d/listings", searchID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+
+	tokens := make(map[string]bool)
+	for _, item := range resp.Items {
+		tokens[item.Token] = true
+	}
+	if !tokens["pass-1"] {
+		t.Error("pass-1 should appear")
+	}
+	for _, bad := range []string{"fail-km", "fail-hand", "fail-seller", "fail-price", "fail-photo"} {
+		if tokens[bad] {
+			t.Errorf("%s should be filtered out", bad)
+		}
+	}
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+// --- bookmarks: save, unsave, list, hide, unhide ---
+
+func TestBookmarks_SaveUnsaveList(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "bm-tok", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "POST", "/api/v1/listings/bm-tok/save", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("save: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = doRequest(t, srv, "GET", "/api/v1/saved", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list saved: expected 200, got %d", w.Code)
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total != 1 {
+		t.Errorf("expected 1 saved, got %d", resp.Total)
+	}
+
+	w = doRequest(t, srv, "DELETE", "/api/v1/listings/bm-tok/save", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("unsave: expected 204, got %d", w.Code)
+	}
+}
+
+func TestBookmarks_UnsaveMissingToken(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	w := doRequest(t, srv, "DELETE", "/api/v1/listings/nonexistent-tok/save", nil)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("unsave nonexistent should be 204, got %d", w.Code)
+	}
+}
+
+func TestHideListing_HideAndUnhide(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "hide-tok", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "POST", "/api/v1/listings/hide-tok/hide", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("hide: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = doRequest(t, srv, "DELETE", "/api/v1/listings/hide-tok/hide", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("unhide: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- listHistory ---
+
+func TestListHistory_ReturnsRecords(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "hist-tok", ChatID: 999, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/v1/history", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp listingsPageResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Total < 1 {
+		t.Error("expected at least 1 history item")
+	}
+}
+
+// --- createSearch / updateSearch / deleteSearch ---
+
+func TestSearchCRUD_FullLifecycle(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Source: "yad2", Manufacturer: 19, Model: 10226,
+		YearMin: 2018, YearMax: 2024, PriceMax: 200000,
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created searchResponse
+	mustUnmarshal(t, w.Body.Bytes(), &created)
+
+	w = doRequest(t, srv, "PUT", fmt.Sprintf("/api/v1/searches/%d", created.ID), map[string]any{
+		"year_min": 2020, "year_max": 2025, "price_max": 250000,
+		"manufacturer": 19, "model": 10226, "source": "yad2",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = doRequest(t, srv, "GET", "/api/v1/searches", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var list []json.RawMessage
+	mustUnmarshal(t, w.Body.Bytes(), &list)
+	if len(list) < 1 {
+		t.Error("expected at least 1 search")
+	}
+
+	w = doRequest(t, srv, "DELETE", fmt.Sprintf("/api/v1/searches/%d", created.ID), nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateSearch_InvalidYears(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
+		Manufacturer: 19, Model: 10226, YearMin: 2025, YearMax: 2020,
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid year range, got %d", w.Code)
+	}
+}
+
+// --- notificationCount for user with no notifications ---
+
+func TestNotificationCount_NoNotifications(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	w := doRequest(t, srv, "GET", "/api/v1/notifications/count", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp notifCountResponse
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp.Count != 0 {
+		t.Errorf("user with no notifs should get 0, got %d", resp.Count)
+	}
+}
+
+// --- markNotificationsSeen ---
+
+func TestMarkNotificationsSeen(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	searchID := seedNotifSearch(t, store, 999)
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "seen-notif-1", ChatID: 999, SearchID: searchID, SearchName: "notif-s",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(t, srv, "POST", "/api/v1/notifications/seen", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- admin: requireAdmin rejects non-admin ---
+
+func TestRequireAdmin_RejectsNonAdmin(t *testing.T) {
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+	if err := store.UpsertUser(ctx, 888, "nonadmin"); err != nil {
+		t.Fatal(err)
+	}
+
+	otherSrv := New(Config{
+		Catalog: srv.catalog, Searches: srv.searches, Listings: srv.listings,
+		Users: srv.users, Prices: srv.prices, Admin: srv.admin,
+		Saved: srv.saved, Hidden: srv.hidden, Notifs: srv.notifs,
+		Logger: srv.logger,
+		API: config.APIConfig{
+			CORSOrigins: []string{"http://localhost:5173"},
+			DevChatID:   888,
+			AdminChatID: 999,
+		},
+	})
+
+	w := doRequest(t, otherSrv, "GET", "/api/v1/admin/stats", nil)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("non-admin should get 403, got %d", w.Code)
+	}
+}
+
+// --- writeJSON error path ---
+
+func TestWriteJSON_SuccessPath(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusOK, map[string]string{"hello": "world"})
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]string
+	mustUnmarshal(t, w.Body.Bytes(), &resp)
+	if resp["hello"] != "world" {
+		t.Errorf("expected world, got %s", resp["hello"])
+	}
+}

--- a/internal/bot/phase4_coverage_test.go
+++ b/internal/bot/phase4_coverage_test.go
@@ -102,6 +102,9 @@ func TestHandlePriceMin_ExceedsMax(t *testing.T) {
 	if last.ChatID != 100 {
 		t.Errorf("expected error message, got %d", last.ChatID)
 	}
+	if last.HasKB {
+		t.Error("exceeds-max error should NOT produce a keyboard")
+	}
 }
 
 func TestRegisterHandlers_NilBot(t *testing.T) {

--- a/internal/bot/phase4_coverage_test.go
+++ b/internal/bot/phase4_coverage_test.go
@@ -1,0 +1,111 @@
+package bot
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIsLowerHex(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"abc123", true},
+		{"0123456789abcdef", true},
+		{"", true},
+		{"ABC", false},
+		{"xyz", false},
+		{"0x123", false},
+		{"12 34", false},
+	}
+	for _, tt := range tests {
+		if got := isLowerHex(tt.input); got != tt.want {
+			t.Errorf("isLowerHex(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func setupWizardAtPriceMin(t *testing.T, tb *testBot, chatID int64, priceMax int) {
+	t.Helper()
+	ctx := context.Background()
+	tb.createUser(ctx, t, chatID, "alice")
+	tb.simulateCommand(ctx, chatID, "/watch")
+	wd := tb.bot.loadWizardData(ctx, chatID)
+	wd.PriceMax = priceMax
+	tb.bot.saveWizardState(ctx, chatID, StateAskPriceMin, wd)
+	tb.msg.reset()
+}
+
+func TestHandlePriceMin_ValidInput(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	setupWizardAtPriceMin(t, tb, 100, 200000)
+
+	tb.bot.handlePriceMin(ctx, 100, "50000")
+
+	last := tb.msg.last()
+	if last.ChatID != 100 {
+		t.Errorf("expected message to chat 100, got %d", last.ChatID)
+	}
+	if !last.HasKB {
+		t.Error("expected gearbox keyboard after valid price min")
+	}
+}
+
+func TestHandlePriceMin_Skip(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	setupWizardAtPriceMin(t, tb, 100, 200000)
+
+	tb.bot.handlePriceMin(ctx, 100, "0")
+
+	last := tb.msg.last()
+	if last.ChatID != 100 {
+		t.Errorf("expected message to chat 100, got %d", last.ChatID)
+	}
+	if !last.HasKB {
+		t.Error("expected gearbox keyboard after skip")
+	}
+}
+
+func TestHandlePriceMin_InvalidInput(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	setupWizardAtPriceMin(t, tb, 100, 200000)
+
+	tb.bot.handlePriceMin(ctx, 100, "not-a-number")
+
+	last := tb.msg.last()
+	if last.ChatID != 100 {
+		t.Errorf("expected error message to chat 100, got %d", last.ChatID)
+	}
+	if last.HasKB {
+		t.Error("invalid input should NOT produce a keyboard")
+	}
+}
+
+func TestHandlePriceMin_ExceedsMax(t *testing.T) {
+	tb := newTestBot(t)
+	ctx := context.Background()
+	tb.createUser(ctx, t, 100, "alice")
+
+	tb.simulateCommand(ctx, 100, "/watch")
+
+	wd := tb.bot.loadWizardData(ctx, 100)
+	wd.PriceMax = 100000
+	tb.bot.saveWizardState(ctx, 100, StateAskPriceMin, wd)
+	tb.msg.reset()
+
+	tb.bot.handlePriceMin(ctx, 100, "200000")
+
+	last := tb.msg.last()
+	if last.ChatID != 100 {
+		t.Errorf("expected error message, got %d", last.ChatID)
+	}
+}
+
+func TestRegisterHandlers_NilBot(t *testing.T) {
+	tb := newTestBot(t)
+	tb.bot.bot = nil
+	tb.bot.RegisterHandlers()
+}

--- a/internal/fetcher/phase4_coverage_test.go
+++ b/internal/fetcher/phase4_coverage_test.go
@@ -1,0 +1,24 @@
+package fetcher
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestWithCBLogger(t *testing.T) {
+	inner := &mockFetcherCB{}
+	l := slog.Default()
+	cb := NewCircuitBreaker(inner, 3, 5*time.Second, WithCBLogger(l))
+	if cb.logger != l {
+		t.Error("expected custom logger to be set")
+	}
+}
+
+func TestWithCBLogger_Nil(t *testing.T) {
+	inner := &mockFetcherCB{}
+	cb := NewCircuitBreaker(inner, 3, 5*time.Second, WithCBLogger(nil))
+	if cb.logger == nil {
+		t.Error("nil logger should not replace default")
+	}
+}

--- a/internal/health/phase4_coverage_test.go
+++ b/internal/health/phase4_coverage_test.go
@@ -1,0 +1,45 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMarkBotPollingAlive(t *testing.T) {
+	s := New()
+	s.RecordSuccess()
+	s.MarkBotPollingAlive()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.Handler()(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["bot_polling"] != true {
+		t.Errorf("bot_polling = %v, want true", resp["bot_polling"])
+	}
+}
+
+func TestMarkBotPollingDead(t *testing.T) {
+	s := New()
+	s.RecordSuccess()
+	s.MarkBotPollingAlive()
+	s.MarkBotPollingDead()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	s.Handler()(w, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["bot_polling"] != false {
+		t.Errorf("bot_polling = %v, want false", resp["bot_polling"])
+	}
+}

--- a/internal/notifier/phase3_baseprice_test.go
+++ b/internal/notifier/phase3_baseprice_test.go
@@ -1,0 +1,48 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/locale"
+)
+
+func TestBasePriceLine_BelowBase(t *testing.T) {
+	line := basePriceLine(locale.Hebrew, 100000, 80000)
+	if line == "" {
+		t.Fatal("expected non-empty line for price well below base")
+	}
+	if !strings.Contains(line, "20") {
+		t.Errorf("expected ~20%% below mention, got: %s", line)
+	}
+}
+
+func TestBasePriceLine_NearBase(t *testing.T) {
+	line := basePriceLine(locale.Hebrew, 100000, 98000)
+	if line == "" {
+		t.Fatal("expected non-empty line for price near base")
+	}
+	if !strings.Contains(line, "100,000") {
+		t.Errorf("near-base line should mention the base price, got: %s", line)
+	}
+}
+
+func TestBasePriceLine_AboveBase(t *testing.T) {
+	line := basePriceLine(locale.Hebrew, 100000, 120000)
+	if line == "" {
+		t.Fatal("expected non-empty line for price well above base")
+	}
+	if !strings.Contains(line, "20") {
+		t.Errorf("expected ~20%% above mention, got: %s", line)
+	}
+}
+
+func TestBasePriceLine_English(t *testing.T) {
+	below := basePriceLine(locale.English, 100000, 80000)
+	near := basePriceLine(locale.English, 100000, 100000)
+	above := basePriceLine(locale.English, 100000, 120000)
+
+	if below == "" || near == "" || above == "" {
+		t.Error("expected non-empty lines for all English cases")
+	}
+}

--- a/internal/scheduler/phase3_coverage_test.go
+++ b/internal/scheduler/phase3_coverage_test.go
@@ -1,0 +1,141 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/storage/sqlite"
+)
+
+func TestPrefillFromDB(t *testing.T) {
+	store, err := sqlite.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	if err := store.UpsertUser(ctx, 100, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "tok-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		Km: 50000, City: "Tel Aviv", ImageURL: "https://img.com/1.jpg",
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfig()
+	s, err := NewWithOptions(cfg, &mockFetcher{}, store, &mockNotifier{}, testLogger(), Options{
+		ListingStore: store,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listings := []model.RawListing{
+		{Token: "tok-1", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000, Km: 0, City: "", ImageURL: ""},
+		{Token: "tok-2", Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000, Km: 30000, City: "Haifa", ImageURL: "https://img.com/2.jpg"},
+	}
+
+	s.prefillFromDB(ctx, listings)
+
+	if listings[0].Km != 50000 {
+		t.Errorf("tok-1 Km = %d, want 50000", listings[0].Km)
+	}
+	if listings[0].City != "Tel Aviv" {
+		t.Errorf("tok-1 City = %q, want Tel Aviv", listings[0].City)
+	}
+	if listings[0].ImageURL != "https://img.com/1.jpg" {
+		t.Errorf("tok-1 ImageURL = %q, want https://img.com/1.jpg", listings[0].ImageURL)
+	}
+	if listings[1].Km != 30000 {
+		t.Errorf("tok-2 Km should remain 30000, got %d", listings[1].Km)
+	}
+}
+
+func TestPrefillFromDB_AllFieldsPresent(t *testing.T) {
+	cfg := testConfig()
+	s, err := NewWithOptions(cfg, &mockFetcher{}, newMockDedup(), &mockNotifier{}, testLogger(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listings := []model.RawListing{
+		{Token: "tok", Km: 1000, City: "Haifa", ImageURL: "https://img.com/x.jpg"},
+	}
+	s.prefillFromDB(context.Background(), listings)
+
+	if listings[0].Km != 1000 {
+		t.Error("should not overwrite present fields")
+	}
+}
+
+func TestBackfillEnrichedListings(t *testing.T) {
+	store, err := sqlite.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	if err := store.UpsertUser(ctx, 100, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "bf-tok", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		Km: 0, City: "", ImageURL: "",
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfig()
+	s, err := NewWithOptions(cfg, &mockFetcher{}, store, &mockNotifier{}, testLogger(), Options{
+		ListingStore: store,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listings := []model.RawListing{
+		{Token: "bf-tok", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+			Km: 60000, City: "Eilat", ImageURL: "https://img.com/new.jpg"},
+		{Token: "bf-noop", Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+			Km: 0},
+	}
+
+	s.backfillEnrichedListings(ctx, listings)
+
+	rec, err := store.GetListing(ctx, 100, "bf-tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec == nil {
+		t.Fatal("bf-tok should still exist after backfill")
+	}
+	if rec.Km != 60000 {
+		t.Errorf("bf-tok Km = %d, want 60000 after backfill", rec.Km)
+	}
+	if rec.City != "Eilat" {
+		t.Errorf("bf-tok City = %q, want Eilat after backfill", rec.City)
+	}
+	if rec.ImageURL != "https://img.com/new.jpg" {
+		t.Errorf("bf-tok ImageURL = %q, want https://img.com/new.jpg after backfill", rec.ImageURL)
+	}
+}
+
+func TestBackfillEnrichedListings_Empty(t *testing.T) {
+	cfg := testConfig()
+	s, err := NewWithOptions(cfg, &mockFetcher{}, newMockDedup(), &mockNotifier{}, testLogger(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.backfillEnrichedListings(context.Background(), nil)
+}

--- a/internal/storage/sql_helpers_test.go
+++ b/internal/storage/sql_helpers_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestListingCommercialToSQL(t *testing.T) {
+	if got := ListingCommercialToSQL(nil); got != nil {
+		t.Errorf("nil -> expected nil, got %v", got)
+	}
+
+	tr := true
+	if got := ListingCommercialToSQL(&tr); got != 1 {
+		t.Errorf("true -> expected 1, got %v", got)
+	}
+
+	fl := false
+	if got := ListingCommercialToSQL(&fl); got != 0 {
+		t.Errorf("false -> expected 0, got %v", got)
+	}
+}
+
+func TestListingCommercialFromSQL(t *testing.T) {
+	if got := ListingCommercialFromSQL(sql.NullInt64{Valid: false}); got != nil {
+		t.Errorf("NULL -> expected nil, got %v", got)
+	}
+
+	got := ListingCommercialFromSQL(sql.NullInt64{Int64: 0, Valid: true})
+	if got == nil || *got != false {
+		t.Errorf("0 -> expected false, got %v", got)
+	}
+
+	got = ListingCommercialFromSQL(sql.NullInt64{Int64: 1, Valid: true})
+	if got == nil || *got != true {
+		t.Errorf("1 -> expected true, got %v", got)
+	}
+
+	got = ListingCommercialFromSQL(sql.NullInt64{Int64: 42, Valid: true})
+	if got == nil || *got != true {
+		t.Errorf("42 -> expected true (non-zero), got %v", got)
+	}
+}

--- a/internal/storage/sqlite/phase1_coverage_test.go
+++ b/internal/storage/sqlite/phase1_coverage_test.go
@@ -1,0 +1,423 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// --- UnmarkListingUserSeen ---
+
+func TestUnmarkListingUserSeen(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+	searchID := seedSearchForNotif(t, store, 100)
+
+	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "unsee-1", ChatID: 100, SearchID: searchID, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.MarkListingUserSeen(ctx, 100, "unsee-1"); err != nil {
+		t.Fatal(err)
+	}
+	listings, err := store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 0 {
+		t.Fatalf("after mark seen: expected 0, got %d", len(listings))
+	}
+
+	if err = store.UnmarkListingUserSeen(ctx, 100, "unsee-1"); err != nil {
+		t.Fatal(err)
+	}
+	listings, err = store.NewListingsSince(ctx, 100, cutoff, 20, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 1 {
+		t.Errorf("after unmark: expected 1, got %d", len(listings))
+	}
+}
+
+func TestUnmarkListingUserSeen_EmptyToken(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.UnmarkListingUserSeen(context.Background(), 100, ""); err != nil {
+		t.Errorf("empty token should be no-op, got %v", err)
+	}
+}
+
+func TestMarkListingUserSeen_EmptyToken(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.MarkListingUserSeen(context.Background(), 100, ""); err != nil {
+		t.Errorf("empty token should be no-op, got %v", err)
+	}
+}
+
+// --- ListingUserSeenAmong ---
+
+func TestListingUserSeenAmong(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.MarkListingUserSeen(ctx, 100, "tok-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkListingUserSeen(ctx, 100, "tok-b"); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := store.ListingUserSeenAmong(ctx, 100, []string{"tok-a", "tok-b", "tok-c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result["tok-a"] || !result["tok-b"] {
+		t.Error("tok-a and tok-b should be seen")
+	}
+	if result["tok-c"] {
+		t.Error("tok-c should not be seen")
+	}
+}
+
+func TestListingUserSeenAmong_EmptyInput(t *testing.T) {
+	store := newTestStore(t)
+	result, err := store.ListingUserSeenAmong(context.Background(), 100, nil)
+	if err != nil || result != nil {
+		t.Errorf("nil input: expected nil,nil got %v,%v", result, err)
+	}
+	result, err = store.ListingUserSeenAmong(context.Background(), 100, []string{})
+	if err != nil || result != nil {
+		t.Errorf("empty input: expected nil,nil got %v,%v", result, err)
+	}
+}
+
+func TestListingUserSeenAmong_DeduplicatesAndSkipsEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.MarkListingUserSeen(ctx, 100, "dup-tok"); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := store.ListingUserSeenAmong(ctx, 100, []string{"dup-tok", "dup-tok", "", "dup-tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result["dup-tok"] {
+		t.Error("dup-tok should be seen")
+	}
+}
+
+// --- PriceListEntry ---
+
+func TestPriceListEntry_RoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	entry := storage.PriceListEntry{
+		SubModelID: 12345,
+		Year:       2022,
+		BasePrice:  150000,
+		Title:      "Corolla GLi",
+	}
+	if err := store.SetPriceListEntry(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetPriceListEntry(ctx, 12345, 2022)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if got.BasePrice != 150000 || got.Title != "Corolla GLi" {
+		t.Errorf("unexpected entry: %+v", got)
+	}
+}
+
+func TestPriceListEntry_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	got, err := store.GetPriceListEntry(context.Background(), 99999, 2030)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for non-existent entry, got %+v", got)
+	}
+}
+
+func TestPriceListEntry_Upsert(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.SetPriceListEntry(ctx, storage.PriceListEntry{
+		SubModelID: 100, Year: 2020, BasePrice: 80000, Title: "Old",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetPriceListEntry(ctx, storage.PriceListEntry{
+		SubModelID: 100, Year: 2020, BasePrice: 90000, Title: "Updated",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetPriceListEntry(ctx, 100, 2020)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected entry after upsert, got nil")
+	}
+	if got.BasePrice != 90000 || got.Title != "Updated" {
+		t.Errorf("upsert did not update: %+v", got)
+	}
+}
+
+// --- BackfillListings ---
+
+func TestBackfillListings_FillsMissingFieldsOnly(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "bf-1", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		Km: 0, City: "", ImageURL: "",
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "bf-2", ChatID: 100, SearchName: "s1",
+		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
+		Km: 50000, City: "Haifa", ImageURL: "https://img.com/1.jpg",
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.BackfillListings(ctx, []storage.ListingRecord{
+		{Token: "bf-1", Km: 30000, City: "Tel Aviv", ImageURL: "https://img.com/2.jpg"},
+		{Token: "bf-2", Km: 99999, City: "Eilat", ImageURL: "https://img.com/3.jpg"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	l1, _ := store.GetListing(ctx, 100, "bf-1")
+	if l1.Km != 30000 || l1.City != "Tel Aviv" || l1.ImageURL != "https://img.com/2.jpg" {
+		t.Errorf("bf-1 should be backfilled: km=%d city=%s img=%s", l1.Km, l1.City, l1.ImageURL)
+	}
+
+	l2, _ := store.GetListing(ctx, 100, "bf-2")
+	if l2.Km != 50000 || l2.City != "Haifa" || l2.ImageURL != "https://img.com/1.jpg" {
+		t.Errorf("bf-2 should NOT be overwritten: km=%d city=%s img=%s", l2.Km, l2.City, l2.ImageURL)
+	}
+}
+
+func TestBackfillListings_EmptySlice(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.BackfillListings(context.Background(), nil); err != nil {
+		t.Errorf("empty backfill should be no-op, got %v", err)
+	}
+}
+
+// --- PruneLinkTokens ---
+
+func TestPruneLinkTokens(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	fresh, err := store.CreateLinkToken(ctx, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expired, err := generateLinkTokenBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.db.ExecContext(ctx,
+		`INSERT INTO link_tokens (token, web_chat_id, expires_at, used)
+		 VALUES (?, ?, ?, 0)`,
+		expired, int64(2000), time.Now().UTC().Add(-2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pruned, err := store.PruneLinkTokens(ctx, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned, got %d", pruned)
+	}
+
+	_, err = store.ConsumeLinkToken(ctx, fresh)
+	if err != nil {
+		t.Errorf("fresh token should still be valid, got %v", err)
+	}
+}
+
+// --- AdminDeleteUser ---
+
+func TestAdminDeleteUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	if _, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "del-test", Manufacturer: 1, Model: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "del-l1", ChatID: 100, SearchName: "del-test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
+		FirstSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.AdminDeleteUser(ctx, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	searches, err := store.ListSearches(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(searches) != 0 {
+		t.Errorf("expected 0 searches after delete, got %d", len(searches))
+	}
+	listings, err := store.ListUserListings(ctx, 100, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings after delete, got %d", len(listings))
+	}
+}
+
+// --- AdminListPriceHistory ---
+
+func TestAdminListPriceHistory(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.db.ExecContext(ctx,
+		"INSERT INTO price_history (token, price) VALUES (?, ?)", "ph-tok", 100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := store.AdminListPriceHistory(ctx, 20, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(items) != 1 {
+		t.Errorf("all: total=%d items=%d", total, len(items))
+	}
+
+	items, total, err = store.AdminListPriceHistory(ctx, 20, 0, "ph-tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(items) != 1 || items[0].Token != "ph-tok" {
+		t.Errorf("filtered: total=%d items=%d", total, len(items))
+	}
+
+	items, total, err = store.AdminListPriceHistory(ctx, 20, 0, "nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 || len(items) != 0 {
+		t.Errorf("no match: total=%d items=%d", total, len(items))
+	}
+}
+
+// --- AdminListSeenListings ---
+
+func TestAdminListSeenListings(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "seen-test", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ClaimNew(ctx, "seen-tok", 100, searchID); err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := store.AdminListSeenListings(ctx, 20, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total < 1 || len(items) < 1 {
+		t.Errorf("all: total=%d items=%d", total, len(items))
+	}
+
+	items, total, err = store.AdminListSeenListings(ctx, 20, 0, searchID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || items[0].Token != "seen-tok" {
+		t.Errorf("filtered: total=%d", total)
+	}
+}
+
+// --- AdminActivityStats ---
+
+func TestAdminActivityStats(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	items, err := store.AdminActivityStats(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) < 7 {
+		t.Errorf("expected at least 7 days, got %d", len(items))
+	}
+}
+
+func TestAdminActivityStats_DefaultDays(t *testing.T) {
+	store := newTestStore(t)
+	items, err := store.AdminActivityStats(context.Background(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) < 30 {
+		t.Errorf("days=0 should default to 30, got %d rows", len(items))
+	}
+}
+
+// --- DBPoolStats ---
+
+func TestDBPoolStats(t *testing.T) {
+	store := newTestStore(t)
+	stats := store.DBPoolStats()
+	if stats == nil {
+		t.Fatal("expected non-nil stats")
+	}
+	if stats.MaxOpenConnections <= 0 {
+		t.Errorf("MaxOpenConnections = %d, want > 0", stats.MaxOpenConnections)
+	}
+}

--- a/internal/storage/sqlite/phase1_coverage_test.go
+++ b/internal/storage/sqlite/phase1_coverage_test.go
@@ -216,12 +216,18 @@ func TestBackfillListings_FillsMissingFieldsOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	l1, _ := store.GetListing(ctx, 100, "bf-1")
+	l1, err := store.GetListing(ctx, 100, "bf-1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if l1.Km != 30000 || l1.City != "Tel Aviv" || l1.ImageURL != "https://img.com/2.jpg" {
 		t.Errorf("bf-1 should be backfilled: km=%d city=%s img=%s", l1.Km, l1.City, l1.ImageURL)
 	}
 
-	l2, _ := store.GetListing(ctx, 100, "bf-2")
+	l2, err := store.GetListing(ctx, 100, "bf-2")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if l2.Km != 50000 || l2.City != "Haifa" || l2.ImageURL != "https://img.com/1.jpg" {
 		t.Errorf("bf-2 should NOT be overwritten: km=%d city=%s img=%s", l2.Km, l2.City, l2.ImageURL)
 	}
@@ -378,8 +384,8 @@ func TestAdminListSeenListings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if total != 1 || items[0].Token != "seen-tok" {
-		t.Errorf("filtered: total=%d", total)
+	if total != 1 || len(items) != 1 || items[0].Token != "seen-tok" {
+		t.Errorf("filtered: total=%d items=%d", total, len(items))
 	}
 }
 

--- a/internal/storage/sqlite/pricelist.go
+++ b/internal/storage/sqlite/pricelist.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/dsionov/carwatch/internal/storage"
@@ -17,7 +18,7 @@ func (s *Store) GetPriceListEntry(ctx context.Context, subModelID, year int) (*s
 		 FROM price_list_cache
 		 WHERE sub_model_id = ? AND year = ?`, subModelID, year,
 	).Scan(&e.SubModelID, &e.Year, &e.BasePrice, &e.Title, &fetchedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/storage/sqlite/pricelist.go
+++ b/internal/storage/sqlite/pricelist.go
@@ -6,20 +6,26 @@ import (
 	"fmt"
 
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/timeutil"
 )
 
 func (s *Store) GetPriceListEntry(ctx context.Context, subModelID, year int) (*storage.PriceListEntry, error) {
 	var e storage.PriceListEntry
+	var fetchedAt string
 	err := s.db.QueryRowContext(ctx,
 		`SELECT sub_model_id, year, base_price, title, fetched_at
 		 FROM price_list_cache
 		 WHERE sub_model_id = ? AND year = ?`, subModelID, year,
-	).Scan(&e.SubModelID, &e.Year, &e.BasePrice, &e.Title, &e.FetchedAt)
+	).Scan(&e.SubModelID, &e.Year, &e.BasePrice, &e.Title, &fetchedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get price list entry: %w", err)
+	}
+	e.FetchedAt, err = timeutil.ParseFlexible(fetchedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse fetched_at: %w", err)
 	}
 	return &e, nil
 }

--- a/web/src/components/ui/MatchScoreBox.test.tsx
+++ b/web/src/components/ui/MatchScoreBox.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MatchScoreBox } from "./MatchScoreBox";
+
+describe("MatchScoreBox", () => {
+  it("renders formatted score", () => {
+    render(<MatchScoreBox score={8.5} />);
+    expect(screen.getByText("8.5")).toBeInTheDocument();
+  });
+
+  it("clamps score above 10 to 10.0", () => {
+    render(<MatchScoreBox score={15} />);
+    expect(screen.getByText("10.0")).toBeInTheDocument();
+  });
+
+  it("clamps negative score to 0.0", () => {
+    render(<MatchScoreBox score={-3} />);
+    expect(screen.getByText("0.0")).toBeInTheDocument();
+  });
+
+  it("handles NaN as 0.0", () => {
+    render(<MatchScoreBox score={NaN} />);
+    expect(screen.getByText("0.0")).toBeInTheDocument();
+  });
+
+  it("renders /10 denominator", () => {
+    render(<MatchScoreBox score={7} />);
+    expect(screen.getByText("/10")).toBeInTheDocument();
+  });
+
+  it("has correct aria-label", () => {
+    render(<MatchScoreBox score={9.2} />);
+    expect(
+      screen.getByLabelText("ציון 9.2 מתוך 10"),
+    ).toBeInTheDocument();
+  });
+
+  it("applies sm size class", () => {
+    const { container } = render(<MatchScoreBox score={5} size="sm" />);
+    expect(container.firstElementChild?.classList.contains("h-9")).toBe(true);
+  });
+
+  it("applies lg size class", () => {
+    const { container } = render(<MatchScoreBox score={5} size="lg" />);
+    expect(container.firstElementChild?.classList.contains("h-14")).toBe(true);
+  });
+});

--- a/web/src/components/ui/MatchScoreBox.test.tsx
+++ b/web/src/components/ui/MatchScoreBox.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { MatchScoreBox } from "./MatchScoreBox";

--- a/web/src/contexts/ThemeContext.test.tsx
+++ b/web/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ThemeProvider, useTheme } from "./ThemeContext";
+
+const listeners: Array<(e: { matches: boolean }) => void> = [];
+const mockMatchMedia = vi.fn().mockImplementation(() => ({
+  matches: false,
+  addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+    listeners.push(cb);
+  },
+  removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+    const idx = listeners.indexOf(cb);
+    if (idx >= 0) listeners.splice(idx, 1);
+  },
+}));
+
+function ThemeDisplay() {
+  const { theme, toggle } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={toggle}>Toggle</button>
+    </div>
+  );
+}
+
+describe("ThemeContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    listeners.length = 0;
+    window.matchMedia = mockMatchMedia;
+  });
+
+  it("defaults to dark when no preference stored", () => {
+    render(
+      <ThemeProvider>
+        <ThemeDisplay />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+  });
+
+  it("respects stored light preference", () => {
+    localStorage.setItem("theme", "light");
+    render(
+      <ThemeProvider>
+        <ThemeDisplay />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+  });
+
+  it("toggles from dark to light", async () => {
+    render(
+      <ThemeProvider>
+        <ThemeDisplay />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+
+    await act(async () => {
+      screen.getByText("Toggle").click();
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(localStorage.getItem("theme")).toBe("light");
+  });
+
+  it("persists toggle to localStorage", async () => {
+    render(
+      <ThemeProvider>
+        <ThemeDisplay />
+      </ThemeProvider>,
+    );
+
+    await act(async () => {
+      screen.getByText("Toggle").click();
+    });
+    expect(localStorage.getItem("theme")).toBe("light");
+
+    await act(async () => {
+      screen.getByText("Toggle").click();
+    });
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("throws when useTheme is used outside provider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<ThemeDisplay />)).toThrow(
+      "useTheme must be used within ThemeProvider",
+    );
+    spy.mockRestore();
+  });
+});

--- a/web/src/contexts/ThemeContext.test.tsx
+++ b/web/src/contexts/ThemeContext.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ThemeProvider, useTheme } from "./ThemeContext";

--- a/web/src/hooks/useListingSeen.test.ts
+++ b/web/src/hooks/useListingSeen.test.ts
@@ -1,0 +1,79 @@
+import React, { type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import { useMarkListingSeen, useUnmarkListingSeen } from "./useListingSeen";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...mod,
+    api: {
+      ...mod.api,
+      markListingSeen: vi.fn(),
+      unmarkListingSeen: vi.fn(),
+    },
+  };
+});
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function withProviders(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe("useListingSeen hooks", () => {
+  const mockedApi = vi.mocked(api);
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("useMarkListingSeen calls api and invalidates queries", async () => {
+    mockedApi.markListingSeen.mockResolvedValue(undefined);
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useMarkListingSeen(), {
+      wrapper: withProviders(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("tok-123");
+    });
+
+    expect(mockedApi.markListingSeen).toHaveBeenCalledWith("tok-123");
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("useUnmarkListingSeen calls api and invalidates queries", async () => {
+    mockedApi.unmarkListingSeen.mockResolvedValue(undefined);
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUnmarkListingSeen(), {
+      wrapper: withProviders(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("tok-456");
+    });
+
+    expect(mockedApi.unmarkListingSeen).toHaveBeenCalledWith("tok-456");
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useNotifications.test.ts
+++ b/web/src/hooks/useNotifications.test.ts
@@ -1,0 +1,92 @@
+import React, { type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { notificationsApi } from "@/lib/api";
+import {
+  useNotificationCount,
+  useNotifications,
+  useMarkNotificationsSeen,
+} from "./useNotifications";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...mod,
+    notificationsApi: {
+      count: vi.fn(),
+      list: vi.fn(),
+      markSeen: vi.fn(),
+    },
+  };
+});
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchInterval: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function withProviders(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe("useNotifications hooks", () => {
+  const mockedNotifs = vi.mocked(notificationsApi);
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("useNotificationCount returns count", async () => {
+    mockedNotifs.count.mockResolvedValue({ count: 5 });
+
+    const { result } = renderHook(() => useNotificationCount(), {
+      wrapper: withProviders(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ count: 5 });
+  });
+
+  it("useNotifications returns listings page", async () => {
+    const response = { items: [], total: 0, limit: 20, offset: 0 };
+    mockedNotifs.list.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useNotifications(20, 0), {
+      wrapper: withProviders(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(response);
+  });
+
+  it("useMarkNotificationsSeen resets count to 0", async () => {
+    mockedNotifs.markSeen.mockResolvedValue(undefined);
+    queryClient.setQueryData(["notification-count"], { count: 5 });
+
+    const { result } = renderHook(() => useMarkNotificationsSeen(), {
+      wrapper: withProviders(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockedNotifs.markSeen).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(["notification-count"])).toEqual({
+      count: 0,
+    });
+  });
+});

--- a/web/src/lib/auth-token.test.ts
+++ b/web/src/lib/auth-token.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getAuthToken, setAuthTokenGetter } from "./auth-token";
+
+describe("auth-token", () => {
+  beforeEach(() => {
+    setAuthTokenGetter(async () => null);
+  });
+
+  it("returns null by default", async () => {
+    const token = await getAuthToken();
+    expect(token).toBeNull();
+  });
+
+  it("returns the token from a custom getter", async () => {
+    setAuthTokenGetter(async () => "my-token");
+    const token = await getAuthToken();
+    expect(token).toBe("my-token");
+  });
+
+  it("passes forceRefresh to the getter", async () => {
+    let receivedRefresh: boolean | undefined;
+    setAuthTokenGetter(async (forceRefresh) => {
+      receivedRefresh = forceRefresh;
+      return "token";
+    });
+    await getAuthToken(true);
+    expect(receivedRefresh).toBe(true);
+  });
+});

--- a/web/src/lib/error-messages.test.ts
+++ b/web/src/lib/error-messages.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { errorToHebrew } from "./error-messages";
+import { ApiError } from "./api";
+
+describe("errorToHebrew", () => {
+  it("returns auth-expired for 401", () => {
+    const msg = errorToHebrew(new ApiError(401, "unauthorized"));
+    expect(msg).toContain("הרשאה");
+  });
+
+  it("returns auth-expired for 403", () => {
+    const msg = errorToHebrew(new ApiError(403, "forbidden"));
+    expect(msg).toContain("הרשאה");
+  });
+
+  it("returns conflict message for 409", () => {
+    const msg = errorToHebrew(new ApiError(409, ""));
+    expect(msg).toContain("מתנגשת");
+  });
+
+  it("returns custom message for 409 with message", () => {
+    const msg = errorToHebrew(new ApiError(409, "custom conflict"));
+    expect(msg).toBe("custom conflict");
+  });
+
+  it("returns rate-limit message for 429", () => {
+    const msg = errorToHebrew(new ApiError(429, "too many"));
+    expect(msg).toContain("בקשות");
+  });
+
+  it("returns server error for 500+", () => {
+    const msg = errorToHebrew(new ApiError(500, "internal"));
+    expect(msg).toContain("שרת");
+  });
+
+  it("returns generic ApiError message for other status codes", () => {
+    const msg = errorToHebrew(new ApiError(422, "custom error"));
+    expect(msg).toBe("custom error");
+  });
+
+  it("returns network error for TypeError with 'failed to fetch'", () => {
+    const msg = errorToHebrew(new TypeError("Failed to fetch"));
+    expect(msg).toContain("חיבור");
+  });
+
+  it("returns network error for TypeError with 'network'", () => {
+    const msg = errorToHebrew(new TypeError("network error"));
+    expect(msg).toContain("חיבור");
+  });
+
+  it("returns generic error for unknown Error", () => {
+    const msg = errorToHebrew(new Error("something unknown"));
+    expect(msg).toContain("שגיאה");
+  });
+
+  it("returns generic error for non-Error value", () => {
+    const msg = errorToHebrew("string error");
+    expect(msg).toContain("שגיאה");
+  });
+});


### PR DESCRIPTION
## Summary

- Add **14 new test files** (8 Go, 6 React/Vitest) covering previously untested code paths across the full stack
- Fix a bug in `GetPriceListEntry` where SQLite datetime strings were scanned directly into `time.Time` instead of using `timeutil.ParseFlexible`
- Add `web/coverage/` to `.gitignore`

### Backend coverage additions

| Package | Tests added |
|---------|------------|
| `storage` | `sql_helpers` (ListingCommercialToSQL/FromSQL) |
| `storage/sqlite` | Admin delete/list, PriceListEntry CRUD, ListingUserSeen mark/unmark, BackfillListings, PruneLinkTokens, ActivityStats, DBPoolStats |
| `api` | Admin endpoints (getMe, setUserActive, logLevel, priceHistory, seenListings, activity), listingFilterFromSearch, bookmarks CRUD, search CRUD, listHistory, notificationCount, markNotificationsSeen, requireAdmin, writeJSON |
| `scheduler` | prefillFromDB, backfillEnrichedListings |
| `notifier` | basePriceLine (below/near/above base, Hebrew + English) |
| `bot` | isLowerHex, handlePriceMin (valid/skip/invalid/exceeds-max), RegisterHandlers nil guard |
| `health` | MarkBotPollingAlive/Dead |
| `fetcher` | WithCBLogger option (custom + nil) |

### Frontend coverage additions

| Module | Tests added |
|--------|------------|
| `lib/error-messages` | errorToHebrew for all ApiError statuses, TypeError, generic errors |
| `lib/auth-token` | setAuthTokenGetter, getAuthToken, forceRefresh parameter |
| `hooks/useNotifications` | useNotificationCount, useNotifications, useMarkNotificationsSeen + cache invalidation |
| `hooks/useListingSeen` | useMarkListingSeen, useUnmarkListingSeen + query invalidation |
| `components/ui/MatchScoreBox` | Score formatting, clamping (min/max/NaN), /10 denominator, aria-label, size classes |
| `contexts/ThemeContext` | Default/stored theme, toggle, localStorage persistence, out-of-provider error |

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `npx vitest run` passes (170 tests)
- [ ] CI lint + test + build checks pass

closes #297

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timestamp parsing for price history records.

* **Tests**
  * Expanded test coverage for API endpoints, search functionality, bookmarks, notifications, and admin features.
  * Added comprehensive test coverage for bot polling, price filtering, listing enrichment, and theme management.
  * Added tests for authentication, error handling, and component rendering.

* **Chores**
  * Updated version control settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->