### PR TITLE
fix: backfill enrichment for DB listings stuck with km=0

### DIFF
--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -3,6 +3,8 @@ package scheduler
 import (
 	"context"
 	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
 )
 
 func (s *Scheduler) pruneOldData(ctx context.Context) {
@@ -37,6 +39,42 @@ func (s *Scheduler) pruneOldData(ctx context.Context) {
 		}
 	}
 	s.lastPruneTime = time.Now()
+}
+
+func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
+	if s.kmEnricher == nil || s.stores.Listings == nil {
+		return
+	}
+
+	tokens, err := s.stores.Listings.ListUnenrichedTokens(ctx, 50)
+	if err != nil {
+		s.logger.Error("list unenriched tokens failed", "error", err)
+		return
+	}
+	if len(tokens) == 0 {
+		return
+	}
+
+	s.logger.Info("backfill enrichment: fetching km for DB listings missing data",
+		"candidates", len(tokens),
+	)
+
+	raw := make([]model.RawListing, len(tokens))
+	for i, t := range tokens {
+		raw[i] = model.RawListing{Token: t}
+	}
+
+	enrichCtx, cancel := context.WithTimeout(ctx, kmEnrichTimeout)
+	enriched := s.kmEnricher.Enrich(enrichCtx, raw)
+	cancel()
+
+	if enriched > 0 {
+		s.logger.Info("backfill enrichment complete",
+			"enriched", enriched,
+			"candidates", len(tokens),
+		)
+		s.backfillEnrichedListings(ctx, raw)
+	}
 }
 
 func (s *Scheduler) processExpiredPremium(ctx context.Context) {

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -862,3 +862,42 @@ func TestRunMultiTenantCycle_HiddenTokensCachedPerChatID(t *testing.T) {
 		t.Errorf("expected 1 ListHiddenTokens call (cached per chatID), got %d", calls)
 	}
 }
+
+func TestRunMultiTenantCycle_BackfillUnenrichedListings(t *testing.T) {
+	enrichCalls := 0
+	f := &mockFetcher{listings: []model.RawListing{}}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{}
+
+	ls := &mockListingStore{
+		unenrichedTokens: []string{"old-tok-1", "old-tok-2"},
+	}
+
+	kmEnricher := &countingEnricher{calls: &enrichCalls}
+
+	s, _ := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore:  ss,
+		ListingStore: ls,
+		KmEnricher:   kmEnricher,
+	})
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	if enrichCalls != 1 {
+		t.Errorf("expected 1 backfill Enrich call for unenriched tokens, got %d", enrichCalls)
+	}
+}
+
+type countingEnricher struct {
+	calls *int
+}
+
+func (e *countingEnricher) Enrich(_ context.Context, listings []model.RawListing) int {
+	*e.calls++
+	return 0
+}

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -56,6 +56,9 @@ func (s *prefillTrackingStore) PruneListings(_ context.Context, _ time.Duration)
 func (s *prefillTrackingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
 }
+func (s *prefillTrackingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
+	return nil, nil
+}
 
 func pipelineTestLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1}))

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -310,3 +310,6 @@ func (m *mockListingStore) SearchStats(_ context.Context, _ int64, _ int64, _ st
 func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
 }
+func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
+	return nil, nil
+}

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -252,8 +252,9 @@ func TestFlushAndSendDigest_WithHealth(t *testing.T) {
 }
 
 type mockListingStore struct {
-	saved      []storage.ListingRecord
-	pruneCalls int
+	saved            []storage.ListingRecord
+	pruneCalls       int
+	unenrichedTokens []string
 }
 
 func (m *mockListingStore) SaveListing(_ context.Context, r storage.ListingRecord) error {
@@ -311,5 +312,5 @@ func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int
 	return 0, nil
 }
 func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
-	return nil, nil
+	return m.unenrichedTokens, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -530,6 +530,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	s.processDigests(ctx)
 	s.processDailyDigests(ctx)
+	s.backfillUnenrichedListings(ctx)
 
 	s.logger.Info("scan complete",
 		"scan", cycle,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -507,6 +507,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.processExpiredPremium(ctx)
 
 	if len(searches) == 0 {
+		s.backfillUnenrichedListings(ctx)
 		s.logger.Info("scan complete (no active searches)", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
 		s.observer.RecordSuccess()
 		return nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -239,6 +239,7 @@ type ListingStore interface {
 	// applying each search row's price/year/km/hand constraints like CountSearchListings.
 	CountSearchListingsForChat(ctx context.Context, chatID int64) (map[int64]int64, error)
 	SearchStats(ctx context.Context, chatID int64, searchID int64, f ListingFilter) (*SearchStats, error)
+	ListUnenrichedTokens(ctx context.Context, limit int) ([]string, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
 }

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -551,6 +551,31 @@ func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID 
 	return removed, nil
 }
 
+func (s *Store) ListUnenrichedTokens(ctx context.Context, limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT token FROM listing_history
+		WHERE km <= 0
+		ORDER BY token
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, rows.Err()
+}
+
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, `

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -558,7 +558,7 @@ func (s *Store) ListUnenrichedTokens(ctx context.Context, limit int) ([]string, 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT DISTINCT token FROM listing_history
 		WHERE km <= 0
-		ORDER BY token
+		ORDER BY RANDOM()
 		LIMIT $1`, limit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Listings saved to the DB with `km=0` that have since fallen off the Yad2 global feed (older listings pushed down by newer ones) were stuck with `km=0` forever. The enricher only processes listings present in the current feed — old listings never got another chance.

### What was happening

Your Mazda 3 search had 62 listings, but only 17 (27%) had km data. The 45 missing-km listings were from May 20th when the enrichment limit was 25/cycle. They were saved with `km=0`, dropped off the feed, and never got re-enriched.

### Fix

Added a **backfill enrichment pass** that runs after each scan cycle:
1. Queries `listing_history` for up to 50 tokens with `km <= 0`
2. Fetches their Yad2 item pages for km/city data
3. Backfills the DB with results

Over a few cycles, all previously-unenriched listings will gradually get their km data filled in.

### DB method added
- `ListUnenrichedTokens(ctx, limit)` — returns distinct tokens from `listing_history` where `km <= 0`

## Test plan

- [ ] CI passes
- [ ] After deploy, scraper logs show "backfill enrichment: fetching km for DB listings missing data"
- [ ] Mazda 3 listings gradually show km values over the next few scan cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic backfill processing for unenriched listings during each scheduler cycle. The system now fetches and processes listings in batches of up to 50, with enrichment completion logged for monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->