### PR TITLE
fix: revert price records when persistListings fails

### DIFF
--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -208,6 +208,14 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 		log.Error("record price failed", "token", l.Token, "error", err)
 		return false
 	}
+	// Track tokens where RecordPrice inserted a row so that we can revert
+	// them if downstream persistence fails (prevents spurious price-drop
+	// notifications on the next scheduler cycle).
+	// A row is inserted when: (a) first observation (changed=false, oldPrice=0)
+	// or (b) price actually changed (changed=true).
+	if changed || oldPrice == 0 {
+		out.recordedTokens = append(out.recordedTokens, l.Token)
+	}
 	if !changed || l.Price >= oldPrice {
 		return false
 	}
@@ -287,6 +295,23 @@ func (s *Scheduler) deduplicateListings(ctx context.Context, token string, chatI
 		return false, false
 	}
 	return isNew, true
+}
+
+// revertPriceRecords undoes RecordPrice calls for the given tokens.
+// Called when persistListings fails to avoid stale price records that
+// would cause spurious price-drop notifications on the next cycle.
+func (s *Scheduler) revertPriceRecords(ctx context.Context, tokens []string, log *slog.Logger) {
+	if s.stores.Prices == nil || len(tokens) == 0 {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, token := range tokens {
+		if err := s.stores.Prices.RevertPrice(cleanupCtx, token); err != nil {
+			log.Error("revert price after persist failure",
+				"token", token, "error", err)
+		}
+	}
 }
 
 func (s *Scheduler) loadHiddenTokens(ctx context.Context, chatID int64) map[string]bool {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -116,6 +116,11 @@ type searchResult struct {
 	newListings       []model.Listing
 	priceDropMessages []string
 	listingRecords    []storage.ListingRecord
+	// recordedTokens tracks tokens whose prices were recorded via
+	// RecordPrice during this processing pass.  When persistListings
+	// fails the scheduler reverts these records so the next cycle does
+	// not see stale prices and fire spurious price-drop notifications.
+	recordedTokens []string
 }
 
 type Options struct {
@@ -712,6 +717,9 @@ func (s *Scheduler) processGroup(ctx context.Context, group CanonicalGroup, mark
 		if !persistOK {
 			sr.newListings = nil
 			sr.listingRecords = nil
+			// Roll back price records so the next cycle does not see
+			// stale prices and fire spurious price-drop notifications.
+			s.revertPriceRecords(ctx, sr.recordedTokens, searchLog)
 		}
 		gs.newListings += len(sr.newListings)
 		delivered := s.deliverResults(ctx, search, lang, sr, searchLog)

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -20,6 +20,20 @@ import (
 
 // --- Error-returning mock variants ---
 
+// errListingStore wraps mockListingStore and lets tests inject errors into
+// SaveListings (used by persistListings).
+type errListingStore struct {
+	mockListingStore
+	saveErr error
+}
+
+func (m *errListingStore) SaveListings(_ context.Context, records []storage.ListingRecord) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	return m.mockListingStore.SaveListings(context.Background(), records)
+}
+
 type errDedup struct {
 	mockDedup
 	claimErr   error
@@ -1050,5 +1064,92 @@ func TestFlushAndSendDigest_CapsOverflowItems(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "digest queue exceeded max pending items") {
 		t.Error("expected overflow warning in log")
+	}
+}
+
+// TestProcessGroup_PersistFails_RevertsPriceRecords verifies that when
+// persistListings fails, any prices recorded during processSearchListings
+// are reverted so the next scheduler cycle does not fire spurious
+// price-drop notifications (see issue #860).
+func TestProcessGroup_PersistFails_RevertsPriceRecords(t *testing.T) {
+	// Set up a listing with a known price that will be recorded by
+	// tryPriceDropListing on the first cycle.
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "tok-860", Manufacturer: "Toyota", ModelID: 1, Model: "Corolla",
+				Price: 85000, Year: 2021, EngineVolume: 2000, Km: 30000},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+	pt := newMockPriceTracker()
+	ls := &errListingStore{saveErr: errors.New("db write failed")}
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 200, Name: "test-search", Source: "yad2",
+				Manufacturer: 1, Model: 1,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore:  ss,
+		Prices:       pt,
+		ListingStore: ls,
+	})
+
+	// Cycle 1: persistListings fails. The price should be reverted.
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle 1: %v", err)
+	}
+
+	// Verify the price was reverted (token should not exist in the tracker).
+	pt.mu.Lock()
+	_, priceExists := pt.prices["tok-860"]
+	pt.mu.Unlock()
+	if priceExists {
+		t.Fatal("price for tok-860 should have been reverted after persistListings failure")
+	}
+
+	// Verify the dedup claim was also released (so the listing can be
+	// re-processed on the next cycle).
+	d.mu.Lock()
+	_, claimExists := d.seen[dedupKey{"tok-860", 200}]
+	d.mu.Unlock()
+	if claimExists {
+		t.Fatal("dedup claim for tok-860 should have been released after persistListings failure")
+	}
+
+	// Cycle 2: fix the listing store so persist succeeds. Simulate a seller
+	// price change between cycles.
+	ls.saveErr = nil
+	f.mu.Lock()
+	f.listings = []model.RawListing{
+		{Token: "tok-860", Manufacturer: "Toyota", ModelID: 1, Model: "Corolla",
+			Price: 80000, Year: 2021, EngineVolume: 2000, Km: 30000},
+	}
+	f.mu.Unlock()
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle 2: %v", err)
+	}
+
+	// The listing should be treated as a brand-new listing (first price
+	// observation), NOT as a price drop from 85000 -> 80000.
+	n.mu.Lock()
+	rawCount := len(n.rawMessages)
+	n.mu.Unlock()
+	if rawCount != 0 {
+		t.Errorf("expected 0 price-drop notifications (spurious), got %d", rawCount)
+	}
+
+	// The new listing should have been notified via Notify (batch), not
+	// NotifyRaw (price drop).
+	n.mu.Lock()
+	batchCount := len(n.messages)
+	n.mu.Unlock()
+	if batchCount != 1 {
+		t.Errorf("expected 1 batch notification for new listing, got %d", batchCount)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -138,6 +138,13 @@ func (m *mockPriceTracker) RecordPrice(_ context.Context, token string, price in
 	return 0, false, nil
 }
 
+func (m *mockPriceTracker) RevertPrice(_ context.Context, token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.prices, token)
+	return nil
+}
+
 func (m *mockPriceTracker) PrunePrices(_ context.Context, _ time.Duration) (int64, error) {
 	return 0, nil
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -118,6 +118,11 @@ type NotificationQueue interface {
 
 type PriceTracker interface {
 	RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error)
+	// RevertPrice removes the most recent price_history row for the given
+	// token.  It is used to undo a RecordPrice call when downstream
+	// persistence (e.g. listing save) fails, preventing spurious price-drop
+	// notifications on the next scheduler cycle.
+	RevertPrice(ctx context.Context, token string) error
 	PrunePrices(ctx context.Context, olderThan time.Duration) (int64, error)
 	GetPriceHistory(ctx context.Context, token string) ([]PricePoint, error)
 }

--- a/internal/storage/postgres/prices.go
+++ b/internal/storage/postgres/prices.go
@@ -58,6 +58,16 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	return prev, false, nil
 }
 
