### PR TITLE
fix: reject unknown manufacturer/model IDs in search validation

### DIFF
--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -228,35 +228,25 @@ func TestCreateSearch_ModelRequiresManufacturer(t *testing.T) {
 	}
 }
 
-func TestCreateSearch_UnknownManufacturer_AcceptsWithFallback(t *testing.T) {
+func TestCreateSearch_UnknownManufacturer_Rejected(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
 		Manufacturer: 999999, Model: 10226,
 	})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201 (catalog falls back to 'Unknown'), got %d", w.Code)
-	}
-	var resp searchResponse
-	mustUnmarshal(t, w.Body.Bytes(), &resp)
-	if resp.ManufacturerName != "Unknown" {
-		t.Errorf("manufacturer_name = %q, want Unknown", resp.ManufacturerName)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown manufacturer, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
-func TestCreateSearch_UnknownModel_AcceptsWithFallback(t *testing.T) {
+func TestCreateSearch_UnknownModel_Rejected(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	w := doRequest(t, srv, "POST", "/api/v1/searches", createSearchRequest{
 		Manufacturer: 19, Model: 999999,
 	})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201 (catalog falls back to 'Unknown'), got %d", w.Code)
-	}
-	var resp searchResponse
-	mustUnmarshal(t, w.Body.Bytes(), &resp)
-	if resp.ModelName != "Unknown" {
-		t.Errorf("model_name = %q, want Unknown", resp.ModelName)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown model, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -237,7 +237,7 @@ func (s *Server) validateCreateSearchInput(ctx context.Context, chatID int64, re
 	var mfrName, modelName string
 	if req.Manufacturer > 0 {
 		mfrName = s.catalog.ManufacturerName(req.Manufacturer)
-		if mfrName == "" {
+		if mfrName == "" || mfrName == "Unknown" {
 			return "", http.StatusBadRequest, "unknown manufacturer id"
 		}
 	}
@@ -246,7 +246,7 @@ func (s *Server) validateCreateSearchInput(ctx context.Context, chatID int64, re
 			return "", http.StatusBadRequest, "model requires a manufacturer"
 		}
 		modelName = s.catalog.ModelName(req.Manufacturer, req.Model)
-		if modelName == "" {
+		if modelName == "" || modelName == "Unknown" {
 			return "", http.StatusBadRequest, "unknown model id"
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix dead validation code in `validateCreateSearchInput` that never rejected unknown manufacturer/model IDs
- The catalog's `ManufacturerName()` and `ModelName()` return `"Unknown"` (not `""`) for unrecognized IDs, so the `== ""` check was always false
- Now also reject `"Unknown"` so bogus IDs properly return 400 Bad Request
- Update tests to assert 400 instead of incorrectly expecting 201 for unknown IDs

closes #854

## Test plan

- [x] `go test ./internal/api/ -count=1` passes
- [x] `golangci-lint run ./internal/api/` reports 0 issues
- [x] `TestCreateSearch_UnknownManufacturer_Rejected` asserts 400 for manufacturer=999999
- [x] `TestCreateSearch_UnknownModel_Rejected` asserts 400 for model=999999