### PR TITLE
refactor: replace in-memory market cache with PostgreSQL materialized view

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
-	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.36.0
 	google.golang.org/api v0.276.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -134,6 +133,7 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/appengine/v2 v2.0.6 // indirect

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -579,22 +579,29 @@ func (s *Scheduler) getOrBuildMarketCache(ctx context.Context) *scoring.MarketCa
 }
 
 func (s *Scheduler) buildMarketCache(ctx context.Context) *scoring.MarketCache {
-	listings, err := s.stores.Market.MarketListings(ctx)
+	if err := s.stores.Market.RefreshMarketMedians(ctx); err != nil {
+		s.logger.Error("refresh market medians failed", "error", err)
+		// Continue with stale view data — better than no data.
+	}
+
+	rows, err := s.stores.Market.LoadMarketMedians(ctx)
 	if err != nil {
-		s.logger.Error("load market data failed", "error", err)
+		s.logger.Error("load market medians failed", "error", err)
 		return nil
 	}
-	data := make([]scoring.ListingData, len(listings))
-	for i, l := range listings {
-		data[i] = scoring.ListingData{
-			Manufacturer: l.Manufacturer,
-			Model:        l.Model,
-			Year:         l.Year,
-			Price:        l.Price,
-			Km:           l.Km,
+
+	entries := make([]scoring.MedianEntry, len(rows))
+	for i, r := range rows {
+		entries[i] = scoring.MedianEntry{
+			Manufacturer: r.Manufacturer,
+			Model:        r.Model,
+			Year:         r.Year,
+			MedianPrice:  r.MedianPrice,
+			MedianKm:     r.MedianKm,
+			CohortSize:   r.CohortSize,
 		}
 	}
-	return scoring.NewMarketCache(data)
+	return scoring.NewMarketCacheFromMedians(entries)
 }
 
 func (s *Scheduler) invalidateMarketCache() {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -573,20 +573,21 @@ func (s *Scheduler) getOrBuildMarketCache(ctx context.Context) *scoring.MarketCa
 	}
 
 	mc := s.buildMarketCache(ctx)
-	s.marketCache = mc
-	s.marketCacheBuiltAt = time.Now()
-	return mc
+	if mc != nil {
+		s.marketCache = mc
+		s.marketCacheBuiltAt = time.Now()
+	}
+	return s.marketCache
 }
 
 func (s *Scheduler) buildMarketCache(ctx context.Context) *scoring.MarketCache {
 	if err := s.stores.Market.RefreshMarketMedians(ctx); err != nil {
 		s.logger.Error("refresh market medians failed", "error", err)
-		// Continue with stale view data — better than no data.
 	}
 
 	rows, err := s.stores.Market.LoadMarketMedians(ctx)
 	if err != nil {
-		s.logger.Error("load market medians failed", "error", err)
+		s.logger.Error("load market medians failed, keeping previous cache", "error", err)
 		return nil
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -374,24 +374,26 @@ func TestRunMultiTenantCycle_ObserverSuccessPath(t *testing.T) {
 // --- mockMarketStore ---
 
 type mockMarketStore struct {
-	mu       sync.Mutex
-	listings []storage.MarketListing
-	calls    int
+	mu    sync.Mutex
+	rows  []storage.MarketMedianRow
+	calls int // counts LoadMarketMedians calls
 }
 
-func (m *mockMarketStore) MarketListings(_ context.Context) ([]storage.MarketListing, error) {
+func (m *mockMarketStore) RefreshMarketMedians(_ context.Context) error {
+	return nil
+}
+
+func (m *mockMarketStore) LoadMarketMedians(_ context.Context) ([]storage.MarketMedianRow, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls++
-	return m.listings, nil
+	return m.rows, nil
 }
 
 func TestMarketCacheReusedAcrossCycles(t *testing.T) {
 	ms := &mockMarketStore{
-		listings: []storage.MarketListing{
-			{Manufacturer: "toyota", Model: "corolla", Year: 2020, Price: 100000, Km: 50000},
-			{Manufacturer: "toyota", Model: "corolla", Year: 2020, Price: 110000, Km: 60000},
-			{Manufacturer: "toyota", Model: "corolla", Year: 2020, Price: 120000, Km: 40000},
+		rows: []storage.MarketMedianRow{
+			{Manufacturer: "toyota", Model: "corolla", Year: 2020, MedianPrice: 110000, MedianKm: 50000, CohortSize: 15},
 		},
 	}
 
@@ -440,10 +442,8 @@ func TestMarketCacheReusedAcrossCycles(t *testing.T) {
 
 func TestMarketCacheInvalidatedOnNewListings(t *testing.T) {
 	ms := &mockMarketStore{
-		listings: []storage.MarketListing{
-			{Manufacturer: "mazda", Model: "3", Year: 2020, Price: 90000, Km: 50000},
-			{Manufacturer: "mazda", Model: "3", Year: 2020, Price: 95000, Km: 55000},
-			{Manufacturer: "mazda", Model: "3", Year: 2020, Price: 100000, Km: 60000},
+		rows: []storage.MarketMedianRow{
+			{Manufacturer: "mazda", Model: "3", Year: 2020, MedianPrice: 95000, MedianKm: 55000, CohortSize: 15},
 		},
 	}
 

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -96,18 +96,31 @@ func medianKey(manufacturer, model string, year int) string {
 }
 
 // Lookup returns the median price, median km, cohort size, and whether enough data exists.
+// For precomputed data, it checks year ±1 band and aggregates cohorts (matching the raw path behavior).
 func (mc *MarketCache) Lookup(manufacturer, model string, year int) (median int, medianKm int, cohortSize int, ok bool) {
 	if mc.precomputed != nil {
-		res, found := mc.precomputed[medianKey(manufacturer, model, year)]
-		if !found {
-			return 0, 0, 0, false
-		}
-		return res.median, res.medianKm, res.cohortSize, res.ok
+		return mc.lookupPrecomputed(manufacturer, model, year)
 	}
-
-	// Raw path: compute medians from listings with year-band matching.
 	res := mc.computeFromRaw(manufacturer, model, year)
 	return res.median, res.medianKm, res.cohortSize, res.ok
+}
+
+func (mc *MarketCache) lookupPrecomputed(manufacturer, model string, year int) (int, int, int, bool) {
+	var totalPrice, totalKm, totalCohort int
+	var count int
+	for dy := -1; dy <= 1; dy++ {
+		res, found := mc.precomputed[medianKey(manufacturer, model, year+dy)]
+		if found && res.ok {
+			totalPrice += res.median * res.cohortSize
+			totalKm += res.medianKm * res.cohortSize
+			totalCohort += res.cohortSize
+			count++
+		}
+	}
+	if totalCohort < MinCohortSize {
+		return 0, 0, 0, false
+	}
+	return totalPrice / totalCohort, totalKm / totalCohort, totalCohort, true
 }
 
 func (mc *MarketCache) computeFromRaw(manufacturer, model string, year int) lookupResult {

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -1,13 +1,11 @@
 package scoring
 
 import (
-	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -15,6 +13,9 @@ const (
 	minPriceFloor = 5000 // ignore placeholder prices below this (NIS)
 )
 
+// ListingData holds a raw listing for building a MarketCache from unprocessed
+// listings (used by instant search). For the scheduler path prefer
+// NewMarketCacheFromMedians which accepts pre-aggregated data.
 type ListingData struct {
 	Manufacturer string
 	Model        string
@@ -29,18 +30,58 @@ type entry struct {
 	Km    int
 }
 
-type MarketCache struct {
-	data map[string][]entry
-	sf   singleflight.Group
+// MedianEntry holds pre-computed median data for a single
+// (manufacturer, model, year) cohort from the materialized view.
+type MedianEntry struct {
+	Manufacturer string
+	Model        string
+	Year         int
+	MedianPrice  int
+	MedianKm     int
+	CohortSize   int
 }
 
+// MarketCache provides market median lookups.
+//
+// Two construction paths exist:
+//   - NewMarketCache: builds from raw listings; Lookup performs year-band
+//     matching (+/- 1 year) and computes medians on demand.
+//   - NewMarketCacheFromMedians: builds from pre-aggregated medians
+//     (materialized view); Lookup does a direct map hit on exact year.
+type MarketCache struct {
+	// raw path: populated by NewMarketCache
+	raw map[string][]entry
+
+	// precomputed path: populated by NewMarketCacheFromMedians
+	precomputed map[string]lookupResult
+}
+
+// NewMarketCache builds a cache from raw listings. Lookup computes medians
+// lazily using a year +/- 1 band (used by instant search).
 func NewMarketCache(listings []ListingData) *MarketCache {
-	m := make(map[string][]entry)
+	m := make(map[string][]entry, len(listings))
 	for _, l := range listings {
 		key := cacheKey(l.Manufacturer, l.Model)
 		m[key] = append(m[key], entry{Year: l.Year, Price: l.Price, Km: l.Km})
 	}
-	return &MarketCache{data: m}
+	return &MarketCache{raw: m}
+}
+
+// NewMarketCacheFromMedians builds a cache from pre-computed medians (e.g.
+// loaded from the market_medians materialized view). Lookup is a direct map
+// hit on the exact (manufacturer, model, year) key.
+func NewMarketCacheFromMedians(entries []MedianEntry) *MarketCache {
+	m := make(map[string]lookupResult, len(entries))
+	for _, e := range entries {
+		key := medianKey(e.Manufacturer, e.Model, e.Year)
+		m[key] = lookupResult{
+			median:     e.MedianPrice,
+			medianKm:   e.MedianKm,
+			cohortSize: e.CohortSize,
+			ok:         e.CohortSize >= MinCohortSize,
+		}
+	}
+	return &MarketCache{precomputed: m}
 }
 
 type lookupResult struct {
@@ -50,22 +91,27 @@ type lookupResult struct {
 	ok         bool
 }
 
-func cohortLookupKey(manufacturer, model string, year int) string {
-	return fmt.Sprintf("%s|%d", cacheKey(manufacturer, model), year)
+func medianKey(manufacturer, model string, year int) string {
+	return strings.ToLower(manufacturer) + "|" + strings.ToLower(model) + "|" + strconv.Itoa(year)
 }
 
 // Lookup returns the median price, median km, cohort size, and whether enough data exists.
 func (mc *MarketCache) Lookup(manufacturer, model string, year int) (median int, medianKm int, cohortSize int, ok bool) {
-	key := cohortLookupKey(manufacturer, model, year)
-	v, _, _ := mc.sf.Do(key, func() (interface{}, error) {
-		return mc.lookupUnsynchronized(manufacturer, model, year), nil
-	})
-	res := v.(lookupResult)
+	if mc.precomputed != nil {
+		res, found := mc.precomputed[medianKey(manufacturer, model, year)]
+		if !found {
+			return 0, 0, 0, false
+		}
+		return res.median, res.medianKm, res.cohortSize, res.ok
+	}
+
+	// Raw path: compute medians from listings with year-band matching.
+	res := mc.computeFromRaw(manufacturer, model, year)
 	return res.median, res.medianKm, res.cohortSize, res.ok
 }
 
-func (mc *MarketCache) lookupUnsynchronized(manufacturer, model string, year int) lookupResult {
-	entries := mc.data[cacheKey(manufacturer, model)]
+func (mc *MarketCache) computeFromRaw(manufacturer, model string, year int) lookupResult {
+	entries := mc.raw[cacheKey(manufacturer, model)]
 	var prices, kms []int
 	for _, e := range entries {
 		if abs(e.Year-year) <= 1 && e.Price >= minPriceFloor {

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -699,11 +699,24 @@ func TestNewMarketCacheFromMedians(t *testing.T) {
 		}
 	})
 
-	t.Run("no year band matching", func(t *testing.T) {
-		// Unlike the raw-listing constructor, pre-computed medians use exact year.
-		_, _, _, ok := mc.Lookup("Toyota", "Corolla", 2021)
+	t.Run("year band matching", func(t *testing.T) {
+		// Precomputed path uses ±1 year band, same as raw path.
+		median, _, cohort, ok := mc.Lookup("Toyota", "Corolla", 2021)
+		if !ok {
+			t.Fatal("expected ok=true for adjacent year (2021 within ±1 of 2020)")
+		}
+		if median != 105000 {
+			t.Errorf("median=%d, want 105000", median)
+		}
+		if cohort != 25 {
+			t.Errorf("cohort=%d, want 25", cohort)
+		}
+	})
+
+	t.Run("year too far", func(t *testing.T) {
+		_, _, _, ok := mc.Lookup("Toyota", "Corolla", 2023)
 		if ok {
-			t.Error("precomputed path should not do year-band matching")
+			t.Error("expected ok=false for year 2023 (>1 from 2020)")
 		}
 	})
 

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -669,6 +669,90 @@ func TestMarketCache_LookupConcurrent(t *testing.T) {
 	}
 }
 
+func TestNewMarketCacheFromMedians(t *testing.T) {
+	entries := []MedianEntry{
+		{Manufacturer: "Toyota", Model: "Corolla", Year: 2020, MedianPrice: 105000, MedianKm: 55000, CohortSize: 25},
+		{Manufacturer: "Honda", Model: "Civic", Year: 2021, MedianPrice: 98000, MedianKm: 40000, CohortSize: 18},
+	}
+	mc := NewMarketCacheFromMedians(entries)
+
+	t.Run("exact match", func(t *testing.T) {
+		median, medianKm, cohort, ok := mc.Lookup("Toyota", "Corolla", 2020)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if median != 105000 {
+			t.Errorf("median=%d, want 105000", median)
+		}
+		if medianKm != 55000 {
+			t.Errorf("medianKm=%d, want 55000", medianKm)
+		}
+		if cohort != 25 {
+			t.Errorf("cohort=%d, want 25", cohort)
+		}
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		_, _, _, ok := mc.Lookup("toyota", "corolla", 2020)
+		if !ok {
+			t.Error("expected case-insensitive lookup to work")
+		}
+	})
+
+	t.Run("no year band matching", func(t *testing.T) {
+		// Unlike the raw-listing constructor, pre-computed medians use exact year.
+		_, _, _, ok := mc.Lookup("Toyota", "Corolla", 2021)
+		if ok {
+			t.Error("precomputed path should not do year-band matching")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, _, _, ok := mc.Lookup("Mazda", "3", 2020)
+		if ok {
+			t.Error("expected ok=false for missing manufacturer/model")
+		}
+	})
+
+	t.Run("below min cohort", func(t *testing.T) {
+		small := []MedianEntry{
+			{Manufacturer: "Kia", Model: "Rio", Year: 2020, MedianPrice: 60000, MedianKm: 30000, CohortSize: 5},
+		}
+		mc2 := NewMarketCacheFromMedians(small)
+		_, _, _, ok := mc2.Lookup("Kia", "Rio", 2020)
+		if ok {
+			t.Error("expected ok=false when cohort < MinCohortSize")
+		}
+	})
+
+	t.Run("empty entries", func(t *testing.T) {
+		mc3 := NewMarketCacheFromMedians(nil)
+		_, _, _, ok := mc3.Lookup("Toyota", "Corolla", 2020)
+		if ok {
+			t.Error("expected ok=false for empty cache")
+		}
+	})
+
+	t.Run("concurrent reads", func(t *testing.T) {
+		var wg sync.WaitGroup
+		var bad atomic.Int32
+		for range 32 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				median, _, cohort, ok := mc.Lookup("Honda", "Civic", 2021)
+				if !ok || cohort != 18 || median != 98000 {
+					bad.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+		if bad.Load() != 0 {
+			t.Fatalf("concurrent lookups: %d mismatches", bad.Load())
+		}
+	})
+}
+
 // stubCurrentYear overrides the currentYear func for deterministic scoring tests.
 func stubCurrentYear(t *testing.T, year int) {
 	t.Helper()

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -277,16 +277,22 @@ type PriceListStore interface {
 	SetPriceListEntry(ctx context.Context, e PriceListEntry) error
 }
 
-type MarketListing struct {
+// MarketMedianRow holds a pre-aggregated median row from the market_medians
+// materialized view.
+type MarketMedianRow struct {
 	Manufacturer string
 	Model        string
 	Year         int
-	Price        int
-	Km           int
+	MedianPrice  int
+	MedianKm     int
+	CohortSize   int
 }
 
 type MarketStore interface {
-	MarketListings(ctx context.Context) ([]MarketListing, error)
+	// RefreshMarketMedians refreshes the market_medians materialized view.
+	RefreshMarketMedians(ctx context.Context) error
+	// LoadMarketMedians returns all rows from the materialized view.
+	LoadMarketMedians(ctx context.Context) ([]MarketMedianRow, error)
 }
 
 type DailyDigestUser struct {

--- a/internal/storage/postgres/market.go
+++ b/internal/storage/postgres/market.go
@@ -14,8 +14,8 @@ func (s *Store) RefreshMarketMedians(ctx context.Context) error {
 func (s *Store) LoadMarketMedians(ctx context.Context) ([]storage.MarketMedianRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT manufacturer, model, year,
-		       COALESCE(median_price, 0)::int,
-		       COALESCE(median_km, 0)::int,
+		       ROUND(COALESCE(median_price, 0))::int,
+		       ROUND(COALESCE(median_km, 0))::int,
 		       cohort_size
 		FROM market_medians`)
 	if err != nil {

--- a/internal/storage/postgres/market.go
+++ b/internal/storage/postgres/market.go
@@ -6,26 +6,30 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-func (s *Store) MarketListings(ctx context.Context) ([]storage.MarketListing, error) {
+func (s *Store) RefreshMarketMedians(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY market_medians")
+	return err
+}
+
+func (s *Store) LoadMarketMedians(ctx context.Context) ([]storage.MarketMedianRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT DISTINCT ON (token) manufacturer, model, year, price, km
-		FROM listing_history
-		WHERE manufacturer IS NOT NULL AND manufacturer != ''
-		  AND model IS NOT NULL AND model != ''
-		  AND year > 0 AND price > 0
-		ORDER BY token, first_seen_at DESC`)
+		SELECT manufacturer, model, year,
+		       COALESCE(median_price, 0)::int,
+		       COALESCE(median_km, 0)::int,
+		       cohort_size
+		FROM market_medians`)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 
-	var listings []storage.MarketListing
+	var result []storage.MarketMedianRow
 	for rows.Next() {
-		var l storage.MarketListing
-		if err := rows.Scan(&l.Manufacturer, &l.Model, &l.Year, &l.Price, &l.Km); err != nil {
+		var r storage.MarketMedianRow
+		if err := rows.Scan(&r.Manufacturer, &r.Model, &r.Year, &r.MedianPrice, &r.MedianKm, &r.CohortSize); err != nil {
 			return nil, err
 		}
-		listings = append(listings, l)
+		result = append(result, r)
 	}
-	return listings, rows.Err()
+	return result, rows.Err()
 }

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -858,10 +859,10 @@ func TestPostgres_PriceTracking(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Market listings
+// Market medians (materialized view)
 // ---------------------------------------------------------------------------
 
-func TestPostgres_MarketListings(t *testing.T) {
+func TestPostgres_MarketMedians(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 	seedPgUser(t, store, 100)
@@ -869,60 +870,58 @@ func TestPostgres_MarketListings(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	// Insert listings for two users with same token
-	for _, chatID := range []int64{100, 200} {
+	// Seed enough listings for a cohort (>= 10 with price > 5000).
+	for i := range 12 {
 		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: "tok1", ChatID: chatID, SearchName: "toyota",
+			Token: fmt.Sprintf("mkt-%d", i), ChatID: 100, SearchName: "toyota",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
-			Price: 100000, FirstSeenAt: now,
+			Price: 90000 + i*2000, Km: 40000 + i*1000,
+			FirstSeenAt: now,
 		})
 	}
-	// Another unique token
+	// A few listings with empty manufacturer (should be excluded).
 	_ = store.SaveListing(ctx, storage.ListingRecord{
-		Token: "tok2", ChatID: 100, SearchName: "toyota",
-		Manufacturer: "Toyota", Model: "Corolla", Year: 2021,
-		Price: 110000, FirstSeenAt: now,
-	})
-	// Empty manufacturer should be excluded
-	_ = store.SaveListing(ctx, storage.ListingRecord{
-		Token: "tok3", ChatID: 100, SearchName: "test",
+		Token: "mkt-empty", ChatID: 100, SearchName: "test",
 		Manufacturer: "", Model: "X", Year: 2020,
 		Price: 50000, FirstSeenAt: now,
 	})
-
-	listings, err := store.MarketListings(ctx)
-	if err != nil {
-		t.Fatalf("MarketListings: %v", err)
-	}
-	if len(listings) != 2 {
-		t.Errorf("expected 2 deduplicated listings, got %d", len(listings))
-	}
-
-	// Verify latest by first_seen_at is returned
-	t.Run("selects latest first_seen_at", func(t *testing.T) {
-		older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		newer := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-
-		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: "tok-parity", ChatID: 100, SearchName: "test",
-			Manufacturer: "Honda", Model: "Civic", Year: 2021,
-			Price: 90000, FirstSeenAt: newer,
-		})
-		_ = store.SaveListing(ctx, storage.ListingRecord{
-			Token: "tok-parity", ChatID: 200, SearchName: "test",
-			Manufacturer: "Honda", Model: "Civic", Year: 2021,
-			Price: 100000, FirstSeenAt: older,
-		})
-
-		all, _ := store.MarketListings(ctx)
-		for _, l := range all {
-			if l.Manufacturer == "Honda" && l.Model == "Civic" {
-				if l.Price != 90000 {
-					t.Errorf("expected price 90000 (newer), got %d", l.Price)
-				}
-			}
-		}
+	// A few listings below the price floor (should be excluded).
+	_ = store.SaveListing(ctx, storage.ListingRecord{
+		Token: "mkt-cheap", ChatID: 100, SearchName: "test",
+		Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
+		Price: 1000, FirstSeenAt: now,
 	})
+
+	// Refresh the materialized view.
+	if err := store.RefreshMarketMedians(ctx); err != nil {
+		t.Fatalf("RefreshMarketMedians: %v", err)
+	}
+
+	// Load the computed medians.
+	rows, err := store.LoadMarketMedians(ctx)
+	if err != nil {
+		t.Fatalf("LoadMarketMedians: %v", err)
+	}
+
+	// Should have exactly one cohort (Toyota Corolla 2020).
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 cohort, got %d", len(rows))
+	}
+
+	r := rows[0]
+	if r.Manufacturer != "Toyota" || r.Model != "Corolla" || r.Year != 2020 {
+		t.Errorf("unexpected cohort: %s %s %d", r.Manufacturer, r.Model, r.Year)
+	}
+	if r.CohortSize != 12 {
+		t.Errorf("expected cohort_size=12, got %d", r.CohortSize)
+	}
+	// Median of 90000..112000 (12 values): avg of 6th and 7th = (100000+102000)/2 = 101000
+	if r.MedianPrice < 95000 || r.MedianPrice > 107000 {
+		t.Errorf("median_price=%d out of expected range [95000, 107000]", r.MedianPrice)
+	}
+	if r.MedianKm <= 0 {
+		t.Error("median_km should be positive")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/migrations/000012_market_medians_view.down.sql
+++ b/migrations/000012_market_medians_view.down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS market_medians;

--- a/migrations/000012_market_medians_view.up.sql
+++ b/migrations/000012_market_medians_view.up.sql
@@ -1,0 +1,20 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS market_medians AS
+SELECT
+    manufacturer,
+    model,
+    year,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price) AS median_price,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY NULLIF(km, 0)) AS median_km,
+    COUNT(*) AS cohort_size
+FROM listing_history
+WHERE manufacturer IS NOT NULL
+  AND manufacturer != ''
+  AND model IS NOT NULL
+  AND model != ''
+  AND year > 0
+  AND price > 5000
+GROUP BY manufacturer, model, year
+HAVING COUNT(*) >= 10;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_market_medians_lookup
+    ON market_medians (manufacturer, model, year);


### PR DESCRIPTION
## Summary

Replace the singleflight-based in-memory MarketCache with a PostgreSQL materialized view that pre-aggregates market medians at the database level.

### Before
- `MarketStore.MarketListings()` loaded all raw listings into memory
- `scoring.NewMarketCache()` built a Go map, computed medians lazily via singleflight
- 30-minute TTL with invalidation after persisting new listings

### After
- `market_medians` materialized view computes `PERCENTILE_CONT(0.5)` for price/km, grouped by (manufacturer, model, year)
- Scheduler calls `REFRESH MATERIALIZED VIEW CONCURRENTLY` each cycle
- `LoadMarketMedians()` loads pre-computed rows into a lightweight in-memory map
- Instant search retains its own raw-listing-based cache path (`NewMarketCacheFromListings`)

### What changed
- **Migration 000012** — creates `market_medians` view with unique index
- **MarketStore interface** — `RefreshMarketMedians()` + `LoadMarketMedians()` replace `MarketListings()`
- **scoring.go** — two cache constructors: `NewMarketCacheFromMedians` (scheduler) and `NewMarketCacheFromListings` (instant search). Singleflight removed.
- **scheduler.go** — `buildMarketCache()` refreshes view then loads pre-computed data

closes #916

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] New scoring tests for `NewMarketCacheFromMedians`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Market valuation now uses aggregated median data for more reliable pricing calculations
  * Database performance optimized through materialized view implementation

* **Chores**
  * Updated dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->