### PR TITLE
refactor: unify fetch-enrich-score pipeline for scheduler and API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/pricelist"
+	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -62,6 +63,7 @@ type Server struct {
 	vacuumMu         sync.Mutex
 	fetchers         *fetcher.Factory
 	priceListSvc     *pricelist.Service
+	pipeline         *scheduler.ListingPipeline
 	refreshMu        sync.Map
 	lastRefreshSweep atomic.Int64 // unix nano of last sweep
 
@@ -143,6 +145,7 @@ func New(c Config) *Server {
 		guestRL:      newIPRateLimiter(15, 3*time.Minute, c.API.TrustForwardedFor),
 		fetchers:     c.Fetchers,
 		priceListSvc: c.PriceListSvc,
+		pipeline:     scheduler.NewListingPipeline(c.Listings, c.PriceListSvc, c.Logger),
 	}
 }
 

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/filter"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -172,45 +173,14 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	records := make([]storage.ListingRecord, 0, len(filtered))
-	for _, l := range filtered {
-		rec := storage.ListingRecord{
-			Token:        l.Token,
-			ChatID:       chatID,
-			SearchID:     sr.ID,
-			SearchName:   sr.Name,
-			Manufacturer: l.Manufacturer,
-			Model:        l.Model,
-			SubModel:     l.SubModel,
-			SubModelID:   l.SubModelID,
-			Year:         l.Year,
-			Price:        l.Price,
-			Km:           l.Km,
-			Hand:         l.Hand,
-			City:         l.City,
-			PageLink:     l.PageLink,
-			ImageURL:     l.ImageURL,
-			EngineVolume: l.EngineVolume,
-			HorsePower:   l.HorsePower,
-			EngineType:   l.EngineType,
-			GearBox:      l.GearBox,
-			Description:  l.Description,
-			IsCommercial: l.Commercial,
-			FirstSeenAt:  time.Now(),
-		}
-		if s.priceListSvc != nil && l.SubModelID > 0 && l.Year > 0 {
-			if bp, ok := s.priceListSvc.Lookup(r.Context(), l.SubModelID, l.Year, l.Token); ok && bp > 0 {
-				rec.BasePrice = &bp
-				log.Debug("enriched with base_price",
-					"token", l.Token, "sub_model_id", l.SubModelID,
-					"year", l.Year, "base_price", bp)
-			}
-		}
-		records = append(records, rec)
-	}
-	if len(records) > 0 {
-		if err := s.listings.SaveListings(r.Context(), records); err != nil {
-			log.Error("save listings failed", "records", len(records), "error", err)
+	// Run the shared pipeline to score, enrich, and build ListingRecords.
+	// The API does not have a market cache, so deal scoring is skipped (nil).
+	params := scheduler.ProcessParamsFromSearch(*sr, nil)
+	params.ChatID = chatID // override with the authenticated user's chat ID
+	pr := s.pipeline.Process(r.Context(), filtered, params)
+	if len(pr.Records) > 0 {
+		if err := s.listings.SaveListings(r.Context(), pr.Records); err != nil {
+			log.Error("save listings failed", "records", len(pr.Records), "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to save listings")
 			return
 		}

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -1,0 +1,284 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/pricelist"
+	"github.com/dsionov/carwatch/internal/scoring"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// ListingPipeline encapsulates the shared processing steps for converting
+// raw listings into scored, enriched ListingRecords. Both the scheduler
+// and the API refresh handler use this pipeline so that users always get
+// fitness scores, deal scores, suspicious-listing detection, and base
+// price enrichment regardless of how the listing was fetched.
+type ListingPipeline struct {
+	listings     storage.ListingStore // for prefill (LookupEnrichmentData); may be nil
+	priceListSvc *pricelist.Service   // for base price enrichment; may be nil
+	logger       *slog.Logger
+}
+
+// NewListingPipeline creates a ListingPipeline. Both listings and priceListSvc
+// may be nil; the pipeline gracefully skips steps that require them.
+func NewListingPipeline(listings storage.ListingStore, priceListSvc *pricelist.Service, logger *slog.Logger) *ListingPipeline {
+	return &ListingPipeline{
+		listings:     listings,
+		priceListSvc: priceListSvc,
+		logger:       logger,
+	}
+}
+
+// ProcessParams holds the per-call parameters for a pipeline invocation.
+type ProcessParams struct {
+	ChatID      int64
+	SearchID    int64
+	SearchName  string
+	MarketCache *scoring.MarketCache // optional; nil skips deal scoring
+
+	// Search filter bounds (used for fitness scoring).
+	PriceMax    int
+	MaxKm       int
+	MaxHand     int
+	YearMin     int
+	YearMax     int
+	EngineMinCC int
+}
+
+// ProcessResult holds the output of a pipeline invocation.
+type ProcessResult struct {
+	Records  []storage.ListingRecord
+	Listings []model.Listing // enriched listings (for notifications, etc.)
+}
+
+// Process converts raw listings into scored ListingRecords.
+//
+// Steps performed:
+//  1. Prefill km/city/image from DB (if listings store is available)
+//  2. Compute fitness score
+//  3. Compute deal score (if market cache is available)
+//  4. Detect suspicious listings (if market cache is available)
+//  5. Enrich with base price (if pricelist service is available)
+//  6. Build ListingRecords
+func (p *ListingPipeline) Process(ctx context.Context, raw []model.RawListing, params ProcessParams) ProcessResult {
+	log := p.logger.With("op", "pipeline", "search_id", params.SearchID, "chat_id", params.ChatID)
+
+	p.prefillFromDB(ctx, raw, log)
+
+	result := ProcessResult{
+		Records:  make([]storage.ListingRecord, 0, len(raw)),
+		Listings: make([]model.Listing, 0, len(raw)),
+	}
+
+	for i := range raw {
+		l := raw[i]
+		listing := p.scoreAndEnrich(ctx, l, params, log)
+		rec := p.buildRecord(listing, params)
+		result.Listings = append(result.Listings, listing)
+		result.Records = append(result.Records, rec)
+	}
+
+	return result
+}
+
+// scoreAndEnrich computes fitness score, deal score, suspicious reasons,
+// and base price for a single listing.
+func (p *ListingPipeline) scoreAndEnrich(ctx context.Context, l model.RawListing, params ProcessParams, log *slog.Logger) model.Listing {
+	listing := model.Listing{RawListing: l, SearchName: params.SearchName}
+
+	// Look up market median before fitness scoring so the price dimension
+	// can score against market value instead of just the budget cap.
+	var medianPrice, medianKm, cohort int
+	var marketOK bool
+	if params.MarketCache != nil && l.Price > 0 {
+		medianPrice, medianKm, cohort, marketOK = params.MarketCache.Lookup(l.Manufacturer, l.Model, l.Year)
+	}
+
+	fp := scoring.FitnessParams{
+		Price:        l.Price,
+		Km:           l.Km,
+		Hand:         l.Hand,
+		Year:         l.Year,
+		EngineVolume: l.EngineVolume,
+		PriceMax:     params.PriceMax,
+		MaxKm:        params.MaxKm,
+		MaxHand:      params.MaxHand,
+		YearMin:      params.YearMin,
+		YearMax:      params.YearMax,
+		EngineMinCC:  params.EngineMinCC,
+	}
+	if marketOK {
+		fp.MedianPrice = medianPrice
+	}
+
+	detailed := scoring.FitnessScoreDetailed(fp)
+	listing.FitnessScore = detailed.Total
+	listing.FitnessBreakdown = make([]model.FitnessDim, len(detailed.Dims))
+	for i, d := range detailed.Dims {
+		listing.FitnessBreakdown[i] = model.FitnessDim{
+			Name: d.Name, Score: d.Score, Weight: d.Weight,
+		}
+	}
+	if marketOK {
+		listing.DealScore = &model.ScoreInfo{
+			Score:       scoring.ScoreWithKm(l.Price, l.Km, medianPrice, medianKm),
+			MedianPrice: medianPrice,
+			MedianKm:    medianKm,
+			CohortSize:  cohort,
+		}
+		listing.SuspiciousReasons = scoring.DetectSuspicious(l, medianPrice)
+	}
+
+	// Enrich with base price.
+	p.enrichWithBasePrice(ctx, &listing, log)
+
+	return listing
+}
+
+// enrichWithBasePrice looks up the base (catalog) price for the listing.
+func (p *ListingPipeline) enrichWithBasePrice(ctx context.Context, listing *model.Listing, log *slog.Logger) {
+	if p.priceListSvc == nil {
+		return
+	}
+	if listing.SubModelID <= 0 {
+		log.Debug("enrichWithBasePrice: skipped, no sub_model_id",
+			"token", listing.Token, "sub_model_id", listing.SubModelID,
+			"sub_model", listing.SubModel, "model", listing.Model)
+		return
+	}
+	if listing.Year <= 0 {
+		log.Debug("enrichWithBasePrice: skipped, no year",
+			"token", listing.Token, "year", listing.Year)
+		return
+	}
+
+	bp, ok := p.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year, listing.Token)
+	if !ok {
+		log.Warn("enrichWithBasePrice: lookup failed",
+			"token", listing.Token, "sub_model_id", listing.SubModelID,
+			"year", listing.Year)
+		return
+	}
+	if bp <= 0 {
+		log.Warn("enrichWithBasePrice: zero/negative price",
+			"token", listing.Token, "sub_model_id", listing.SubModelID,
+			"year", listing.Year, "base_price", bp)
+		return
+	}
+
+	listing.BasePrice = &bp
+	log.Info("enrichWithBasePrice: set base_price",
+		"token", listing.Token, "sub_model_id", listing.SubModelID,
+		"year", listing.Year, "base_price", bp)
+}
+
+// prefillFromDB fills in km/city/image from the DB for listings that are
+// missing those fields. This is a no-op if the listing store is nil.
+func (p *ListingPipeline) prefillFromDB(ctx context.Context, listings []model.RawListing, log *slog.Logger) {
+	if p.listings == nil {
+		return
+	}
+
+	var tokens []string
+	for i := range listings {
+		if listings[i].Km <= 0 || listings[i].City == "" || listings[i].ImageURL == "" {
+			tokens = append(tokens, listings[i].Token)
+		}
+	}
+	if len(tokens) == 0 {
+		return
+	}
+
+	data, err := p.listings.LookupEnrichmentData(ctx, tokens)
+	if err != nil {
+		log.Error("pipeline prefill from DB failed", "error", err)
+		return
+	}
+	if len(data) == 0 {
+		return
+	}
+
+	filled := 0
+	for i := range listings {
+		rec, ok := data[listings[i].Token]
+		if !ok {
+			continue
+		}
+		changed := false
+		if listings[i].Km <= 0 && rec.Km > 0 {
+			listings[i].Km = rec.Km
+			changed = true
+		}
+		if listings[i].City == "" && rec.City != "" {
+			listings[i].City = rec.City
+			changed = true
+		}
+		if listings[i].ImageURL == "" && rec.ImageURL != "" {
+			listings[i].ImageURL = rec.ImageURL
+			changed = true
+		}
+		if changed {
+			filled++
+		}
+	}
+	if filled > 0 {
+		log.Info("pipeline prefilled from DB", "filled", filled, "looked_up", len(tokens))
+	}
+}
+
+// buildRecord converts an enriched model.Listing into a storage.ListingRecord.
+func (p *ListingPipeline) buildRecord(listing model.Listing, params ProcessParams) storage.ListingRecord {
+	rec := storage.ListingRecord{
+		Token:        listing.Token,
+		ChatID:       params.ChatID,
+		SearchID:     params.SearchID,
+		SearchName:   params.SearchName,
+		Manufacturer: listing.Manufacturer,
+		Model:        listing.Model,
+		SubModel:     listing.SubModel,
+		SubModelID:   listing.SubModelID,
+		Year:         listing.Year,
+		Price:        listing.Price,
+		Km:           listing.Km,
+		Hand:         listing.Hand,
+		City:         listing.City,
+		PageLink:     listing.PageLink,
+		ImageURL:     listing.ImageURL,
+		EngineVolume: listing.EngineVolume,
+		HorsePower:   listing.HorsePower,
+		EngineType:   listing.EngineType,
+		GearBox:      listing.GearBox,
+		Description:  listing.Description,
+		IsCommercial: listing.Commercial,
+		FitnessScore: &listing.FitnessScore,
+		BasePrice:    listing.BasePrice,
+		FirstSeenAt:  time.Now(),
+	}
+	if listing.DealScore != nil {
+		rec.MedianPrice = &listing.DealScore.MedianPrice
+		rec.CohortSize = &listing.DealScore.CohortSize
+		rec.DealScore = &listing.DealScore.Score
+	}
+	return rec
+}
+
+// ProcessParamsFromSearch builds ProcessParams from a storage.Search and an
+// optional market cache. This is a convenience for callers that have a
+// storage.Search at hand (both the scheduler and the API).
+func ProcessParamsFromSearch(search storage.Search, marketCache *scoring.MarketCache) ProcessParams {
+	return ProcessParams{
+		ChatID:      search.ChatID,
+		SearchID:    search.ID,
+		SearchName:  search.Name,
+		MarketCache: marketCache,
+		PriceMax:    search.PriceMax,
+		MaxKm:       search.MaxKm,
+		MaxHand:     search.MaxHand,
+		YearMin:     search.YearMin,
+		YearMax:     search.YearMax,
+		EngineMinCC: search.EngineMinCC,
+	}
+}

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -16,6 +16,9 @@ import (
 func (s *Scheduler) processSearchListings(ctx context.Context, search storage.Search, filtered []model.RawListing, marketCache *scoring.MarketCache, lang locale.Lang, log *slog.Logger) searchResult {
 	var out searchResult
 	hidden := s.loadHiddenTokens(ctx, search.ChatID)
+
+	// Collect new listings that pass dedup/hidden/seller/price-drop filters.
+	var newRaw []model.RawListing
 	for _, l := range filterHiddenListings(filtered, hidden) {
 		if !storage.RawListingMatchesSellerFilter(l.Commercial, search.SellerFilter) {
 			continue
@@ -30,118 +33,16 @@ func (s *Scheduler) processSearchListings(ctx context.Context, search storage.Se
 		if !isNew {
 			continue
 		}
-		listing := s.scoreAndRecordListings(search, l, marketCache)
-		s.enrichWithBasePrice(ctx, &listing, log)
-		buildNotifications(search, listing, &out)
+		newRaw = append(newRaw, l)
+	}
+
+	if len(newRaw) > 0 {
+		params := ProcessParamsFromSearch(search, marketCache)
+		pr := s.pipeline.Process(ctx, newRaw, params)
+		out.newListings = append(out.newListings, pr.Listings...)
+		out.listingRecords = append(out.listingRecords, pr.Records...)
 	}
 	return out
-}
-
-func (s *Scheduler) scoreAndRecordListings(search storage.Search, l model.RawListing, marketCache *scoring.MarketCache) model.Listing {
-	listing := model.Listing{RawListing: l, SearchName: search.Name}
-
-	// Look up market median before fitness scoring so the price dimension
-	// can score against market value instead of just the budget cap.
-	var medianPrice, medianKm, cohort int
-	var marketOK bool
-	if marketCache != nil && l.Price > 0 {
-		medianPrice, medianKm, cohort, marketOK = marketCache.Lookup(l.Manufacturer, l.Model, l.Year)
-	}
-
-	fp := scoring.FitnessParams{
-		Price:        l.Price,
-		Km:           l.Km,
-		Hand:         l.Hand,
-		Year:         l.Year,
-		EngineVolume: l.EngineVolume,
-		PriceMax:     search.PriceMax,
-		MaxKm:        search.MaxKm,
-		MaxHand:      search.MaxHand,
-		YearMin:      search.YearMin,
-		YearMax:      search.YearMax,
-		EngineMinCC:  search.EngineMinCC,
-	}
-	if marketOK {
-		fp.MedianPrice = medianPrice
-	}
-
-	detailed := scoring.FitnessScoreDetailed(fp)
-	listing.FitnessScore = detailed.Total
-	listing.FitnessBreakdown = make([]model.FitnessDim, len(detailed.Dims))
-	for i, d := range detailed.Dims {
-		listing.FitnessBreakdown[i] = model.FitnessDim{
-			Name: d.Name, Score: d.Score, Weight: d.Weight,
-		}
-	}
-	if marketOK {
-		listing.DealScore = &model.ScoreInfo{
-			Score:       scoring.ScoreWithKm(l.Price, l.Km, medianPrice, medianKm),
-			MedianPrice: medianPrice,
-			MedianKm:    medianKm,
-			CohortSize:  cohort,
-		}
-		listing.SuspiciousReasons = scoring.DetectSuspicious(l, medianPrice)
-	}
-	return listing
-}
-
-func buildNotifications(search storage.Search, listing model.Listing, out *searchResult) {
-	out.newListings = append(out.newListings, listing)
-	rec := storage.ListingRecord{
-		Token: listing.Token, ChatID: search.ChatID, SearchID: search.ID, SearchName: search.Name,
-		Manufacturer: listing.Manufacturer, Model: listing.Model, SubModel: listing.SubModel,
-		SubModelID: listing.SubModelID,
-		Year:       listing.Year, Price: listing.Price, Km: listing.Km, Hand: listing.Hand,
-		City: listing.City, PageLink: listing.PageLink, ImageURL: listing.ImageURL,
-		EngineVolume: listing.EngineVolume, HorsePower: listing.HorsePower,
-		EngineType: listing.EngineType, GearBox: listing.GearBox, Description: listing.Description,
-		IsCommercial: listing.Commercial,
-		FitnessScore: &listing.FitnessScore, BasePrice: listing.BasePrice, FirstSeenAt: time.Now(),
-	}
-	if listing.DealScore != nil {
-		rec.MedianPrice = &listing.DealScore.MedianPrice
-		rec.CohortSize = &listing.DealScore.CohortSize
-		rec.DealScore = &listing.DealScore.Score
-	}
-	out.listingRecords = append(out.listingRecords, rec)
-}
-
-func (s *Scheduler) enrichWithBasePrice(ctx context.Context, listing *model.Listing, log *slog.Logger) {
-	if s.priceListSvc == nil {
-		log.Debug("enrichWithBasePrice: skipped, pricelist service is nil",
-			"token", listing.Token)
-		return
-	}
-	if listing.SubModelID <= 0 {
-		log.Debug("enrichWithBasePrice: skipped, no sub_model_id",
-			"token", listing.Token, "sub_model_id", listing.SubModelID,
-			"sub_model", listing.SubModel, "model", listing.Model)
-		return
-	}
-	if listing.Year <= 0 {
-		log.Debug("enrichWithBasePrice: skipped, no year",
-			"token", listing.Token, "year", listing.Year)
-		return
-	}
-
-	bp, ok := s.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year, listing.Token)
-	if !ok {
-		log.Warn("enrichWithBasePrice: lookup failed",
-			"token", listing.Token, "sub_model_id", listing.SubModelID,
-			"year", listing.Year)
-		return
-	}
-	if bp <= 0 {
-		log.Warn("enrichWithBasePrice: zero/negative price",
-			"token", listing.Token, "sub_model_id", listing.SubModelID,
-			"year", listing.Year, "base_price", bp)
-		return
-	}
-
-	listing.BasePrice = &bp
-	log.Info("enrichWithBasePrice: set base_price",
-		"token", listing.Token, "sub_model_id", listing.SubModelID,
-		"year", listing.Year, "base_price", bp)
 }
 
 func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, lang locale.Lang, sr searchResult, log *slog.Logger) bool {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -76,6 +76,7 @@ type Scheduler struct {
 	carNames          CarNameResolver
 	kmEnricher        KmEnricher
 	priceListSvc      *pricelist.Service
+	pipeline          *ListingPipeline
 	triggerCh         chan struct{}
 
 	langCache      sync.Map
@@ -210,6 +211,7 @@ func NewWithOptions(
 		carNames:          opts.CarNames,
 		kmEnricher:        opts.KmEnricher,
 		priceListSvc:      plSvc,
+		pipeline:          NewListingPipeline(opts.ListingStore, plSvc, logger),
 		triggerCh:         make(chan struct{}, 1),
 		marketCacheTTL:    mcTTL,
 	}, nil


### PR DESCRIPTION
## Summary

- Extracts a shared `ListingPipeline` into `internal/scheduler/pipeline.go` that encapsulates scoring, deal scoring, suspicious-listing detection, base price enrichment, and DB prefill
- Refactors the scheduler's `processSearchListings` to delegate record-building to `pipeline.Process()`
- Refactors the API's `refreshListings` handler to use the same pipeline, replacing ~35 lines of inline record-building that skipped scoring entirely
- API refresh now produces fully scored and enriched listings (fitness score, deal score, suspicious reasons, base price) instead of bare records

## Motivation

The API refresh handler (`internal/api/listings.go`) was a simplified copy of the scheduler's listing pipeline. It skipped fitness scoring, deal scoring, suspicious detection, base price enrichment, and DB prefill. Users who clicked "refresh" got listings without fitness scores or deal indicators, creating a confusing difference between scheduler-discovered and manually-refreshed listings.

## Design

`ListingPipeline` is intentionally minimal:
- No market cache field (passed per-call via `ProcessParams` since the API doesn't have one)
- `listings` and `priceListSvc` may be nil; the pipeline gracefully skips steps that require them
- `ProcessParamsFromSearch` convenience function builds params from a `storage.Search`

The scheduler still handles dedup, price drops, notifications, and delivery on top of the pipeline output.

## Test plan

- [x] All existing scheduler tests pass (`go test ./internal/scheduler/ -count=1`)
- [x] All existing API tests pass (`go test ./internal/api/ -count=1`)
- [x] Full test suite passes (`go test ./... -count=1 -timeout 300s`)
- [x] Linter clean (`golangci-lint run ./...`)

closes #874