### PR TITLE
fix: add wall-clock time to next-scan log and fix unenriched tokens SQL

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -272,7 +272,9 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			}
 		}
 
-		s.logger.Info("scheduling next scan cycle", "in", delay.Round(time.Second).String())
+		s.logger.Info("scheduling next scan cycle",
+			"in", delay.Round(time.Second).String(),
+			"at", time.Now().Add(delay).In(s.loc).Format("15:04:05"))
 
 		timer.Reset(delay)
 

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -556,8 +556,10 @@ func (s *Store) ListUnenrichedTokens(ctx context.Context, limit int) ([]string, 
 		limit = 50
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT DISTINCT token FROM listing_history
-		WHERE km <= 0
+		SELECT token FROM (
+			SELECT DISTINCT token FROM listing_history
+			WHERE km <= 0
+		) t
 		ORDER BY RANDOM()
 		LIMIT $1`, limit)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds `at` field to the "next scan" log line showing the wall-clock time of the next cycle in the configured timezone, so operators don't have to compute `now + delay` mentally
- Fixes `ListUnenrichedTokens` SQL query that was failing with `SQLSTATE 42P10` — PostgreSQL rejects `ORDER BY RANDOM()` with `SELECT DISTINCT`; wraps the distinct selection in a subquery

closes #959

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced logging in the scan scheduler to include additional timestamp context.
  * Optimized database query structure for token enumeration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->