### PR TITLE
fix: api-server health returns 200 instead of 503

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -46,6 +46,7 @@ type Status struct {
 	lastSuccessUnixNs atomic.Int64
 	listingsFound     atomic.Int64
 	notificationsSent atomic.Int64
+	schedulerExpected atomic.Bool
 	schedulerStarted  atomic.Bool
 	botPollingAlive   atomic.Bool
 
@@ -96,6 +97,7 @@ func (s *Status) SetDBSizer(d DBSizer) {
 }
 
 func (s *Status) MarkSchedulerStarted() {
+	s.schedulerExpected.Store(true)
 	s.schedulerStarted.Store(true)
 }
 
@@ -178,19 +180,22 @@ func (s *Status) coreMetrics() map[string]any {
 
 	status := "ok"
 	uptime := time.Since(s.startTime)
+	expectsScheduler := s.schedulerExpected.Load()
 	schedulerUp := s.schedulerStarted.Load()
 
-	switch {
-	case uptime <= startupGracePeriod:
-		if schedulerUp && cycles > 0 && lastSuccessNs == 0 {
-			status = "starting"
+	if expectsScheduler {
+		switch {
+		case uptime <= startupGracePeriod:
+			if schedulerUp && cycles > 0 && lastSuccessNs == 0 {
+				status = "starting"
+			}
+		case !schedulerUp:
+			status = "degraded"
+		case cycles == 0:
+			status = "degraded"
+		case lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold:
+			status = "degraded"
 		}
-	case !schedulerUp:
-		status = "degraded"
-	case cycles == 0:
-		status = "degraded"
-	case lastSuccessNs == 0 || time.Since(lastSuccess) > degradedThreshold:
-		status = "degraded"
 	}
 
 	return map[string]any{

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -387,13 +387,13 @@ func TestStatus_DegradedAfterGracePeriod(t *testing.T) {
 	}
 }
 
-func TestStatus_DegradedWhenSchedulerNeverStarts(t *testing.T) {
+func TestStatus_OKWhenNoSchedulerExpected(t *testing.T) {
 	s := New()
 	s.startTime = time.Now().Add(-10 * time.Minute)
 
 	snap := s.Snapshot()
-	if snap["status"] != "degraded" {
-		t.Errorf("status = %q, want degraded when scheduler never started past grace period", snap["status"])
+	if snap["status"] != "ok" {
+		t.Errorf("status = %q, want ok when no scheduler is expected (api-server mode)", snap["status"])
 	}
 }
 


### PR DESCRIPTION
## Summary

The frontend was getting `503 Service Unavailable` from `/healthz` because the api-server's health endpoint checked for scheduler state — but the scheduler runs in the scraper binary, not api-server. After the 5-minute grace period, health permanently reported "degraded" (503).

### Root cause

`coreMetrics()` in `health.go` checked `schedulerStarted` unconditionally. Since api-server never calls `MarkSchedulerStarted()`, the check `!schedulerUp` always triggered "degraded" after grace period.

### Fix

Added `schedulerExpected` flag, only set when `MarkSchedulerStarted()` is called. Binaries without a scheduler (api-server, bot-poller, notifier) skip the scheduler health check entirely and report "ok".

## Test plan

- [ ] `go test ./internal/health/` passes
- [ ] Deploy → `GET /healthz` returns `200 {"status":"ok"}` (not 503)

🤖 Generated with [Claude Code](https://claude.com/claude-code)