### PR TITLE
fix: prevent concurrent probes in circuit breaker half-open state

### DIFF
--- a/internal/fetcher/circuitbreaker.go
+++ b/internal/fetcher/circuitbreaker.go
@@ -92,16 +92,12 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params model.SourceParams) 
 	cb.probing = cb.state == StateHalfOpen
 	cb.mu.Unlock()
 
-	defer func() {
-		cb.mu.Lock()
-		cb.probing = false
-		cb.mu.Unlock()
-	}()
-
 	listings, err := cb.inner.Fetch(ctx, params)
 
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
+
+	cb.probing = false
 
 	if err != nil {
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {

--- a/internal/scheduler/observer_test.go
+++ b/internal/scheduler/observer_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -15,18 +16,18 @@ func TestNopObserver_DoesNotPanic(t *testing.T) {
 }
 
 type countingObserver struct {
-	successes     int
-	errors        int
-	listingsFound int
-	notifications int
-	fetches       int
+	successes     atomic.Int64
+	errors        atomic.Int64
+	listingsFound atomic.Int64
+	notifications atomic.Int64
+	fetches       atomic.Int64
 }
 
-func (o *countingObserver) RecordSuccess()                                 { o.successes++ }
-func (o *countingObserver) RecordError()                                   { o.errors++ }
-func (o *countingObserver) RecordListingsFound(n int)                      { o.listingsFound += n }
-func (o *countingObserver) RecordNotificationSent()                        { o.notifications++ }
-func (o *countingObserver) RecordFetch(_ string, _ time.Duration, _ error) { o.fetches++ }
+func (o *countingObserver) RecordSuccess()                                 { o.successes.Add(1) }
+func (o *countingObserver) RecordError()                                   { o.errors.Add(1) }
+func (o *countingObserver) RecordListingsFound(n int)                      { o.listingsFound.Add(int64(n)) }
+func (o *countingObserver) RecordNotificationSent()                        { o.notifications.Add(1) }
+func (o *countingObserver) RecordFetch(_ string, _ time.Duration, _ error) { o.fetches.Add(1) }
 
 func TestCycleObserver_Interface(t *testing.T) {
 	var obs CycleObserver = &countingObserver{}
@@ -36,17 +37,17 @@ func TestCycleObserver_Interface(t *testing.T) {
 	obs.RecordNotificationSent()
 
 	co := obs.(*countingObserver)
-	if co.successes != 1 {
-		t.Errorf("successes = %d, want 1", co.successes)
+	if v := co.successes.Load(); v != 1 {
+		t.Errorf("successes = %d, want 1", v)
 	}
-	if co.errors != 1 {
-		t.Errorf("errors = %d, want 1", co.errors)
+	if v := co.errors.Load(); v != 1 {
+		t.Errorf("errors = %d, want 1", v)
 	}
-	if co.listingsFound != 5 {
-		t.Errorf("listingsFound = %d, want 5", co.listingsFound)
+	if v := co.listingsFound.Load(); v != 5 {
+		t.Errorf("listingsFound = %d, want 5", v)
 	}
-	if co.notifications != 1 {
-		t.Errorf("notifications = %d, want 1", co.notifications)
+	if v := co.notifications.Load(); v != 1 {
+		t.Errorf("notifications = %d, want 1", v)
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -351,20 +351,20 @@ func TestRunMultiTenantCycle_ObserverSuccessPath(t *testing.T) {
 		t.Fatalf("runMultiTenantCycle: %v", err)
 	}
 
-	if obs.fetches != 1 {
-		t.Errorf("RecordFetch calls = %d, want 1", obs.fetches)
+	if v := obs.fetches.Load(); v != 1 {
+		t.Errorf("RecordFetch calls = %d, want 1", v)
 	}
-	if obs.listingsFound != 1 {
-		t.Errorf("listings aggregate = %d, want 1", obs.listingsFound)
+	if v := obs.listingsFound.Load(); v != 1 {
+		t.Errorf("listings aggregate = %d, want 1", v)
 	}
-	if obs.notifications != 1 {
-		t.Errorf("notifications = %d, want 1", obs.notifications)
+	if v := obs.notifications.Load(); v != 1 {
+		t.Errorf("notifications = %d, want 1", v)
 	}
-	if obs.successes != 1 {
-		t.Errorf("successes = %d, want 1", obs.successes)
+	if v := obs.successes.Load(); v != 1 {
+		t.Errorf("successes = %d, want 1", v)
 	}
-	if obs.errors != 0 {
-		t.Errorf("errors = %d, want 0", obs.errors)
+	if v := obs.errors.Load(); v != 0 {
+		t.Errorf("errors = %d, want 0", v)
 	}
 }
 
@@ -542,13 +542,13 @@ func TestRunMultiTenantCycle_ObserverErrorOnFetchFailure(t *testing.T) {
 	if err := s.runMultiTenantCycle(ctx); err == nil {
 		t.Fatal("expected error when all fetch groups fail")
 	}
-	if obs.errors != 1 {
-		t.Errorf("errors = %d, want 1", obs.errors)
+	if v := obs.errors.Load(); v != 1 {
+		t.Errorf("errors = %d, want 1", v)
 	}
-	if obs.fetches != 1 {
-		t.Errorf("fetches = %d, want 1", obs.fetches)
+	if v := obs.fetches.Load(); v != 1 {
+		t.Errorf("fetches = %d, want 1", v)
 	}
-	if obs.successes != 0 {
-		t.Errorf("successes = %d, want 0", obs.successes)
+	if v := obs.successes.Load(); v != 0 {
+		t.Errorf("successes = %d, want 0", v)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix race condition in `CircuitBreaker.Fetch` where the `probing` flag was cleared in a separate `defer` before the result-handling lock acquisition, allowing a second goroutine to start a duplicate probe in the half-open state
- Move `probing = false` inside the result-handling critical section so it is always cleared atomically with state transitions
- Switch `countingObserver` test helper fields from plain `int` to `sync/atomic.Int64` to eliminate data races under concurrent use

## Test plan

- [x] `go test ./internal/fetcher/ -count=1` passes
- [x] `go test ./internal/scheduler/ -count=1` passes
- [x] `golangci-lint run ./internal/fetcher/ ./internal/scheduler/` reports 0 issues

Closes #866