### PR TITLE
feat: enrich minimal logs with context and demote noisy per-listing logs

### DIFF
--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -188,13 +188,12 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 
 	recipient := fmt.Sprintf("%d", alert.ChatID)
 	if err := c.notify(ctx, recipient, alert.Message); err != nil {
-		c.logger.Error("deliver alert failed", "id", msg.ID, "chat_id", alert.ChatID, "error", err)
-		// Don't ack -- will be retried on next read of pending.
+		c.logger.Error("deliver alert failed", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
 		return
 	}
 
 	c.ack(ctx, msg.ID)
-	c.logger.Debug("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
+	c.logger.Info("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
 }
 
 func (c *Consumer) ack(ctx context.Context, id string) {

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -193,7 +193,7 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 
 	reqURL := buildURL(f.baseURL, params)
 	fetchStart := time.Now()
-	f.logger.Info("fetching listings",
+	f.logger.Debug("fetching listings",
 		"url", reqURL,
 		"manufacturer", params.Manufacturer,
 		"model", params.Model,
@@ -230,7 +230,7 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 		return nil, fmt.Errorf("parse page: %w", err)
 	}
 
-	f.logger.Info("fetched listings",
+	f.logger.Debug("fetched listings",
 		"count", len(listings),
 		"manufacturer", params.Manufacturer,
 		"model", params.Model,

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -17,25 +17,25 @@ func (s *Scheduler) pruneOldData(ctx context.Context) {
 	if pruneAfter > 0 {
 		pruned, err := s.stores.Dedup.Prune(ctx, pruneAfter)
 		if err != nil {
-			s.logger.Error("prune failed", "error", err)
+			s.logger.Error("prune dedup failed", "retention", pruneAfter.String(), "error", err)
 		} else if pruned > 0 {
-			s.logger.Info("pruned old listings", "count", pruned)
+			s.logger.Info("pruned old dedup entries", "count", pruned, "retention", pruneAfter.String())
 		}
 	}
 	if s.stores.Prices != nil {
 		pruned, err := s.stores.Prices.PrunePrices(ctx, priceHistoryRetention)
 		if err != nil {
-			s.logger.Error("prune prices failed", "error", err)
+			s.logger.Error("prune prices failed", "retention", priceHistoryRetention.String(), "error", err)
 		} else if pruned > 0 {
-			s.logger.Info("pruned old price history", "count", pruned)
+			s.logger.Info("pruned old price history", "count", pruned, "retention", priceHistoryRetention.String())
 		}
 	}
 	if s.stores.Listings != nil {
 		pruned, err := s.stores.Listings.PruneListings(ctx, listingHistoryRetention)
 		if err != nil {
-			s.logger.Error("prune listing history failed", "error", err)
+			s.logger.Error("prune listing history failed", "retention", listingHistoryRetention.String(), "error", err)
 		} else if pruned > 0 {
-			s.logger.Info("pruned old listing history", "count", pruned)
+			s.logger.Info("pruned old listing history", "count", pruned, "retention", listingHistoryRetention.String())
 		}
 	}
 	s.lastPruneTime = time.Now()

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -161,20 +161,20 @@ func (p *ListingPipeline) enrichWithBasePrice(ctx context.Context, listing *mode
 
 	bp, ok := p.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year, listing.Token)
 	if !ok {
-		log.Warn("enrichWithBasePrice: lookup failed",
+		log.Debug("base price lookup miss",
 			"token", listing.Token, "sub_model_id", listing.SubModelID,
 			"year", listing.Year)
 		return
 	}
 	if bp <= 0 {
-		log.Warn("enrichWithBasePrice: zero/negative price",
+		log.Debug("base price zero/negative",
 			"token", listing.Token, "sub_model_id", listing.SubModelID,
 			"year", listing.Year, "base_price", bp)
 		return
 	}
 
 	listing.BasePrice = &bp
-	log.Info("enrichWithBasePrice: set base_price",
+	log.Debug("enriched with base price",
 		"token", listing.Token, "sub_model_id", listing.SubModelID,
 		"year", listing.Year, "base_price", bp)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -694,13 +694,14 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			}
 
 			// Per-user, per-search dedup.
-			isNew, ok := s.deduplicateListings(ctx, raw[i].Token, m.ChatID, m.SearchID, s.logger)
+			matchLog := s.logger.With("search_id", m.SearchID, "chat_id", m.ChatID, "search_name", m.SearchName)
+			isNew, ok := s.deduplicateListings(ctx, raw[i].Token, m.ChatID, m.SearchID, matchLog)
 			if !ok {
 				continue
 			}
 
 			// Price drop detection.
-			if s.tryPriceDropListing(ctx, m.Search, raw[i], acc.lang, marketCache, &acc.result, s.logger) {
+			if s.tryPriceDropListing(ctx, m.Search, raw[i], acc.lang, marketCache, &acc.result, matchLog) {
 				continue
 			}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -604,11 +604,20 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 
 	fetchStart := time.Now()
 	raw, err := s.fetchWithRetryUsing(fetchCtx, activeFetcher, globalParams, s.logger)
-	s.observer.RecordFetch("yad2", time.Since(fetchStart), err)
+	fetchDuration := time.Since(fetchStart)
+	s.observer.RecordFetch("yad2", fetchDuration, err)
 	if err != nil {
 		return stats, fmt.Errorf("global feed fetch failed: %w", err)
 	}
 	stats.listingsFetched = len(raw)
+
+	s.logger.Info("global feed fetched",
+		"scan", s.cycleCount,
+		"source", "yad2",
+		"listings", len(raw),
+		"active_searches", len(searches),
+		"duration_ms", fetchDuration.Milliseconds(),
+	)
 
 	// 2. Catalog ingestion.
 	if s.catalogIngester != nil {


### PR DESCRIPTION
## Summary

Follow-up enrichment pass for logs that were still minimal after PR #957.

### Changes
- **Scheduler fetch log**: Added rich "global feed fetched" Info log with scan number, source, listing count, active searches, duration. Demoted fetcher's "fetching/fetched listings" to Debug
- **Maintenance prune logs**: Added retention duration to all prune error/info logs
- **Pipeline base price**: Demoted Warn→Debug for lookup miss/zero (fires per-listing, not actionable)
- **Per-match logger**: scheduler now passes logger with search_id/chat_id/search_name to dedup and price-drop functions
- **Consumer**: "alert delivered" promoted Debug→Info with search_name, error log also gets search_name

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)