### PR TITLE
fix: remove active=true override from web/WhatsApp user upsert

### DIFF
--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -99,7 +99,6 @@ func (s *Store) tryUpsertChannelUser(ctx context.Context, channel, channelID, us
 		`SELECT chat_id FROM users WHERE channel = $1 AND channel_id = $2`,
 		channel, channelID).Scan(&existingID)
 	if err == nil {
-		_, _ = tx.ExecContext(ctx, `UPDATE users SET active = true WHERE chat_id = $1`, existingID)
 		_ = tx.Commit()
 		return existingID, nil
 	}


### PR DESCRIPTION
## Summary

Follow-up to #963. The `tryUpsertChannelUser` path (used by `UpsertWebUser` and `UpsertWhatsAppUser`) had the same force-reactivation bug: every web authentication call set `active = true`, undoing admin deactivation for web users (chat_id >= 2000000000000).

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Verified no remaining `active = true` UPDATE/INSERT paths in users.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)