### PR TITLE
fix: use injectable time in bot rate limiter, fix hardcoded year validation

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -68,22 +68,22 @@ const (
 )
 
 func (b *Bot) isRateLimited(chatID int64) bool {
+	now := b.now()
 	v, _ := b.rateLimiter.LoadOrStore(chatID, &userRateLimit{
 		tokens:   rateLimitBurst,
-		lastTick: time.Now(),
+		lastTick: now,
 	})
 	rl, ok := v.(*userRateLimit)
 	if !ok {
 		rl = &userRateLimit{
 			tokens:   rateLimitBurst,
-			lastTick: time.Now(),
+			lastTick: now,
 		}
 		b.rateLimiter.Store(chatID, rl)
 	}
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	now := time.Now()
 	elapsed := now.Sub(rl.lastTick)
 	refill := int(elapsed / rateLimitInterval)
 	if refill > 0 {

--- a/internal/bot/coverage_test.go
+++ b/internal/bot/coverage_test.go
@@ -21,7 +21,7 @@ func mustNoErr(t *testing.T, err error) {
 
 func newTestBotFull(t *testing.T) *testBot {
 	t.Helper()
-	store, err := sqlite.New("file::memory:?cache=shared")
+	store, err := sqlite.New(":memory:")
 	if err != nil {
 		t.Fatalf("create store: %v", err)
 	}

--- a/internal/bot/validation_test.go
+++ b/internal/bot/validation_test.go
@@ -1,26 +1,29 @@
 package bot
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestYearValidation(t *testing.T) {
+	maxYear := time.Now().Year() + 2
 	tests := []struct {
 		input string
 		valid bool
 	}{
 		{"2020", true},
 		{"1990", true},
-		{"2030", true},
+		{fmt.Sprintf("%d", maxYear), true},
 		{"1989", false},
-		{"2031", false},
+		{fmt.Sprintf("%d", maxYear+1), false},
 		{"abc", false},
 		{"", false},
 	}
 	for _, tt := range tests {
 		year, err := strconv.Atoi(tt.input)
-		valid := err == nil && year >= 1990 && year <= 2030
+		valid := err == nil && year >= 1990 && year <= maxYear
 		if valid != tt.valid {
 			t.Errorf("year %q: valid=%v, want %v", tt.input, valid, tt.valid)
 		}


### PR DESCRIPTION
## Summary
- `isRateLimited()` now uses `b.now()` instead of `time.Now()`, making rate limit behavior testable without wall-clock sleeps
- Year validation test uses `time.Now().Year()+2` instead of hardcoded 2030/2031, preventing test breakage around 2028
- `coverage_test.go` uses `:memory:` instead of `file::memory:?cache=shared` to prevent potential parallel test interference

closes #864

## Test plan
- [x] `go test ./internal/bot/` — all tests pass
- [x] `golangci-lint run ./internal/bot/` — 0 issues
- [ ] CI pipeline passes