### PR TITLE
fix: report degraded health when scheduler fails to start or hangs

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -178,12 +178,19 @@ func (s *Status) coreMetrics() map[string]any {
 
 	status := "ok"
 	uptime := time.Since(s.startTime)
-	if s.schedulerStarted.Load() && cycles > 0 && (lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold) {
-		if uptime > startupGracePeriod {
-			status = "degraded"
-		} else {
+	schedulerUp := s.schedulerStarted.Load()
+
+	switch {
+	case uptime <= startupGracePeriod:
+		if schedulerUp && cycles > 0 && lastSuccessNs == 0 {
 			status = "starting"
 		}
+	case !schedulerUp:
+		status = "degraded"
+	case cycles == 0:
+		status = "degraded"
+	case lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold:
+		status = "degraded"
 	}
 
 	return map[string]any{

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -398,3 +398,33 @@ func TestStatus_DegradedAfterGracePeriod(t *testing.T) {
 		t.Errorf("status = %q, want degraded", resp["status"])
 	}
 }
+
+func TestStatus_DegradedWhenSchedulerNeverStarts(t *testing.T) {
+	s := New()
+	s.startTime = time.Now().Add(-10 * time.Minute)
+
+	snap := s.Snapshot()
+	if snap["status"] != "degraded" {
+		t.Errorf("status = %q, want degraded when scheduler never started past grace period", snap["status"])
+	}
+}
+
+func TestStatus_DegradedWhenZeroCyclesPastGrace(t *testing.T) {
+	s := New()
+	s.startTime = time.Now().Add(-10 * time.Minute)
+	s.MarkSchedulerStarted()
+
+	snap := s.Snapshot()
+	if snap["status"] != "degraded" {
+		t.Errorf("status = %q, want degraded when zero cycles completed past grace period", snap["status"])
+	}
+}
+
+func TestStatus_OKDuringGracePeriodBeforeSchedulerStarts(t *testing.T) {
+	s := New()
+
+	snap := s.Snapshot()
+	if snap["status"] != "ok" {
+		t.Errorf("status = %q, want ok during grace period before scheduler starts", snap["status"])
+	}
+}


### PR DESCRIPTION
## Summary
- Health check now reports `degraded` when past the startup grace period and the scheduler hasn't started or has completed zero cycles
- Previously reported `ok` forever in these scenarios, masking complete system failures
- Adds 3 new test cases for the missing scenarios

closes #855

## Test plan
- [x] `go test ./internal/health/ -v` — all 22 tests pass
- [x] `golangci-lint run ./internal/health/` — 0 issues
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced health status determination logic with clearer conditions for more reliable status reporting during system startup and recovery phases.

* **Tests**
  * Added test coverage for health status behavior during scheduler startup and grace period scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->