### PR TITLE
fix: hide Try Search sidebar link for authenticated users

### DIFF
--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -31,6 +31,7 @@ interface NavItem {
   badge?: boolean;
   adminOnly?: boolean;
   authOnly?: boolean;
+  guestOnly?: boolean;
 }
 
 const mainNav: NavItem[] = [
@@ -47,7 +48,7 @@ const libraryNav: NavItem[] = [
 const systemNav: NavItem[] = [
   { path: "/settings", label: "הגדרות", icon: Settings, authOnly: true },
   { path: "/admin", label: "ניהול", icon: Wrench, adminOnly: true },
-  { path: "/try", label: "נסה חיפוש", icon: Search },
+  { path: "/try", label: "נסה חיפוש", icon: Search, guestOnly: true },
 ];
 
 interface MobileNavItem {
@@ -144,7 +145,7 @@ function SidebarSection({
   isAuthenticated: boolean;
 }) {
   const visibleItems = items.filter(
-    (item) => (!item.adminOnly || isAdmin) && (!item.authOnly || isAuthenticated),
+    (item) => (!item.adminOnly || isAdmin) && (!item.authOnly || isAuthenticated) && (!item.guestOnly || !isAuthenticated),
   );
   if (visibleItems.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- Adds `guestOnly` flag to `NavItem` interface
- Marks `/try` nav item as `guestOnly: true`
- Filters out `guestOnly` items when user is authenticated

Authenticated users no longer see the "נסה חיפוש" (Try Search) link in the sidebar — they already have full search access via "חיפוש חדש" (New Search).

closes #893

## Test plan
- [x] `npm test` — all 222 tests pass
- [x] `npx tsc -b` — type check clean
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation items now support guest-only visibility. The "try search" feature is now restricted to unauthenticated users only. Updated sidebar visibility logic to properly filter items based on authentication status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->