### PR TITLE
fix: resolve /api/v1/vitals 401 and /healthz 503 errors

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -272,6 +272,7 @@ func (s *Server) Routes() http.Handler {
 	// --- Top-level router ---
 	// More-specific prefixes are matched first by net/http.ServeMux.
 	top := http.NewServeMux()
+	top.HandleFunc("POST /api/v1/vitals", s.receiveVitals)
 	top.Handle("/api/v1/guest/", guestChain)
 	top.Handle("/api/v1/catalog/", catalogChain)
 	top.Handle("GET /api/v1/me", optAuthChain)

--- a/internal/api/vitals.go
+++ b/internal/api/vitals.go
@@ -5,7 +5,12 @@ import (
 	"net/http"
 )
 
+const vitalsMaxBody = 128 << 10 // 128 KB
+
 func (s *Server) receiveVitals(w http.ResponseWriter, r *http.Request) {
-	_, _ = io.Copy(io.Discard, r.Body)
+	r.Body = http.MaxBytesReader(w, r.Body, vitalsMaxBody)
+	if _, err := io.Copy(io.Discard, r.Body); err != nil {
+		s.logger.Debug("failed to drain vitals payload", "error", err)
+	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/vitals.go
+++ b/internal/api/vitals.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"io"
+	"net/http"
+)
+
+func (s *Server) receiveVitals(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.Copy(io.Discard, r.Body)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -495,6 +495,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	if len(searches) == 0 {
 		s.logger.Info("scan complete (no active searches)", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
+		s.observer.RecordSuccess()
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/vitals` endpoint outside auth middleware so `navigator.sendBeacon` web-vitals reports stop getting 401
- Call `RecordSuccess()` on the scheduler's "no active searches" early-return path so `/healthz` doesn't report "degraded" after 2h idle

### Root causes

**`/api/v1/vitals` 401**: The frontend sends web vitals via `navigator.sendBeacon` (which cannot attach Authorization headers). No backend endpoint existed for `/api/v1/vitals`, so requests fell through to the catch-all auth middleware and were rejected.

**`/healthz` 503**: When the scheduler has no active searches, it returns early without calling `observer.RecordSuccess()`. After the 2-hour `degradedThreshold` passes with no success recorded, the health check switches to "degraded" status and returns 503.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/api/... ./internal/scheduler/...` passes
- [ ] CI lint + test + build pass
- [ ] Deploy and verify `/api/v1/vitals` returns 204, `/healthz` returns 200

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new POST `/api/v1/vitals` endpoint for submitting vital metrics and system health data to the API.

* **Bug Fixes**
  * Fixed scheduler behavior to correctly record success metrics even when there are no active tasks to process, ensuring consistent and accurate operational monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->