### PR TITLE
feat: unified cross-service log streaming via Redis pub/sub

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -62,6 +62,16 @@ func run(configPath string, logger *slog.Logger) error {
 	logger = slog.New(teeHandler)
 	slog.SetDefault(logger)
 
+	if cfg.Redis.Addr != "" {
+		logSub, subErr := logstream.NewRedisSubscriber(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB, logHub, logger)
+		if subErr != nil {
+			logger.Warn("redis log subscriber failed, only api-server logs will be visible", "error", subErr)
+		} else {
+			defer func() { _ = logSub.Close() }()
+			logger.Info("subscribed to cross-service log stream", "redis", cfg.Redis.Addr)
+		}
+	}
+
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/bot-poller/main.go
+++ b/cmd/bot-poller/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/app"
 	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/logstream"
 )
 
 var (
@@ -52,6 +53,19 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
+
+	if cfg.Redis.Addr != "" {
+		logPub, pubErr := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
+		if pubErr != nil {
+			logger.Warn("redis log publisher failed", "error", pubErr)
+		} else {
+			defer func() { _ = logPub.Close() }()
+			teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub, "bot", "telegram")
+			logger = slog.New(teeHandler)
+			slog.SetDefault(logger)
+		}
+	}
+
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dsionov/carwatch/internal/app"
 	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/logstream"
 )
 
 var (
@@ -56,7 +57,24 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
+
+	logPub, pubErr := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
+	if pubErr != nil {
+		logger.Warn("redis log publisher failed", "error", pubErr)
+	} else {
+		defer func() { _ = logPub.Close() }()
+		teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub,
+			"notifier", "telegram", "webpush", "broker-consumer",
+		)
+		logger = slog.New(teeHandler)
+		slog.SetDefault(logger)
+	}
+
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
+
+	if cfg.Redis.Addr == "" {
+		return fmt.Errorf("redis.addr is required for the notifier worker")
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -66,10 +84,6 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		return err
 	}
 	defer func() { _ = telShutdown(context.Background()) }()
-
-	if cfg.Redis.Addr == "" {
-		return fmt.Errorf("redis.addr is required for the notifier worker")
-	}
 
 	// The notifier worker needs a user store for channel resolution and a
 	// push subscription store for WebPush delivery. Both come from PostgreSQL.

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/scheduler"
 )
@@ -56,11 +57,25 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
-	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
 	if cfg.Redis.Addr == "" {
 		return fmt.Errorf("redis.addr is required for the scraper; alerts must go through the Redis-backed notifier worker for rate limiting")
 	}
+
+	logPub, err := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
+	if err != nil {
+		logger.Warn("redis log publisher failed, logs won't stream to admin", "error", err)
+	} else {
+		defer func() { _ = logPub.Close() }()
+		teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub,
+			"yad2", "scheduler", "enricher", "circuit_breaker",
+			"api-pricelist", "broker-consumer",
+		)
+		logger = slog.New(teeHandler)
+		slog.SetDefault(logger)
+	}
+
+	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/internal/logstream/handler.go
+++ b/internal/logstream/handler.go
@@ -8,12 +8,17 @@ import (
 	"time"
 )
 
+// LogSink receives captured log entries.
+type LogSink interface {
+	Publish(e LogEntry)
+}
+
 // TeeHandler wraps an slog.Handler, forwarding all records to it while also
 // capturing records whose "component" attribute matches the allow-list and
