### PR TITLE
fix: consolidate Docker build layers and enable Redis AOF persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
 ENV LDFLAGS="-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildTime=${BUILD_TIME}"
-RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/bot ./cmd/bot
-RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/api-server ./cmd/api-server
-RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/scraper ./cmd/scraper
-RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier
+RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/bot ./cmd/bot && \
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/api-server ./cmd/api-server && \
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/scraper ./cmd/scraper && \
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata \

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -30,6 +30,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: carwatch-redis
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
     networks:
       - carwatch-net
     volumes:


### PR DESCRIPTION
## Summary

Address 2 unresolved CodeRabbit comments from PR #943.

1. **Consolidate Go builds into single RUN layer** — 4 separate `RUN go build` steps created unnecessary intermediate layers. Merged into one `RUN` with `&&` chaining.

2. **Enable Redis AOF persistence** — without append-only file, a container crash drops recent `XADD` entries from the alert stream, silently losing queued notifications. Added `--appendonly yes --appendfsync everysec`.

## Test plan
- [ ] CI passes (Docker image builds correctly with single layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)