### PR TITLE
refactor!: remove composed Store god-interface

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dsionov/carwatch/internal/pricelist"
 	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/spa"
-	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/postgres"
 	"github.com/dsionov/carwatch/web"
 )
@@ -228,11 +227,11 @@ func buildFetchers(cfg *config.Config, logger *slog.Logger) (*yad2.Yad2Fetcher, 
 	return yad2Fetcher, cachingFetcher, fetcherFactory, proxyPool, nil
 }
 
-func openStore(cfg *config.Config) (storage.Store, error) {
+func openStore(cfg *config.Config) (*postgres.Store, error) {
 	return postgres.New(cfg.Storage.DSN, cfg.Storage.MigrationsPath)
 }
 
-func buildBot(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, h *health.Status, logger *slog.Logger) (*cwbot.Bot, *telegram.Notifier, *notifier.MultiNotifier, error) {
+func buildBot(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, h *health.Status, logger *slog.Logger) (*cwbot.Bot, *telegram.Notifier, *notifier.MultiNotifier, error) {
 	botHandler := cwbot.New(nil, store, store, cwbot.Config{
 		AdminChatID:  cfg.Telegram.AdminChatID,
 		MaxSearches:  cfg.Telegram.MaxSearches,
@@ -263,24 +262,18 @@ func buildBot(cfg *config.Config, store storage.Store, dynCatalog *catalog.Dynam
 		return nil, nil, nil, fmt.Errorf("register telegram notifier: %w", err)
 	}
 
-	// Register web push notifier when VAPID keys are configured and the storage
-	// backend implements the PushSubscriptionStore interface (added in PR #898).
 	if cfg.Push.VAPIDPublicKey != "" && cfg.Push.VAPIDPrivateKey != "" {
-		if subStore, ok := store.(webpush.SubscriptionStore); ok {
-			wpNotif := webpush.New(subStore, cfg.Push.VAPIDPublicKey, cfg.Push.VAPIDPrivateKey, cfg.Push.VAPIDSubject, logger.With("component", "webpush"))
-			if err := multi.Register("webpush", wpNotif); err != nil {
-				return nil, nil, nil, fmt.Errorf("register webpush notifier: %w", err)
-			}
-			logger.Info("webpush notifier registered")
-		} else {
-			logger.Warn("VAPID keys configured but storage does not support push subscriptions yet")
+		wpNotif := webpush.New(store, cfg.Push.VAPIDPublicKey, cfg.Push.VAPIDPrivateKey, cfg.Push.VAPIDSubject, logger.With("component", "webpush"))
+		if err := multi.Register("webpush", wpNotif); err != nil {
+			return nil, nil, nil, fmt.Errorf("register webpush notifier: %w", err)
 		}
+		logger.Info("webpush notifier registered")
 	}
 
 	return botHandler, tgNotif, multi, nil
 }
 
-func buildAPI(cfg *config.Config, store storage.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger, fetchers *fetcher.Factory, plSvc *pricelist.Service) (*api.Server, error) {
+func buildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, logHub *logstream.Hub, logLevel *slog.LevelVar, logger *slog.Logger, fetchers *fetcher.Factory, plSvc *pricelist.Service) (*api.Server, error) {
 	var firebaseAuth api.TokenVerifier
 	if cfg.Firebase.ProjectID != "" {
 		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/pgtest"
+	"github.com/dsionov/carwatch/internal/storage/postgres"
 )
 
 type fakeTokenVerifier struct {
@@ -37,7 +38,7 @@ func (f *fakeTokenVerifier) VerifyIDToken(_ context.Context, _ string) (*fbauth.
 	}, nil
 }
 
-func setupTestServer(t *testing.T) (*Server, storage.Store) {
+func setupTestServer(t *testing.T) (*Server, *postgres.Store) {
 	t.Helper()
 	store := pgtest.NewStore(t)
 
@@ -1235,7 +1236,7 @@ func TestAdminStats_FirebaseNonAdmin(t *testing.T) {
 	}
 }
 
-func setLastSeenAt(t *testing.T, store storage.Store, chatID int64, when time.Time) {
+func setLastSeenAt(t *testing.T, store *postgres.Store, chatID int64, when time.Time) {
 	t.Helper()
 	db := store.DB()
 	if _, err := db.Exec("UPDATE users SET last_seen_at = $1 WHERE chat_id = $2", when, chatID); err != nil {
@@ -1243,7 +1244,7 @@ func setLastSeenAt(t *testing.T, store storage.Store, chatID int64, when time.Ti
 	}
 }
 
-func seedNotifSearch(t *testing.T, store storage.Store, chatID int64) int64 {
+func seedNotifSearch(t *testing.T, store *postgres.Store, chatID int64) int64 {
 	t.Helper()
 	id, err := store.CreateSearch(context.Background(), storage.Search{
 		ChatID: chatID, Name: "notif-test", Manufacturer: 1, Model: 1,

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/pgtest"
+	"github.com/dsionov/carwatch/internal/storage/postgres"
 )
 
 func TestIsRateLimited(t *testing.T) {
@@ -546,7 +547,7 @@ func searchString(s, substr string) bool {
 	return false
 }
 
-func newBotTestStore(t *testing.T) storage.Store {
+func newBotTestStore(t *testing.T) *postgres.Store {
 	t.Helper()
 	return pgtest.NewStore(t)
 }

--- a/internal/bot/testhelpers_test.go
+++ b/internal/bot/testhelpers_test.go
@@ -11,8 +11,8 @@ import (
 	tgmodels "github.com/go-telegram/bot/models"
 
 	"github.com/dsionov/carwatch/internal/catalog"
-	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/pgtest"
+	"github.com/dsionov/carwatch/internal/storage/postgres"
 )
 
 type sentMessage struct {
@@ -76,7 +76,7 @@ func (m *mockMessenger) reset() {
 type testBot struct {
 	bot   *Bot
 	msg   *mockMessenger
-	store storage.Store
+	store *postgres.Store
 }
 
 func newTestBot(t *testing.T) *testBot {

--- a/internal/bot/wizard_test.go
+++ b/internal/bot/wizard_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/pgtest"
+	"github.com/dsionov/carwatch/internal/storage/postgres"
 )
 
-func newTestStore(t *testing.T) storage.Store {
+func newTestStore(t *testing.T) *postgres.Store {
 	t.Helper()
 	return pgtest.NewStore(t)
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -99,7 +99,6 @@ type DedupStore interface {
 	ClaimNew(ctx context.Context, token string, chatID int64, searchID int64) (bool, error)
 	ReleaseClaim(ctx context.Context, token string, chatID int64) error
 	Prune(ctx context.Context, olderThan time.Duration) (int64, error)
-	Close() error
 }
 
 type PendingNotification struct {

--- a/internal/storage/pgtest/pgtest.go
+++ b/internal/storage/pgtest/pgtest.go
@@ -1,4 +1,4 @@
-// Package pgtest provides a PostgreSQL-backed storage.Store for tests.
+// Package pgtest provides a PostgreSQL-backed store for tests.
 //
 // If TEST_POSTGRES_DSN is set, it connects directly and creates an isolated
 // schema per test. Otherwise it spins up a throwaway PostgreSQL container
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dsionov/carwatch/internal/storage"
 	"github.com/dsionov/carwatch/internal/storage/postgres"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -30,14 +29,14 @@ func migrationsDir() string {
 	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "migrations")
 }
 
-// NewStore returns a storage.Store backed by PostgreSQL.
+// NewStore returns a *postgres.Store backed by PostgreSQL.
 //
 // When TEST_POSTGRES_DSN is set the store creates an isolated schema per
 // test to avoid interference between concurrent tests. Otherwise a
 // disposable PostgreSQL 16 container is started via testcontainers.
 // In both cases migrations are applied automatically and t.Cleanup
 // drops the schema (or terminates the container).
-func NewStore(t *testing.T) storage.Store {
+func NewStore(t *testing.T) *postgres.Store {
 	t.Helper()
 
 	dsn := os.Getenv("TEST_POSTGRES_DSN")

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -2,25 +2,8 @@ package storage
 
 import "database/sql"
 
-// Store is the combined interface that postgres.Store satisfies.
-type Store interface {
-	UserStore
-	LinkTokenStore
-	SearchStore
-	DedupStore
-	NotificationQueue
-	PriceTracker
-	DigestStore
-	ListingStore
-	SavedListingStore
-	HiddenListingStore
-	MarketStore
-	PriceListStore
-	DailyDigestStore
-	AdminStore
-	NotificationStore
-	PushSubscriptionStore
-
+// DBAccessor provides raw database access for admin operations and test helpers.
+type DBAccessor interface {
 	DB() *sql.DB
 	DBSizeBytes() (int64, error)
 }


### PR DESCRIPTION
## Summary

Remove the monolithic `storage.Store` composed interface (16 embedded sub-interfaces) in favor of direct use of `*postgres.Store` concrete type in the wiring layer.

All consumer packages already depend on narrow sub-interfaces — only `cmd/bot/main.go` and test helpers referenced the composed interface. This change makes that explicit.

### What changed

- **Removed `storage.Store`** — the 16-interface composed type is gone
- **Added `storage.DBAccessor`** — small interface for `DB()` and `DBSizeBytes()` (admin/test use)
- **Removed `Close()` from `DedupStore`** — lifecycle concern doesn't belong in domain interface
- **`openStore()` / `buildBot()` / `buildAPI()`** now accept `*postgres.Store` directly
- **`pgtest.NewStore()`** returns `*postgres.Store` instead of the removed interface
- **Simplified webpush registration** — no type assertion needed on concrete type
- **Updated 4 test files** — helper return types changed accordingly

### Why this matters

Each consumer already declared exactly which storage capabilities it needs via narrow interfaces (`UserStore`, `SearchStore`, `ListingStore`, etc.). The composed `Store` interface was only used at the wiring boundary in `main.go` — removing it makes the dependency graph honest.

closes #911

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] No `storage.Store` references remain in source code
- [ ] CI passes (lint, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)