### PR TITLE
fix: return 404 for admin delete of nonexistent search, guard basePriceLine

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -339,6 +340,10 @@ func (s *Server) adminDeleteSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.admin.AdminDeleteSearch(r.Context(), id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "search not found")
+			return
+		}
 		s.logger.Error("admin: delete search", "id", id, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete search")
 		return

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -895,8 +895,8 @@ func TestAdminDeleteSearch_NotFound(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	w := doRequest(t, srv, "DELETE", "/api/v1/admin/searches/999", nil)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/notifier/formatter.go
+++ b/internal/notifier/formatter.go
@@ -194,6 +194,9 @@ func formatBreakdown(dims []model.FitnessDim, lang locale.Lang) string {
 }
 
 func basePriceLine(lang locale.Lang, basePrice, price int) string {
+	if basePrice <= 0 {
+		return ""
+	}
 	bpStr := format.Number(basePrice)
 	pctDiff := int(math.Round(100.0 * (1.0 - float64(price)/float64(basePrice))))
 	if pctDiff > 5 {


### PR DESCRIPTION
## Summary
- `adminDeleteSearch` now returns **404** (not 500) when the search doesn't exist, consistent with the user-facing `deleteSearch` endpoint
- `basePriceLine` now guards against `basePrice <= 0` to prevent division by zero
- Updated test expectation from 500 to 404

closes #862

## Test plan
- [x] `go test ./internal/api/ ./internal/notifier/` — all tests pass
- [x] `golangci-lint run ./internal/api/ ./internal/notifier/` — 0 issues
- [ ] CI pipeline passes