### PR TITLE
feat: add context-aware structured logging with cwlog package

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/app"
+	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/logstream"
 )
@@ -59,7 +60,7 @@ func run(configPath string, logger *slog.Logger) error {
 		"api-pricelist", "bot", "telegram", "notifier",
 		"circuit_breaker",
 	)
-	logger = slog.New(teeHandler)
+	logger = slog.New(cwlog.NewContextHandler(teeHandler))
 	slog.SetDefault(logger)
 
 	if cfg.Redis.Addr != "" {

--- a/cmd/bot-poller/main.go
+++ b/cmd/bot-poller/main.go
@@ -55,17 +55,18 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		return err
 	}
 
+	baseHandler := logger.Handler()
 	if cfg.Redis.Addr != "" {
 		logPub, pubErr := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
 		if pubErr != nil {
 			logger.Warn("redis log publisher failed", "error", pubErr)
 		} else {
 			defer func() { _ = logPub.Close() }()
-			teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub, "bot", "telegram")
-			logger = slog.New(cwlog.NewContextHandler(teeHandler))
-			slog.SetDefault(logger)
+			baseHandler = logstream.NewTeeHandler(baseHandler, logPub, "bot", "telegram")
 		}
 	}
+	logger = slog.New(cwlog.NewContextHandler(baseHandler))
+	slog.SetDefault(logger)
 
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 

--- a/cmd/bot-poller/main.go
+++ b/cmd/bot-poller/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/app"
+	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/logstream"
 )
@@ -61,7 +62,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		} else {
 			defer func() { _ = logPub.Close() }()
 			teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub, "bot", "telegram")
-			logger = slog.New(teeHandler)
+			logger = slog.New(cwlog.NewContextHandler(teeHandler))
 			slog.SetDefault(logger)
 		}
 	}

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/app"
 	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/logstream"
 )
@@ -66,7 +67,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub,
 			"notifier", "telegram", "webpush", "broker-consumer",
 		)
-		logger = slog.New(teeHandler)
+		logger = slog.New(cwlog.NewContextHandler(teeHandler))
 		slog.SetDefault(logger)
 	}
 

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -59,17 +59,18 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		return err
 	}
 
+	baseHandler := logger.Handler()
 	logPub, pubErr := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
 	if pubErr != nil {
 		logger.Warn("redis log publisher failed", "error", pubErr)
 	} else {
 		defer func() { _ = logPub.Close() }()
-		teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub,
+		baseHandler = logstream.NewTeeHandler(baseHandler, logPub,
 			"notifier", "telegram", "webpush", "broker-consumer",
 		)
-		logger = slog.New(cwlog.NewContextHandler(teeHandler))
-		slog.SetDefault(logger)
 	}
+	logger = slog.New(cwlog.NewContextHandler(baseHandler))
+	slog.SetDefault(logger)
 
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -63,18 +63,19 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 		return fmt.Errorf("redis.addr is required for the scraper; alerts must go through the Redis-backed notifier worker for rate limiting")
 	}
 
+	baseHandler := logger.Handler()
 	logPub, err := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
 	if err != nil {
 		logger.Warn("redis log publisher failed, logs won't stream to admin", "error", err)
 	} else {
 		defer func() { _ = logPub.Close() }()
-		teeHandler := logstream.NewTeeHandler(logger.Handler(), logPub,
+		baseHandler = logstream.NewTeeHandler(baseHandler, logPub,
 			"yad2", "scheduler", "enricher", "circuit_breaker",
 			"api-pricelist", "broker-consumer",
 		)
-		logger = slog.New(cwlog.NewContextHandler(teeHandler))
-		slog.SetDefault(logger)
 	}
+	logger = slog.New(cwlog.NewContextHandler(baseHandler))
+	slog.SetDefault(logger)
 
 	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
 

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/app"
 	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/logstream"
@@ -71,7 +72,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 			"yad2", "scheduler", "enricher", "circuit_breaker",
 			"api-pricelist", "broker-consumer",
 		)
-		logger = slog.New(teeHandler)
+		logger = slog.New(cwlog.NewContextHandler(teeHandler))
 		slog.SetDefault(logger)
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dsionov/carwatch/internal/botcore"
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/pricelist"
@@ -173,6 +174,7 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 
 		w.Header().Set("X-Request-ID", id)
 		ctx := context.WithValue(r.Context(), requestIDKey, id)
+		ctx = cwlog.WithRequestID(ctx, id)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/cwlog/attrs.go
+++ b/internal/cwlog/attrs.go
@@ -1,0 +1,61 @@
+package cwlog
+
+import (
+	"log/slog"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// ListingAttrs returns structured slog attributes for a raw listing.
+// Zero-value optional fields are omitted to keep logs compact.
+func ListingAttrs(l model.RawListing) []slog.Attr {
+	attrs := []slog.Attr{
+		slog.String("token", l.Token),
+		slog.String("manufacturer", l.Manufacturer),
+		slog.String("model", l.Model),
+		slog.Int("year", l.Year),
+		slog.Int("price", l.Price),
+	}
+	if l.Km > 0 {
+		attrs = append(attrs, slog.Int("km", l.Km))
+	}
+	if l.SubModel != "" {
+		attrs = append(attrs, slog.String("sub_model", l.SubModel))
+	}
+	if l.SubModelID > 0 {
+		attrs = append(attrs, slog.Int("sub_model_id", l.SubModelID))
+	}
+	return attrs
+}
+
+// SearchAttrs returns structured slog attributes for a search.
+func SearchAttrs(s storage.Search) []slog.Attr {
+	return []slog.Attr{
+		slog.Int64("search_id", s.ID),
+		slog.Int64("chat_id", s.ChatID),
+		slog.String("search_name", s.Name),
+		slog.String("source", s.Source),
+	}
+}
+
+// ErrorEvent returns the standardized error/impact/action_taken attribute
+// triple for error logging. Every error log should include these fields
+// to make debugging actionable.
+func ErrorEvent(err error, impact, actionTaken string) []slog.Attr {
+	return []slog.Attr{
+		slog.String("error", err.Error()),
+		slog.String("impact", impact),
+		slog.String("action_taken", actionTaken),
+	}
+}
+
+// PriceDropAttrs returns structured slog attributes for a price change event.
+func PriceDropAttrs(token string, oldPrice, newPrice int) []slog.Attr {
+	return []slog.Attr{
+		slog.String("token", token),
+		slog.Int("old_price", oldPrice),
+		slog.Int("new_price", newPrice),
+		slog.Int("price_change", newPrice-oldPrice),
+	}
+}

--- a/internal/cwlog/attrs.go
+++ b/internal/cwlog/attrs.go
@@ -43,8 +43,12 @@ func SearchAttrs(s storage.Search) []slog.Attr {
 // triple for error logging. Every error log should include these fields
 // to make debugging actionable.
 func ErrorEvent(err error, impact, actionTaken string) []slog.Attr {
+	errMsg := "<nil>"
+	if err != nil {
+		errMsg = err.Error()
+	}
 	return []slog.Attr{
-		slog.String("error", err.Error()),
+		slog.String("error", errMsg),
 		slog.String("impact", impact),
 		slog.String("action_taken", actionTaken),
 	}

--- a/internal/cwlog/context.go
+++ b/internal/cwlog/context.go
@@ -1,0 +1,40 @@
+package cwlog
+
+import "context"
+
+type ctxKey int
+
+const (
+	keyCycleID ctxKey = iota
+	keySearchID
+	keyChatID
+	keyRequestID
+	keyComponent
+)
+
+func WithCycleID(ctx context.Context, id uint64) context.Context {
+	return context.WithValue(ctx, keyCycleID, id)
+}
+
+func WithSearchID(ctx context.Context, id int64) context.Context {
+	return context.WithValue(ctx, keySearchID, id)
+}
+
+func WithChatID(ctx context.Context, id int64) context.Context {
+	return context.WithValue(ctx, keyChatID, id)
+}
+
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, keyRequestID, id)
+}
+
+func WithComponent(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, keyComponent, name)
+}
+
+// WithSearch sets both search_id and chat_id in a single call.
+func WithSearch(ctx context.Context, searchID, chatID int64) context.Context {
+	ctx = context.WithValue(ctx, keySearchID, searchID)
+	ctx = context.WithValue(ctx, keyChatID, chatID)
+	return ctx
+}