-// publishing them to a Hub.
+// publishing them to a sink (Hub or RedisPublisher).
 type TeeHandler struct {
 	inner      slog.Handler
-	hub        *Hub
+	hub        LogSink
 	components map[string]bool
 	// preAttrs are attributes added via WithAttrs
 	preAttrs []slog.Attr
@@ -21,17 +26,17 @@ type TeeHandler struct {
 	groups []string
 }
 
-// NewTeeHandler wraps inner and publishes matching records to hub.
+// NewTeeHandler wraps inner and publishes matching records to the sink.
 // Only records with a "component" attr matching one of the given components
 // are captured; all records are forwarded to inner regardless.
-func NewTeeHandler(inner slog.Handler, hub *Hub, components ...string) *TeeHandler {
+func NewTeeHandler(inner slog.Handler, sink LogSink, components ...string) *TeeHandler {
 	m := make(map[string]bool, len(components))
 	for _, c := range components {
 		m[c] = true
 	}
 	return &TeeHandler{
 		inner:      inner,
-		hub:        hub,
+		hub:        sink,
 		components: m,
 	}
 }

--- a/internal/logstream/redis.go
+++ b/internal/logstream/redis.go
@@ -1,0 +1,97 @@
+package logstream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const logChannel = "carwatch:logs"
+
+// RedisPublisher publishes LogEntry values to a Redis pub/sub channel.
+type RedisPublisher struct {
+	client *redis.Client
+}
+
+// NewRedisPublisher creates a publisher that sends log entries to Redis.
+func NewRedisPublisher(addr, password string, db int) (*RedisPublisher, error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	})
+	ctx := context.Background()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+	return &RedisPublisher{client: client}, nil
+}
+
+// Publish sends a log entry to the Redis pub/sub channel.
+func (p *RedisPublisher) Publish(e LogEntry) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	p.client.Publish(context.Background(), logChannel, string(data))
+}
+
+// Close shuts down the Redis connection.
+func (p *RedisPublisher) Close() error { return p.client.Close() }
+
+// RedisSubscriber reads log entries from a Redis pub/sub channel and
+// feeds them into a Hub for SSE streaming.
+type RedisSubscriber struct {
+	client *redis.Client
+	cancel context.CancelFunc
+}
+
+// NewRedisSubscriber subscribes to the log channel and publishes
+// received entries to the given hub. Call Close to stop.
+func NewRedisSubscriber(addr, password string, db int, hub *Hub, logger *slog.Logger) (*RedisSubscriber, error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pubsub := client.Subscribe(ctx, logChannel)
+	if _, err := pubsub.Receive(ctx); err != nil {
+		cancel()
+		_ = client.Close()
+		return nil, err
+	}
+
+	go func() {
+		ch := pubsub.Channel()
+		for {
+			select {
+			case <-ctx.Done():
+				_ = pubsub.Close()
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				var entry LogEntry
+				if err := json.Unmarshal([]byte(msg.Payload), &entry); err != nil {
+					logger.Debug("redis log subscriber: unmarshal failed", "error", err)
+					continue
+				}
+				hub.Publish(entry)
+			}
+		}
+	}()
+
+	return &RedisSubscriber{client: client, cancel: cancel}, nil
+}
+
+// Close stops the subscriber and shuts down the Redis connection.
+func (s *RedisSubscriber) Close() error {
+	s.cancel()
+	return s.client.Close()
+}

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -40,7 +40,11 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 
 	s.observer.RecordListingsFound(len(sr.newListings))
 
-	log.Info("notifying user of new listings", "count", len(sr.newListings))
+	log.Info("delivering new listings to user",
+		"count", len(sr.newListings),
+		"search", search.Name,
+		"user", search.ChatID,
+	)
 
 	if err := delivery.DeliverBatch(ctx, search.ChatID, sr.newListings); err != nil {
 		if errors.Is(err, notifier.ErrRecipientBlocked) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -741,6 +741,12 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			"chat_id", acc.search.ChatID,
 			"search_name", acc.search.Name,
 		)
+		if len(acc.result.newListings) > 0 || len(acc.result.priceDropMessages) > 0 {
+			searchLog.Info("search matched listings",
+				"new", len(acc.result.newListings),
+				"price_drops", len(acc.result.priceDropMessages),
+			)
+		}
 		delivered := s.deliverResults(ctx, acc.search, acc.lang, acc.result, searchLog)
 		if delivered {
 			stats.notificationsSent++


### PR DESCRIPTION
## Summary

The admin Logs tab previously only showed api-server logs. Now it shows logs from **all 4 services** — scraper, bot-poller, notifier, and api-server — piped through Redis pub/sub.

### How it works

```
scraper  ─┐
bot-poller─┤── Redis pub/sub (carwatch:logs) ──→ api-server ──→ SSE ──→ LogsTab
notifier ─┘
api-server (local TeeHandler) ────────────────────────────────↗
```

Each binary's `TeeHandler` publishes matching log entries (by component) to Redis. The api-server subscribes and feeds them into the existing log Hub alongside its own local entries.

### What you'll see in the Logs tab

| Component | Source Binary | What it logs |
|-----------|-------------|-------------|
| `scheduler` | scraper | Scan cycles, search matching, delivery |
| `yad2` | scraper | Feed fetching, response parsing |
| `enricher` | scraper | KM/city enrichment per listing |
| `circuit_breaker` | scraper | Yad2 outage detection |
| `bot` | bot-poller | Telegram commands, wizard state |
| `telegram` | bot-poller/notifier | Message delivery, rate limits |
| `notifier` | notifier | Alert processing, WebPush |
| `broker-consumer` | notifier | Redis stream consumption |

### Enhanced log messages

Per-search delivery logs now include search name, user ID, and match counts for better traceability.

## Test plan

- [ ] CI passes
- [ ] Deploy → admin Logs tab shows scraper/bot/notifier logs (not just API logs)
- [ ] Component filter still works (can filter by scheduler, yad2, enricher, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)