### PR TITLE
feat: add web push notification frontend (service worker, API, settings UI)

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -17,6 +17,40 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+/* ── Push Notifications ─────────────────────────────────── */
+
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() ?? {};
+  const title = data.title || 'CarWatch';
+  const options = {
+    body: data.body || '',
+    icon: '/logo-192.png',
+    badge: '/logo-192.png',
+    data: { url: data.url || '/dashboard' },
+    dir: 'rtl',
+    lang: 'he',
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || '/dashboard';
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.includes(self.location.origin) && 'focus' in client) {
+          client.navigate(url);
+          return client.focus();
+        }
+      }
+      return clients.openWindow(url);
+    })
+  );
+});
+
+/* ── Caching / Fetch ───────────────────────────────────── */
+
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 

--- a/web/src/hooks/usePushSubscription.ts
+++ b/web/src/hooks/usePushSubscription.ts
@@ -1,0 +1,76 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { pushApi } from "@/lib/api";
+
+export interface PushState {
+  supported: boolean;
+  permission: NotificationPermission;
+  subscribed: boolean;
+}
+
+const unsupportedState: PushState = {
+  supported: false,
+  permission: "denied",
+  subscribed: false,
+};
+
+export function usePushSubscription(enabled: boolean) {
+  const qc = useQueryClient();
+
+  const { data: pushState } = useQuery({
+    queryKey: ["push-state"],
+    queryFn: async (): Promise<PushState> => {
+      if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+        return unsupportedState;
+      }
+      const permission = Notification.permission;
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      return { supported: true, permission, subscribed: !!sub };
+    },
+    enabled,
+    staleTime: Infinity,
+  });
+
+  const subscribe = useMutation({
+    mutationFn: async () => {
+      const { public_key } = await pushApi.vapidKey();
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") throw new Error("Permission denied");
+
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(public_key),
+      });
+      await pushApi.subscribe(sub.toJSON());
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["push-state"] }),
+  });
+
+  const unsubscribe = useMutation({
+    mutationFn: async () => {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await pushApi.unsubscribe(sub.endpoint);
+        await sub.unsubscribe();
+      }
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["push-state"] }),
+  });
+
+  return {
+    pushState: pushState ?? unsupportedState,
+    subscribe,
+    unsubscribe,
+  };
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding)
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  const rawData = atob(base64);
+  return Uint8Array.from(rawData, (char) => char.charCodeAt(0));
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -514,6 +514,20 @@ export interface TelegramStatus {
   telegram_username: string | null;
 }
 
