### PR TITLE
perf: match-first enrichment to reduce API calls by ~90%

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -140,7 +140,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 
 	kmEnricher := yad2.NewEnricher(fb.Yad2, logger.With("component", "enricher"), yad2.EnricherConfig{
 		Delay:       time.Second,
-		MaxPerCycle: 100,
+		MaxPerCycle: 25,
 	})
 
 	var n notifier.Notifier = multi

--- a/internal/scheduler/enrichment_test.go
+++ b/internal/scheduler/enrichment_test.go
@@ -138,6 +138,14 @@ func TestMatchFirstEnrichment_PostEnrichmentKmFilter(t *testing.T) {
 	if len(n.messages) != 0 {
 		t.Errorf("expected 0 notifications (km exceeded MaxKm after enrichment), got %d", len(n.messages))
 	}
+
+	// Verify the dedup claim was released so the listing can be re-evaluated.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	key := dedupKey{token: "high-km", chatID: 100}
+	if d.seen[key] {
+		t.Error("dedup claim should be released for km-filtered listing")
+	}
 }
 
 func TestMatchFirstEnrichment_KmWithinLimit(t *testing.T) {

--- a/internal/scheduler/enrichment_test.go
+++ b/internal/scheduler/enrichment_test.go
@@ -243,12 +243,15 @@ func TestBackfillBatchSize(t *testing.T) {
 	enricher := &countingEnricher{calls: &enrichCalls}
 
 	cfg := testConfig()
-	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{
+	s, err := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{
 		SearchStore:      &mockSearchStore{},
 		ListingStore:     ls,
 		KmEnricher:       enricher,
 		BackfillCooldown: time.Millisecond,
 	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
 
 	s.backfillUnenrichedListings(context.Background())
 

--- a/internal/scheduler/enrichment_test.go
+++ b/internal/scheduler/enrichment_test.go
@@ -1,0 +1,260 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+type trackingEnricher struct {
+	mu       sync.Mutex
+	calls    int
+	tokens   [][]string
+	enrichFn func(listings []model.RawListing) int
+}
+
+func (e *trackingEnricher) Enrich(_ context.Context, listings []model.RawListing) int {
+	e.mu.Lock()
+	tokens := make([]string, len(listings))
+	for i, l := range listings {
+		tokens[i] = l.Token
+	}
+	e.tokens = append(e.tokens, tokens)
+	e.calls++
+	e.mu.Unlock()
+	if e.enrichFn != nil {
+		return e.enrichFn(listings)
+	}
+	return 0
+}
+
+func TestMatchFirstEnrichment_OnlyEnrichesMatchedListings(t *testing.T) {
+	enricher := &trackingEnricher{
+		enrichFn: func(listings []model.RawListing) int {
+			for i := range listings {
+				listings[i].Km = 50000
+			}
+			return len(listings)
+		},
+	}
+
+	f := &mockFetcher{listings: []model.RawListing{
+		{Token: "match-1", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3", Price: 90000, Year: 2020},
+		{Token: "match-2", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3", Price: 85000, Year: 2021},
+		{Token: "no-match-1", ManufacturerID: 99, Manufacturer: "BMW", ModelID: 555, Model: "X5", Price: 200000, Year: 2022},
+		{Token: "no-match-2", ManufacturerID: 88, Manufacturer: "Audi", ModelID: 444, Model: "A4", Price: 150000, Year: 2020},
+		{Token: "no-match-3", ManufacturerID: 77, Manufacturer: "Honda", ModelID: 333, Model: "Civic", Price: 70000, Year: 2019},
+	}}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
+				Manufacturer: 27, Model: 10332, Active: true},
+		},
+	}
+
+	s, err := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		KmEnricher:  enricher,
+	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	enricher.mu.Lock()
+	defer enricher.mu.Unlock()
+
+	if enricher.calls != 1 {
+		t.Fatalf("expected 1 enricher call, got %d", enricher.calls)
+	}
+
+	enrichedTokens := enricher.tokens[0]
+	tokenSet := make(map[string]bool)
+	for _, tok := range enrichedTokens {
+		tokenSet[tok] = true
+	}
+
+	if !tokenSet["match-1"] || !tokenSet["match-2"] {
+		t.Errorf("expected matched tokens to be enriched, got %v", enrichedTokens)
+	}
+	if tokenSet["no-match-1"] || tokenSet["no-match-2"] || tokenSet["no-match-3"] {
+		t.Errorf("unmatched tokens should not be enriched, got %v", enrichedTokens)
+	}
+	if len(enrichedTokens) != 2 {
+		t.Errorf("expected 2 tokens enriched, got %d: %v", len(enrichedTokens), enrichedTokens)
+	}
+}
+
+func TestMatchFirstEnrichment_PostEnrichmentKmFilter(t *testing.T) {
+	enricher := &trackingEnricher{
+		enrichFn: func(listings []model.RawListing) int {
+			for i := range listings {
+				listings[i].Km = 150000
+			}
+			return len(listings)
+		},
+	}
+
+	f := &mockFetcher{listings: []model.RawListing{
+		{Token: "high-km", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+			Price: 90000, Year: 2020, EngineVolume: 2000},
+	}}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
+				Manufacturer: 27, Model: 10332, MaxKm: 100000, Active: true},
+		},
+	}
+
+	s, err := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		KmEnricher:  enricher,
+	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 notifications (km exceeded MaxKm after enrichment), got %d", len(n.messages))
+	}
+}
+
+func TestMatchFirstEnrichment_KmWithinLimit(t *testing.T) {
+	enricher := &trackingEnricher{
+		enrichFn: func(listings []model.RawListing) int {
+			for i := range listings {
+				listings[i].Km = 80000
+				listings[i].City = "Tel Aviv"
+			}
+			return len(listings)
+		},
+	}
+
+	f := &mockFetcher{listings: []model.RawListing{
+		{Token: "good-km", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+			Price: 90000, Year: 2020, EngineVolume: 2000},
+	}}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
+				Manufacturer: 27, Model: 10332, MaxKm: 100000, Active: true},
+		},
+	}
+
+	s, err := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		KmEnricher:  enricher,
+	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("expected 1 notification (km within limit), got %d", len(n.messages))
+	}
+}
+
+func TestMatchFirstEnrichment_SkipsEnrichmentWhenAllHaveData(t *testing.T) {
+	enricher := &trackingEnricher{}
+
+	f := &mockFetcher{listings: []model.RawListing{
+		{Token: "full-data", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+			Price: 90000, Year: 2020, Km: 50000, City: "Haifa", ImageURL: "https://img.yad2.co.il/test.jpg"},
+	}}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
+				Manufacturer: 27, Model: 10332, Active: true},
+		},
+	}
+
+	s, err := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		KmEnricher:  enricher,
+	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	enricher.mu.Lock()
+	defer enricher.mu.Unlock()
+	if enricher.calls != 0 {
+		t.Errorf("expected 0 enricher calls when all data present, got %d", enricher.calls)
+	}
+}
+
+func TestBackfillBatchSize(t *testing.T) {
+	var capturedLimit int
+	ls := &batchTrackingListingStore{
+		mockListingStore: mockListingStore{
+			unenrichedTokens: []string{"t1", "t2", "t3"},
+		},
+		captureLimit: &capturedLimit,
+	}
+
+	enrichCalls := 0
+	enricher := &countingEnricher{calls: &enrichCalls}
+
+	cfg := testConfig()
+	s, _ := NewWithOptions(cfg, nil, nil, nil, testLogger(), Options{
+		SearchStore:      &mockSearchStore{},
+		ListingStore:     ls,
+		KmEnricher:       enricher,
+		BackfillCooldown: time.Millisecond,
+	})
+
+	s.backfillUnenrichedListings(context.Background())
+
+	if capturedLimit != 15 {
+		t.Errorf("expected backfill batch limit of 15, got %d", capturedLimit)
+	}
+}
+
+type batchTrackingListingStore struct {
+	mockListingStore
+	captureLimit *int
+}
+
+func (m *batchTrackingListingStore) ListUnenrichedTokens(_ context.Context, limit int) ([]string, error) {
+	*m.captureLimit = limit
+	return m.unenrichedTokens, nil
+}

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -46,7 +46,7 @@ func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
 		return
 	}
 
