### PR TITLE
fix: resolve dealInfo gap, SSE CRLF handling, and fetchGuestAPI 204

### DIFF
--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -47,15 +47,13 @@ function dealInfo(listing: Listing): {
       priceClass: "text-muted-foreground",
     };
   }
-  if (mc.diffPercent < -10) {
-    return {
-      label: `+${-mc.diffPercent}%`,
-      icon: TrendingUp,
-      badgeClass: "bg-red-500/90 text-white",
-      priceClass: "text-red-400",
-    };
-  }
-  return null;
+  // Remaining range: diffPercent < -5 (slightly to heavily overpriced)
+  return {
+    label: `+${-mc.diffPercent}%`,
+    icon: TrendingUp,
+    badgeClass: "bg-red-500/90 text-white",
+    priceClass: "text-red-400",
+  };
 }
 
 export function ListingCardBody({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -530,6 +530,7 @@ async function fetchGuestAPI<T>(path: string, options?: RequestInit): Promise<T>
     const body = await res.json().catch(() => ({ error: "Unknown error" }));
     throw new ApiError(res.status, body.error);
   }
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 

--- a/web/src/lib/sse-parse.test.ts
+++ b/web/src/lib/sse-parse.test.ts
@@ -49,4 +49,18 @@ describe("feedSSE", () => {
     feedSSE("data:  spaced\n\n", "", onData);
     expect(onData).toHaveBeenCalledWith(" spaced");
   });
+
+  it("handles CRLF line endings", () => {
+    const onData = vi.fn();
+    feedSSE("data: hello\r\ndata: world\r\n\r\n", "", onData);
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith("hello\nworld");
+  });
+
+  it("handles bare CR line endings", () => {
+    const onData = vi.fn();
+    feedSSE("data: solo\r\r", "", onData);
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith("solo");
+  });
 });

--- a/web/src/lib/sse-parse.ts
+++ b/web/src/lib/sse-parse.ts
@@ -8,7 +8,8 @@ export function feedSSE(
   buffer: string,
   onData: (payload: string) => void,
 ): string {
-  let buf = buffer + chunk;
+  // Normalize CRLF / bare CR to LF per SSE spec.
+  let buf = buffer + chunk.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   for (;;) {
     const idx = buf.indexOf("\n\n");
     if (idx === -1) {


### PR DESCRIPTION
## Summary

Fixes three small frontend bugs:

- **ListingCardBody `dealInfo` gap**: `diffPercent` values between -5 (exclusive) and -10 (inclusive) fell through all conditions and returned `null`, producing no deal badge. Changed the last conditional branch to an `else` clause so the remaining range is caught.
- **SSE parser CRLF handling**: `feedSSE` only split on `\n`, but the SSE spec allows `\r\n` and bare `\r`. Added line-ending normalization before processing.
- **`fetchGuestAPI` missing 204 guard**: Unlike `fetchAPI`, the guest variant always called `res.json()`, which throws on empty 204 responses. Added the same `if (res.status === 204) return undefined as T` guard.

## Test plan

- [x] Added two new SSE parser tests covering `\r\n` and bare `\r` line endings
- [x] All 199 frontend tests pass (`npm test`)
- [x] TypeScript type-check passes (`tsc -b`)

closes #868