### PR TITLE
perf: skip enrichment for searches without km filter

### DIFF
--- a/internal/scheduler/enrichment_test.go
+++ b/internal/scheduler/enrichment_test.go
@@ -56,7 +56,7 @@ func TestMatchFirstEnrichment_OnlyEnrichesMatchedListings(t *testing.T) {
 	ss := &mockSearchStore{
 		searches: []storage.Search{
 			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
-				Manufacturer: 27, Model: 10332, Active: true},
+				Manufacturer: 27, Model: 10332, MaxKm: 200000, Active: true},
 		},
 	}
 
@@ -193,12 +193,12 @@ func TestMatchFirstEnrichment_KmWithinLimit(t *testing.T) {
 	}
 }
 
-func TestMatchFirstEnrichment_SkipsEnrichmentWhenAllHaveData(t *testing.T) {
+func TestMatchFirstEnrichment_SkipsEnrichmentWhenNoKmFilter(t *testing.T) {
 	enricher := &trackingEnricher{}
 
 	f := &mockFetcher{listings: []model.RawListing{
-		{Token: "full-data", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
-			Price: 90000, Year: 2020, Km: 50000, City: "Haifa", ImageURL: "https://img.yad2.co.il/test.jpg"},
+		{Token: "no-km", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+			Price: 90000, Year: 2020},
 	}}
 	d := newMockDedup()
 	n := &mockNotifier{}
@@ -206,8 +206,8 @@ func TestMatchFirstEnrichment_SkipsEnrichmentWhenAllHaveData(t *testing.T) {
 
 	ss := &mockSearchStore{
 		searches: []storage.Search{
-			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
-				Manufacturer: 27, Model: 10332, Active: true},
+			{ID: 1, ChatID: 100, Name: "all-mazda", Source: "yad2",
+				Manufacturer: 27, Model: 10332, MaxKm: 0, Active: true},
 		},
 	}
 
@@ -226,7 +226,13 @@ func TestMatchFirstEnrichment_SkipsEnrichmentWhenAllHaveData(t *testing.T) {
 	enricher.mu.Lock()
 	defer enricher.mu.Unlock()
 	if enricher.calls != 0 {
-		t.Errorf("expected 0 enricher calls when all data present, got %d", enricher.calls)
+		t.Errorf("expected 0 enricher calls when no search has MaxKm filter, got %d", enricher.calls)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("expected 1 notification (listing should still be delivered without enrichment), got %d", len(n.messages))
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -676,9 +676,12 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	var priceDropCandidates []priceDropCandidate
 
 	// 5. Percolator match: for each listing, find matching searches.
-	// Track which raw indices matched so we only enrich those.
+	// Track which raw indices matched. needsKmEnrich marks indices where
+	// at least one matching search has a MaxKm filter, meaning we need to
+	// fetch the listing's actual km via the enricher API.
 	hiddenCache := make(map[int64]map[string]bool)
 	matchedIndices := make(map[int]struct{})
+	needsKmEnrich := make(map[int]struct{})
 
 	for i := range raw {
 		matches := s.percolator.Match(raw[i])
@@ -686,6 +689,12 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			continue
 		}
 		matchedIndices[i] = struct{}{}
+		for _, m := range matches {
+			if m.Search.MaxKm > 0 {
+				needsKmEnrich[i] = struct{}{}
+				break
+			}
+		}
 
 		for _, m := range matches {
 			acc, ok := accums[m.SearchID]
@@ -744,10 +753,11 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		}
 	}
 
-	// 5b. Enrich only matched listings that still need data.
-	if s.kmEnricher != nil && len(matchedIndices) > 0 {
+	// 5b. Enrich only matched listings that need km data for filtering.
+	// Skip enrichment for listings where no matching search has a MaxKm cap.
+	if s.kmEnricher != nil && len(needsKmEnrich) > 0 {
 		var enrichIndices []int
-		for idx := range matchedIndices {
+		for idx := range needsKmEnrich {
 			if raw[idx].Km <= 0 || raw[idx].City == "" || raw[idx].ImageURL == "" {
 				enrichIndices = append(enrichIndices, idx)
 			}
@@ -777,8 +787,9 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				}
 			}
 		} else {
-			s.logger.InfoContext(ctx, "all matched listings already have enrichment data, skipping API calls",
+			s.logger.InfoContext(ctx, "all km-filtered matched listings already have enrichment data, skipping API calls",
 				"matched", len(matchedIndices),
+				"needing_km", len(needsKmEnrich),
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

- Only enrich matched listings where at least one matching search has `MaxKm > 0`
- Searches like `all-cars` (`MaxKm=0`) don't need km data, so enriching all 200 listings for them would waste API calls and trigger rate limiting
- Adds `needsKmEnrich` tracking alongside `matchedIndices` during the percolator loop
- Updates test to verify enrichment is skipped when no search has a km filter, while still delivering the listing

## Test plan

- [x] `TestMatchFirstEnrichment_SkipsEnrichmentWhenNoKmFilter` — verifies 0 enricher calls and listing still delivered
- [x] All other enrichment tests pass with `MaxKm` set on searches that need it
- [x] `go build ./...` and `golangci-lint run ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the scheduler to selectively process listings only when km-based filtering constraints are applied, improving overall efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->