### PR TITLE
fix: address 6 unresolved CodeRabbit findings across PRs 928-940

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -112,6 +112,9 @@ func run(configPath string, logger *slog.Logger) error {
 		}
 	}()
 
+	// TODO: migrate to webhook-based Telegram integration for multi-replica
+	// deployments. Long-polling only works with a single api-server replica
+	// because getUpdates is exclusive to one consumer per bot token.
 	// Start Telegram bot polling in a goroutine with restart-on-failure.
 	bb.Handler.StartCleanup(ctx)
 	go func() {

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -106,6 +106,9 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		logger.Info("redis publisher enabled", "addr", cfg.Redis.Addr)
 	}
 
+	// TODO: remove direct delivery fallback once Redis is mandatory.
+	// When this fallback fires, Telegram rate limiting and dead-letter
+	// retry logic (which live in the notifier worker) are bypassed.
 	// Build a notifier for direct delivery fallback when Redis is not
 	// configured. When Redis IS configured, the scheduler still needs a
 	// notifier for non-alert messages (e.g., digest delivery).

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	firebase.google.com/go/v4 v4.19.0
 	github.com/Noooste/azuretls-client v1.13.2
 	github.com/SherClockHolmes/webpush-go v1.4.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-telegram/bot v1.20.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lmittmann/tint v1.1.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.19.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
@@ -23,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	golang.org/x/text v0.36.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.276.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -50,7 +53,6 @@ require (
 	github.com/Noooste/uquic-go v1.0.5 // indirect
 	github.com/Noooste/utls v1.3.20 // indirect
 	github.com/Noooste/websocket v1.0.3 // indirect
-	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/bdandy/go-errors v1.2.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -116,7 +118,6 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
@@ -139,7 +140,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/appengine/v2 v2.0.6 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,10 @@ github.com/bdandy/go-errors v1.2.2 h1:WdFv/oukjTJCLa79UfkGmwX7ZxONAihKu4V0mLIs11
 github.com/bdandy/go-errors v1.2.2/go.mod h1:NkYHl4Fey9oRRdbB1CoC6e84tuqQHiqrOcZpqFEkBxM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -179,6 +183,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -285,6 +291,8 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -69,11 +69,17 @@ func NewConsumer(addr, password string, db int, notify NotifyFunc, logger *slog.
 }
 
 // Run reads and processes alerts in a loop until the context is cancelled.
+// It alternates between reclaiming failed pending messages and reading new ones.
 func (c *Consumer) Run(ctx context.Context) error {
+	reclaimTicker := time.NewTicker(30 * time.Second)
+	defer reclaimTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-reclaimTicker.C:
+			c.reclaimPending(ctx)
 		default:
 		}
 
@@ -102,6 +108,56 @@ func (c *Consumer) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// reclaimPending reclaims messages that were delivered but not acked
+// (failed deliveries). Messages exceeding MaxRetries are dead-lettered.
+func (c *Consumer) reclaimPending(ctx context.Context) {
+	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream:   StreamName,
+		Group:    GroupName,
+		Consumer: c.consumer,
+		Start:    "-",
+		End:      "+",
+		Count:    50,
+		Idle:     30 * time.Second,
+	}).Result()
+	if err != nil || len(pending) == 0 {
+		return
+	}
+
+	c.logger.Info("reclaiming pending messages", "count", len(pending))
+	for _, p := range pending {
+		if p.RetryCount >= int64(MaxRetries) {
+			c.deadLetter(ctx, p.ID)
+			continue
+		}
+		msgs, err := c.client.XRangeN(ctx, StreamName, p.ID, p.ID, 1).Result()
+		if err != nil || len(msgs) == 0 {
+			continue
+		}
+		c.processMessage(ctx, msgs[0])
+	}
+}
+
+// deadLetter moves a message to the dead-letter stream and acks it from the main stream.
+func (c *Consumer) deadLetter(ctx context.Context, id string) {
+	msgs, err := c.client.XRangeN(ctx, StreamName, id, id, 1).Result()
+	if err != nil || len(msgs) == 0 {
+		c.ack(ctx, id)
+		return
+	}
+	if err := c.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: DeadLetterStream,
+		MaxLen: 10000,
+		Approx: true,
+		Values: msgs[0].Values,
+	}).Err(); err != nil {
+		c.logger.Error("dead-letter failed", "id", id, "error", err)
+	} else {
+		c.logger.Warn("message dead-lettered after max retries", "id", id, "max_retries", MaxRetries)
+	}
+	c.ack(ctx, id)
 }
 
 func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,8 +249,13 @@ func validate(cfg *Config) error {
 	default:
 		return fmt.Errorf("telemetry.traces_exporter %q: must be none, stdout, or otlp", cfg.Telemetry.TracesExporter)
 	}