+export const pushApi = {
+  vapidKey: () => fetchAPI<{ public_key: string }>("/push/vapid-key"),
+  subscribe: (subscription: PushSubscriptionJSON) =>
+    fetchAPI<void>("/push/subscribe", {
+      method: "POST",
+      body: JSON.stringify(subscription),
+    }),
+  unsubscribe: (endpoint: string) =>
+    fetchAPI<void>("/push/subscribe", {
+      method: "DELETE",
+      body: JSON.stringify({ endpoint }),
+    }),
+};
+
 export const telegramApi = {
   status: () => fetchAPI<TelegramStatus>("/telegram/status"),
   createLink: () =>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -10,6 +10,9 @@ import {
   Moon,
   User,
   LogOut,
+  Bell,
+  BellOff,
+  BellRing,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { PageHeader } from "@/components/ui/PageHeader";
@@ -17,12 +20,16 @@ import { useToast } from "@/components/ui/Toast";
 import { telegramApi, type TelegramStatus } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
+import { usePushSubscription } from "@/hooks/usePushSubscription";
 
 export function SettingsPage() {
   usePageTitle("הגדרות");
   const { toast } = useToast();
   const { user, signOut } = useAuth();
   const { theme, toggle: toggleTheme } = useTheme();
+
+  const { pushState, subscribe: pushSubscribe, unsubscribe: pushUnsubscribe } =
+    usePushSubscription(!!user);
 
   const [tgStatus, setTgStatus] = useState<TelegramStatus | null>(null);
   const [tgLoading, setTgLoading] = useState(true);
@@ -173,6 +180,84 @@ export function SettingsPage() {
                 <ExternalLink className="h-4 w-4" />
               )}
               חבר חשבון Telegram
+            </Button>
+          </div>
+        )}
+      </section>
+
+      {/* Push Notifications */}
+      <section className="rounded-2xl border border-border/50 bg-card p-5 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            {pushState.subscribed ? (
+              <BellRing className="h-4 w-4 text-primary" />
+            ) : (
+              <Bell className="h-4 w-4 text-primary" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-foreground">
+              התראות Push
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              קבל התראות ישירות בדפדפן על מודעות חדשות
+            </p>
+          </div>
+        </div>
+
+        {!pushState.supported ? (
+          <div className="flex items-center gap-3 rounded-xl bg-muted/50 border border-border/30 p-3">
+            <BellOff className="h-5 w-5 text-muted-foreground shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              הדפדפן שלך לא תומך בהתראות
+            </p>
+          </div>
+        ) : pushState.permission === "denied" ? (
+          <div className="flex items-center gap-3 rounded-xl bg-destructive/5 border border-destructive/20 p-3">
+            <BellOff className="h-5 w-5 text-destructive shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              ההתראות חסומות בדפדפן. שנה את ההגדרות בדפדפן.
+            </p>
+          </div>
+        ) : pushState.subscribed ? (
+          <div className="space-y-3">
+            <div className="flex items-center gap-3 rounded-xl bg-success/5 border border-success/20 p-3">
+              <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
+              <p className="text-sm font-medium text-foreground">
+                התראות Push מופעלות
+              </p>
+            </div>
+            <Button
+              onClick={() => pushUnsubscribe.mutate()}
+              disabled={pushUnsubscribe.isPending}
+              variant="secondary"
+              className="w-full sm:w-auto"
+            >
+              {pushUnsubscribe.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <BellOff className="h-4 w-4" />
+              )}
+              כבה התראות
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              הפעל התראות Push כדי לקבל עדכונים מיידיים על מודעות חדשות ישירות בדפדפן.
+            </p>
+            <Button
+              onClick={() => pushSubscribe.mutate()}
+              disabled={pushSubscribe.isPending}
+              variant="secondary"
+              className="w-full sm:w-auto"
+            >
+              {pushSubscribe.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Bell className="h-4 w-4" />
+              )}
+              הפעל התראות
             </Button>
           </div>
         )}


### PR DESCRIPTION
## Summary

Part of #747, depends on #898.

Implements the frontend half of web push notifications:

- **Service worker** (`web/public/sw.js`): Added `push` and `notificationclick` event handlers to the existing service worker. Shows RTL Hebrew notifications with the app icon. On click, focuses an existing window or opens a new one to the notification URL.

- **Push API client** (`web/src/lib/api.ts`): Added `pushApi` object with `vapidKey()`, `subscribe()`, and `unsubscribe()` methods that call the backend endpoints from #898.

- **usePushSubscription hook** (`web/src/hooks/usePushSubscription.ts`): React Query hook that checks browser push support, current permission state, and active subscription. Provides `subscribe` and `unsubscribe` mutations that handle VAPID key exchange and the full Web Push API flow.

- **Settings page UI** (`web/src/pages/SettingsPage.tsx`): New "Push Notifications" section below Telegram, matching the existing card/button patterns. Shows contextual states: unsupported browser, blocked permissions, active subscription with disable button, or inactive with enable button. All labels in Hebrew.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc -b`)
- [x] All 222 existing tests pass (`npm test`)
- [ ] Manual: open Settings page in a browser that supports Push API, verify section renders
- [ ] Manual: click "Enable notifications", grant permission, verify subscription created
- [ ] Manual: click "Disable notifications", verify subscription removed
- [ ] Manual: open Settings in Safari/older browser, verify "unsupported" message shown
- [ ] Manual: block notifications in browser settings, verify "blocked" message shown
- [ ] Integration: with #898 backend running, verify end-to-end push delivery