### PR TITLE
fix: update deploy script for multi-service architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
-            PREV=$(docker inspect carwatch --format='{{.Config.Image}}' 2>/dev/null || echo 'none')
+            PREV=$(docker inspect carwatch-api --format='{{.Config.Image}}' 2>/dev/null || echo 'none')
             echo "$PREV" > ~/carwatch/prev_image_tag
             echo "Saved previous image tag: $PREV"
 
@@ -188,25 +188,25 @@ jobs:
             # Ensure the shared network exists
             docker network create carwatch-net 2>/dev/null || true
 
-            # Remove any manually-created container so compose can take over
+            # Remove any legacy all-in-one container
             docker stop carwatch 2>/dev/null || true
             docker rm carwatch 2>/dev/null || true
 
             echo "==> Pulling latest image..."
-            docker compose -f docker-compose.prod.yaml pull carwatch
+            docker compose -f docker-compose.prod.yaml pull
 
             # NOTE: Migrations run automatically on app startup.
             # The postgres.New() constructor runs golang-migrate/migrate before
             # returning, so no explicit migration step is needed here.
 
-            echo "==> Recreating container..."
-            docker compose -f docker-compose.prod.yaml up -d --no-deps carwatch
+            echo "==> Recreating containers..."
+            docker compose -f docker-compose.prod.yaml up -d
 
-            echo "==> Waiting for health check..."
+            echo "==> Waiting for API health check..."
             for i in $(seq 1 15); do
-              if docker exec carwatch wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
+              if docker exec carwatch-api wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
                 echo "==> Health check passed!"
-                docker exec carwatch /bot -version
+                docker exec carwatch-api /api-server -version
                 exit 0
               fi
               echo "    attempt $i/15 — waiting 5s..."
@@ -214,9 +214,11 @@ jobs:
             done
 
             echo "==> Health check failed after 75s"
-            docker inspect carwatch --format 'status={{.State.Status}} exit={{.State.ExitCode}} started={{.State.StartedAt}}' || true
-            echo "==> Container logs (last 80 lines):"
-            docker logs carwatch --tail 80 2>&1 || true
+            for svc in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier; do
+              echo "--- $svc ---"
+              docker inspect "$svc" --format 'status={{.State.Status}} exit={{.State.ExitCode}} started={{.State.StartedAt}}' 2>/dev/null || echo "(not found)"
+              docker logs "$svc" --tail 20 2>&1 || true
+            done
             exit 1
 
       - name: Rollback on failure
@@ -232,7 +234,7 @@ jobs:
             if [ "$PREV" != 'none' ]; then
               echo "==> Rolling back to previous image: $PREV"
               docker tag "$PREV" ghcr.io/danielsio/carwatch:latest
-              docker compose -f docker-compose.prod.yaml up -d --no-deps carwatch
+              docker compose -f docker-compose.prod.yaml up -d
               echo "==> Rolled back to previous version"
             else
               echo "==> No previous image tag found, skipping rollback"


### PR DESCRIPTION
## Summary

The deploy workflow (`release.yml`) still referenced the monolithic `carwatch` service name after PR #945 split docker-compose.prod.yaml into `api`, `bot-poller`, `scraper`, and `notifier` services. This caused `docker compose pull carwatch` to fail with "no such service: carwatch".

### Changes
- `docker compose pull` — pull all services (no service name filter)
- `docker compose up -d` — recreate all services (removed `--no-deps carwatch`)
- Health-check targets `carwatch-api` container on port 8080
- Version check uses `/api-server -version` (not `/bot -version`)
- Failure logs show all 4 service containers
- Rollback uses `up -d` without `--no-deps`
- Previous image tag saved from `carwatch-api` (not `carwatch`)

## Test plan

- [ ] CI checks pass
- [ ] Merge triggers Release workflow → deploy succeeds

closes the deploy failure from PR #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability through improved container orchestration and multi-service health monitoring during releases
  * Expanded diagnostic logging to capture status across multiple services, enabling faster issue detection during deployment failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->