### PR TITLE
fix: surface search limit error as meaningful Hebrew message

### DIFF
--- a/internal/api/accesslog.go
+++ b/internal/api/accesslog.go
@@ -57,6 +57,11 @@ func (s *Server) withAccessLog(next http.Handler) http.Handler {
 		if chatID > 0 {
 			fields = append(fields, "chat_id", chatID)
 		}
+		if rec.status >= 400 {
+			if detail := rec.Header().Get("X-Error-Detail"); detail != "" {
+				fields = append(fields, "error", detail)
+			}
+		}
 		s.logger.Info("http_request", fields...)
 	})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -494,6 +494,7 @@ func (s *Server) handlerLogger(r *http.Request, extras ...any) *slog.Logger {
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("X-Error-Detail", msg)
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -331,7 +331,7 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if count >= int64(s.cfg.MaxSearches) {
-			writeError(w, http.StatusForbidden, "search limit reached")
+			writeError(w, http.StatusConflict, "search limit reached")
 			return
 		}
 	}

--- a/web/src/lib/error-messages.ts
+++ b/web/src/lib/error-messages.ts
@@ -1,7 +1,16 @@
 import { ApiError } from "./api";
 
+const knownMessages: Record<string, string> = {
+  "search limit reached": "הגעת למגבלת החיפושים — מחק חיפוש קיים כדי ליצור חדש",
+  "search name already exists": "שם החיפוש כבר קיים — בחר שם אחר",
+};
+
 export function errorToHebrew(error: unknown): string {
   if (error instanceof ApiError) {
+    const translated = knownMessages[error.message];
+    if (translated) {
+      return translated;
+    }
     if (error.status === 401 || error.status === 403) {
       return "ההרשאה פגה — נסה להתחבר מחדש";
     }

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useCreateSearch } from "@/hooks/useSearches";
 import { useToast } from "@/components/ui/Toast";
 import { cn } from "@/lib/utils";
+import { errorToHebrew } from "@/lib/error-messages";
 import {
   type SearchFormData,
   defaultFormData,
@@ -124,7 +125,7 @@ export function NewSearchPage() {
         toast("החיפוש נוצר בהצלחה!", "success");
         navigate("/dashboard");
       },
-      onError: () => setError("שגיאה ביצירת החיפוש, נסה שוב"),
+      onError: (err) => setError(errorToHebrew(err)),
     });
   }
 


### PR DESCRIPTION
## Summary

- **Backend:** search-limit check returned 403 → changed to 409 Conflict (semantically correct)
- **Backend:** `writeError` now sets `X-Error-Detail` header; access log includes error messages for 4xx/5xx responses
- **Frontend:** added `knownMessages` map in `error-messages.ts` to translate server errors to actionable Hebrew
- **Frontend:** `NewSearchPage` uses `errorToHebrew(err)` instead of a generic fallback string

## Problem

When hitting the 10-search limit, the user saw "ההרשאה פגה — נסה להתחבר מחדש" (authorization expired) instead of the actual "search limit reached" error. This happened because:

1. Backend used HTTP 403 for the limit check — frontend treated all 403s as auth failures
2. `NewSearchPage.onError` overrode the error with a generic Hebrew message
3. Access logs didn't include the error body, making it hard to diagnose from server logs

## Test plan

- [x] `make test` — all Go tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `npm run build` — frontend builds clean
- [x] `npx vitest run` — all 222 frontend tests pass
- [ ] Manual: create searches until limit → verify Hebrew "limit reached" message appears
- [ ] Manual: check server access logs include `"error":"search limit reached"` for 409 responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search operation errors now display localized Hebrew error messages with specific error details instead of generic fallbacks.

* **Improvements**
  * Enhanced error logging captures additional error context for better monitoring and troubleshooting.

* **Changes**
  * HTTP status code when search limit is exceeded changed from 403 Forbidden to 409 Conflict.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->