### PR TITLE
fix: validate callback sender matches chat to prevent forwarded-message abuse

### DIFF
--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -39,11 +39,17 @@ func (b *Bot) handleCallback(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	}
 
 	chatID := update.CallbackQuery.Message.Message.Chat.ID
+	fromID := update.CallbackQuery.From.ID
 	data := update.CallbackQuery.Data
-	b.logger.Debug("callback received", "chat_id", chatID, "data", data)
+	b.logger.Debug("callback received", "chat_id", chatID, "from_id", fromID, "data", data)
 
 	if err := b.msg.AnswerCallback(ctx, update.CallbackQuery.ID); err != nil {
 		b.logger.Error("answer callback query failed", "chat_id", chatID, "error", err)
+	}
+
+	if chatID != fromID {
+		b.logger.Warn("callback from non-owner ignored", "chat_id", chatID, "from_id", fromID)
+		return
 	}
 
 	b.dispatchCallbackData(ctx, chatID, data)

--- a/internal/bot/testhelpers_test.go
+++ b/internal/bot/testhelpers_test.go
@@ -123,7 +123,7 @@ func fakeCallback(chatID int64, data string) *tgmodels.Update {
 		CallbackQuery: &tgmodels.CallbackQuery{
 			ID:   "cb-1",
 			Data: data,
-			From: tgmodels.User{Username: "testuser"},
+			From: tgmodels.User{ID: chatID, Username: "testuser"},
 			Message: tgmodels.MaybeInaccessibleMessage{
 				Message: &tgmodels.Message{
 					Chat: tgmodels.Chat{ID: chatID},


### PR DESCRIPTION
## Summary
- Validates that `CallbackQuery.From.ID` matches `Chat.ID` before dispatching callbacks
- Prevents forwarded bot messages with inline buttons from modifying another user's wizard state
- Test helper updated to set `From.ID` consistently

closes #871

## Test plan
- [x] `go test ./internal/bot/` — all tests pass
- [x] `golangci-lint run ./internal/bot/` — 0 issues
- [ ] CI pipeline passes