-	tokens, err := s.stores.Listings.ListUnenrichedTokens(ctx, 50)
+	tokens, err := s.stores.Listings.ListUnenrichedTokens(ctx, 15)
 	if err != nil {
 		s.logger.Error("list unenriched tokens failed", "error", err)
 		return
@@ -58,6 +58,14 @@ func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
 	s.logger.Info("backfill enrichment: fetching km for DB listings missing data",
 		"candidates", len(tokens),
 	)
+
+	// Cooldown before backfill to reduce rate-limit pressure after the
+	// main cycle's enrichment pass.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(s.backfillCooldown):
+	}
 
 	raw := make([]model.RawListing, len(tokens))
 	for i, t := range tokens {

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -61,10 +61,12 @@ func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
 
 	// Cooldown before backfill to reduce rate-limit pressure after the
 	// main cycle's enrichment pass.
+	cooldown := time.NewTimer(s.backfillCooldown)
+	defer cooldown.Stop()
 	select {
 	case <-ctx.Done():
 		return
-	case <-time.After(s.backfillCooldown):
+	case <-cooldown.C:
 	}
 
 	raw := make([]model.RawListing, len(tokens))

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -7,9 +7,7 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/locale"
-	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/notifier"
-	"github.com/dsionov/carwatch/internal/scoring"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -89,85 +87,6 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 		sent = true
 	}
 	return sent
