### PR TITLE
fix: decouple search activation from user active status

### DIFF
--- a/internal/storage/postgres/searches.go
+++ b/internal/storage/postgres/searches.go
@@ -228,8 +228,7 @@ func (s *Store) ListAllActiveSearches(ctx context.Context) ([]storage.Search, er
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max, COALESCE(s.price_min, 0), s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys, COALESCE(s.seller_filter, 'any'), COALESCE(s.gear_box, ''), s.price_only, s.photo_only, s.active, s.created_at, COALESCE(s.share_token, '')
 		FROM searches s
-		JOIN users u ON s.chat_id = u.chat_id
-		WHERE s.active = true AND u.active = true
+		WHERE s.active = true
 		ORDER BY s.source, s.manufacturer, s.model`)
 	if err != nil {
 		return nil, fmt.Errorf("list active searches: %w", err)


### PR DESCRIPTION
## Summary

- Removes `JOIN users u ON s.chat_id = u.chat_id ... AND u.active = true` from `ListAllActiveSearches`
- User activity should be derived from having active searches, not a separate boolean flag
- The scheduler already handles blocked users gracefully via `ErrRecipientBlocked` detection
- This was causing searches from users with `active=false` to be silently skipped by the scheduler

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Expected: `active_searches` in scheduler logs should now include searches from all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search retrieval logic to filter active searches based exclusively on the search's own status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->