### PR TITLE
chore: standardize local dev with docker-compose PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all build run test test-cover test-e2e lint ci clean docker-build docker-run \
+       dev dev-db dev-stop dev-reset dev-pg-shell \
        vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-deploy vm-deploy-all vm-sync \
        vm-backup vm-backup-list vm-pg-shell \
        vm-setup-backup vm-backup-status \
@@ -63,6 +64,23 @@ web-dev:
 
 web-build:
 	cd web && npm run build
+
+dev-db:
+	docker compose -f docker-compose.dev.yaml up -d
+	@echo "PostgreSQL running on localhost:5432 (user: carwatch, pass: carwatch, db: carwatch)"
+
+dev-stop:
+	docker compose -f docker-compose.dev.yaml down
+
+dev-reset:
+	docker compose -f docker-compose.dev.yaml down -v
+	@echo "Database volume removed. Run 'make dev-db' to start fresh."
+
+dev-pg-shell:
+	docker exec -it carwatch-dev-pg psql -U carwatch carwatch
+
+dev: build dev-db
+	./bot -config config.dev.yaml
 
 docker-build:
 	docker build -t carwatch .

--- a/README.md
+++ b/README.md
@@ -97,14 +97,28 @@ carwatch/
 
 ## Development
 
+### Local setup
+
+Prerequisites: Go 1.25+, Docker (for PostgreSQL).
+
+```bash
+make dev-db        # Start PostgreSQL via Docker
+make dev           # Build + run with local PostgreSQL
+make dev-stop      # Stop PostgreSQL
+make dev-reset     # Wipe database and start fresh
+make dev-pg-shell  # Open psql shell to local database
+```
+
+Set `TELEGRAM_BOT_TOKEN` in your environment before running `make dev`.
+
+### Testing
+
 ```bash
 make test          # Run tests with coverage
 make lint          # Run golangci-lint
 make ci            # Lint + test (what CI runs)
 make test-cover    # Generate HTML coverage report
 ```
-
-Requires Go 1.25+ and PostgreSQL (or Docker for local dev).
 
 ## License
 

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,0 +1,31 @@
+# Local development configuration.
+# Connects to the PostgreSQL started by: make dev-db
+# Run the app with: make dev
+
+log_level: debug
+log_format: pretty
+
+telegram:
+  token: "${TELEGRAM_BOT_TOKEN}"
+  admin_chat_id: 0
+  max_searches: 10
+
+polling:
+  interval: 15m
+  jitter: 5m
+  active_hours:
+    start: "08:00"
+    end: "23:00"
+  timezone: "Asia/Jerusalem"
+
+storage:
+  dsn: "postgres://carwatch:carwatch@localhost:5432/carwatch?sslmode=disable"
+  migrations_path: "./migrations"
+  prune_after: 720h
+
+http:
+  bind: "0.0.0.0:8080"
+
+api:
+  cors_origins:
+    - "http://localhost:5173"

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,9 +1,20 @@
 services:
-  bot:
-    build: .
+  postgres:
+    image: postgres:17-alpine
+    container_name: carwatch-dev-pg
+    ports:
+      - "5432:5432"
     volumes:
-      - ./data:/data
-      - ./config.yaml:/config.yaml:ro
+      - dev-pgdata:/var/lib/postgresql/data
     environment:
-      - TZ=Asia/Jerusalem
-    restart: unless-stopped
+      POSTGRES_USER: carwatch
+      POSTGRES_PASSWORD: carwatch
+      POSTGRES_DB: carwatch
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U carwatch"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  dev-pgdata:


### PR DESCRIPTION
## Summary

Standardize the local development environment now that SQLite is gone. Developers only need Docker and Go installed.

### What changed

- **`docker-compose.dev.yaml`** — rewritten to provide a PostgreSQL 17 container with health checks (replaces the old bot-only compose)
- **`config.dev.yaml`** — new tracked config for local dev (debug logging, pretty output, connects to local PostgreSQL)
- **Makefile** — 5 new targets: `dev-db`, `dev`, `dev-stop`, `dev-reset`, `dev-pg-shell`
- **README** — updated Development section with local setup instructions

### Local dev workflow

```bash
export TELEGRAM_BOT_TOKEN=your-token
make dev       # starts PostgreSQL + builds + runs the app
make dev-stop  # stop PostgreSQL when done
```

closes #912

## Test plan
- [ ] `make dev-db` starts PostgreSQL container
- [ ] `make dev-pg-shell` connects to running database
- [ ] `make dev-reset` wipes and recreates the volume
- [ ] CI passes (no runtime changes, only config/infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)