-}
-
-func (s *Scheduler) tryPriceDropListing(ctx context.Context, search storage.Search, l model.RawListing, lang locale.Lang, marketCache *scoring.MarketCache, out *searchResult, log *slog.Logger) bool {
-	if s.stores.Prices == nil || l.Price <= 0 {
-		return false
-	}
-	oldPrice, changed, err := s.stores.Prices.RecordPrice(ctx, l.Token, l.Price)
-	if err != nil {
-		log.ErrorContext(ctx, "failed to record listing price in price tracker",
-			"token", l.Token,
-			"error", err.Error(),
-			"impact", "price drop detection will not work for this listing this cycle",
-			"action_taken", "skipping price drop check, listing will be processed as normal")
-		return false
-	}
-	// Track tokens where RecordPrice inserted a row so that we can revert
-	// them if downstream persistence fails (prevents spurious price-drop
-	// notifications on the next scheduler cycle).
-	// A row is inserted when: (a) first observation (changed=false, oldPrice=0)
-	// or (b) price actually changed (changed=true).
-	if changed || oldPrice == 0 {
-		out.recordedTokens = append(out.recordedTokens, l.Token)
-	}
-	if !changed || l.Price >= oldPrice {
-		return false
-	}
-	log.InfoContext(ctx, "detected price drop for matched listing, preparing to notify user",
-		"token", l.Token,
-		"old_price", oldPrice,
-		"new_price", l.Price,
-		"price_change", l.Price-oldPrice,
-		"manufacturer", l.Manufacturer,
-		"model", l.Model,
-		"year", l.Year,
-	)
-	listing := model.Listing{RawListing: l, SearchName: search.Name}
-	fp := scoring.FitnessParams{
-		Price: l.Price, Km: l.Km, Hand: l.Hand, Year: l.Year,
-		EngineVolume: l.EngineVolume, PriceMax: search.PriceMax,
-		MaxKm: search.MaxKm, MaxHand: search.MaxHand,
-		YearMin: search.YearMin, YearMax: search.YearMax,
-		EngineMinCC: search.EngineMinCC,
-	}
-	if marketCache != nil {
-		if median, _, _, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year); ok {
-			fp.MedianPrice = median
-		}
-	}
-	listing.FitnessScore = scoring.FitnessScore(fp)
-	out.priceDropMessages = append(out.priceDropMessages, notifier.FormatPriceDrop(listing, oldPrice, lang))
-	if s.stores.Listings != nil {
-		rec := storage.ListingRecord{
-			Token: l.Token, ChatID: search.ChatID, SearchID: search.ID, SearchName: search.Name,
-			Manufacturer: l.Manufacturer, Model: l.Model, SubModel: l.SubModel,
-			SubModelID: l.SubModelID,
-			Year:       l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
-			City: l.City, PageLink: l.PageLink, ImageURL: l.ImageURL,
-			EngineVolume: l.EngineVolume, HorsePower: l.HorsePower,
-			EngineType: l.EngineType, GearBox: l.GearBox, Description: l.Description,
-			IsCommercial: l.Commercial,
-			FitnessScore: &listing.FitnessScore, FirstSeenAt: time.Now(),
-		}
-		if marketCache != nil {
-			if median, medKm, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year); ok {
-				ds := scoring.ScoreWithKm(l.Price, l.Km, median, medKm)
-				rec.MedianPrice = &median
-				rec.CohortSize = &cohort
-				rec.DealScore = &ds
-			}
-		}
-		if err := s.stores.Listings.SaveListing(ctx, rec); err != nil {
-			log.ErrorContext(ctx, "failed to persist price-drop listing to history",
-				"token", l.Token,
-				"error", err.Error(),
-				"impact", "price drop record will be missing from listing history",
-				"action_taken", "notification will still be sent, but history is incomplete")
-		}
-	}
-	return true
 }
 
 func (s *Scheduler) persistListings(ctx context.Context, records []storage.ListingRecord, log *slog.Logger) error {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -665,11 +665,13 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	}
 	accums := make(map[int64]*searchAccum, len(searches))
 
