### PR TITLE
test: add page tests for SavedPage, HistoryPage, and NotificationsPage

### DIFF
--- a/web/src/pages/HistoryPage.test.tsx
+++ b/web/src/pages/HistoryPage.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HistoryPage } from "./HistoryPage";
+
+const mockListing = {
+  token: "tok1",
+  manufacturer: "Toyota",
+  model: "Corolla",
+  year: 2021,
+  price: 120000,
+  km: 50000,
+  hand: 2,
+  city: "Tel Aviv",
+  page_link: "https://yad2.co.il/item/tok1",
+  image_url: "https://img.yad2.co.il/tok1.jpg",
+  first_seen_at: "2024-01-01T00:00:00Z",
+  saved: false,
+  seen: true,
+};
+
+let historyReturn: {
+  data: { items: typeof mockListing[]; total: number } | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = {
+  data: { items: [mockListing], total: 1 },
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock("@/hooks/useBookmarks", () => ({
+  useHistory: () => historyReturn,
+}));
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <HistoryPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("HistoryPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    historyReturn = {
+      data: { items: [mockListing], total: 1 },
+      isLoading: false,
+      isError: false,
+    };
+  });
+
+  it("renders page header", () => {
+    renderPage();
+    expect(screen.getByText("היסטוריה")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no history", () => {
+    historyReturn = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+    };
+    renderPage();
+    expect(screen.getByText("אין מודעות בהיסטוריה")).toBeInTheDocument();
+    expect(screen.getByText("חזרה ללוח הבקרה")).toBeInTheDocument();
+  });
+
+  it("renders history listings with total count", () => {
+    renderPage();
+    expect(screen.getByText("(1 מודעות)")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while loading", () => {
+    historyReturn = { data: undefined, isLoading: true, isError: false };
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(
+      '[class*="shimmer"], [class*="skeleton"], [class*="Skeleton"]',
+    );
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state on fetch failure", () => {
+    historyReturn = { data: undefined, isLoading: false, isError: true };
+    renderPage();
+    expect(screen.getByText("שגיאה בטעינת ההיסטוריה")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/NotificationsPage.test.tsx
+++ b/web/src/pages/NotificationsPage.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NotificationsPage } from "./NotificationsPage";
+
+const mockListing = {
+  token: "tok1",
+  manufacturer: "Toyota",
+  model: "Corolla",
+  year: 2021,
+  price: 120000,
+  km: 50000,
+  hand: 2,
+  city: "Tel Aviv",
+  page_link: "https://yad2.co.il/item/tok1",
+  image_url: "https://img.yad2.co.il/tok1.jpg",
+  first_seen_at: "2024-01-01T00:00:00Z",
+  saved: false,
+  seen: false,
+};
+
+const mockMarkSeenMutate = vi.fn();
+const mockMarkOneMutate = vi.fn();
+
+let notificationsReturn: {
+  data: { items: typeof mockListing[]; total: number } | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = {
+  data: { items: [mockListing], total: 1 },
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => notificationsReturn,
+  useMarkNotificationsSeen: () => ({
+    mutate: mockMarkSeenMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/useListingSeen", () => ({
+  useMarkListingSeen: () => ({
+    mutate: mockMarkOneMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <NotificationsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("NotificationsPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    notificationsReturn = {
+      data: { items: [mockListing], total: 1 },
+      isLoading: false,
+      isError: false,
+    };
+  });
+
+  it("renders page header", () => {
+    renderPage();
+    expect(screen.getByText("התראות")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no notifications", () => {
+    notificationsReturn = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+    };
+    renderPage();
+    expect(screen.getByText("אין התראות חדשות")).toBeInTheDocument();
+    expect(screen.getByText("חזרה ללוח הבקרה")).toBeInTheDocument();
+  });
+
+  it("renders notifications with total count", () => {
+    renderPage();
+    expect(screen.getByText("(1 חדשות)")).toBeInTheDocument();
+  });
+
+  it("shows mark-all-seen button when notifications exist", () => {
+    renderPage();
+    expect(screen.getByText("סמן הכל כנקרא")).toBeInTheDocument();
+  });
+
+  it("calls markSeen when mark-all button is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const btn = screen.getByText("סמן הכל כנקרא");
+    await user.click(btn);
+    expect(mockMarkSeenMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading skeletons while loading", () => {
+    notificationsReturn = { data: undefined, isLoading: true, isError: false };
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(
+      '[class*="shimmer"], [class*="skeleton"], [class*="Skeleton"]',
+    );
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state on fetch failure", () => {
+    notificationsReturn = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    };
+    renderPage();
+    expect(screen.getByText("שגיאה בטעינת ההתראות")).toBeInTheDocument();
+  });
+
+  it("renders dismiss button on each notification card", () => {
+    renderPage();
+    const dismissBtn = screen.getByLabelText("סמן כנצפה והסר מהחדשות");
+    expect(dismissBtn).toBeInTheDocument();
+  });
+
+  it("calls markListingSeen when dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const dismissBtn = screen.getByLabelText("סמן כנצפה והסר מהחדשות");
+    await user.click(dismissBtn);
+    expect(mockMarkOneMutate).toHaveBeenCalledWith("tok1");
+  });
+});

--- a/web/src/pages/SavedPage.test.tsx
+++ b/web/src/pages/SavedPage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SavedPage } from "./SavedPage";
+import { ToastProvider } from "@/components/ui/Toast";
+
+const mockListing = {
+  token: "tok1",
+  manufacturer: "Toyota",
+  model: "Corolla",
+  year: 2021,
+  price: 120000,
+  km: 50000,
+  hand: 2,
+  city: "Tel Aviv",
+  page_link: "https://yad2.co.il/item/tok1",
+  image_url: "https://img.yad2.co.il/tok1.jpg",
+  first_seen_at: "2024-01-01T00:00:00Z",
+  saved: true,
+  seen: false,
+};
+
+const mockRemoveMutate = vi.fn();
+
+let savedReturn: {
+  data: { items: typeof mockListing[]; total: number } | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = {
+  data: { items: [mockListing], total: 1 },
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock("@/hooks/useBookmarks", () => ({
+  useSavedListings: () => savedReturn,
+  useRemoveBookmark: () => ({ mutate: mockRemoveMutate }),
+}));
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ToastProvider>
+          <SavedPage />
+        </ToastProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SavedPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    savedReturn = {
+      data: { items: [mockListing], total: 1 },
+      isLoading: false,
+      isError: false,
+    };
+  });
+
+  it("renders page header", () => {
+    renderPage();
+    expect(screen.getByText("שמורים")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no saved listings", () => {
+    savedReturn = {
+      data: { items: [], total: 0 },
+      isLoading: false,
+      isError: false,
+    };
+    renderPage();
+    expect(screen.getByText("אין מודעות שמורות")).toBeInTheDocument();
+    expect(screen.getByText("חזרה ללוח הבקרה")).toBeInTheDocument();
+  });
+
+  it("renders saved listings with total count", () => {
+    renderPage();
+    expect(screen.getByText("(1)")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while loading", () => {
+    savedReturn = { data: undefined, isLoading: true, isError: false };
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(
+      '[class*="shimmer"], [class*="skeleton"], [class*="Skeleton"]',
+    );
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state on fetch failure", () => {
+    savedReturn = { data: undefined, isLoading: false, isError: true };
+    renderPage();
+    expect(screen.getByText("שגיאה בטעינת המודעות")).toBeInTheDocument();
+  });
+
+  it("calls removeBookmark when remove button is clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const removeBtn = screen.getByText("הסר");
+    await user.click(removeBtn);
+    expect(mockRemoveMutate).toHaveBeenCalledWith(
+      "tok1",
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add smoke tests for **SavedPage**, **HistoryPage**, and **NotificationsPage** -- the three most critical pages with zero test coverage
- Each test file covers: empty state, data rendering, loading skeletons, error state
- **NotificationsPage** tests also cover the "mark all as read" button and per-card dismiss interaction
- **SavedPage** tests also cover the remove-bookmark interaction
- Follows existing page test patterns (mocked hooks, QueryClient + MemoryRouter wrapper)

Partially closes #870

## Test plan

- [x] `npm test` -- all 222 tests pass (20 new)
- [x] `npx tsc -b` -- no type errors
- [ ] CI lint, test, and build checks pass