### PR TITLE
chore: validate polling interval and jitter are non-negative

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,6 +181,13 @@ func validate(cfg *Config) error {
 		return fmt.Errorf("firebase.credentials_file or firebase.credentials_json is required when project_id is set")
 	}
 
+	if cfg.Polling.Interval <= 0 {
+		return fmt.Errorf("polling.interval must be positive, got %s", cfg.Polling.Interval)
+	}
+	if cfg.Polling.Jitter < 0 {
+		return fmt.Errorf("polling.jitter must be non-negative, got %s", cfg.Polling.Jitter)
+	}
+
 	if ah := cfg.Polling.ActiveHours; ah != nil {
 		if _, err := parseTimeOfDay(ah.Start); err != nil {
 			return fmt.Errorf("active_hours.start %q: must be HH:MM format", ah.Start)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -216,6 +216,26 @@ polling:
 	}
 }
 
+func TestLoad_NegativeInterval(t *testing.T) {
+	yaml := `
+telegram:
+  token: "test-token"
+polling:
+  interval: -5m
+`
+	expectLoadError(t, yaml, "polling.interval must be positive")
+}
+
+func TestLoad_NegativeJitter(t *testing.T) {
+	yaml := `
+telegram:
+  token: "test-token"
+polling:
+  jitter: -1m
+`
+	expectLoadError(t, yaml, "polling.jitter must be non-negative")
+}
+
 func loadFromString(t *testing.T, yaml string) *Config {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Rejects negative polling intervals and jitter during config validation
- A negative interval would cause `time.Sleep` to return immediately, creating a tight polling loop
- Adds 2 test cases for negative interval and jitter

closes #872

## Test plan
- [x] `go test ./internal/config/` — all tests pass
- [x] `golangci-lint run ./internal/config/` — 0 issues
- [ ] CI pipeline passes