### PR TITLE
fix: apply search filters to SearchStats query

### DIFF
--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -516,7 +516,7 @@ func (s *Server) searchStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stats, err := s.listings.SearchStats(r.Context(), chatID, id)
+	stats, err := s.listings.SearchStats(r.Context(), chatID, id, listingFilterFromSearch(sr))
 	if err != nil {
 		log.Error("search stats query failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get search stats")

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -303,7 +303,7 @@ func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (in
 	return 0, nil
 }
 
-func (m *mockListingStore) SearchStats(_ context.Context, _ int64, _ int64) (*storage.SearchStats, error) {
+func (m *mockListingStore) SearchStats(_ context.Context, _ int64, _ int64, _ storage.ListingFilter) (*storage.SearchStats, error) {
 	return &storage.SearchStats{}, nil
 }
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -238,7 +238,7 @@ type ListingStore interface {
 	// CountSearchListingsForChat returns listing counts per search_id for chatID,
 	// applying each search row's price/year/km/hand constraints like CountSearchListings.
 	CountSearchListingsForChat(ctx context.Context, chatID int64) (map[int64]int64, error)
-	SearchStats(ctx context.Context, chatID int64, searchID int64) (*SearchStats, error)
+	SearchStats(ctx context.Context, chatID int64, searchID int64, f ListingFilter) (*SearchStats, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
 }

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -456,10 +456,10 @@ func (s *Store) CountSearchListingsForChat(ctx context.Context, chatID int64) (m
 	return out, rows.Err()
 }
 
-func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64) (*storage.SearchStats, error) {
-	var st storage.SearchStats
-	var avgPrice, minPrice, maxPrice sql.NullFloat64
-	err := s.db.QueryRowContext(ctx, `
+func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64, f storage.ListingFilter) (*storage.SearchStats, error) {
+	filterSQL, filterArgs, _ := buildFilterClauses(f, 3)
+
+	query := `
 		SELECT
 			COUNT(*) AS total,
 			COUNT(CASE WHEN first_seen_at > NOW() - INTERVAL '1 day' THEN 1 END) AS new_24h,
@@ -467,7 +467,13 @@ func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64) (
 			MIN(CASE WHEN price > 0 THEN price END) AS min_price,
 			MAX(CASE WHEN price > 0 THEN price END) AS max_price
 		FROM listing_history
-		WHERE search_id = $1 AND chat_id = $2`, searchID, chatID).
+		WHERE search_id = $1 AND chat_id = $2` + filterSQL
+
+	args := append([]any{searchID, chatID}, filterArgs...)
+
+	var st storage.SearchStats
+	var avgPrice, minPrice, maxPrice sql.NullFloat64
+	err := s.db.QueryRowContext(ctx, query, args...).
 		Scan(&st.Total, &st.New24h, &avgPrice, &minPrice, &maxPrice)
 	if err != nil {
 		return nil, fmt.Errorf("search stats: %w", err)


### PR DESCRIPTION
## Summary

The search card in the dashboard showed two different listing counts:
- **Stats total** (bigger) — raw `COUNT(*)` with no filters
- **Listings count** (smaller) — `CountSearchListingsForChat` with search filter criteria applied

This caused confusion — the stats section showed more listings than the filtered count below it.

### Root cause

`SearchStats()` queried `SELECT COUNT(*) FROM listing_history WHERE search_id = $1 AND chat_id = $2` without applying the search's own filter criteria (price_max, year range, km, max_hand, seller_filter, gearbox, price_only, photo_only).

### Fix

Added `ListingFilter` parameter to `SearchStats()` and applied the same `buildFilterClauses()` used by `CountSearchListings`. The API caller now passes `listingFilterFromSearch(sr)` so stats match the filtered listing count.

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI passes
- [ ] Search card shows consistent counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)