### PR TITLE
fix: scope deploy to app services only, skip watchtower/caddy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,15 +192,19 @@ jobs:
             docker stop carwatch 2>/dev/null || true
             docker rm carwatch 2>/dev/null || true
 
+            # Only manage app + infra services; watchtower and caddy are
+            # long-lived infrastructure that must not be recreated on every deploy.
+            APP_SERVICES="postgres redis api bot-poller scraper notifier"
+
             echo "==> Pulling latest image..."
-            docker compose -f docker-compose.prod.yaml pull
+            docker compose -f docker-compose.prod.yaml pull $APP_SERVICES
 
             # NOTE: Migrations run automatically on app startup.
             # The postgres.New() constructor runs golang-migrate/migrate before
             # returning, so no explicit migration step is needed here.
 
             echo "==> Recreating containers..."
-            docker compose -f docker-compose.prod.yaml up -d
+            docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES
 
             echo "==> Waiting for API health check..."
             for i in $(seq 1 15); do
@@ -234,7 +238,7 @@ jobs:
             if [ "$PREV" != 'none' ]; then
               echo "==> Rolling back to previous image: $PREV"
               docker tag "$PREV" ghcr.io/danielsio/carwatch:latest
-              docker compose -f docker-compose.prod.yaml up -d
+              docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier
               echo "==> Rolled back to previous version"
             else
               echo "==> No previous image tag found, skipping rollback"


### PR DESCRIPTION
## Summary

Deploy still failing after #946 — `docker compose up -d` without service names tries to create ALL services including `watchtower` and `caddy`. Those containers already exist on the VM, so compose fails with "container name already in use".

Explicitly scopes `pull`, `up -d`, and rollback to only the 6 app services: `postgres redis api bot-poller scraper notifier`.

## Root cause

The previous fix (#946) changed from `up -d --no-deps carwatch` (single monolithic service) to `up -d` (all services). But "all services" includes `watchtower` and `caddy` which are long-lived infrastructure containers that should not be recreated on every deploy.

## Test plan

- [ ] CI passes
- [ ] Merge triggers Release workflow → deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)