### PR TITLE
fix: prefill from DB before enrichment so km=0 listings get re-enriched

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -622,8 +622,13 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		}
 	}
 
-	// 3. KM enrichment on the global feed.
+	// 3. Prefill from DB first so the enricher sees which listings still
+	// lack km data even after previous cycles. Then enrich the remainder.
 	prefilled := false
+	if s.stores.Listings != nil {
+		s.prefillFromDB(ctx, raw)
+		prefilled = true
+	}
 	if s.kmEnricher != nil {
 		enrichCtx, cancelEnrich := context.WithTimeout(ctx, kmEnrichTimeout)
 		enriched := s.kmEnricher.Enrich(enrichCtx, raw)
@@ -636,10 +641,6 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			if s.stores.Listings != nil {
 				s.backfillEnrichedListings(ctx, raw)
 			}
-		}
-		if s.stores.Listings != nil {
-			s.prefillFromDB(ctx, raw)
-			prefilled = true
 		}
 	}
 


### PR DESCRIPTION
## Summary

Listings saved to the DB with `km=0` (because the enrichment limit was reached or the item page failed) never got re-enriched in subsequent cycles.

**Root cause:** The enricher ran BEFORE `prefillFromDB`. So it only saw listings with `km=0` from the current Yad2 feed. After enrichment, `prefillFromDB` filled remaining gaps from the DB — but if the DB also had `km=0`, the listing was stuck permanently.

**Fix:** Swap the order: `prefillFromDB` runs first (fills known km from DB), then the enricher processes whatever still has `km=0`. Listings that were previously saved with `km=0` and reappear in the feed now get another enrichment attempt each cycle.

## Test plan

- [ ] CI passes
- [ ] After deploy, scraper logs show enrichment attempts for previously-unenriched listings
- [ ] Listings that showed "—" for km gradually fill in over subsequent cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)