### PR TITLE
feat: create enrichment consumer in broker package

### DIFF
--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -1,0 +1,275 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	enrichMaxRetries        = 5
+	enrichDeadLetterMaxLen  = 10000
+	enrichOrphanIdleDefault = 5 * time.Minute
+)
+
+// EnrichFunc processes a single enrichment request. It should return nil
+// on success (or skip), and an error to leave the message pending for retry.
+type EnrichFunc func(ctx context.Context, req EnrichRequest) error
+
+// EnrichConsumer reads enrichment requests from the carwatch:enrich
+// Redis Stream, sorts each batch by priority, and processes them via
+// a caller-provided EnrichFunc.
+type EnrichConsumer struct {
+	client   *redis.Client
+	enrich   EnrichFunc
+	logger   *slog.Logger
+	consumer string
+}
+
+// NewEnrichConsumer connects to Redis, creates the consumer group if
+// needed, and returns a consumer ready to process enrichment requests.
+func NewEnrichConsumer(addr, password string, db int, fn EnrichFunc, logger *slog.Logger) (*EnrichConsumer, error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	err := client.XGroupCreateMkStream(ctx, EnrichStreamName, EnrichGroupName, "0").Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return nil, err
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = fmt.Sprintf("enricher-%d", time.Now().UnixNano())
+	}
+	return &EnrichConsumer{
+		client:   client,
+		enrich:   fn,
+		logger:   logger,
+		consumer: hostname,
+	}, nil
+}
+
+// Run reads and processes enrichment requests until the context is cancelled.
+func (c *EnrichConsumer) Run(ctx context.Context) error {
+	reclaimTicker := time.NewTicker(30 * time.Second)
+	defer reclaimTicker.Stop()
+
+	orphanTicker := time.NewTicker(60 * time.Second)
+	defer orphanTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-reclaimTicker.C:
+			c.reclaimPending(ctx)
+		case <-orphanTicker.C:
+			c.reclaimOrphans(ctx)
+		default:
+		}
+
+		streams, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    EnrichGroupName,
+			Consumer: c.consumer,
+			Streams:  []string{EnrichStreamName, ">"},
+			Count:    10,
+			Block:    5 * time.Second,
+		}).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			c.logger.Error("read from enrich stream failed", "error", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		for _, stream := range streams {
+			c.processBatch(ctx, stream.Messages)
+		}
+	}
+}
+
+// processBatch sorts messages by priority and processes them sequentially.
+func (c *EnrichConsumer) processBatch(ctx context.Context, msgs []redis.XMessage) {
+	type parsed struct {
+		msg redis.XMessage
+		req EnrichRequest
+	}
+
+	var items []parsed
+	for _, msg := range msgs {
+		data, ok := msg.Values["data"].(string)
+		if !ok {
+			c.ack(ctx, msg.ID)
+			continue
+		}
+		var req EnrichRequest
+		if err := json.Unmarshal([]byte(data), &req); err != nil {
+			c.logger.Error("unmarshal enrich request", "id", msg.ID, "error", err)
+			c.ack(ctx, msg.ID)
+			continue
+		}
+		items = append(items, parsed{msg: msg, req: req})
+	}
+
+	slices.SortFunc(items, func(a, b parsed) int {
+		return a.req.Priority - b.req.Priority
+	})
+
+	for _, item := range items {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := c.enrich(ctx, item.req); err != nil {
+			c.logger.Warn("enrich request failed, will retry",
+				"token", item.req.Token, "priority", item.req.Priority, "error", err)
+			return
+		}
+		c.ack(ctx, item.msg.ID)
+	}
+}
+
+func (c *EnrichConsumer) reclaimPending(ctx context.Context) {
+	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream:   EnrichStreamName,
+		Group:    EnrichGroupName,
+		Consumer: c.consumer,
+		Start:    "-",
+		End:      "+",
+		Count:    50,
+		Idle:     30 * time.Second,
+	}).Result()
+	if err != nil || len(pending) == 0 {
+		return
+	}
+
+	c.logger.Info("reclaiming pending enrich messages", "count", len(pending))
+	for _, p := range pending {
+		if p.RetryCount >= int64(enrichMaxRetries) {
+			c.deadLetter(ctx, p.ID)
+			continue
+		}
+		msgs, err := c.client.XRangeN(ctx, EnrichStreamName, p.ID, p.ID, 1).Result()
+		if err != nil || len(msgs) == 0 {
+			continue
+		}
+		c.processBatch(ctx, msgs)
+	}
+}
+
+func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
+	msgs, err := c.client.XRangeN(ctx, EnrichStreamName, id, id, 1).Result()
+	if err != nil || len(msgs) == 0 {
+		c.ack(ctx, id)
+		return
+	}
+	if err := c.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: EnrichDeadLetterStream,
+		MaxLen: enrichDeadLetterMaxLen,
+		Approx: true,
+		Values: msgs[0].Values,
+	}).Err(); err != nil {
+		c.logger.Error("enrich dead-letter failed", "id", id, "error", err)
+	} else {
+		c.logger.Warn("enrich message dead-lettered after max retries",
+			"id", id, "max_retries", enrichMaxRetries)
+	}
+	c.ack(ctx, id)
+}
+
+func (c *EnrichConsumer) reclaimOrphans(ctx context.Context) {
+	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream: EnrichStreamName,
+		Group:  EnrichGroupName,
+		Start:  "-",
+		End:    "+",
+		Count:  50,
+		Idle:   enrichOrphanIdleDefault,
+	}).Result()
+	if err != nil || len(pending) == 0 {
+		return
+	}
+
+	var orphanIDs []string
+	for _, p := range pending {
+		if p.Consumer == c.consumer {
+			continue
+		}
+		if p.RetryCount >= int64(enrichMaxRetries) {
+			c.deadLetter(ctx, p.ID)
+			continue
+		}
+		orphanIDs = append(orphanIDs, p.ID)
+	}
+	if len(orphanIDs) == 0 {
+		return
+	}
+
+	c.logger.Info("reclaiming orphaned enrich messages", "count", len(orphanIDs))
+
+	claimed, err := c.client.XClaim(ctx, &redis.XClaimArgs{
+		Stream:   EnrichStreamName,
+		Group:    EnrichGroupName,
+		Consumer: c.consumer,
+		MinIdle:  enrichOrphanIdleDefault,
+		Messages: orphanIDs,
+	}).Result()
+	if err != nil {
+		c.logger.Error("xclaim enrich orphans failed", "error", err)
+		return
+	}
+
+	c.processBatch(ctx, claimed)
+}
+
+// Drain processes any pending (claimed but unacked) messages before shutdown.
+func (c *EnrichConsumer) Drain(ctx context.Context) {
+	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream:   EnrichStreamName,
+		Group:    EnrichGroupName,
+		Consumer: c.consumer,
+		Start:    "-",
+		End:      "+",
+		Count:    100,
+	}).Result()
+	if err != nil || len(pending) == 0 {
+		return
+	}
+	c.logger.Info("draining pending enrich messages", "count", len(pending))
+	for _, p := range pending {
+		msgs, err := c.client.XRangeN(ctx, EnrichStreamName, p.ID, p.ID, 1).Result()
+		if err != nil || len(msgs) == 0 {
+			continue
+		}
+		c.processBatch(ctx, msgs)
+	}
+}
+
+// Close shuts down the Redis connection.
+func (c *EnrichConsumer) Close() error { return c.client.Close() }
+
+func (c *EnrichConsumer) ack(ctx context.Context, id string) {
+	if err := c.client.XAck(ctx, EnrichStreamName, EnrichGroupName, id).Err(); err != nil {
+		c.logger.Error("enrich ack failed", "id", id, "error", err)
+	}
+}

