### PR TITLE
fix: stop UpsertUser from overriding admin user deactivation

### DIFF
--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -115,13 +115,13 @@ func TestPostgres_UserCRUD(t *testing.T) {
 		t.Errorf("count = %d, want 1", count)
 	}
 
-	// UpsertUser reactivates inactive user
+	// UpsertUser preserves admin-set active status (does not force reactivate)
 	if err := store.UpsertUser(ctx, 200, "reactivated"); err != nil {
 		t.Fatalf("upsert reactivate: %v", err)
 	}
 	u, _ = store.GetUser(ctx, 200)
-	if !u.Active {
-		t.Error("UpsertUser should reactivate an inactive user")
+	if u.Active {
+		t.Error("UpsertUser should not override admin deactivation")
 	}
 
 	// SetUserLanguage

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -23,7 +23,6 @@ func (s *Store) UpsertUser(ctx context.Context, chatID int64, username string) e
 		INSERT INTO users (chat_id, username, channel_id) VALUES ($1, $2, $3)
 		ON CONFLICT (chat_id) DO UPDATE SET
 			username = excluded.username,
-			active = true,
 			channel_id = CASE WHEN users.channel_id = '' THEN excluded.channel_id ELSE users.channel_id END`,
 		chatID, username, channelID)
 	return err


### PR DESCRIPTION
## Summary

- Removes `active = true` from `UpsertUser`'s `ON CONFLICT DO UPDATE` clause
- Root cause: the bot-poller calls `UpsertUser` on every Telegram interaction, which force-set `active = true` and immediately undid any admin deactivation via the dashboard
- New users still get `active = true` from the column default on INSERT

## Test plan

- [x] `go build ./...` compiles clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./internal/storage/... -short` — passes
- [x] Verified direct SQL `UPDATE users SET active = false` persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified how user information is updated when accounts already exist in the system, affecting active status and channel assignment behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->