### PR TITLE
fix: address unresolved CodeRabbit feedback from PR #940

### DIFF
--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -112,18 +112,24 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	)
 
 	// Run consumer with restart-on-failure.
+	// On SIGTERM: stop reading new messages, let in-flight deliveries finish
+	// within a 10-second grace period.
 	const maxBackoff = 30 * time.Second
 	backoff := time.Second
 	for {
 		if err := cons.Run(ctx); err != nil {
 			if ctx.Err() != nil {
-				logger.Info("notifier worker shutting down")
+				logger.Info("notifier worker draining in-flight deliveries")
+				drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cons.Drain(drainCtx)
+				drainCancel()
+				logger.Info("notifier worker shut down")
 				return nil
 			}
 			logger.Error("redis consumer exited, restarting", "backoff", backoff.String(), "error", err)
 			select {
 			case <-ctx.Done():
-				logger.Info("notifier worker shutting down")
+				logger.Info("notifier worker shut down")
 				return nil
 			case <-time.After(backoff):
 			}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -78,7 +78,7 @@ storage:
 	}
 }
 
-func TestSetupLogger_InvalidLevel(t *testing.T) {
+func TestLoadConfig_InvalidLogLevel(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	cfgYAML := `

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -140,5 +140,28 @@ func (c *Consumer) ack(ctx context.Context, id string) {
 	}
 }
 
+// Drain processes any pending (claimed but unacked) messages before shutdown.
+func (c *Consumer) Drain(ctx context.Context) {
+	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream:   StreamName,
+		Group:    GroupName,
+		Consumer: c.consumer,
+		Start:    "-",
+		End:      "+",
+		Count:    100,
+	}).Result()
+	if err != nil || len(pending) == 0 {
+		return
+	}
+	c.logger.Info("draining pending messages", "count", len(pending))
+	for _, p := range pending {
+		msgs, err := c.client.XRangeN(ctx, StreamName, p.ID, p.ID, 1).Result()
+		if err != nil || len(msgs) == 0 {
+			continue
+		}
+		c.processMessage(ctx, msgs[0])
+	}
+}
+
 // Close shuts down the Redis connection.
 func (c *Consumer) Close() error { return c.client.Close() }


### PR DESCRIPTION
## Summary

Address two actionable CodeRabbit review comments from the monolith split PR (#940) that were merged before resolution.

### Changes

1. **Graceful shutdown drain for notifier worker** (`internal/broker/consumer.go`)
   - Added `Consumer.Drain(ctx)` method that processes pending (claimed-but-unacked) messages before shutdown
   - Uses `XPENDING` to find in-flight messages for this consumer, then processes each within the drain context deadline
   - Called from `cmd/notifier/main.go` with a 10-second grace period on SIGTERM

2. **Test naming fix** (`internal/app/app_test.go`)
   - Renamed `TestSetupLogger_InvalidLevel` → `TestLoadConfig_InvalidLogLevel` to match its actual scope (tests config validation, not logger setup)

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)