### PR TITLE
feat!: split monolith into 3 binaries (Phase 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
     needs: [changes, lint, test, web]
     if: |
       always() &&
-      needs.changes.outputs.infra == 'true' &&
+      (needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true') &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped') &&
       (needs.web.result == 'success' || needs.web.result == 'skipped')
@@ -181,7 +181,7 @@ jobs:
           if [ ! -f web/dist/index.html ]; then
             mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
           fi
-      - name: Build binary
-        run: make build
+      - name: Build all binaries
+        run: make build-all
       - name: Build Docker image
         run: docker build -t carwatch:ci .

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ data/
 config.yaml
 *.db
 /bot
+/api-server
+/scraper
+/notifier-worker
 coverage.out
 .idea/
 .coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: all build run test test-cover test-e2e lint ci clean docker-build docker-run \
+.PHONY: all build build-api build-scraper build-notifier build-all \
+       run test test-cover test-e2e lint ci clean docker-build docker-run \
        dev dev-db dev-stop dev-reset dev-pg-shell \
        vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-deploy vm-deploy-all vm-sync \
        vm-backup vm-backup-list vm-pg-shell \
@@ -24,6 +25,17 @@ LDFLAGS := -ldflags "-s -w \
 
 build:
 	go build $(LDFLAGS) -o bot ./cmd/bot
+
+build-api:
+	go build $(LDFLAGS) -o api-server ./cmd/api-server
+
+build-scraper:
+	go build $(LDFLAGS) -o scraper ./cmd/scraper
+
+build-notifier:
+	go build $(LDFLAGS) -o notifier-worker ./cmd/notifier
+
+build-all: build build-api build-scraper build-notifier
 
 catalog-refresh:
 	go run ./cmd/catalog-gen -output internal/catalog/catalog_data.json
@@ -53,7 +65,7 @@ lint:
 ci: lint test
 
 clean:
-	rm -f bot
+	rm -f bot api-server scraper notifier-worker
 	rm -rf $(COVER_DIR)
 
 web-install:

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -1,3 +1,6 @@
+// Command api-server runs the REST API, SPA, and Telegram bot without the
+// scheduler or Redis consumer. Use this when the scraper and notifier run
+// as separate processes.
 package main
 
 import (
@@ -11,10 +14,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/app"
-	"github.com/dsionov/carwatch/internal/broker"
-	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/health"
-	"github.com/dsionov/carwatch/internal/scheduler"
 )
 
 var (
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("carwatch %s (commit: %s, built: %s)\n", version, gitCommit, buildTime)
+		fmt.Printf("api-server %s (commit: %s, built: %s)\n", version, gitCommit, buildTime)
 		return
 	}
 
@@ -56,7 +56,7 @@ func run(configPath string, logger *slog.Logger) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	telShutdown, err := app.InitTelemetry(ctx, "carwatch", version, cfg, logger)
+	telShutdown, err := app.InitTelemetry(ctx, "carwatch-api", version, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -112,74 +112,8 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
-	// Redis broker (optional): publish alerts to a stream instead of
-	// delivering directly; a consumer goroutine processes them with
-	// rate limiting.
-	var pub *broker.Publisher
-	if cfg.Redis.Addr != "" {
-		p, err := broker.NewPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
-		if err != nil {
-			return fmt.Errorf("create redis publisher: %w", err)
-		}
-		pub = p
-		defer func() { _ = pub.Close() }()
-
-		cons, err := broker.NewConsumer(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB,
-			bb.Multi.NotifyRaw, logger.With("component", "broker-consumer"))
-		if err != nil {
-			return fmt.Errorf("create redis consumer: %w", err)
-		}
-		defer func() { _ = cons.Close() }()
-		go func() {
-			const maxBackoff = 30 * time.Second
-			backoff := time.Second
-			for {
-				if err := cons.Run(ctx); err != nil {
-					if ctx.Err() != nil {
-						return
-					}
-					logger.Error("redis consumer exited, restarting", "backoff", backoff.String(), "error", err)
-					select {
-					case <-ctx.Done():
-						return
-					case <-time.After(backoff):
-					}
-					backoff = min(backoff*2, maxBackoff)
-				}
-			}
-		}()
-		logger.Info("redis broker enabled", "addr", cfg.Redis.Addr)
-	}
-
-	kmEnricher := yad2.NewEnricher(fb.Yad2, logger.With("component", "enricher"), yad2.EnricherConfig{})
-
-	sched, err := scheduler.NewWithOptions(cfg, fb.Caching, store, bb.Multi, logger.With("component", "scheduler"), scheduler.Options{
-		Observer:         h,
-		Prices:           store,
-		ConfigPath:       configPath,
-		FetcherFactory:   fb.Factory,
-		ListingStore:     store,
-		SearchStore:      store,
-		UserStore:        store,
-		DigestStore:      store,
-		HiddenStore:      store,
-		CatalogIngester:  dynCatalog,
-		CarNames:         dynCatalog,
-		KmEnricher:       kmEnricher,
-		MarketStore:      store,
-		PriceListStore:   store,
-		PriceListSvc:     plSvc,
-		DailyDigestStore: store,
-		Publisher:        pub,
-	})
-	if err != nil {
-		return fmt.Errorf("create scheduler: %w", err)
-	}
-
-	bb.Handler.SetPollTrigger(sched)
-	apiServer.SetPollTrigger(sched)
+	// Start Telegram bot polling in a goroutine with restart-on-failure.
 	bb.Handler.StartCleanup(ctx)
-
 	go func() {
 		const maxBackoff = 30 * time.Second
 		backoff := time.Second
@@ -200,10 +134,13 @@ func run(configPath string, logger *slog.Logger) error {
 			backoff = min(backoff*2, maxBackoff)
 		}
 	}()
-	logger.Info("bot started",
+
+	logger.Info("api-server started",
 		"health", "http://"+cfg.HTTP.Bind+"/healthz",
 	)
 
-	h.MarkSchedulerStarted()
-	return sched.Run(ctx)
+	// Block until shutdown signal.
+	<-ctx.Done()
+	logger.Info("api-server shutting down")
+	return nil
 }

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -1,0 +1,133 @@
+// Command notifier runs the Redis consumer that reads alerts from the
+// carwatch:alerts stream and delivers notifications via Telegram and WebPush.
+// It does not need PostgreSQL for listing data, but it does need a user store
+// to resolve notification channels and a push subscription store for WebPush.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/app"
+	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/health"
+)
+
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
+func main() {
+	configPath := flag.String("config", "config.yaml", "path to config file")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	healthBind := flag.String("health-bind", "0.0.0.0:8082", "health endpoint bind address")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("notifier %s (commit: %s, built: %s)\n", version, gitCommit, buildTime)
+		return
+	}
+
+	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
+
+	if err := run(*configPath, *healthBind, logger); err != nil {
+		logger.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(configPath, healthBind string, logger *slog.Logger) error {
+	cfg, err := app.LoadConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	logger, _, err = app.SetupLogger(cfg)
+	if err != nil {
+		return err
+	}
+	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	telShutdown, err := app.InitTelemetry(ctx, "carwatch-notifier", version, cfg, logger)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = telShutdown(context.Background()) }()
+
+	if cfg.Redis.Addr == "" {
+		return fmt.Errorf("redis.addr is required for the notifier worker")
+	}
+
+	// The notifier worker needs a user store for channel resolution and a
+	// push subscription store for WebPush delivery. Both come from PostgreSQL.
+	store, err := app.OpenStore(cfg)
+	if err != nil {
+		return fmt.Errorf("create store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	multi, err := app.BuildMultiNotifier(cfg, store, store, logger)
+	if err != nil {
+		return err
+	}
+	if err := multi.Connect(ctx); err != nil {
+		return fmt.Errorf("connect notifiers: %w", err)
+	}
+	defer func() { _ = multi.Disconnect() }()
+
+	h := health.New()
+	h.SetVersion(version)
+
+	// Health endpoint on a separate port.
+	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := healthSrv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("health server shutdown failed", "error", err)
+		}
+	}()
+
+	cons, err := broker.NewConsumer(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB,
+		multi.NotifyRaw, logger.With("component", "broker-consumer"))
+	if err != nil {
+		return fmt.Errorf("create redis consumer: %w", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	logger.Info("notifier worker started",
+		"redis", cfg.Redis.Addr,
+		"health", "http://"+healthBind+"/healthz",
+	)
+
+	// Run consumer with restart-on-failure.
+	const maxBackoff = 30 * time.Second
+	backoff := time.Second
+	for {
+		if err := cons.Run(ctx); err != nil {
+			if ctx.Err() != nil {
+				logger.Info("notifier worker shutting down")
+				return nil
+			}
+			logger.Error("redis consumer exited, restarting", "backoff", backoff.String(), "error", err)
+			select {
+			case <-ctx.Done():
+				logger.Info("notifier worker shutting down")
+				return nil
+			case <-time.After(backoff):
+			}
+			backoff = min(backoff*2, maxBackoff)
+		}
+	}
+}

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -1,0 +1,159 @@
+// Command scraper runs the scheduler, global feed fetching, and Percolator
+// without the REST API, SPA, or Telegram bot. It optionally publishes alerts
+// to Redis for the notifier worker, or delivers them directly as a fallback.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/app"
+	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/fetcher/yad2"
+	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/scheduler"
+)
+
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
+func main() {
+	configPath := flag.String("config", "config.yaml", "path to config file")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	healthBind := flag.String("health-bind", "0.0.0.0:8081", "health endpoint bind address")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("scraper %s (commit: %s, built: %s)\n", version, gitCommit, buildTime)
+		return
+	}
+
+	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
+
+	if err := run(*configPath, *healthBind, logger); err != nil {
+		logger.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(configPath, healthBind string, logger *slog.Logger) error {
+	cfg, err := app.LoadConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	logger, _, err = app.SetupLogger(cfg)
+	if err != nil {
+		return err
+	}
+	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	telShutdown, err := app.InitTelemetry(ctx, "carwatch-scraper", version, cfg, logger)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = telShutdown(context.Background()) }()
+
+	store, err := app.OpenStore(cfg)
+	if err != nil {
+		return fmt.Errorf("create store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	fb, err := app.BuildFetchers(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	dynCatalog := app.BuildDynamicCatalog(ctx, fb.Yad2, logger)
+
+	h := health.New()
+	h.SetVersion(version)
+
+	// Health endpoint on a separate port.
+	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := healthSrv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("health server shutdown failed", "error", err)
+		}
+	}()
+
+	// Redis publisher (optional): when configured, alerts go through Redis
+	// for the notifier worker to consume.
+	var pub *broker.Publisher
+	if cfg.Redis.Addr != "" {
+		p, err := broker.NewPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
+		if err != nil {
+			return fmt.Errorf("create redis publisher: %w", err)
+		}
+		pub = p
+		defer func() { _ = pub.Close() }()
+		logger.Info("redis publisher enabled", "addr", cfg.Redis.Addr)
+	}
+
+	// Build a notifier for direct delivery fallback when Redis is not
+	// configured. When Redis IS configured, the scheduler still needs a
+	// notifier for non-alert messages (e.g., digest delivery).
+	multi, err := app.BuildMultiNotifier(cfg, store, store, logger)
+	if err != nil {
+		return err
+	}
+	if err := multi.Connect(ctx); err != nil {
+		return fmt.Errorf("connect notifiers: %w", err)
+	}
+	defer func() { _ = multi.Disconnect() }()
+
+	plSvc, plCleanup, err := app.BuildPriceListService(cfg, store, logger)
+	if err != nil {
+		return err
+	}
+	defer plCleanup()
+
+	kmEnricher := yad2.NewEnricher(fb.Yad2, logger.With("component", "enricher"), yad2.EnricherConfig{})
+
+	var n notifier.Notifier = multi
+	sched, err := scheduler.NewWithOptions(cfg, fb.Caching, store, n, logger.With("component", "scheduler"), scheduler.Options{
+		Observer:         h,
+		Prices:           store,
+		ConfigPath:       configPath,
+		FetcherFactory:   fb.Factory,
+		ListingStore:     store,
+		SearchStore:      store,
+		UserStore:        store,
+		DigestStore:      store,
+		HiddenStore:      store,
+		CatalogIngester:  dynCatalog,
+		CarNames:         dynCatalog,
+		KmEnricher:       kmEnricher,
+		MarketStore:      store,
+		PriceListStore:   store,
+		PriceListSvc:     plSvc,
+		DailyDigestStore: store,
+		Publisher:        pub,
+	})
+	if err != nil {
+		return fmt.Errorf("create scheduler: %w", err)
+	}
+
+	logger.Info("scraper started",
+		"health", "http://"+healthBind+"/healthz",
+	)
+
+	h.MarkSchedulerStarted()
+	return sched.Run(ctx)
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,340 @@
+// Package app provides shared initialization helpers used by all entry points
+// (cmd/bot, cmd/api-server, cmd/scraper, cmd/notifier). Each binary's main.go
+// is thin wiring that composes these building blocks.
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	tgbot "github.com/go-telegram/bot"
+	"github.com/lmittmann/tint"
+	"github.com/mattn/go-isatty"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/dsionov/carwatch/internal/api"
+	cwbot "github.com/dsionov/carwatch/internal/bot"
+	"github.com/dsionov/carwatch/internal/catalog"
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/fetcher/yad2"
+	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/notifier/telegram"
+	"github.com/dsionov/carwatch/internal/notifier/webpush"
+	"github.com/dsionov/carwatch/internal/pricelist"
+	"github.com/dsionov/carwatch/internal/spa"
+	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/storage/postgres"
+	"github.com/dsionov/carwatch/internal/telemetry"
+	"github.com/dsionov/carwatch/web"
+)
+
+// LoadConfig reads and validates the configuration file at the given path.
+func LoadConfig(path string) (*config.Config, error) {
+	return config.Load(path)
+}
+
+// OpenStore opens a PostgreSQL store using the configuration's DSN.
+func OpenStore(cfg *config.Config) (*postgres.Store, error) {
+	return postgres.New(cfg.Storage.DSN, cfg.Storage.MigrationsPath)
+}
+
+// FetcherBundle groups all fetcher-related objects returned by BuildFetchers.
+type FetcherBundle struct {
+	Yad2    *yad2.Yad2Fetcher
+	Caching fetcher.Fetcher
+	Factory *fetcher.Factory
+	Pool    *fetcher.ProxyPool
+}
+
+// BuildFetchers creates the Yad2 fetcher, paginating/caching wrappers,
+// circuit breaker, and fetcher factory.
+func BuildFetchers(cfg *config.Config, logger *slog.Logger) (*FetcherBundle, error) {
+	var proxyPool *fetcher.ProxyPool
+	if len(cfg.HTTP.Proxies) > 0 {
+		proxyPool = fetcher.NewProxyPool(cfg.HTTP.Proxies)
+	}
+
+	yad2Logger := logger.With("component", "yad2")
+	var yad2Fetcher *yad2.Yad2Fetcher
+	var err error
+	if proxyPool != nil {
+		yad2Fetcher, err = yad2.NewFetcherWithProxyPool(cfg.HTTP.UserAgents, proxyPool, yad2Logger)
+	} else {
+		yad2Fetcher, err = yad2.NewFetcher(cfg.HTTP.UserAgents, cfg.HTTP.Proxy, yad2Logger)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create fetcher: %w", err)
+	}
+
+	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, cfg.HTTP.MaxPages)
+	cachingFetcher := fetcher.NewCachingFetcher(paginatingFetcher, 5*time.Minute)
+	yad2CB := fetcher.NewCircuitBreaker(cachingFetcher, 5, 10*time.Minute,
+		fetcher.WithCBLogger(logger.With("component", "circuit_breaker", "source", "yad2")))
+
+	fetcherFactory := fetcher.NewFactory()
+	fetcherFactory.Register("yad2", yad2CB)
+
+	return &FetcherBundle{
+		Yad2:    yad2Fetcher,
+		Caching: cachingFetcher,
+		Factory: fetcherFactory,
+		Pool:    proxyPool,
+	}, nil
+}
+
+// BotBundle groups the bot handler, Telegram notifier, and multi-notifier
+// returned by BuildBot.
+type BotBundle struct {
+	Handler    *cwbot.Bot
+	TgNotifier *telegram.Notifier
+	Multi      *notifier.MultiNotifier
+}
+
+// BuildBot creates the Telegram bot handler, Telegram notifier, and
+// multi-notifier (Telegram + optional WebPush).
+func BuildBot(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, h *health.Status, logger *slog.Logger) (*BotBundle, error) {
+	botHandler := cwbot.New(nil, store, store, cwbot.Config{
+		AdminChatID:  cfg.Telegram.AdminChatID,
+		MaxSearches:  cfg.Telegram.MaxSearches,
+		BotUsername:  cfg.Telegram.BotUsername,
+		PollInterval: cfg.Polling.Interval,
+		Health:       h,
+		Digests:      store,
+		Listings:     store,
+		Saved:        store,
+		Hidden:       store,
+		DailyDigests: store,
+		Catalog:      dynCatalog,
+		LinkTokens:   store,
+	}, logger.With("component", "bot"))
+
+	tgNotif, err := telegram.New(cfg.Telegram.Token, logger.With("component", "telegram"),
+		tgbot.WithDefaultHandler(botHandler.DefaultHandler()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create telegram bot: %w", err)
+	}
+
+	botHandler.SetBot(tgNotif.Bot())
+	botHandler.RegisterHandlers()
+
+	multi := notifier.NewMultiNotifier(store, logger.With("component", "notifier"))
+	if err := multi.Register("telegram", tgNotif); err != nil {
+		return nil, fmt.Errorf("register telegram notifier: %w", err)
+	}
+
+	if cfg.Push.VAPIDPublicKey != "" && cfg.Push.VAPIDPrivateKey != "" {
+		wpNotif := webpush.New(store, cfg.Push.VAPIDPublicKey, cfg.Push.VAPIDPrivateKey, cfg.Push.VAPIDSubject, logger.With("component", "webpush"))
+		if err := multi.Register("webpush", wpNotif); err != nil {
+			return nil, fmt.Errorf("register webpush notifier: %w", err)
+		}
+		logger.Info("webpush notifier registered")
+	}
+
+	return &BotBundle{
+		Handler:    botHandler,
+		TgNotifier: tgNotif,
+		Multi:      multi,
+	}, nil
+}
+
+// BuildMultiNotifier creates a multi-notifier with Telegram and optional
+// WebPush channels, without creating a bot handler. Used by the notifier
+// worker which only needs to deliver messages.
+func BuildMultiNotifier(cfg *config.Config, userStore storage.UserStore, subStore webpush.SubscriptionStore, logger *slog.Logger) (*notifier.MultiNotifier, error) {
+	tgNotif, err := telegram.New(cfg.Telegram.Token, logger.With("component", "telegram"))
+	if err != nil {
+		return nil, fmt.Errorf("create telegram notifier: %w", err)
+	}
+
+	multi := notifier.NewMultiNotifier(userStore, logger.With("component", "notifier"))
+	if err := multi.Register("telegram", tgNotif); err != nil {
+		return nil, fmt.Errorf("register telegram notifier: %w", err)
+	}
+
+	if cfg.Push.VAPIDPublicKey != "" && cfg.Push.VAPIDPrivateKey != "" {
+		wpNotif := webpush.New(subStore, cfg.Push.VAPIDPublicKey, cfg.Push.VAPIDPrivateKey, cfg.Push.VAPIDSubject, logger.With("component", "webpush"))
+		if err := multi.Register("webpush", wpNotif); err != nil {
+			return nil, fmt.Errorf("register webpush notifier: %w", err)
+		}
+		logger.Info("webpush notifier registered")
+	}
+
+	return multi, nil
+}
+
+// BuildDynamicCatalog creates and loads the dynamic catalog from the Yad2
+// fetcher.
+func BuildDynamicCatalog(ctx context.Context, yad2Fetcher *yad2.Yad2Fetcher, logger *slog.Logger) *catalog.DynamicCatalog {
+	dynCatalog := catalog.NewDynamic(logger)
+	pageFetcher := &catalog.HTTPPageFetcher{
+		GetPage: yad2Fetcher.FetchRawPage,
+	}
+	dynCatalog.Load(ctx, pageFetcher)
+	logger.Info("dynamic catalog loaded")
+	return dynCatalog
+}
+
+// BuildAPI creates the API server with all REST endpoints.
+func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, logger *slog.Logger, fetcherFactory *fetcher.Factory, plSvc *pricelist.Service) (*api.Server, error) {
+	var firebaseAuth api.TokenVerifier
+	if cfg.Firebase.ProjectID != "" {
+		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("init firebase: %w", err)
+		}
+		firebaseAuth = v
+	}
+
+	cfg.API.AdminChatID = cfg.Telegram.AdminChatID
+	cfg.API.MaxSearches = cfg.Telegram.MaxSearches
+	apiServer := api.New(api.Config{
+		Catalog:      dynCatalog,
+		Searches:     store,
+		Listings:     store,
+		Users:        store,
+		LinkTokens:   store,
+		Prices:       store,
+		Admin:        store,
+		Saved:        store,
+		Hidden:       store,
+		Notifs:       store,
+		PushSubs:     store,
+		Logger:       logger,
+		API:          cfg.API,
+		Push:         cfg.Push,
+		FirebaseAuth: firebaseAuth,
+		BotUsername:  cfg.Telegram.BotUsername,
+		Fetchers:     fetcherFactory,
+		PriceListSvc: plSvc,
+		Bind:         cfg.HTTP.Bind,
+	})
+
+	return apiServer, nil
+}
+
+// BuildPriceListService creates the pricelist HTTP client and service.
+func BuildPriceListService(cfg *config.Config, store *postgres.Store, logger *slog.Logger) (*pricelist.Service, func(), error) {
+	plClient, err := yad2.NewClient(cfg.HTTP.UserAgents, cfg.HTTP.Proxy)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create pricelist client: %w", err)
+	}
+	plHTTP := pricelist.NewYad2Client(plClient)
+	svc := pricelist.NewService(store, plHTTP, logger.With("component", "api-pricelist"))
+	cleanup := func() { plClient.Close() }
+	return svc, cleanup, nil
+}
+
+// BuildHTTPServer creates and starts the HTTP server with health, API, SPA,
+// and metrics endpoints.
+func BuildHTTPServer(cfg *config.Config, h *health.Status, apiServer *api.Server, logger *slog.Logger) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", h.PublicHandler())
+	mux.Handle("/api/v1/", apiServer.Routes())
+	mux.Handle("/", spa.Handler(web.DistFS()))
+
+	metricsHandler, err := telemetry.MetricsHandler()
+	if err != nil {
+		logger.Error("metrics handler setup failed", "error", err)
+	} else {
+		mux.Handle(cfg.Telemetry.MetricsPath, metricsHandler)
+	}
+
+	srv := &http.Server{
+		Addr:              cfg.HTTP.Bind,
+		Handler:           otelhttp.NewHandler(mux, "carwatch"),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("http server failed", "error", err)
+		}
+	}()
+	return srv
+}
+
+// BuildHealthServer creates and starts a minimal HTTP server with only the
+// health endpoint, for use by headless services (scraper, notifier).
+func BuildHealthServer(bind string, h *health.Status, logger *slog.Logger) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", h.PublicHandler())
+
+	srv := &http.Server{
+		Addr:              bind,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("health server failed", "error", err)
+		}
+	}()
+	return srv
+}
+
+// NewLogHandler creates a slog.Handler, choosing between pretty (tint) and
+// JSON output based on the format string and terminal detection.
+func NewLogHandler(format string, level slog.Leveler) slog.Handler {
+	fd := os.Stdout.Fd()
+	usePretty := format == "pretty" ||
+		(format == "auto" && (isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)))
+
+	if usePretty {
+		return tint.NewHandler(os.Stdout, &tint.Options{
+			Level:      level,
+			TimeFormat: time.Kitchen,
+		})
+	}
+	return slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})
+}
+
+// InitTelemetry initializes OpenTelemetry tracing and metrics. Returns a
+// shutdown function that should be deferred.
+func InitTelemetry(ctx context.Context, serviceName, version string, cfg *config.Config, logger *slog.Logger) (func(context.Context) error, error) {
+	shutdown, err := telemetry.Init(ctx, telemetry.Config{
+		ServiceName:    serviceName,
+		ServiceVersion: version,
+		Exporter:       cfg.Telemetry.TracesExporter,
+		OTLPEndpoint:   cfg.Telemetry.OTLPEndpoint,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init telemetry: %w", err)
+	}
+
+	if err := telemetry.InitMetrics(); err != nil {
+		logger.Error("init metrics failed", "error", err)
+	}
+
+	return shutdown, nil
+}
+
+// SetupLogger creates a slog.Logger from the configuration, applying log
+// level and format. Returns the logger and the underlying LevelVar (so
+// callers can adjust the level at runtime if needed).
+func SetupLogger(cfg *config.Config) (*slog.Logger, *slog.LevelVar, error) {
+	logLevel, err := config.ParseLogLevel(cfg.LogLevel)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse log_level %q: %w", cfg.LogLevel, err)
+	}
+	var logLevelVar slog.LevelVar
+	logLevelVar.Set(logLevel)
+	handler := NewLogHandler(cfg.LogFormat, &logLevelVar)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+	return logger, &logLevelVar, nil
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,193 @@
+package app
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing config file")
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte("invalid: {[broken yaml"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoadConfig_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+telegram:
+  token: "test-token"
+storage:
+  dsn: "postgres://localhost/test"
+`
+	if err := os.WriteFile(path, []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Telegram.Token != "test-token" {
+		t.Errorf("unexpected token: %s", c.Telegram.Token)
+	}
+}
+
+func TestOpenStore_InvalidDSN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := `
+log_level: info
+polling:
+  interval: 1m
+  timezone: UTC
+telegram:
+  token: "test-token"
+storage:
+  dsn: "postgres://localhost:99999/nonexistent?sslmode=disable&connect_timeout=1"
+`
+	if err := os.WriteFile(path, []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = OpenStore(c)
+	if err == nil {
+		t.Fatal("expected error for invalid DSN")
+	}
+}
+
+func TestSetupLogger_InvalidLevel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+log_level: "invalid_level"
+telegram:
+  token: "test-token"
+storage:
+  dsn: "postgres://localhost/test"
+`
+	if err := os.WriteFile(path, []byte(cfgYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Use config.Load directly since LoadConfig validates before returning
+	// and log_level is validated inside config.Load.
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid log level")
+	}
+	if !strings.Contains(err.Error(), "log_level") {
+		t.Errorf("expected log_level error, got: %v", err)
+	}
+}
+
+func TestSetupLogger_ValidLevels(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "error"} {
+		t.Run(level, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			cfgYAML := `
+log_level: ` + level + `
+telegram:
+  token: "test-token"
+storage:
+  dsn: "postgres://localhost/test"
+`
+			if err := os.WriteFile(path, []byte(cfgYAML), 0644); err != nil {
+				t.Fatal(err)
+			}
+			c, err := LoadConfig(path)
+			if err != nil {
+				t.Fatalf("log level %q should be valid, got: %v", level, err)
+			}
+			logger, levelVar, err := SetupLogger(c)
+			if err != nil {
+				t.Fatalf("SetupLogger failed for level %q: %v", level, err)
+			}
+			if logger == nil {
+				t.Fatal("expected non-nil logger")
+			}
+			if levelVar == nil {
+				t.Fatal("expected non-nil levelVar")
+			}
+		})
+	}
+}
+
+func TestNewLogHandler_Auto(t *testing.T) {
+	handler := NewLogHandler("auto", slog.LevelInfo)
+	if handler == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestNewLogHandler_JSON(t *testing.T) {
+	handler := NewLogHandler("json", slog.LevelDebug)
+	if handler == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestNewLogHandler_Pretty(t *testing.T) {
+	handler := NewLogHandler("pretty", slog.LevelWarn)
+	if handler == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestBuildFetchers_NoProxy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfgYAML := `
+log_level: info
+telegram:
+  token: "test-token"
+storage:
+  dsn: "postgres://localhost/test"
+`
+	if err := os.WriteFile(path, []byte(cfgYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := slog.New(NewLogHandler("json", slog.LevelError))
+	fb, err := BuildFetchers(c, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fb.Yad2 == nil {
+		t.Error("expected non-nil Yad2 fetcher")
+	}
+	if fb.Caching == nil {
+		t.Error("expected non-nil Caching fetcher")
+	}
+	if fb.Factory == nil {
+		t.Error("expected non-nil Factory")
+	}
+	if fb.Pool != nil {
+		t.Error("expected nil Pool when no proxies configured")
+	}
+}


### PR DESCRIPTION
## Summary

Split the monolith `cmd/bot/main.go` into 3 focused entry points, completing the V2 architecture redesign.

### New binaries

| Binary | Responsibility | Port |
|--------|---------------|------|
| `cmd/api-server` | REST API, SPA, Telegram bot | 8080 |
| `cmd/scraper` | Scheduler, global feed, Percolator | 8081 |
| `cmd/notifier` | Redis consumer, notification delivery | 8082 |
| `cmd/bot` (kept) | All-in-one backwards-compatible mode | 8080 |

### Shared helpers (`internal/app/`)
Extracted common initialization into `internal/app/app.go`:
- `LoadConfig`, `OpenStore`, `SetupLogger`, `InitTelemetry`
- `BuildFetchers`, `BuildBot`, `BuildMultiNotifier`, `BuildAPI`
- `BuildDynamicCatalog`, `BuildPriceListService`
- `BuildHTTPServer`, `BuildHealthServer`, `NewLogHandler`

### Makefile targets
```
make build-api       # build api-server binary
make build-scraper   # build scraper binary
make build-notifier  # build notifier binary
make build-all       # build all 4 binaries
```

closes #924, closes #925, closes #926

## Test plan
- [x] `go build ./...` passes (all 4 binaries compile)
- [x] `golangci-lint run ./...` — 0 issues
- [x] 10 new app helper tests pass
- [x] `make build-all` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system to support independent compilation of application services, enabling flexible deployment configurations.
  * Reorganized application initialization and wiring for improved modularity across different service entry points.

* **Tests**
  * Added tests covering core application component initialization and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->