-	// Deferred price drop candidates: collected during matching, processed
-	// after enrichment so price-drop notifications use enriched km data.
+	// Deferred price drop candidates: we record prices during matching
+	// (to detect changes) but defer notification formatting until after
+	// enrichment so messages include enriched km/city data.
 	type priceDropCandidate struct {
 		rawIdx   int
 		searchID int64
+		oldPrice int
 	}
 	var priceDropCandidates []priceDropCandidate
 
@@ -713,11 +715,25 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				continue
 			}
 
-			// Defer price drop detection until after enrichment so
-			// notifications include enriched km/city data.
-			priceDropCandidates = append(priceDropCandidates, priceDropCandidate{
-				rawIdx: i, searchID: m.SearchID,
-			})
+			// Record price to detect changes. If a drop is detected,
+			// defer notification until after enrichment.
+			if s.stores.Prices != nil && raw[i].Price > 0 {
+				oldPrice, changed, err := s.stores.Prices.RecordPrice(ctx, raw[i].Token, raw[i].Price)
+				if err != nil {
+					matchLog.ErrorContext(ctx, "failed to record listing price in price tracker",
+						"token", raw[i].Token, "error", err.Error())
+				} else {
+					if changed || oldPrice == 0 {
+						acc.result.recordedTokens = append(acc.result.recordedTokens, raw[i].Token)
+					}
+					if changed && raw[i].Price < oldPrice {
+						priceDropCandidates = append(priceDropCandidates, priceDropCandidate{
+							rawIdx: i, searchID: m.SearchID, oldPrice: oldPrice,
+						})
+						continue
+					}
+				}
+			}
 
 			if !isNew {
 				continue
@@ -773,8 +789,52 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		if acc == nil {
 			continue
 		}
-		matchLog := s.logger.With("search_id", pd.searchID, "chat_id", acc.search.ChatID)
-		s.tryPriceDropListing(ctx, acc.search, raw[pd.rawIdx], acc.lang, marketCache, &acc.result, matchLog)
+		l := raw[pd.rawIdx]
+		s.logger.InfoContext(ctx, "detected price drop for matched listing, preparing to notify user",
+			"token", l.Token, "old_price", pd.oldPrice, "new_price", l.Price,
+			"price_change", l.Price-pd.oldPrice,
+			"manufacturer", l.Manufacturer, "model", l.Model, "year", l.Year,
+		)
+		listing := model.Listing{RawListing: l, SearchName: acc.search.Name}
+		fp := scoring.FitnessParams{
+			Price: l.Price, Km: l.Km, Hand: l.Hand, Year: l.Year,
+			EngineVolume: l.EngineVolume, PriceMax: acc.search.PriceMax,
+			MaxKm: acc.search.MaxKm, MaxHand: acc.search.MaxHand,
+			YearMin: acc.search.YearMin, YearMax: acc.search.YearMax,
+			EngineMinCC: acc.search.EngineMinCC,
+		}
+		if marketCache != nil {
+			if median, _, _, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year); ok {
+				fp.MedianPrice = median
+			}
+		}
+		listing.FitnessScore = scoring.FitnessScore(fp)
+		acc.result.priceDropMessages = append(acc.result.priceDropMessages, notifier.FormatPriceDrop(listing, pd.oldPrice, acc.lang))
+		if s.stores.Listings != nil {
+			rec := storage.ListingRecord{
+				Token: l.Token, ChatID: acc.search.ChatID, SearchID: acc.search.ID, SearchName: acc.search.Name,
+				Manufacturer: l.Manufacturer, Model: l.Model, SubModel: l.SubModel,
+				SubModelID: l.SubModelID,
+				Year:       l.Year, Price: l.Price, Km: l.Km, Hand: l.Hand,
+				City: l.City, PageLink: l.PageLink, ImageURL: l.ImageURL,
+				EngineVolume: l.EngineVolume, HorsePower: l.HorsePower,
+				EngineType: l.EngineType, GearBox: l.GearBox, Description: l.Description,
+				IsCommercial: l.Commercial,
+				FitnessScore: &listing.FitnessScore, FirstSeenAt: time.Now(),
+			}
+			if marketCache != nil {
+				if median, medKm, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year); ok {
+					ds := scoring.ScoreWithKm(l.Price, l.Km, median, medKm)
+					rec.MedianPrice = &median
+					rec.CohortSize = &cohort
+					rec.DealScore = &ds
+				}
+			}
+			if err := s.stores.Listings.SaveListing(ctx, rec); err != nil {
+				s.logger.ErrorContext(ctx, "failed to persist price-drop listing to history",
+					"token", l.Token, "error", err.Error())
+			}
+		}
 	}
 
 	// Build a token→index map so the pipeline reads enriched data from raw.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -40,6 +40,7 @@ const (
 	priceHistoryRetention   = 90 * 24 * time.Hour
 	listingHistoryRetention = 90 * 24 * time.Hour
 	defaultMarketCacheTTL   = 30 * time.Minute
