### PR TITLE
fix: unify access log IP parsing with rate limiter

### DIFF
--- a/internal/api/accesslog.go
+++ b/internal/api/accesslog.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -44,16 +43,7 @@ func (s *Server) withAccessLog(next http.Handler) http.Handler {
 		}
 
 		chatID, _ := chatIDFromContext(r.Context())
-		remoteAddr := r.RemoteAddr
-		if s.cfg.TrustForwardedFor {
-			if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-				if i := strings.IndexByte(fwd, ','); i >= 0 {
-					remoteAddr = strings.TrimSpace(fwd[:i])
-				} else {
-					remoteAddr = strings.TrimSpace(fwd)
-				}
-			}
-		}
+		remoteAddr := extractIP(r, s.cfg.TrustForwardedFor)
 
 		fields := []any{
 			"method", r.Method,


### PR DESCRIPTION
## Summary
- Access log now uses the same `extractIP()` function as the rate limiter
- Previously, the access log took the **leftmost** X-Forwarded-For entry (attacker-spoofable), while the rate limiter correctly took the **rightmost** non-private IP
- An incident responder looking at access logs would have investigated the wrong IP address

This is a net code deletion — 11 lines of inline parsing replaced with 1 function call.

closes #856

## Test plan
- [x] `go test ./internal/api/` — all tests pass
- [x] `golangci-lint run ./internal/api/` — 0 issues
- [ ] CI pipeline passes