-	if cfg.Redis.Addr != "" && cfg.Redis.DB < 0 {
-		return fmt.Errorf("redis.db must be >= 0, got %d", cfg.Redis.DB)
+	if cfg.Redis.Addr != "" {
+		if _, err := net.ResolveTCPAddr("tcp", cfg.Redis.Addr); err != nil {
+			return fmt.Errorf("redis.addr %q: must be a valid host:port", cfg.Redis.Addr)
+		}
+		if cfg.Redis.DB < 0 {
+			return fmt.Errorf("redis.db must be >= 0, got %d", cfg.Redis.DB)
+		}
 	}
 
 	for _, origin := range cfg.API.CORSOrigins {

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -872,25 +872,31 @@ func TestPostgres_MarketMedians(t *testing.T) {
 
 	// Seed enough listings for a cohort (>= 10 with price > 5000).
 	for i := range 12 {
-		_ = store.SaveListing(ctx, storage.ListingRecord{
+		if err := store.SaveListing(ctx, storage.ListingRecord{
 			Token: fmt.Sprintf("mkt-%d", i), ChatID: 100, SearchName: "toyota",
 			Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
 			Price: 90000 + i*2000, Km: 40000 + i*1000,
 			FirstSeenAt: now,
-		})
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
 	// A few listings with empty manufacturer (should be excluded).
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "mkt-empty", ChatID: 100, SearchName: "test",
 		Manufacturer: "", Model: "X", Year: 2020,
 		Price: 50000, FirstSeenAt: now,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	// A few listings below the price floor (should be excluded).
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "mkt-cheap", ChatID: 100, SearchName: "test",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2020,
 		Price: 1000, FirstSeenAt: now,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Refresh the materialized view.
 	if err := store.RefreshMarketMedians(ctx); err != nil {
@@ -1003,14 +1009,18 @@ func TestPostgres_DeleteSearchCascade(t *testing.T) {
 	_, _ = store.ClaimNew(ctx, "tok1", 200, id2)
 
 	// Seed listing_history
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "tok1", ChatID: 100, SearchID: id1, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "tok1", ChatID: 200, SearchID: id2, SearchName: "mazda-3",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 95000,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Delete user 100's search
 	if err := store.DeleteSearch(ctx, id1, 100); err != nil {
@@ -1060,14 +1070,18 @@ func TestPostgres_PruneListings(t *testing.T) {
 	old := time.Now().Add(-100 * 24 * time.Hour)
 	recent := time.Now().Add(-10 * 24 * time.Hour)
 
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-1", ChatID: 100, SearchName: "test",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000, FirstSeenAt: old,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "recent-1", ChatID: 100, SearchName: "test",
 		Manufacturer: "Honda", Model: "Civic", Year: 2022, Price: 95000, FirstSeenAt: recent,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
 	if err != nil {
@@ -1090,14 +1104,18 @@ func TestPostgres_PruneListingsPreservesSaved(t *testing.T) {
 
 	old := time.Now().Add(-100 * 24 * time.Hour)
 
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-saved", ChatID: 100, SearchName: "test",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000, FirstSeenAt: old,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "old-unsaved", ChatID: 100, SearchName: "test",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 85000, FirstSeenAt: old,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	_ = store.SaveBookmark(ctx, 100, "old-saved")
 
 	pruned, _ := store.PruneListings(ctx, 90*24*time.Hour)
@@ -1121,10 +1139,12 @@ func TestPostgres_DeleteStaleListings(t *testing.T) {
 	})
 
 	for _, tok := range []string{"a", "b", "c", "d"} {
-		_ = store.SaveListing(ctx, storage.ListingRecord{
+		if err := store.SaveListing(ctx, storage.ListingRecord{
 			Token: tok, ChatID: 100, SearchID: searchID, SearchName: "test",
 			Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
-		})
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	removed, err := store.DeleteStaleListings(ctx, 100, searchID, []string{"a", "c"})
@@ -1218,16 +1238,20 @@ func TestPostgres_NotificationCenter(t *testing.T) {
 	cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Now().UTC()
 
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "new-1", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000,
 		FirstSeenAt: now,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "new-2", ChatID: 100, SearchID: searchID, SearchName: "s1",
 		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000,
 		FirstSeenAt: now,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// NewListingsSince
 	listings, err := store.NewListingsSince(ctx, 100, cutoff, 20, 0)
@@ -1357,18 +1381,24 @@ func TestPostgres_CountSearchListingsForChat(t *testing.T) {
 		Manufacturer: 9, Model: 10062,
 	})
 
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "cfc-1", ChatID: 100, SearchID: idCapped, SearchName: "capped",
 		Manufacturer: "Mazda", Model: "3", Year: 2022, Price: 90000, Km: 30000, Hand: 1,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "cfc-2", ChatID: 100, SearchID: idCapped, SearchName: "capped",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 120000, Km: 50000, Hand: 2,
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "cfc-3", ChatID: 100, SearchID: idOpen, SearchName: "open",
 		Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 80000, Km: 70000, Hand: 3,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := store.CountSearchListingsForChat(ctx, 100)
 	if err != nil {
@@ -1409,16 +1439,20 @@ func TestPostgres_Admin(t *testing.T) {
 	}
 
 	// Insert listings
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "admin-1", ChatID: 100, SearchName: "s1",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000,
 		FirstSeenAt: time.Now(),
-	})
-	_ = store.SaveListing(ctx, storage.ListingRecord{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "admin-2", ChatID: 100, SearchName: "s1",
 		Manufacturer: "Honda", Model: "Civic", Year: 2021, Price: 90000,
 		FirstSeenAt: time.Now(),
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	cnt, _ = store.CountAllListings(ctx)
 	if cnt != 2 {


### PR DESCRIPTION
## Summary

Audit of CodeRabbit review comments across the last 30 PRs (884-941) found 6 still-valid issues. This PR addresses all of them.

### Commits

1. **fix: correct go.mod direct/indirect dependency markers**
   `go-redis/v9` and `miniredis/v2` were directly imported but marked `// indirect`. Fixed by `go mod tidy`.
   _(PR #939)_

2. **fix: implement retry reclaim and dead-letter for Redis consumer**
   The consumer only read new messages (`">"`). Failed deliveries stayed pending indefinitely — `MaxRetries` and `DeadLetterStream` constants were defined but unused. Now reclaims pending messages every 30s and dead-letters after 3 failures.
   _(PR #939, critical data integrity)_

3. **fix: validate redis.addr as host:port at config load time**
   Malformed addresses passed validation and only failed at runtime. Now uses `net.ResolveTCPAddr` for fail-fast validation.
   _(PR #939)_

4. **fix: check SaveListing errors in postgres integration tests**
   17 calls to `store.SaveListing` silently discarded errors. Test setup failures would produce misleading assertion errors instead of clear setup failure messages.
   _(PR #937)_

5. **docs: add TODO comments for architectural constraints**
   - `api-server`: Telegram long-polling is single-replica only (webhook migration needed for horizontal scaling)
   - `scraper`: direct notification fallback bypasses notifier worker rate limiting
   _(PR #940)_

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)