+	defaultBackfillCooldown = 30 * time.Second
 )
 
 type CatalogIngester interface {
@@ -91,6 +92,7 @@ type Scheduler struct {
 	marketCache        *scoring.MarketCache
 	marketCacheBuiltAt time.Time
 	marketCacheTTL     time.Duration
+	backfillCooldown   time.Duration
 }
 
 type digestMeta struct {
@@ -147,6 +149,7 @@ type Options struct {
 	DailyDigestStore storage.DailyDigestStore
 	CycleLogStore    storage.CycleLogStore
 	MarketCacheTTL   time.Duration
+	BackfillCooldown time.Duration
 	Publisher        *broker.Publisher
 }
 
@@ -188,6 +191,11 @@ func NewWithOptions(
 		mcTTL = defaultMarketCacheTTL
 	}
 
+	bfCooldown := opts.BackfillCooldown
+	if bfCooldown <= 0 {
+		bfCooldown = defaultBackfillCooldown
+	}
+
 	return &Scheduler{
 		cfg:        cfg,
 		configPath: opts.ConfigPath,
@@ -220,6 +228,7 @@ func NewWithOptions(
 		percolator:        percolator.New(),
 		triggerCh:         make(chan struct{}, 1),
 		marketCacheTTL:    mcTTL,
+		backfillCooldown:  bfCooldown,
 	}, nil
 }
 
@@ -595,10 +604,10 @@ func (s *Scheduler) writeCycleLog(ctx context.Context, entry storage.CycleLogEnt
 	}
 }
 
-// fetchGlobalAndMatch fetches the global Yad2 feed once, enriches it, then
-// uses the percolator to match each listing against all active searches.
-// Per-user dedup, pipeline processing, and notification delivery happen
-// per match.
+// fetchGlobalAndMatch fetches the global Yad2 feed once, matches each listing
+// against all active searches via the percolator, then enriches only the
+// matched listings to minimize API calls. Per-user dedup, pipeline processing,
+// and notification delivery happen per match.
 func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.Search, marketCache *scoring.MarketCache) (cycleStats, error) {
 	var stats cycleStats
 
@@ -640,26 +649,12 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		}
 	}
 
-	// 3. Prefill from DB first so the enricher sees which listings still
-	// lack km data even after previous cycles. Then enrich the remainder.
+	// 3. Prefill from DB so listings with known km/city/image from prior
+	// cycles get that data before matching.
 	prefilled := false
 	if s.stores.Listings != nil {
 		s.prefillFromDB(ctx, raw)
 		prefilled = true
-	}
-	if s.kmEnricher != nil {
-		enrichCtx, cancelEnrich := context.WithTimeout(ctx, kmEnrichTimeout)
-		enriched := s.kmEnricher.Enrich(enrichCtx, raw)
-		cancelEnrich()
-		if enriched > 0 {
-			s.logger.InfoContext(ctx, "enriched listings with mileage and location data from individual pages",
-				"enriched", enriched,
-				"total", len(raw),
-			)
-			if s.stores.Listings != nil {
-				s.backfillEnrichedListings(ctx, raw)
-			}
-		}
 	}
 
 	// 4. Build a per-search accumulator to collect results across listings.
