### PR TITLE
fix: guard bookmark optimistic update when listing not in cache

### DIFF
--- a/web/src/hooks/useBookmarks.ts
+++ b/web/src/hooks/useBookmarks.ts
@@ -89,7 +89,8 @@ export function useSaveBookmark() {
           });
           continue;
         }
-        if (params.offset === 0 && savedListing) {
+        if (!savedListing) continue;
+        if (params.offset === 0) {
           qc.setQueryData(queryKey, {
             ...d,
             items: [savedListing, ...d.items],


### PR DESCRIPTION
## Summary

- When bookmarking from a page where the listing is not in any query cache (e.g., notifications page), `findListingByToken` returns `undefined`. The `useSaveBookmark` optimistic update was incrementing the saved list `total` without adding an item, causing the saved page to show a wrong count until server invalidation corrected it.
- Added an early `continue` when `savedListing` is `undefined`, skipping the saved-list optimistic update entirely. The mutation still runs and `onSuccess` invalidation refreshes the UI correctly.

## Test plan

- [x] All 202 existing frontend tests pass
- [x] TypeScript type-check passes (`tsc -b`)
- [ ] Manual: bookmark a listing from notifications page, verify saved page count is correct
- [ ] Manual: bookmark a listing from listings page (listing in cache), verify optimistic prepend still works

closes #869