+func (s *Store) RevertPrice(ctx context.Context, token string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM price_history WHERE id = (SELECT id FROM price_history WHERE token = $1 ORDER BY observed_at DESC, id DESC LIMIT 1)`,
+		token)
+	if err != nil {
+		return fmt.Errorf("revert price: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) GetPriceHistory(ctx context.Context, token string) ([]storage.PricePoint, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT price, observed_at FROM price_history WHERE token = $1 ORDER BY observed_at DESC, id DESC`,

--- a/internal/storage/sqlite/prices.go
+++ b/internal/storage/sqlite/prices.go
@@ -57,6 +57,16 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	return prev, false, nil
 }
 
+func (s *Store) RevertPrice(ctx context.Context, token string) error {
+	_, err := s.db.ExecContext(ctx,
+		"DELETE FROM price_history WHERE rowid = (SELECT rowid FROM price_history WHERE token = ? ORDER BY observed_at DESC, rowid DESC LIMIT 1)",
+		token)
+	if err != nil {
+		return fmt.Errorf("revert price: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) GetPriceHistory(ctx context.Context, token string) ([]storage.PricePoint, error) {
 	rows, err := s.db.QueryContext(ctx,
 		"SELECT price, observed_at FROM price_history WHERE token = ? ORDER BY observed_at DESC, rowid DESC", token)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -887,6 +887,68 @@ func TestRecordPrice(t *testing.T) {
 	}
 }
 
+func TestRevertPrice(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Record an initial price.
+	_, _, _ = store.RecordPrice(ctx, "rev1", 100000)
+
+	// Revert should remove the most recent row.
+	if err := store.RevertPrice(ctx, "rev1"); err != nil {
+		t.Fatalf("RevertPrice: %v", err)
+	}
+
+	// After revert, recording the same token should behave like a first
+	// observation (no change detected, no old price).
+	oldPrice, changed, err := store.RecordPrice(ctx, "rev1", 90000)
+	if err != nil {
+		t.Fatalf("RecordPrice after revert: %v", err)
+	}
+	if changed {
+		t.Error("first observation after revert should not be a change")
+	}
+	if oldPrice != 0 {
+		t.Errorf("old price = %d, want 0 (first observation)", oldPrice)
+	}
+}
+
+func TestRevertPrice_MultipleRows(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Record two prices: 100k then 90k.
+	_, _, _ = store.RecordPrice(ctx, "rev2", 100000)
+	_, _, _ = store.RecordPrice(ctx, "rev2", 90000)
+
+	// Revert removes only the most recent row (90k).
+	if err := store.RevertPrice(ctx, "rev2"); err != nil {
+		t.Fatalf("RevertPrice: %v", err)
+	}
+
+	// Next observation should see prev=100k (the remaining row).
+	oldPrice, changed, err := store.RecordPrice(ctx, "rev2", 80000)
+	if err != nil {
+		t.Fatalf("RecordPrice after revert: %v", err)
+	}
+	if !changed {
+		t.Error("price change should be detected after revert")
+	}
+	if oldPrice != 100000 {
+		t.Errorf("old price = %d, want 100000", oldPrice)
+	}
+}
+
+func TestRevertPrice_NoRows(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Reverting a token that was never recorded should not error.
+	if err := store.RevertPrice(ctx, "nonexistent"); err != nil {
+		t.Fatalf("RevertPrice on nonexistent token: %v", err)
+	}
+}
+
 func TestRecordPrice_OscillationNoFalseDrop(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- When `persistListings` fails, dedup claims are released but `RecordPrice` entries remain in the database. On the next scheduler cycle, the same listings pass dedup again, and if the seller changed the price between cycles, a spurious "price drop" notification fires for a listing the user never saw.
- Add `RevertPrice` to the `PriceTracker` interface (SQLite + Postgres) and call it when `persistListings` fails, rolling back any price records made during that processing pass.
- Track recorded tokens via `searchResult.recordedTokens` so we know exactly which prices to revert.

Closes #860 (part 1: spurious price-drop notifications). Part 2 (CachingFetcher stale-serve cap) can be addressed in a follow-up PR.

## Test plan

- [x] `TestProcessGroup_PersistFails_RevertsPriceRecords` — two-cycle integration test: cycle 1 fails persist, cycle 2 succeeds with a different price; verifies no spurious price-drop notification fires and the listing is treated as brand-new
- [x] `TestRevertPrice` — sqlite unit test: revert after single price record, next RecordPrice behaves as first observation
- [x] `TestRevertPrice_MultipleRows` — sqlite unit test: revert only removes the most recent row, preserving earlier history
- [x] `TestRevertPrice_NoRows` — sqlite unit test: revert on nonexistent token does not error
- [x] All existing scheduler tests pass (`go test ./internal/scheduler/ -count=1`)
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)