--- a/internal/cwlog/cwlog_test.go
+++ b/internal/cwlog/cwlog_test.go
@@ -1,0 +1,319 @@
+package cwlog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/logstream"
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func parseJSON(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("failed to parse JSON log output: %v\nraw: %s", err, buf.String())
+	}
+	return m
+}
+
+func TestContextHandler_ExtractsAllKeys(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewContextHandler(inner))
+
+	ctx := context.Background()
+	ctx = WithCycleID(ctx, 42)
+	ctx = WithSearchID(ctx, 100)
+	ctx = WithChatID(ctx, 999)
+	ctx = WithRequestID(ctx, "abc-123")
+	ctx = WithComponent(ctx, "scheduler")
+
+	logger.InfoContext(ctx, "test message")
+
+	m := parseJSON(t, &buf)
+
+	if m["cycle_id"] != float64(42) {
+		t.Errorf("cycle_id = %v, want 42", m["cycle_id"])
+	}
+	if m["search_id"] != float64(100) {
+		t.Errorf("search_id = %v, want 100", m["search_id"])
+	}
+	if m["chat_id"] != float64(999) {
+		t.Errorf("chat_id = %v, want 999", m["chat_id"])
+	}
+	if m["request_id"] != "abc-123" {
+		t.Errorf("request_id = %v, want abc-123", m["request_id"])
+	}
+	if m["component"] != "scheduler" {
+		t.Errorf("component = %v, want scheduler", m["component"])
+	}
+	if m["msg"] != "test message" {
+		t.Errorf("msg = %v, want 'test message'", m["msg"])
+	}
+}
+
+func TestContextHandler_OmitsZeroValues(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewContextHandler(inner))
+
+	logger.InfoContext(context.Background(), "no context")
+
+	m := parseJSON(t, &buf)
+
+	for _, key := range []string{"cycle_id", "search_id", "chat_id", "request_id", "component"} {
+		if _, exists := m[key]; exists {
+			t.Errorf("key %q should not appear when context is empty, got %v", key, m[key])
+		}
+	}
+}
+
+func TestContextHandler_PartialContext(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewContextHandler(inner))
+
+	ctx := WithCycleID(context.Background(), 7)
+	ctx = WithChatID(ctx, 555)
+
+	logger.InfoContext(ctx, "partial")
+
+	m := parseJSON(t, &buf)
+
+	if m["cycle_id"] != float64(7) {
+		t.Errorf("cycle_id = %v, want 7", m["cycle_id"])
+	}
+	if m["chat_id"] != float64(555) {
+		t.Errorf("chat_id = %v, want 555", m["chat_id"])
+	}
+	for _, key := range []string{"search_id", "request_id", "component"} {
+		if _, exists := m[key]; exists {
+			t.Errorf("key %q should not appear, got %v", key, m[key])
+		}
+	}
+}
+
+func TestWithSearch_SetsBothKeys(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewContextHandler(inner))
+
+	ctx := WithSearch(context.Background(), 10, 20)
+	logger.InfoContext(ctx, "both")
+
+	m := parseJSON(t, &buf)
+
+	if m["search_id"] != float64(10) {
+		t.Errorf("search_id = %v, want 10", m["search_id"])
+	}
+	if m["chat_id"] != float64(20) {
+		t.Errorf("chat_id = %v, want 20", m["chat_id"])
+	}
+}
+
+func TestContextHandler_WithAttrsPreservation(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewContextHandler(inner))
+
+	scoped := logger.With("component", "yad2", "extra", "val")
+	ctx := WithCycleID(context.Background(), 3)
+
+	scoped.InfoContext(ctx, "scoped")
+
+	m := parseJSON(t, &buf)
+
+	if m["component"] != "yad2" {
+		t.Errorf("component = %v, want yad2", m["component"])
+	}
+	if m["extra"] != "val" {
+		t.Errorf("extra = %v, want val", m["extra"])
+	}
+	if m["cycle_id"] != float64(3) {
+		t.Errorf("cycle_id = %v, want 3", m["cycle_id"])
+	}
+}
+
+func TestContextHandler_WithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewContextHandler(inner))
+
+	grouped := logger.WithGroup("details").With("key", "value")
+	ctx := WithSearchID(context.Background(), 77)
+
+	grouped.InfoContext(ctx, "grouped")
+
+	m := parseJSON(t, &buf)
+
+	// slog nests both pre-set attrs and record-level attrs (including
+	// context-injected ones) under the active group.
+	details, ok := m["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'details' group in output, got %v", m)
+	}
+	if details["key"] != "value" {
+		t.Errorf("details.key = %v, want value", details["key"])
+	}
+	if details["search_id"] != float64(77) {
+		t.Errorf("details.search_id = %v, want 77", details["search_id"])
+	}
+}
+
+func TestContextHandler_ComposesWithTeeHandler(t *testing.T) {
+	hub := logstream.NewHub(100)
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	tee := logstream.NewTeeHandler(base, hub, "scheduler")
+	logger := slog.New(NewContextHandler(tee))
+
+	ctx := WithCycleID(context.Background(), 5)
+	ctx = WithSearchID(ctx, 42)
+
+	scoped := logger.With("component", "scheduler")
+	scoped.InfoContext(ctx, "matched listing")
+
+	entries := hub.Recent(0)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 captured entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Component != "scheduler" {
+		t.Errorf("component = %q, want scheduler", entry.Component)
+	}
+	if entry.Attrs["cycle_id"] != "5" {
+		t.Errorf("attrs[cycle_id] = %q, want 5", entry.Attrs["cycle_id"])
+	}
+	if entry.Attrs["search_id"] != "42" {
+		t.Errorf("attrs[search_id] = %q, want 42", entry.Attrs["search_id"])
+	}
+}
+
+func TestListingAttrs_FullListing(t *testing.T) {
+	l := model.RawListing{
+		Token:        "tok-123",
+		Manufacturer: "Toyota",
+		Model:        "Corolla",
+		Year:         2020,
+		Price:        85000,
+		Km:           45000,
+		SubModel:     "GLi",
+		SubModelID:   99,
+	}
+	attrs := ListingAttrs(l)
+
+	expected := map[string]any{
+		"token":        "tok-123",
+		"manufacturer": "Toyota",
+		"model":        "Corolla",
+		"year":         int64(2020),
+		"price":        int64(85000),
+		"km":           int64(45000),
+		"sub_model":    "GLi",
+		"sub_model_id": int64(99),
+	}
+
+	got := make(map[string]any)
+	for _, a := range attrs {
+		got[a.Key] = a.Value.Any()
+	}
+	for k, v := range expected {
+		if got[k] != v {
+			t.Errorf("ListingAttrs[%q] = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+func TestListingAttrs_OmitsZeroOptionals(t *testing.T) {
+	l := model.RawListing{
+		Token:        "tok-456",
+		Manufacturer: "Honda",
+		Model:        "Civic",
+		Year:         2019,
+		Price:        70000,
+	}
+	attrs := ListingAttrs(l)
+
+	keys := make(map[string]bool)
+	for _, a := range attrs {
+		keys[a.Key] = true
+	}
+	for _, key := range []string{"km", "sub_model", "sub_model_id"} {
+		if keys[key] {
+			t.Errorf("ListingAttrs should omit zero-value %q", key)
+		}
+	}
+}
+
+func TestSearchAttrs(t *testing.T) {
+	s := storage.Search{
+		ID:     10,
+		ChatID: 20,
+		Name:   "my search",
+		Source: "yad2",
+	}
+	attrs := SearchAttrs(s)
+
+	got := make(map[string]any)
+	for _, a := range attrs {
+		got[a.Key] = a.Value.Any()
+	}
+	if got["search_id"] != int64(10) {
+		t.Errorf("search_id = %v, want 10", got["search_id"])
+	}
+	if got["chat_id"] != int64(20) {
+		t.Errorf("chat_id = %v, want 20", got["chat_id"])
+	}
+	if got["search_name"] != "my search" {
+		t.Errorf("search_name = %v, want 'my search'", got["search_name"])
+	}
+}
+
+func TestErrorEvent(t *testing.T) {
+	err := &testError{msg: "connection refused"}
+	attrs := ErrorEvent(err, "listings will not persist", "releasing dedup claims")
+
+	got := make(map[string]string)
+	for _, a := range attrs {
+		got[a.Key] = a.Value.String()
+	}
+	if got["error"] != "connection refused" {
+		t.Errorf("error = %q, want 'connection refused'", got["error"])
+	}
+	if got["impact"] != "listings will not persist" {
+		t.Errorf("impact = %q", got["impact"])
+	}
+	if got["action_taken"] != "releasing dedup claims" {
+		t.Errorf("action_taken = %q", got["action_taken"])
+	}
+}
+
+func TestPriceDropAttrs(t *testing.T) {
+	attrs := PriceDropAttrs("tok-789", 100000, 90000)
+
+	got := make(map[string]any)
+	for _, a := range attrs {
+		got[a.Key] = a.Value.Any()
+	}
+	if got["token"] != "tok-789" {
+		t.Errorf("token = %v", got["token"])
+	}
+	if got["old_price"] != int64(100000) {
+		t.Errorf("old_price = %v", got["old_price"])
+	}
+	if got["new_price"] != int64(90000) {
+		t.Errorf("new_price = %v", got["new_price"])
+	}
+	if got["price_change"] != int64(-10000) {
+		t.Errorf("price_change = %v, want -10000", got["price_change"])
+	}
+}
+
+type testError struct{ msg string }
+
+func (e *testError) Error() string { return e.msg }

--- a/internal/cwlog/handler.go
+++ b/internal/cwlog/handler.go
@@ -1,0 +1,50 @@
+package cwlog
+
+import (
+	"context"
+	"log/slog"
+)
+
+// ContextHandler is an slog.Handler that extracts well-known values from
+// context.Context and injects them as record attributes before forwarding
+// to its inner handler. It composes with any slog.Handler (TeeHandler,
+// JSONHandler, etc.).
+type ContextHandler struct {
+	inner slog.Handler
+}
+
+// NewContextHandler wraps inner with automatic context-key extraction.
+func NewContextHandler(inner slog.Handler) *ContextHandler {
+	return &ContextHandler{inner: inner}
+}
+
+func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
+	if v, ok := ctx.Value(keyCycleID).(uint64); ok && v != 0 {
+		r.AddAttrs(slog.Uint64("cycle_id", v))
+	}
+	if v, ok := ctx.Value(keySearchID).(int64); ok && v != 0 {
+		r.AddAttrs(slog.Int64("search_id", v))
+	}
+	if v, ok := ctx.Value(keyChatID).(int64); ok && v != 0 {
+		r.AddAttrs(slog.Int64("chat_id", v))
+	}
+	if v, ok := ctx.Value(keyRequestID).(string); ok && v != "" {
+		r.AddAttrs(slog.String("request_id", v))
+	}
+	if v, ok := ctx.Value(keyComponent).(string); ok && v != "" {
+		r.AddAttrs(slog.String("component", v))
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ContextHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *ContextHandler) WithGroup(name string) slog.Handler {
+	return &ContextHandler{inner: h.inner.WithGroup(name)}
+}

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -3,6 +3,7 @@ package yad2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math/rand/v2"
 	"time"
@@ -87,7 +88,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 
 	for _, i := range candidates {
 		if e.cfg.MaxPerCycle > 0 && enriched >= e.cfg.MaxPerCycle {
-			e.logger.Debug("enrichment limit reached",
+			e.logger.DebugContext(ctx, "reached per-cycle enrichment limit, deferring remaining listings",
 				"enriched", enriched,
 				"attempts", attempts,
 				"remaining", len(candidates)-attempts,
@@ -116,16 +117,17 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			if errors.Is(err, fetcher.ErrChallenge) {
 				challengeRetries++
 				if challengeRetries >= maxChallengeRetries {
-					e.logger.Warn("enrichment aborted after repeated challenges",
+					e.logger.WarnContext(ctx, "halting enrichment pass, source is rate-limiting with bot challenges",
 						"token", listings[i].Token,
 						"challenges", challengeRetries,
+						"impact", fmt.Sprintf("%d remaining listings will not be enriched this cycle", len(candidates)-attempts),
+						"action_taken", "aborting enrichment, will retry unenriched listings next cycle",
+						"enriched_so_far", enriched,
 						"attempts", attempts,
-						"enriched", enriched,
-						"remaining", len(candidates)-attempts,
 					)
 					return enriched
 				}
-				e.logger.Warn("challenge detected, backing off before retry",
+				e.logger.WarnContext(ctx, "bot challenge detected during enrichment, backing off before retry",
 					"token", listings[i].Token,
 					"challenge_count", challengeRetries,
 					"backoff", e.cfg.ChallengeBackoff,
@@ -138,16 +140,20 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 				continue
 			}
 			consecutiveFailures++
-			e.logger.Warn("enrichment failed",
+			e.logger.WarnContext(ctx, "failed to fetch detailed listing data for mileage enrichment",
 				"token", listings[i].Token,
-				"error", err,
+				"error", err.Error(),
+				"impact", "listing will appear without km/city data until next cycle",
+				"action_taken", "continuing with remaining candidates",
+				"consecutive_failures", consecutiveFailures,
 			)
 			if consecutiveFailures >= maxConsecutiveFailures {
-				e.logger.Warn("enrichment aborted after consecutive failures",
+				e.logger.WarnContext(ctx, "halting enrichment pass after consecutive fetch failures",
 					"token", listings[i].Token,
 					"consecutive_failures", consecutiveFailures,
-					"attempts", attempts,
-					"remaining", len(candidates)-attempts,
+					"impact", fmt.Sprintf("%d remaining listings will not be enriched this cycle", len(candidates)-attempts),
+					"action_taken", "aborting enrichment, unenriched listings will be retried next cycle",
+					"enriched_so_far", enriched,
 				)
 				return enriched
 			}
@@ -174,11 +180,11 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 		if changed {
 			enriched++
-			e.logger.Debug("enriched listing",
+			e.logger.DebugContext(ctx, "successfully enriched listing with mileage and location data",
 				"token", listings[i].Token,
 				"km", details.Km,
 				"city", details.City,
-				"image", details.ImageURL != "",
+				"has_image", details.ImageURL != "",
 			)
 		}
 	}

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -67,7 +67,7 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 	if d.publisher != nil {
 		msg := notifier.FormatBatch(listings, d.lang)
 		if notifier.IsMalformedMessage(msg) {
-			d.logger.Error("blocked malformed batch message",
+			d.logger.ErrorContext(ctx, "blocked delivery of malformed batch message, skipping to prevent Telegram API errors",
 				"chat_id", chatID, "msg_len", len(msg))
 			return errMalformedMessage
 		}
@@ -80,7 +80,8 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 			Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		}
 		if err := d.publisher.Publish(ctx, alert); err != nil {
-			d.logger.Error("publish alert failed", "chat_id", chatID, "error", err)
+			d.logger.ErrorContext(ctx, "failed to publish alert to Redis queue for notification delivery",
+				"chat_id", chatID, "error", err)
 			return err
 		}
 		return nil
@@ -94,13 +95,14 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 	if errors.Is(err, notifier.ErrRecipientBlocked) {
 		return err
 	}
-	d.logger.Error("batch notification failed", "chat_id", chatID, "error", err)
+	d.logger.ErrorContext(ctx, "direct notification delivery failed for user",
+		"chat_id", chatID, "error", err)
 	return err
 }
 
 func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
 	if notifier.IsMalformedMessage(message) {
-		d.logger.Error("blocked malformed raw message",
+		d.logger.ErrorContext(ctx, "blocked delivery of malformed raw message, skipping to prevent Telegram API errors",
 			"chat_id", chatID, "msg_len", len(message),
 			"msg_preview", truncateStr(message, 200))
 		return errMalformedMessage
@@ -116,7 +118,8 @@ func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message 
 			Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		}
 		if err := d.publisher.Publish(ctx, alert); err != nil {
-			d.logger.Error("publish raw alert failed", "chat_id", chatID, "error", err)
+			d.logger.ErrorContext(ctx, "failed to publish raw alert to Redis queue for notification delivery",
+				"chat_id", chatID, "error", err)
 			return err
 		}
 		return nil
@@ -125,7 +128,8 @@ func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message 
 	chatIDStr := fmt.Sprintf("%d", chatID)
 	err := d.notifier.NotifyRaw(ctx, chatIDStr, message)
 	if err != nil && !errors.Is(err, notifier.ErrRecipientBlocked) {
-		d.logger.Error("raw notification failed", "chat_id", chatID, "error", err)
+		d.logger.ErrorContext(ctx, "direct raw notification delivery failed for user",
+			"chat_id", chatID, "error", err)
 	}
 	return err
 }

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -148,35 +148,37 @@ func (p *ListingPipeline) enrichWithBasePrice(ctx context.Context, listing *mode
 		return
 	}
 	if listing.SubModelID <= 0 {
-		log.Debug("enrichWithBasePrice: skipped, no sub_model_id",
+		log.DebugContext(ctx, "skipping base price enrichment, listing has no sub-model ID",
 			"token", listing.Token, "sub_model_id", listing.SubModelID,
 			"sub_model", listing.SubModel, "model", listing.Model)
 		return
 	}
 	if listing.Year <= 0 {
-		log.Debug("enrichWithBasePrice: skipped, no year",
+		log.DebugContext(ctx, "skipping base price enrichment, listing has no year",
 			"token", listing.Token, "year", listing.Year)
 		return
 	}
 
 	bp, ok := p.priceListSvc.Lookup(ctx, listing.SubModelID, listing.Year, listing.Token)
 	if !ok {
-		log.Debug("base price lookup miss",
-			"token", listing.Token, "sub_model_id", listing.SubModelID,
-			"year", listing.Year)
+		log.WarnContext(ctx, "base price lookup returned no result for listing",
+			"token", listing.Token, "manufacturer", listing.Manufacturer,
+			"model", listing.Model, "year", listing.Year,
+			"sub_model_id", listing.SubModelID)
 		return
 	}
 	if bp <= 0 {
-		log.Debug("base price zero/negative",
+		log.WarnContext(ctx, "base price lookup returned invalid value, skipping enrichment",
 			"token", listing.Token, "sub_model_id", listing.SubModelID,
 			"year", listing.Year, "base_price", bp)
 		return
 	}
 
 	listing.BasePrice = &bp
-	log.Debug("enriched with base price",
-		"token", listing.Token, "sub_model_id", listing.SubModelID,
-		"year", listing.Year, "base_price", bp)
+	log.InfoContext(ctx, "enriched listing with catalog base price for market comparison",
+		"token", listing.Token, "manufacturer", listing.Manufacturer,
+		"model", listing.Model, "year", listing.Year,
+		"base_price", bp, "listing_price", listing.Price)
 }
 
 // prefillFromDB fills in km/city/image from the DB for listings that are
@@ -198,7 +200,11 @@ func (p *ListingPipeline) prefillFromDB(ctx context.Context, listings []model.Ra
 
 	data, err := p.listings.LookupEnrichmentData(ctx, tokens)
 	if err != nil {
-		log.Error("pipeline prefill from DB failed", "error", err)
+		log.ErrorContext(ctx, "failed to look up enrichment data from database for pipeline prefill",
+			"error", err.Error(),
+			"impact", "listings missing km/city/image will remain incomplete until enricher runs",
+			"action_taken", "continuing pipeline without prefilled data",
+			"tokens_requested", len(tokens))
 		return
 	}
 	if len(data) == 0 {
@@ -229,7 +235,8 @@ func (p *ListingPipeline) prefillFromDB(ctx context.Context, listings []model.Ra
 		}
 	}
 	if filled > 0 {
-		log.Info("pipeline prefilled from DB", "filled", filled, "looked_up", len(tokens))
+		log.InfoContext(ctx, "prefilled listing data from database to supplement missing fields",
+			"filled", filled, "looked_up", len(tokens))
 	}
 }
 

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -20,15 +20,23 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 	for _, msg := range sr.priceDropMessages {
 		if err := delivery.DeliverRaw(ctx, search.ChatID, msg); err != nil {
 			if errors.Is(err, notifier.ErrRecipientBlocked) {
-				log.Warn("user blocked bot, deactivating")
+				log.WarnContext(ctx, "user has blocked the bot, deactivating user account",
+					"impact", "user will stop receiving all notifications",
+					"action_taken", "setting user inactive to prevent further delivery attempts")
 				if s.stores.Users != nil {
 					if err := s.stores.Users.SetUserActive(ctx, search.ChatID, false); err != nil {
-						log.Error("set user inactive after block (price drop)", "error", err)
+						log.ErrorContext(ctx, "failed to deactivate user after bot block",
+							"error", err.Error(),
+							"impact", "user remains active and delivery will fail again next cycle",
+							"action_taken", "no further action, will retry deactivation next cycle")
 					}
 				}
 				return false
 			}
-			log.Error("price drop delivery failed", "error", err)
+			log.ErrorContext(ctx, "failed to deliver price drop notification to user",
+				"error", err.Error(),
+				"impact", "user will not be notified about this price drop",
+				"action_taken", "continuing with remaining notifications")
 		} else {
 			sent = true
 		}
@@ -40,29 +48,40 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 
 	s.observer.RecordListingsFound(len(sr.newListings))
 
-	log.Info("delivering new listings to user",
+	log.InfoContext(ctx, "delivering batch of newly matched listings to user",
 		"count", len(sr.newListings),
-		"search", search.Name,
-		"user", search.ChatID,
+		"search_name", search.Name,
 	)
 
 	if err := delivery.DeliverBatch(ctx, search.ChatID, sr.newListings); err != nil {
 		if errors.Is(err, notifier.ErrRecipientBlocked) {
-			log.Warn("user blocked bot, deactivating")
+			log.WarnContext(ctx, "user has blocked the bot during batch delivery, deactivating user account",
+				"impact", "user will stop receiving all notifications",
+				"action_taken", "setting user inactive, releasing dedup claims for retry")
 			if s.stores.Users != nil {
 				if err := s.stores.Users.SetUserActive(ctx, search.ChatID, false); err != nil {
-					log.Error("set user inactive after block (batch)", "error", err)
+					log.ErrorContext(ctx, "failed to deactivate user after bot block during batch delivery",
+						"error", err.Error(),
+						"impact", "user remains active and delivery will fail again next cycle",
+						"action_taken", "no further action, will retry deactivation next cycle")
 				}
 			}
 		} else {
-			log.Error("batch delivery failed", "count", len(sr.newListings), "error", err)
+			log.ErrorContext(ctx, "failed to deliver listing batch to user, releasing dedup claims for retry",
+				"count", len(sr.newListings),
+				"error", err.Error(),
+				"impact", "user will not see these listings until next successful delivery",
+				"action_taken", "releasing dedup claims so listings are retried next cycle")
 		}
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
 		for _, l := range sr.newListings {
 			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, l.Token, search.ChatID); relErr != nil {
-				log.Error("release claim after delivery failure",
-					"token", l.Token, "error", relErr)
+				log.ErrorContext(ctx, "failed to release dedup claim after delivery failure",
+					"token", l.Token,
+					"error", relErr.Error(),
+					"impact", "this listing may not be re-delivered on subsequent cycles",
+					"action_taken", "manual intervention may be needed to clear stuck claim")
 			}
 		}
 	} else {
@@ -78,7 +97,11 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 	}
 	oldPrice, changed, err := s.stores.Prices.RecordPrice(ctx, l.Token, l.Price)
 	if err != nil {
-		log.Error("record price failed", "token", l.Token, "error", err)
+		log.ErrorContext(ctx, "failed to record listing price in price tracker",
+			"token", l.Token,
+			"error", err.Error(),
+			"impact", "price drop detection will not work for this listing this cycle",
+			"action_taken", "skipping price drop check, listing will be processed as normal")
 		return false
 	}
 	// Track tokens where RecordPrice inserted a row so that we can revert
@@ -92,10 +115,11 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 	if !changed || l.Price >= oldPrice {
 		return false
 	}
-	log.Info("price drop detected",
+	log.InfoContext(ctx, "detected price drop for matched listing, preparing to notify user",
 		"token", l.Token,
 		"old_price", oldPrice,
 		"new_price", l.Price,
+		"price_change", l.Price-oldPrice,
 		"manufacturer", l.Manufacturer,
 		"model", l.Model,
 		"year", l.Year,
@@ -136,10 +160,11 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 			}
 		}
 		if err := s.stores.Listings.SaveListing(ctx, rec); err != nil {
-			log.Error("save price-drop listing failed",
+			log.ErrorContext(ctx, "failed to persist price-drop listing to history",
 				"token", l.Token,
-				"error", err,
-			)
+				"error", err.Error(),
+				"impact", "price drop record will be missing from listing history",
+				"action_taken", "notification will still be sent, but history is incomplete")
 		}
 	}
 	return true
@@ -148,13 +173,21 @@ func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Sear
 func (s *Scheduler) persistListings(ctx context.Context, records []storage.ListingRecord, log *slog.Logger) error {
 	saveStart := time.Now()
 	if err := s.stores.Listings.SaveListings(ctx, records); err != nil {
-		log.Error("batch save listings failed", "batch_size", len(records), "duration_ms", time.Since(saveStart).Milliseconds(), "error", err)
+		log.ErrorContext(ctx, "failed to persist matched listings to database, releasing all dedup claims for retry",
+			"batch_size", len(records),
+			"duration_ms", time.Since(saveStart).Milliseconds(),
+			"error", err.Error(),
+			"impact", "listings will not appear in user history until next successful cycle",
+			"action_taken", "releasing dedup claims so listings are retried next cycle")
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
 		for _, rec := range records {
 			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, rec.Token, rec.ChatID); relErr != nil {
-				log.Error("release claim after batch save failure",
-					"token", rec.Token, "error", relErr)
+				log.ErrorContext(ctx, "failed to release dedup claim after batch save failure, listing may be permanently lost",
+					"token", rec.Token,
+					"error", relErr.Error(),
+					"impact", "this listing will not be re-delivered on subsequent cycles",
+					"action_taken", "manual intervention may be needed to clear stuck claim")
 			}
 		}
 		return err
@@ -165,7 +198,11 @@ func (s *Scheduler) persistListings(ctx context.Context, records []storage.Listi
 func (s *Scheduler) deduplicateListings(ctx context.Context, token string, chatID, searchID int64, log *slog.Logger) (isNew bool, ok bool) {
 	isNew, err := s.stores.Dedup.ClaimNew(ctx, token, chatID, searchID)
 	if err != nil {
-		log.Error("claim failed", "token", token, "error", err)
+		log.ErrorContext(ctx, "failed to claim listing for deduplication, listing will be skipped this cycle",
+			"token", token,
+			"error", err.Error(),
+			"impact", "listing may be re-delivered on next successful cycle if claim is not persisted",
+			"action_taken", "skipping this listing to avoid duplicate delivery")
 		return false, false
 	}
 	return isNew, true
@@ -182,8 +219,11 @@ func (s *Scheduler) revertPriceRecords(ctx context.Context, tokens []string, log
 	defer cancel()
 	for _, token := range tokens {
 		if err := s.stores.Prices.RevertPrice(cleanupCtx, token); err != nil {
-			log.Error("revert price after persist failure",
-				"token", token, "error", err)
+			log.ErrorContext(ctx, "failed to revert price record after persist failure, may cause spurious price-drop notification",
+				"token", token,
+				"error", err.Error(),
+				"impact", "stale price record may trigger a false price-drop notification on next cycle",
+				"action_taken", "continuing with remaining reverts")
 		}
 	}
 }
@@ -194,7 +234,11 @@ func (s *Scheduler) loadHiddenTokens(ctx context.Context, chatID int64) map[stri
 	}
 	tokens, err := s.stores.Hidden.ListHiddenTokens(ctx, chatID)
 	if err != nil {
-		s.logger.Error("load hidden tokens failed", "chat_id", chatID, "error", err)
+		s.logger.ErrorContext(ctx, "failed to load hidden tokens for user, hidden listings may be re-delivered",
+			"chat_id", chatID,
+			"error", err.Error(),
+			"impact", "previously hidden listings may appear in notifications",
+			"action_taken", "continuing without hidden token filter")
 		return nil
 	}
 	return tokens

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
@@ -234,7 +235,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	logInterval := s.cfg.Polling.Interval
 	logJitter := s.cfg.Polling.Jitter
 	s.cfgMu.RUnlock()
-	s.logger.Info("scheduler started",
+	s.logger.Info("scheduler started, entering polling loop",
 		"check_interval", logInterval.String(),
 		"jitter", logJitter.String(),
 	)
@@ -250,7 +251,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			if errors.Is(err, context.Canceled) {
 				return err
 			}
-			s.logger.Error("initial cycle failed", "error", err)
+			s.logger.Error("initial scheduler cycle failed on startup", "error", err)
 		}
 	}
 
@@ -264,21 +265,21 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 		if !s.isActiveHours() {
 			if sleepUntil := s.durationUntilActiveStart(); sleepUntil > 0 {
-				s.logger.Info("outside active hours, sleeping until start",
+				s.logger.Info("outside configured active hours, sleeping until polling window opens",
 					"sleep", sleepUntil.Round(time.Minute).String(),
 				)
 				delay = sleepUntil
 			}
 		}
 
-		s.logger.Info("next scan", "in", delay.Round(time.Second).String())
+		s.logger.Info("scheduling next scan cycle", "in", delay.Round(time.Second).String())
 
 		timer.Reset(delay)
 
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			s.logger.Info("scheduler stopping")
+			s.logger.Info("scheduler received shutdown signal, stopping gracefully")
 			return ctx.Err()
 		case <-sighup:
 			if !timer.Stop() {
@@ -290,7 +291,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			if !timer.Stop() {
 				<-timer.C
 			}
-			s.logger.Info("scan triggered manually")
+			s.logger.Info("scheduler cycle triggered by manual API request")
 		case <-timer.C:
 		}
 
@@ -302,7 +303,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			if errors.Is(err, context.Canceled) {
 				return err
 			}
-			s.logger.Error("scan failed", "error", err)
+			s.logger.Error("scheduler cycle failed, will retry on next interval", "error", err)
 		}
 	}
 }
@@ -358,7 +359,7 @@ func (s *Scheduler) fetchWithRetryUsing(ctx context.Context, f fetcher.Fetcher, 
 		lastErr = err
 
 		if errors.Is(err, fetcher.ErrPartialResults) && len(listings) > 0 {
-			log.Warn("partial results (some pages failed)",
+			log.WarnContext(ctx, "received partial results from source, some pages failed to fetch",
 				"car", s.carName(params.Manufacturer, params.Model),
 				"listings_returned", len(listings),
 				"error", err,
@@ -372,7 +373,7 @@ func (s *Scheduler) fetchWithRetryUsing(ctx context.Context, f fetcher.Fetcher, 
 
 		if attempt < maxRetries-1 {
 			delay := retryBaseDelay * (1 << attempt)
-			log.Warn("fetch failed, retrying",
+			log.WarnContext(ctx, "global feed fetch attempt failed, retrying with exponential backoff",
 				"car", s.carName(params.Manufacturer, params.Model),
 				"attempt", fmt.Sprintf("%d/%d", attempt+1, maxRetries),
 				"retry_in", delay.String(),
@@ -467,30 +468,31 @@ func (s *Scheduler) reloadConfig() {
 		s.logger.Warn("SIGHUP received but no config path set, ignoring")
 		return
 	}
-	s.logger.Info("SIGHUP received, reloading config", "path", s.configPath)
+	s.logger.Info("received SIGHUP signal, reloading configuration from disk", "path", s.configPath)
 	newCfg, err := config.Load(s.configPath)
 	if err != nil {
-		s.logger.Error("config reload failed, keeping current config", "error", err)
+		s.logger.Error("failed to reload configuration, keeping current config", "error", err)
 		return
 	}
 	loc, err := time.LoadLocation(newCfg.Polling.Timezone)
 	if err != nil {
-		s.logger.Error("config reload: invalid timezone, keeping current", "timezone", newCfg.Polling.Timezone, "error", err)
+		s.logger.Error("failed to reload configuration, invalid timezone setting", "timezone", newCfg.Polling.Timezone, "error", err)
 		return
 	}
 	s.cfgMu.Lock()
 	s.cfg = newCfg
 	s.loc = loc
 	s.cfgMu.Unlock()
-	s.logger.Info("config reloaded")
+	s.logger.Info("configuration reloaded successfully")
 }
 
 func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.cycleCount++
 	cycle := s.cycleCount
 	cycleStart := time.Now()
+	ctx = cwlog.WithCycleID(ctx, cycle)
 
-	s.logger.Info("checking for new listings", "scan", cycle)
+	s.logger.InfoContext(ctx, "starting scheduler cycle, loading active searches", "scan", cycle)
 
 	s.langCache.Range(func(k, _ any) bool { s.langCache.Delete(k); return true })
 	s.digestCache.Range(func(k, _ any) bool { s.digestCache.Delete(k); return true })
@@ -510,7 +512,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	if len(searches) == 0 {
 		s.backfillUnenrichedListings(ctx)
-		s.logger.Info("scan complete (no active searches)", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
+		s.logger.InfoContext(ctx, "scheduler cycle completed with no active searches", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
 		s.observer.RecordSuccess()
 		return nil
 	}
@@ -519,7 +521,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.percolator.Load(searches)
 
 	marketCache := s.getOrBuildMarketCache(ctx)
-	s.logger.Info("active searches loaded",
+	s.logger.InfoContext(ctx, "loaded active searches into percolator for reverse matching",
 		"scan", cycle,
 		"searches", len(searches),
 		"db_duration_ms", searchLoadMs,
@@ -536,7 +538,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.processDailyDigests(ctx)
 	s.backfillUnenrichedListings(ctx)
 
-	s.logger.Info("scan complete",
+	s.logger.InfoContext(ctx, "scheduler cycle completed",
 		"scan", cycle,
 		"elapsed", time.Since(cycleStart).Round(time.Millisecond),
 		"searches", len(searches),
@@ -587,7 +589,7 @@ func (s *Scheduler) writeCycleLog(ctx context.Context, entry storage.CycleLogEnt
 		return
 	}
 	if err := s.stores.CycleLog.WriteCycleLog(ctx, entry); err != nil {
-		s.logger.Error("write cycle log failed", "error", err)
+		s.logger.Error("failed to write scheduler cycle log entry", "error", err)
 	}
 }
 
@@ -648,7 +650,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		enriched := s.kmEnricher.Enrich(enrichCtx, raw)
 		cancelEnrich()
 		if enriched > 0 {
-			s.logger.Info("mileage data enriched",
+			s.logger.InfoContext(ctx, "enriched listings with mileage and location data from individual pages",
 				"enriched", enriched,
 				"total", len(raw),
 			)
@@ -719,6 +721,8 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 
 	// 6. Run pipeline and deliver results per search.
 	for _, acc := range accums {
+		searchCtx := cwlog.WithSearch(ctx, acc.search.ID, acc.search.ChatID)
+
 		// Convert collected raw listings through the pipeline.
 		if len(acc.result.newListings) > 0 {
 			rawForPipeline := make([]model.RawListing, len(acc.result.newListings))
@@ -727,7 +731,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			}
 			params := ProcessParamsFromSearch(acc.search, marketCache)
 			params.SkipPrefill = prefilled
-			pr := s.pipeline.Process(ctx, rawForPipeline, params)
+			pr := s.pipeline.Process(searchCtx, rawForPipeline, params)
 			acc.result.newListings = pr.Listings
 			acc.result.listingRecords = pr.Records
 		}
@@ -735,35 +739,29 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		// Persist listings.
 		persistOK := true
 		if s.stores.Listings != nil && len(acc.result.listingRecords) > 0 {
-			searchLog := s.logger.With("search_id", acc.search.ID, "chat_id", acc.search.ChatID)
-			if err := s.persistListings(ctx, acc.result.listingRecords, searchLog); err != nil {
+			if err := s.persistListings(searchCtx, acc.result.listingRecords, s.logger); err != nil {
 				persistOK = false
 			} else {
 				s.invalidateMarketCache()
 			}
 		}
 		if !persistOK {
-			searchLog := s.logger.With("search_id", acc.search.ID, "chat_id", acc.search.ChatID)
 			acc.result.newListings = nil
 			acc.result.listingRecords = nil
-			s.revertPriceRecords(ctx, acc.result.recordedTokens, searchLog)
+			s.revertPriceRecords(searchCtx, acc.result.recordedTokens, s.logger)
 		}
 
 		stats.newListings += len(acc.result.newListings)
 
 		// Deliver notifications.
-		searchLog := s.logger.With(
-			"search_id", acc.search.ID,
-			"chat_id", acc.search.ChatID,
-			"search_name", acc.search.Name,
-		)
 		if len(acc.result.newListings) > 0 || len(acc.result.priceDropMessages) > 0 {
-			searchLog.Info("search matched listings",
+			s.logger.InfoContext(searchCtx, "search matched listings, preparing delivery",
+				"search_name", acc.search.Name,
 				"new", len(acc.result.newListings),
 				"price_drops", len(acc.result.priceDropMessages),
 			)
 		}
-		delivered := s.deliverResults(ctx, acc.search, acc.lang, acc.result, searchLog)
+		delivered := s.deliverResults(searchCtx, acc.search, acc.lang, acc.result, s.logger)
 		if delivered {
 			stats.notificationsSent++
 		}
@@ -808,12 +806,12 @@ func (s *Scheduler) getOrBuildMarketCache(ctx context.Context) *scoring.MarketCa
 func (s *Scheduler) buildMarketCache(ctx context.Context) *scoring.MarketCache {
 	refreshStart := time.Now()
 	if err := s.stores.Market.RefreshMarketMedians(ctx); err != nil {
-		s.logger.Error("refresh market medians failed", "error", err)
+		s.logger.Error("failed to refresh market median materialized view", "error", err)
 	}
 
 	rows, err := s.stores.Market.LoadMarketMedians(ctx)
 	if err != nil {
-		s.logger.Error("load market medians failed, keeping previous cache", "error", err)
+		s.logger.Error("failed to load market medians from database, keeping previous cache", "error", err)
 		return nil
 	}
 	s.logger.Debug("market medians loaded", "rows", len(rows), "duration_ms", time.Since(refreshStart).Milliseconds())
@@ -862,7 +860,8 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 	prefillStart := time.Now()
 	data, err := s.stores.Listings.LookupEnrichmentData(ctx, tokens)
 	if err != nil {
-		s.logger.Error("prefill from DB failed", "looked_up", len(tokens), "error", err)
+		s.logger.ErrorContext(ctx, "failed to look up enrichment data from database for prefill",
+			"error", err, "looked_up", len(tokens))
 		return
 	}
 	if len(data) == 0 {
@@ -893,7 +892,9 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 		}
 	}
 	if filled > 0 {
-		s.logger.Info("prefilled from DB", "filled", filled, "looked_up", len(tokens), "duration_ms", time.Since(prefillStart).Milliseconds())
+		s.logger.InfoContext(ctx, "prefilled listing data from database to supplement missing fields",
+			"filled", filled, "looked_up", len(tokens),
+			"duration_ms", time.Since(prefillStart).Milliseconds())
 	}
 }
 
@@ -923,7 +924,7 @@ func (s *Scheduler) backfillEnrichedListings(ctx context.Context, listings []mod
 		return
 	}
 	if err := s.stores.Listings.BackfillListings(ctx, toUpdate); err != nil {
-		s.logger.Error("km backfill failed", "count", len(toUpdate), "error", err)
+		s.logger.ErrorContext(ctx, "failed to backfill enriched mileage data to listing history", "count", len(toUpdate), "error", err)
 	}
 }
 
@@ -933,7 +934,7 @@ func (s *Scheduler) deactivateExcessSearches(ctx context.Context, chatID int64, 
 	}
 	searches, err := s.stores.Searches.ListSearches(ctx, chatID)
 	if err != nil {
-		s.logger.Error("list searches for downgrade failed", "chat_id", chatID, "error", err)
+		s.logger.Error("failed to list searches for tier downgrade", "chat_id", chatID, "error", err)
 		return
 	}
 	var active []storage.Search
@@ -948,10 +949,10 @@ func (s *Scheduler) deactivateExcessSearches(ctx context.Context, chatID int64, 
 	// Keep the oldest (last in the slice since ListSearches orders by created_at DESC), pause the rest.
 	for i := 0; i < len(active)-maxActive; i++ {
 		if err := s.stores.Searches.SetSearchActive(ctx, active[i].ID, chatID, false); err != nil {
-			s.logger.Error("deactivate excess search failed", "chat_id", chatID, "search_id", active[i].ID, "error", err)
+			s.logger.Error("failed to deactivate excess search during tier downgrade", "chat_id", chatID, "search_id", active[i].ID, "error", err)
 		}
 	}
-	s.logger.Info("deactivated excess searches on downgrade",
+	s.logger.Info("deactivated excess searches after tier downgrade",
 		"chat_id", chatID, "paused", len(active)-maxActive, "kept", maxActive)
 }
 


### PR DESCRIPTION
## Summary

- Introduces `internal/cwlog` package with a `ContextHandler` that wraps `slog.Handler` and auto-injects `cycle_id`, `search_id`, `chat_id`, and `request_id` from `context.Context` into every log line
- Refactors ~40 log call sites across scheduler, pipeline, enricher, and delivery paths from terse messages ("claim failed") to narrative messages with `impact` and `action_taken` fields
- Wires `ContextHandler` into all 4 entry points (scraper, api-server, bot-poller, notifier) composing with the existing `TeeHandler` for Redis log streaming
- Adds domain-aware attribute helpers (`ListingAttrs`, `SearchAttrs`, `ErrorEvent`, `PriceDropAttrs`) for consistent structured logging
- Context propagation at 3 injection points: scheduler cycle start (`cycle_id`), per-search delivery loop (`search_id`/`chat_id`), and API request middleware (`request_id`)

## Test plan

- [x] 12 new unit tests in `internal/cwlog/cwlog_test.go` covering context extraction, zero-value omission, partial context, `WithAttrs`/`WithGroup` preservation, TeeHandler composition, and all attr helpers
- [x] All non-Docker tests pass (`go test -short ./...`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — all 4 binaries compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging infrastructure across all services to capture contextual identifiers (request IDs, search IDs, cycle IDs) and structured diagnostic information, enabling improved troubleshooting and operational visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->