### PR TITLE
feat: production-grade logging overhaul across all services

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -168,6 +168,10 @@ func (b *Bot) SetBot(tg *tgbot.Bot) {
 	}
 }
 
+func (b *Bot) commandLogger(chatID int64, username, command string) *slog.Logger {
+	return b.logger.With("chat_id", chatID, "username", username, "command", command)
+}
+
 func (b *Bot) DefaultHandler() tgbot.HandlerFunc {
 	return b.handleDefault
 }

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -24,6 +24,8 @@ func (b *Bot) handleStart(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 
 	chatID := update.Message.Chat.ID
 	username := update.Message.From.Username
+	log := b.commandLogger(chatID, username, "/start")
+	log.Info("command received")
 
 	b.ensureUser(ctx, chatID, username)
 
@@ -60,6 +62,7 @@ func (b *Bot) handleShare(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/share").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -178,7 +181,8 @@ func (b *Bot) handleWatch(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
-	b.logger.Debug("/watch command", "chat_id", chatID, "username", update.Message.From.Username)
+	log := b.commandLogger(chatID, update.Message.From.Username, "/watch")
+	log.Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -197,6 +201,7 @@ func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/list").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -248,6 +253,7 @@ func (b *Bot) handleStop(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/stop").Info("command received")
 	lang := b.getUserLang(ctx, chatID)
 	parts := strings.Fields(update.Message.Text)
 	if len(parts) < 2 {
@@ -274,6 +280,7 @@ func (b *Bot) handlePause(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/pause").Info("command received")
 	lang := b.getUserLang(ctx, chatID)
 	parts := strings.Fields(update.Message.Text)
 	if len(parts) < 2 {
@@ -311,6 +318,7 @@ func (b *Bot) handleResume(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/resume").Info("command received")
 	lang := b.getUserLang(ctx, chatID)
 	parts := strings.Fields(update.Message.Text)
 	if len(parts) < 2 {
@@ -348,6 +356,7 @@ func (b *Bot) handleCancel(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/cancel").Info("command received")
 	lang := b.getUserLang(ctx, chatID)
 	_ = b.users.UpdateUserState(ctx, chatID, StateIdle, "{}")
 	b.send(ctx, chatID, locale.T(lang, "cancel"))
@@ -357,6 +366,7 @@ func (b *Bot) handleHelp(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	b.commandLogger(update.Message.Chat.ID, update.Message.From.Username, "/help").Info("command received")
 	lang := b.getUserLang(ctx, update.Message.Chat.ID)
 	b.sendMarkdown(ctx, update.Message.Chat.ID, locale.T(lang, "help"))
 }
@@ -366,6 +376,7 @@ func (b *Bot) handleSettings(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/settings").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -386,6 +397,7 @@ func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/stats").Info("command received")
 	if chatID != b.adminChatID {
 		lang := b.getUserLang(ctx, chatID)
 		b.send(ctx, chatID, locale.T(lang, "unknown_command"))
@@ -424,6 +436,7 @@ func (b *Bot) handleDigest(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/digest").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -488,6 +501,7 @@ func (b *Bot) handleLanguage(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/language").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -507,6 +521,7 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/edit").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 
@@ -563,6 +578,7 @@ func (b *Bot) handleUpgrade(ctx context.Context, _ *tgbot.Bot, update *tgmodels.
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/upgrade").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	lang := b.getUserLang(ctx, chatID)
 	b.sendMarkdown(ctx, chatID, locale.T(lang, "upgrade_disabled"))

--- a/internal/bot/history.go
+++ b/internal/bot/history.go
@@ -21,6 +21,7 @@ func (b *Bot) handleHistory(ctx context.Context, _ *tgbot.Bot, update *tgmodels.
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/history").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	b.sendHistoryPage(ctx, chatID, 0)
 }
@@ -135,6 +136,7 @@ func (b *Bot) handleSaved(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/saved").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	b.sendSavedPage(ctx, chatID, 0)
 }
@@ -236,6 +238,7 @@ func (b *Bot) handleHidden(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 	defer cancel()
 
 	chatID := update.Message.Chat.ID
+	b.commandLogger(chatID, update.Message.From.Username, "/hidden").Info("command received")
 	b.ensureUser(ctx, chatID, update.Message.From.Username)
 	b.sendHiddenPage(ctx, chatID, 0)
 }

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -188,13 +188,12 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 
 	recipient := fmt.Sprintf("%d", alert.ChatID)
 	if err := c.notify(ctx, recipient, alert.Message); err != nil {
-		c.logger.Error("deliver alert failed", "id", msg.ID, "chat_id", alert.ChatID, "error", err)
-		// Don't ack -- will be retried on next read of pending.
+		c.logger.Error("deliver alert failed", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
 		return
 	}
 
 	c.ack(ctx, msg.ID)
-	c.logger.Debug("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
+	c.logger.Info("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
 }
 
 func (c *Consumer) ack(ctx context.Context, id string) {

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -206,6 +206,7 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 			f.clientPool.Evict(usedProxy)
 		}
 		f.logger.Error("fetch request failed",
+			"url", reqURL,
 			"manufacturer", params.Manufacturer, "model", params.Model,
 			"duration_ms", time.Since(fetchStart).Milliseconds(), "error", err)
 		return nil, fmt.Errorf("execute request: %w", err)

--- a/internal/notifier/webpush/webpush.go
+++ b/internal/notifier/webpush/webpush.go
@@ -69,6 +69,7 @@ func (n *Notifier) Notify(ctx context.Context, recipient string, listings []mode
 	if err != nil {
 		return fmt.Errorf("webpush: invalid recipient %q: %w", recipient, err)
 	}
+	n.logger.Debug("delivering web push", "chat_id", chatID, "listings", len(listings))
 
 	subs, err := n.subs.ListPushSubscriptions(ctx, chatID)
 	if err != nil {

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -17,25 +17,25 @@ func (s *Scheduler) pruneOldData(ctx context.Context) {
 	if pruneAfter > 0 {
 		pruned, err := s.stores.Dedup.Prune(ctx, pruneAfter)
 		if err != nil {
-			s.logger.Error("prune failed", "error", err)
+			s.logger.Error("prune dedup failed", "retention", pruneAfter.String(), "error", err)
 		} else if pruned > 0 {
-			s.logger.Info("pruned old listings", "count", pruned)
+			s.logger.Info("pruned old dedup entries", "count", pruned, "retention", pruneAfter.String())
 		}
 	}
 	if s.stores.Prices != nil {
 		pruned, err := s.stores.Prices.PrunePrices(ctx, priceHistoryRetention)
 		if err != nil {
-			s.logger.Error("prune prices failed", "error", err)
+			s.logger.Error("prune prices failed", "retention", priceHistoryRetention.String(), "error", err)
 		} else if pruned > 0 {
-			s.logger.Info("pruned old price history", "count", pruned)
+			s.logger.Info("pruned old price history", "count", pruned, "retention", priceHistoryRetention.String())
 		}
 	}
 	if s.stores.Listings != nil {
 		pruned, err := s.stores.Listings.PruneListings(ctx, listingHistoryRetention)
 		if err != nil {
-			s.logger.Error("prune listing history failed", "error", err)
+			s.logger.Error("prune listing history failed", "retention", listingHistoryRetention.String(), "error", err)
 		} else if pruned > 0 {
-			s.logger.Info("pruned old listing history", "count", pruned)
+			s.logger.Info("pruned old listing history", "count", pruned, "retention", listingHistoryRetention.String())
 		}
 	}
 	s.lastPruneTime = time.Now()

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -174,7 +174,7 @@ func (p *ListingPipeline) enrichWithBasePrice(ctx context.Context, listing *mode
 	}
 
 	listing.BasePrice = &bp
-	log.Info("enrichWithBasePrice: set base_price",
+	log.Debug("enriched with base price",
 		"token", listing.Token, "sub_model_id", listing.SubModelID,
 		"year", listing.Year, "base_price", bp)
 }

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -146,8 +146,9 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 }
 
 func (s *Scheduler) persistListings(ctx context.Context, records []storage.ListingRecord, log *slog.Logger) error {
+	saveStart := time.Now()
 	if err := s.stores.Listings.SaveListings(ctx, records); err != nil {
-		log.Error("batch save listings failed", "batch_size", len(records), "error", err)
+		log.Error("batch save listings failed", "batch_size", len(records), "duration_ms", time.Since(saveStart).Milliseconds(), "error", err)
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
 		for _, rec := range records {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -685,13 +685,14 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			}
 
 			// Per-user, per-search dedup.
-			isNew, ok := s.deduplicateListings(ctx, raw[i].Token, m.ChatID, m.SearchID, s.logger)
+			matchLog := s.logger.With("search_id", m.SearchID, "chat_id", m.ChatID, "search_name", m.SearchName)
+			isNew, ok := s.deduplicateListings(ctx, raw[i].Token, m.ChatID, m.SearchID, matchLog)
 			if !ok {
 				continue
 			}
 
 			// Price drop detection.
-			if s.tryPriceDropListing(ctx, m.Search, raw[i], acc.lang, marketCache, &acc.result, s.logger) {
+			if s.tryPriceDropListing(ctx, m.Search, raw[i], acc.lang, marketCache, &acc.result, matchLog) {
 				continue
 			}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -498,10 +498,12 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 		s.priceListSvc.ResetCycleCounter()
 	}
 
+	dbStart := time.Now()
 	searches, err := s.stores.Searches.ListAllActiveSearches(ctx)
 	if err != nil {
 		return fmt.Errorf("load searches: %w", err)
 	}
+	searchLoadMs := time.Since(dbStart).Milliseconds()
 
 	s.pruneOldData(ctx)
 	s.processExpiredPremium(ctx)
@@ -520,6 +522,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.logger.Info("active searches loaded",
 		"scan", cycle,
 		"searches", len(searches),
+		"db_duration_ms", searchLoadMs,
 	)
 
 	// Fetch the global feed (empty SourceParams = no manufacturer/model filter).
@@ -794,6 +797,7 @@ func (s *Scheduler) getOrBuildMarketCache(ctx context.Context) *scoring.MarketCa
 }
 
 func (s *Scheduler) buildMarketCache(ctx context.Context) *scoring.MarketCache {
+	refreshStart := time.Now()
 	if err := s.stores.Market.RefreshMarketMedians(ctx); err != nil {
 		s.logger.Error("refresh market medians failed", "error", err)
 	}
@@ -803,6 +807,7 @@ func (s *Scheduler) buildMarketCache(ctx context.Context) *scoring.MarketCache {
 		s.logger.Error("load market medians failed, keeping previous cache", "error", err)
 		return nil
 	}
+	s.logger.Debug("market medians loaded", "rows", len(rows), "duration_ms", time.Since(refreshStart).Milliseconds())
 
 	entries := make([]scoring.MedianEntry, len(rows))
 	for i, r := range rows {
@@ -845,9 +850,10 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 		return
 	}
 
+	prefillStart := time.Now()
 	data, err := s.stores.Listings.LookupEnrichmentData(ctx, tokens)
 	if err != nil {
-		s.logger.Error("prefill from DB failed", "error", err)
+		s.logger.Error("prefill from DB failed", "looked_up", len(tokens), "error", err)
 		return
 	}
 	if len(data) == 0 {
@@ -878,7 +884,7 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 		}
 	}
 	if filled > 0 {
-		s.logger.Info("prefilled from DB", "filled", filled, "looked_up", len(tokens))
+		s.logger.Info("prefilled from DB", "filled", filled, "looked_up", len(tokens), "duration_ms", time.Since(prefillStart).Milliseconds())
 	}
 }
 


### PR DESCRIPTION
## Summary

Full observability audit and logging overhaul based on review of 389 log statements across 110 Go files.

### Commit 1: Bot command entry-point logging
- Added `commandLogger(chatID, username, command)` helper
- Every Telegram command handler now logs "command received" at Info with chat_id, username, command
- 18 commands covered: /start, /watch, /list, /stop, /pause, /resume, /share, /cancel, /help, /settings, /stats, /digest, /language, /edit, /upgrade, /history, /saved, /hidden

### Commit 2: Enrich error logs with context
- Scheduler: pass per-match logger with search_id/chat_id/search_name to dedup and price-drop functions
- Maintenance: add retention duration to prune logs
- Consumer: promote "alert delivered" Debug→Info, add search_name to error logs
- WebPush: add chat_id to Notify entry log

### Commit 3: DB query duration logging
- `ListAllActiveSearches`: db_duration_ms in "active searches loaded"
- `LookupEnrichmentData`: duration_ms in "prefilled from DB"
- `RefreshMarketMedians`/`LoadMarketMedians`: duration_ms in new debug log
- `SaveListings`: duration_ms in batch save error

### Commit 4: Standardize levels
- "enrichWithBasePrice: set base_price" Info→Debug (per-listing noise)
- Add URL to "fetch request failed" error

## What this does NOT do
- No new logging package (slog + `.With()` is sufficient)
- No DB wrapper (timing at call sites instead)
- No request ID propagation (cycle number is sufficient)
- No fetcher user context (global feed by design)

## Test plan
- [ ] CI passes
- [ ] Deploy → admin Logs tab shows bot commands with chat_id/username
- [ ] Scheduler logs show db_duration_ms for key queries
- [ ] Alert delivery shows at Info level with search_name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced structured logging throughout the application with improved context fields (chat IDs, search names, durations) across command handlers, message processing, and maintenance operations.
  * Added duration metrics to database operations and search loading for better performance visibility.
  * Adjusted log levels for better alert prioritization in critical operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->