@@ -671,13 +666,16 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	accums := make(map[int64]*searchAccum, len(searches))
 
 	// 5. Percolator match: for each listing, find matching searches.
+	// Track which raw indices matched so we only enrich those.
 	hiddenCache := make(map[int64]map[string]bool)
+	matchedIndices := make(map[int]struct{})
 
 	for i := range raw {
 		matches := s.percolator.Match(raw[i])
 		if len(matches) == 0 {
 			continue
 		}
+		matchedIndices[i] = struct{}{}
 
 		for _, m := range matches {
 			acc, ok := accums[m.SearchID]
@@ -721,21 +719,97 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		}
 	}
 
+	// 5b. Enrich only matched listings that still need data.
+	if s.kmEnricher != nil && len(matchedIndices) > 0 {
+		var enrichIndices []int
+		for idx := range matchedIndices {
+			if raw[idx].Km <= 0 || raw[idx].City == "" || raw[idx].ImageURL == "" {
+				enrichIndices = append(enrichIndices, idx)
+			}
+		}
+
+		if len(enrichIndices) > 0 {
+			toEnrich := make([]model.RawListing, len(enrichIndices))
+			for i, idx := range enrichIndices {
+				toEnrich[i] = raw[idx]
+			}
+
+			enrichCtx, cancelEnrich := context.WithTimeout(ctx, kmEnrichTimeout)
+			enriched := s.kmEnricher.Enrich(enrichCtx, toEnrich)
+			cancelEnrich()
+
+			if enriched > 0 {
+				for i, idx := range enrichIndices {
+					raw[idx] = toEnrich[i]
+				}
+				s.logger.InfoContext(ctx, "enriched matched listings with mileage and location data",
+					"enriched", enriched,
+					"matched_needing_enrichment", len(enrichIndices),
+					"total_matched", len(matchedIndices),
+				)
+				if s.stores.Listings != nil {
+					s.backfillEnrichedListings(ctx, toEnrich)
+				}
+			}
+		} else {
+			s.logger.InfoContext(ctx, "all matched listings already have enrichment data, skipping API calls",
+				"matched", len(matchedIndices),
+			)
+		}
+	}
+
+	// Build a token→index map so the pipeline reads enriched data from raw.
+	rawByToken := make(map[string]int, len(raw))
+	for i := range raw {
+		rawByToken[raw[i].Token] = i
+	}
+
 	// 6. Run pipeline and deliver results per search.
 	for _, acc := range accums {
 		searchCtx := cwlog.WithSearch(ctx, acc.search.ID, acc.search.ChatID)
 
-		// Convert collected raw listings through the pipeline.
+		// Convert collected raw listings through the pipeline, using the
+		// enriched version from raw (not the stale copy in newListings).
 		if len(acc.result.newListings) > 0 {
 			rawForPipeline := make([]model.RawListing, len(acc.result.newListings))
 			for i, l := range acc.result.newListings {
-				rawForPipeline[i] = l.RawListing
+				if idx, ok := rawByToken[l.Token]; ok {
+					rawForPipeline[i] = raw[idx]
+				} else {
+					rawForPipeline[i] = l.RawListing
+				}
 			}
-			params := ProcessParamsFromSearch(acc.search, marketCache)
-			params.SkipPrefill = prefilled
-			pr := s.pipeline.Process(searchCtx, rawForPipeline, params)
-			acc.result.newListings = pr.Listings
-			acc.result.listingRecords = pr.Records
+
+			// Post-enrichment MaxKm filter: drop listings whose km
+			// (now known after enrichment) exceeds this search's cap.
+			if acc.search.MaxKm > 0 {
+				filtered := rawForPipeline[:0]
+				for _, r := range rawForPipeline {
+					if r.Km > 0 && r.Km > acc.search.MaxKm {
+						continue
+					}
+					filtered = append(filtered, r)
+				}
+				if len(filtered) < len(rawForPipeline) {
+					s.logger.InfoContext(searchCtx,
+						"filtered listings exceeding km limit after enrichment",
+						"before", len(rawForPipeline),
+						"after", len(filtered),
+						"max_km", acc.search.MaxKm,
+					)
+					rawForPipeline = filtered
+				}
+			}
+
+			if len(rawForPipeline) == 0 {
+				acc.result.newListings = nil
+			} else {
+				params := ProcessParamsFromSearch(acc.search, marketCache)
+				params.SkipPrefill = prefilled
+				pr := s.pipeline.Process(searchCtx, rawForPipeline, params)
+				acc.result.newListings = pr.Listings
+				acc.result.listingRecords = pr.Records
+			}
 		}
 
 		// Persist listings.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -665,6 +665,14 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	}
 	accums := make(map[int64]*searchAccum, len(searches))
 
+	// Deferred price drop candidates: collected during matching, processed
+	// after enrichment so price-drop notifications use enriched km data.
+	type priceDropCandidate struct {
+		rawIdx   int
+		searchID int64
+	}
+	var priceDropCandidates []priceDropCandidate
+
 	// 5. Percolator match: for each listing, find matching searches.
 	// Track which raw indices matched so we only enrich those.
 	hiddenCache := make(map[int64]map[string]bool)
@@ -705,10 +713,11 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				continue
 			}
 
