### PR TITLE
fix: use correct binary path in deploy version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
             for i in $(seq 1 15); do
               if docker exec carwatch-api wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
                 echo "==> Health check passed!"
-                docker exec carwatch-api /api-server -version
+                docker exec carwatch-api api-server -version
                 exit 0
               fi
               echo "    attempt $i/15 — waiting 5s..."


### PR DESCRIPTION
## Summary

Deploy health check passes (all containers start, `/healthz` responds OK) but the workflow fails at the version print step:

```
==> Health check passed!
exec: "/api-server": stat /api-server: no such file or directory
```

The binary is at `/usr/local/bin/api-server`, not `/api-server`. Using the bare name `api-server` lets PATH resolution find it.

## Test plan

- [ ] CI passes
- [ ] Merge → Release → Deploy succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)