--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -132,6 +132,7 @@ func (c *EnrichConsumer) processBatch(ctx context.Context, msgs []redis.XMessage
 		items = append(items, parsed{msg: msg, req: req})
 	}
 
+	// Lower numeric priority = higher urgency (1=match > 2=recent > 3=backfill).
 	slices.SortFunc(items, func(a, b parsed) int {
 		return a.req.Priority - b.req.Priority
 	})
@@ -143,7 +144,7 @@ func (c *EnrichConsumer) processBatch(ctx context.Context, msgs []redis.XMessage
 		if err := c.enrich(ctx, item.req); err != nil {
 			c.logger.Warn("enrich request failed, will retry",
 				"token", item.req.Token, "priority", item.req.Priority, "error", err)
-			return
+			continue
 		}
 		c.ack(ctx, item.msg.ID)
 	}

--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -180,7 +180,11 @@ func (c *EnrichConsumer) reclaimPending(ctx context.Context) {
 
 func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
 	msgs, err := c.client.XRangeN(ctx, EnrichStreamName, id, id, 1).Result()
-	if err != nil || len(msgs) == 0 {
+	if err != nil {
+		c.logger.Error("read enrich message for dead-letter failed", "id", id, "error", err)
+		return
+	}
+	if len(msgs) == 0 {
 		c.ack(ctx, id)
 		return
 	}
@@ -190,11 +194,11 @@ func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
 		Approx: true,
 		Values: msgs[0].Values,
 	}).Err(); err != nil {
-		c.logger.Error("enrich dead-letter failed", "id", id, "error", err)
-	} else {
-		c.logger.Warn("enrich message dead-lettered after max retries",
-			"id", id, "max_retries", enrichMaxRetries)
+		c.logger.Error("enrich dead-letter failed, leaving message pending", "id", id, "error", err)
+		return
 	}