-			// Price drop detection.
-			if s.tryPriceDropListing(ctx, m.Search, raw[i], acc.lang, marketCache, &acc.result, matchLog) {
-				continue
-			}
+			// Defer price drop detection until after enrichment so
+			// notifications include enriched km/city data.
+			priceDropCandidates = append(priceDropCandidates, priceDropCandidate{
+				rawIdx: i, searchID: m.SearchID,
+			})
 
 			if !isNew {
 				continue
@@ -758,6 +767,16 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		}
 	}
 
+	// 5c. Process deferred price drops now that enrichment is complete.
+	for _, pd := range priceDropCandidates {
+		acc := accums[pd.searchID]
+		if acc == nil {
+			continue
+		}
+		matchLog := s.logger.With("search_id", pd.searchID, "chat_id", acc.search.ChatID)
+		s.tryPriceDropListing(ctx, acc.search, raw[pd.rawIdx], acc.lang, marketCache, &acc.result, matchLog)
+	}
+
 	// Build a token→index map so the pipeline reads enriched data from raw.
 	rawByToken := make(map[string]int, len(raw))
 	for i := range raw {
@@ -782,10 +801,17 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 
 			// Post-enrichment MaxKm filter: drop listings whose km
 			// (now known after enrichment) exceeds this search's cap.
+			// Release dedup claims for dropped listings so they can be
+			// re-evaluated in future cycles.
 			if acc.search.MaxKm > 0 {
-				filtered := rawForPipeline[:0]
+				filtered := make([]model.RawListing, 0, len(rawForPipeline))
 				for _, r := range rawForPipeline {
 					if r.Km > 0 && r.Km > acc.search.MaxKm {
+						if relErr := s.stores.Dedup.ReleaseClaim(ctx, r.Token, acc.search.ChatID); relErr != nil {
+							s.logger.ErrorContext(searchCtx,
+								"failed to release dedup claim for km-filtered listing",
+								"token", r.Token, "error", relErr.Error())
+						}
 						continue
 					}
 					filtered = append(filtered, r)


### PR DESCRIPTION
## Summary

- Moves enrichment from before percolator matching to after, so only matched listings (~40 of 200) get enriched via API calls instead of the entire feed
- Adds post-enrichment MaxKm filter that drops listings exceeding the search's km cap after enrichment reveals their true mileage, with dedup claim release so filtered listings can be re-evaluated in future cycles
- Defers price drop detection until after enrichment so notifications include enriched km/city data instead of stale Km=0
- Reduces `MaxPerCycle` from 100 to 25 and backfill batch from 50 to 15 with a configurable 30s cooldown to reduce rate-limit pressure
- Fixes timer leak in backfill cooldown using `time.NewTimer` with `defer Stop()`

**Expected impact**: API calls per cycle drop from ~150 (100 main + 50 backfill) to ~20-25 (10 main + 15 backfill with cooldown).

**Safety invariant**: The percolator's km check (`percolator.go:93`) already passes `Km=0` (unknown) through matching. Confirmed by existing test: "Unknown km (0) should pass".

## Test plan

- [x] 5 new tests in `enrichment_test.go` covering match-first flow, km filtering with dedup claim release, and backfill batch size
- [x] All non-Docker scheduler tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — all binaries compile clean
- [x] 4-agent review (correctness, testing, adversarial, reliability) — all P1/P2 findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for enrichment and backfill cycles, including matched listing filtering and location-based validation scenarios.

* **Performance & Reliability**
  * Optimized processing with reduced per-cycle item limits to manage rate limits.
  * Implemented cooldown periods between backfill cycles.
  * Enhanced location-based filtering accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->