### PR TITLE
test: add filter and scoring edge case tests for zero/unknown values

### DIFF
--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -293,6 +293,47 @@ func TestApply(t *testing.T) {
 			},
 			want: []string{"a", "b"},
 		},
+		// --- Zero/unknown value edge cases (issue #867) ---
+		{
+			name:     "hand=0 passes MaxHand filter (unknown hand not rejected)",
+			criteria: model.FilterCriteria{MaxHand: 2},
+			listings: []model.RawListing{
+				{Token: "unknown-hand", Hand: 0},
+				{Token: "within-limit", Hand: 2},
+				{Token: "over-limit", Hand: 3},
+			},
+			want: []string{"unknown-hand", "within-limit"},
+		},
+		{
+			name:     "km=0 passes MaxKm filter (unknown km not rejected)",
+			criteria: model.FilterCriteria{MaxKm: 100000},
+			listings: []model.RawListing{
+				{Token: "unknown-km", Km: 0},
+				{Token: "within-limit", Km: 80000},
+				{Token: "over-limit", Km: 150000},
+			},
+			want: []string{"unknown-km", "within-limit"},
+		},
+		{
+			name:     "price=0 passes PriceMax filter (no price not rejected)",
+			criteria: model.FilterCriteria{PriceMax: 150000},
+			listings: []model.RawListing{
+				{Token: "no-price", Price: 0},
+				{Token: "within-limit", Price: 120000},
+				{Token: "over-limit", Price: 200000},
+			},
+			want: []string{"no-price", "within-limit"},
+		},
+		{
+			name:     "year=0 rejected by YearMin filter (unknown year is rejected)",
+			criteria: model.FilterCriteria{YearMin: 2018},
+			listings: []model.RawListing{
+				{Token: "unknown-year", Year: 0},
+				{Token: "old-year", Year: 2015},
+				{Token: "valid-year", Year: 2020},
+			},
+			want: []string{"valid-year"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add 4 filter edge-case tests documenting current behavior when listings have zero/unknown values for Hand, Km, Price, and Year
- Hand=0, Km=0, Price=0 all pass their respective max filters (treated as "unknown, don't reject")
- Year=0 is rejected by YearMin (inconsistent with the other zero-value filters -- documented, not changed)
- The suspicious scoring edge case (price at exactly half median) was already covered by `TestDetectSuspicious_ExactlyAtHalfMedian`

## Test plan

- [x] `go test ./internal/filter/ ./internal/scoring/ -count=1` passes
- [x] `golangci-lint run ./internal/filter/ ./internal/scoring/` reports 0 issues
- [x] All 4 new test cases pass and document existing behavior without changing filter logic

closes #867