+	c.logger.Warn("enrich message dead-lettered after max retries",
+		"id", id, "max_retries", enrichMaxRetries)
 	c.ack(ctx, id)
 }
 

--- a/internal/broker/enrich_consumer_test.go
+++ b/internal/broker/enrich_consumer_test.go
@@ -1,0 +1,133 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestEnrichConsumer_ProcessesPriorityOrder(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	// Publish in reverse priority order.
+	for _, p := range []int{3, 1, 2} {
+		req := EnrichRequest{
+			Token:    fmt.Sprintf("tok-p%d", p),
+			Priority: p,
+			Source:   "test",
+		}
+		if err := pub.PublishEnrich(ctx, req); err != nil {
+			t.Fatalf("publish: %v", err)
+		}
+	}
+
+	var mu sync.Mutex
+	var processed []string
+
+	fn := func(_ context.Context, req EnrichRequest) error {
+		mu.Lock()
+		processed = append(processed, req.Token)
+		mu.Unlock()
+		return nil
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	_ = cons.Run(runCtx)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processed) != 3 {
+		t.Fatalf("expected 3 processed, got %d", len(processed))
+	}
+	if processed[0] != "tok-p1" {
+		t.Errorf("first processed = %q, want tok-p1 (highest priority)", processed[0])
+	}
+	if processed[1] != "tok-p2" {
+		t.Errorf("second processed = %q, want tok-p2", processed[1])
+	}
+	if processed[2] != "tok-p3" {
+		t.Errorf("third processed = %q, want tok-p3 (lowest priority)", processed[2])
+	}
+}
+
+func TestEnrichConsumer_AcksOnSuccess(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req := EnrichRequest{Token: "ack-test", Priority: 1, Source: "test"}
+	if err := pub.PublishEnrich(ctx, req); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	called := false
+	fn := func(_ context.Context, r EnrichRequest) error {
+		called = true
+		if r.Token != "ack-test" {
+			t.Errorf("token = %q, want ack-test", r.Token)
+		}
+		return nil
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = cons.Run(runCtx)
+
+	if !called {
+		t.Error("enrich function was not called")
+	}
+
+	// Verify message was acknowledged (no pending).
+	pending, err := client.XPending(ctx, EnrichStreamName, EnrichGroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Errorf("expected 0 pending after ack, got %d", pending.Count)
+	}
+}
+
+func TestEnrichConsumer_ConnectionFailure(t *testing.T) {
+	fn := func(_ context.Context, _ EnrichRequest) error { return nil }
+	_, err := NewEnrichConsumer("localhost:1", "", 0, fn, testLogger())
+	if err == nil {
+		t.Error("expected error for invalid Redis address")
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+type discardWriter struct{}
+
+func (d *discardWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
## Summary

Adds `EnrichConsumer` to the broker package — a Redis Streams consumer for the `carwatch:enrich` stream with priority-aware batch processing.

- Consumer group: `enricher-workers`
- Max retries: 5 (higher than alerts — enrichment is idempotent)
- Dead-letter stream: `carwatch:enrich:dead`
- Priority sorting: lower numeric = higher urgency (1=match > 2=recent > 3=backfill)
- Orphan reclamation: 5 min idle threshold
- Graceful drain on shutdown

closes #969

## Review

✅ 2/2 agents passed (correctness, testing)

| Agent | Verdict | Key Findings |
|-------|---------|-------------|
| correctness | Pass (1 finding fixed) | Early return on failure → changed to continue (P1, fixed). Priority semantics comment added (P2, fixed). |
| testing | Pass (accepted) | Missing tests for error path, dead-letter, drain, malformed input — will address in #980 (edge case tests issue) |

## Test plan

- [x] 3 new tests: priority ordering, ack on success, connection failure
- [x] `go build ./...` and `golangci-lint run ./...` — clean
- [x] All existing broker tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced enrichment request processing with priority-based ordering and automatic retry logic for failed requests, including dead-letter handling.

* **Tests**
  * Comprehensive test coverage for enrichment processing, including priority ordering, message acknowledgment, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->