### PR TITLE
feat: implement enrichment worker core

### DIFF
--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -1,0 +1,113 @@
+package enricher
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// ItemDetails holds enrichment data fetched from an individual listing page.
+type ItemDetails struct {
+	Km       int
+	ImageURL string
+	City     string
+	Area     string
+}
+
+// ItemFetcher fetches detailed data for a single listing by token.
+type ItemFetcher interface {
+	FetchItem(ctx context.Context, token string) (ItemDetails, error)
+}
+
+// Worker processes enrichment requests from a Redis stream by fetching
+// individual listing pages and updating the database.
+type Worker struct {
+	fetcher  ItemFetcher
+	listings storage.ListingStore
+	limiter  *AdaptiveRateLimiter
+	logger   *slog.Logger
+}
+
+// NewWorker creates an enrichment worker.
+func NewWorker(f ItemFetcher, ls storage.ListingStore, rl *AdaptiveRateLimiter, logger *slog.Logger) *Worker {
+	return &Worker{
+		fetcher:  f,
+		listings: ls,
+		limiter:  rl,
+		logger:   logger,
+	}
+}
+
+// HandleRequest is the broker.EnrichFunc callback. It processes a single
+// enrichment request: checks if already enriched, waits for rate limit,
+// fetches the item page, and updates the database.
+func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) error {
+	// Check if already enriched (idempotent skip).
+	existing, err := w.listings.LookupEnrichmentData(ctx, []string{req.Token})
+	if err != nil {
+		w.logger.ErrorContext(ctx, "failed to check enrichment status",
+			"token", req.Token, "error", err.Error())
+		return err
+	}
+	if rec, ok := existing[req.Token]; ok && rec.Km > 0 {
+		w.logger.DebugContext(ctx, "listing already enriched, skipping",
+			"token", req.Token, "km", rec.Km)
+		return nil
+	}
+
+	// Wait for rate limiter.
+	if !w.limiter.Wait(ctx) {
+		return ctx.Err()
+	}
+
+	// Fetch item detail page.
+	details, fetchErr := w.fetcher.FetchItem(ctx, req.Token)
+	if fetchErr != nil {
+		if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
+			w.logger.ErrorContext(ctx, "failed to increment enrich attempt",
+				"token", req.Token, "error", incErr.Error())
+		}
+
+		if errors.Is(fetchErr, fetcher.ErrChallenge) {
+			w.limiter.RecordChallenge()
+			w.logger.WarnContext(ctx, "bot challenge during enrichment, backing off",
+				"token", req.Token, "cooldown", w.limiter.InCooldown(),
+				"current_delay", w.limiter.CurrentDelay())
+			return fetchErr
+		}
+
+		w.logger.WarnContext(ctx, "failed to fetch listing detail page",
+			"token", req.Token, "error", fetchErr.Error())
+		return fetchErr
+	}
+
+	w.limiter.RecordSuccess()
+
+	// Build a minimal listing record for backfill.
+	rec := storage.ListingRecord{
+		Token:    req.Token,
+		Km:       details.Km,
+		City:     details.City,
+		ImageURL: details.ImageURL,
+	}
+	if err := w.listings.BackfillListings(ctx, []storage.ListingRecord{rec}); err != nil {
+		w.logger.ErrorContext(ctx, "failed to backfill enriched data to database",
+			"token", req.Token, "error", err.Error())
+		return err
+	}
+
+	if err := w.listings.IncrementEnrichAttempt(ctx, req.Token); err != nil {
+		w.logger.ErrorContext(ctx, "failed to increment enrich attempt after success",
+			"token", req.Token, "error", err.Error())
+	}
+
+	w.logger.InfoContext(ctx, "enriched listing",
+		"token", req.Token, "km", details.Km, "city", details.City,
+		"has_image", details.ImageURL != "", "priority", req.Priority)
+
+	return nil
+}

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -47,15 +47,17 @@ func NewWorker(f ItemFetcher, ls storage.ListingStore, rl *AdaptiveRateLimiter, 
 // fetches the item page, and updates the database.
 func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) error {
 	// Check if already enriched (idempotent skip).
+	// A listing is considered enriched if any field has been successfully
+	// fetched (Km > 0, or City/ImageURL populated).
 	existing, err := w.listings.LookupEnrichmentData(ctx, []string{req.Token})
 	if err != nil {
 		w.logger.ErrorContext(ctx, "failed to check enrichment status",
 			"token", req.Token, "error", err.Error())
 		return err
 	}
-	if rec, ok := existing[req.Token]; ok && rec.Km > 0 {
+	if rec, ok := existing[req.Token]; ok && (rec.Km > 0 || rec.City != "" || rec.ImageURL != "") {
 		w.logger.DebugContext(ctx, "listing already enriched, skipping",
-			"token", req.Token, "km", rec.Km)
+			"token", req.Token, "km", rec.Km, "city", rec.City)
 		return nil
 	}
 
@@ -98,11 +100,6 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		w.logger.ErrorContext(ctx, "failed to backfill enriched data to database",
 			"token", req.Token, "error", err.Error())
 		return err
-	}
-
-	if err := w.listings.IncrementEnrichAttempt(ctx, req.Token); err != nil {
-		w.logger.ErrorContext(ctx, "failed to increment enrich attempt after success",
-			"token", req.Token, "error", err.Error())
 	}
 
 	w.logger.InfoContext(ctx, "enriched listing",

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -146,8 +146,8 @@ func TestWorker_EnrichesSuccessfully(t *testing.T) {
 	if ls.backfilled[0].City != "Tel Aviv" {
 		t.Errorf("backfilled city = %q, want Tel Aviv", ls.backfilled[0].City)
 	}
-	if ls.enrichAttempts["tok-1"] != 1 {
-		t.Errorf("enrich attempts = %d, want 1", ls.enrichAttempts["tok-1"])
+	if ls.enrichAttempts["tok-1"] != 0 {
+		t.Errorf("enrich attempts = %d, want 0 (not incremented on success)", ls.enrichAttempts["tok-1"])
 	}
 }
 
@@ -168,6 +168,26 @@ func TestWorker_SkipsAlreadyEnriched(t *testing.T) {
 	defer f.mu.Unlock()
 	if f.calls != 0 {
 		t.Errorf("expected 0 fetch calls for already-enriched token, got %d", f.calls)
+	}
+}
+
+func TestWorker_SkipsWhenCityAlreadyEnriched(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{Km: 0, City: "Tel Aviv"}}
+	ls := newMockListingStore()
+	ls.enrichmentData["tok-1"] = storage.EnrichmentRecord{Km: 0, City: "Tel Aviv"}
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls != 0 {
+		t.Errorf("expected 0 fetch calls when city is already enriched (even with Km=0), got %d", f.calls)
 	}
 }
 

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -1,0 +1,276 @@
+package enricher
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+type mockItemFetcher struct {
+	mu      sync.Mutex
+	calls   int
+	details ItemDetails
+	err     error
+}
+
+func (m *mockItemFetcher) FetchItem(_ context.Context, _ string) (ItemDetails, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	return m.details, m.err
+}
+
+type mockListingStore struct {
+	mu             sync.Mutex
+	enrichmentData map[string]storage.EnrichmentRecord
+	backfilled     []storage.ListingRecord
+	enrichAttempts map[string]int
+	backfillErr    error
+	lookupErr      error
+	incrementErr   error
+}
+
+func newMockListingStore() *mockListingStore {
+	return &mockListingStore{
+		enrichmentData: make(map[string]storage.EnrichmentRecord),
+		enrichAttempts: make(map[string]int),
+	}
+}
+
+func (m *mockListingStore) LookupEnrichmentData(_ context.Context, tokens []string) (map[string]storage.EnrichmentRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lookupErr != nil {
+		return nil, m.lookupErr
+	}
+	result := make(map[string]storage.EnrichmentRecord)
+	for _, t := range tokens {
+		if rec, ok := m.enrichmentData[t]; ok {
+			result[t] = rec
+		}
+	}
+	return result, nil
+}
+
+func (m *mockListingStore) BackfillListings(_ context.Context, records []storage.ListingRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.backfillErr != nil {
+		return m.backfillErr
+	}
+	m.backfilled = append(m.backfilled, records...)
+	return nil
+}
+
+func (m *mockListingStore) IncrementEnrichAttempt(_ context.Context, token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.incrementErr != nil {
+		return m.incrementErr
+	}
+	m.enrichAttempts[token]++
+	return nil
+}
+
+func (m *mockListingStore) SaveListing(_ context.Context, _ storage.ListingRecord) error { return nil }
+func (m *mockListingStore) SaveListings(_ context.Context, _ []storage.ListingRecord) error {
+	return nil
+}
+func (m *mockListingStore) GetListing(_ context.Context, _ int64, _ string) (*storage.ListingRecord, error) {
+	return nil, nil
+}
+func (m *mockListingStore) ListUserListings(_ context.Context, _ int64, _, _ int) ([]storage.ListingRecord, error) {
+	return nil, nil
+}
+func (m *mockListingStore) CountUserListings(_ context.Context, _ int64) (int64, error) {
+	return 0, nil
+}
+func (m *mockListingStore) ListSearchListings(_ context.Context, _ int64, _ int64, _ storage.ListingFilter, _, _ int, _ string) ([]storage.ListingRecord, error) {
+	return nil, nil
+}
+func (m *mockListingStore) CountSearchListings(_ context.Context, _ int64, _ int64, _ storage.ListingFilter) (int64, error) {
+	return 0, nil
+}
+func (m *mockListingStore) CountSearchListingsForChat(_ context.Context, _ int64) (map[int64]int64, error) {
+	return nil, nil
+}
+func (m *mockListingStore) SearchStats(_ context.Context, _ int64, _ int64, _ storage.ListingFilter) (*storage.SearchStats, error) {
+	return nil, nil
+}
+func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
+	return nil, nil
+}
+func (m *mockListingStore) CountUnenrichedTokens(_ context.Context) (int64, error) { return 0, nil }
+func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (int64, error) {
+	return 0, nil
+}
+func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
+	return 0, nil
+}
+
+func testWorkerLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+}
+
+type discardWriter struct{}
+
+func (d *discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestWorker_EnrichesSuccessfully(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{Km: 50000, City: "Tel Aviv", ImageURL: "https://img.yad2.co.il/test.jpg"}}
+	ls := newMockListingStore()
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if len(ls.backfilled) != 1 {
+		t.Fatalf("expected 1 backfilled record, got %d", len(ls.backfilled))
+	}
+	if ls.backfilled[0].Km != 50000 {
+		t.Errorf("backfilled km = %d, want 50000", ls.backfilled[0].Km)
+	}
+	if ls.backfilled[0].City != "Tel Aviv" {
+		t.Errorf("backfilled city = %q, want Tel Aviv", ls.backfilled[0].City)
+	}
+	if ls.enrichAttempts["tok-1"] != 1 {
+		t.Errorf("enrich attempts = %d, want 1", ls.enrichAttempts["tok-1"])
+	}
+}
+
+func TestWorker_SkipsAlreadyEnriched(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{Km: 99999}}
+	ls := newMockListingStore()
+	ls.enrichmentData["tok-1"] = storage.EnrichmentRecord{Km: 50000}
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls != 0 {
+		t.Errorf("expected 0 fetch calls for already-enriched token, got %d", f.calls)
+	}
+}
+
+func TestWorker_ChallengeTriggersBackoff(t *testing.T) {
+	f := &mockItemFetcher{err: fetcher.ErrChallenge}
+	ls := newMockListingStore()
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+
+	if !errors.Is(err, fetcher.ErrChallenge) {
+		t.Errorf("expected ErrChallenge, got %v", err)
+	}
+
+	if d := rl.CurrentDelay(); d <= time.Millisecond {
+		t.Errorf("delay should have increased after challenge, got %v", d)
+	}
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if ls.enrichAttempts["tok-1"] != 1 {
+		t.Errorf("enrich attempts = %d, want 1 (even on failure)", ls.enrichAttempts["tok-1"])
+	}
+}
+
+func TestWorker_FetchErrorReturnsError(t *testing.T) {
+	fetchErr := errors.New("network timeout")
+	f := &mockItemFetcher{err: fetchErr}
+	ls := newMockListingStore()
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+
+	if err == nil {
+		t.Error("expected error from fetch failure")
+	}
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if len(ls.backfilled) != 0 {
+		t.Error("should not backfill on fetch error")
+	}
+}
+
+func TestWorker_BackfillErrorReturnsError(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{Km: 50000, City: "Haifa"}}
+	ls := newMockListingStore()
+	ls.backfillErr = errors.New("db write failed")
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+
+	if err == nil {
+		t.Error("expected error from backfill failure")
+	}
+}
+
+func TestWorker_LookupErrorReturnsError(t *testing.T) {
+	f := &mockItemFetcher{}
+	ls := newMockListingStore()
+	ls.lookupErr = errors.New("db read failed")
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+
+	if err == nil {
+		t.Error("expected error from lookup failure")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls != 0 {
+		t.Error("should not fetch if lookup failed")
+	}
+}
+
+func TestWorker_ContextCancellation(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{Km: 50000}}
+	ls := newMockListingStore()
+	rl := NewAdaptiveRateLimiter(5*time.Second, 10*time.Second, time.Minute)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := broker.EnrichRequest{Token: "tok-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(ctx, req)
+
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls != 0 {
+		t.Error("should not fetch when context is cancelled")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the core enrichment processing logic for the standalone enricher worker (#972).

The `Worker` processes enrichment requests from the Redis stream by:
1. Checking if the listing is already enriched — skips if ANY field (Km, City, or ImageURL) has data
2. Waiting for the adaptive rate limiter (respects backoff/cooldown)
3. Fetching the item detail page via `ItemFetcher` interface
4. Backfilling km/city/image to the database via `BackfillListings`
5. Recording enrichment attempt count on failures only (for convergence tracking)

Handles bot challenges by triggering rate limiter backoff, and propagates errors back to the consumer for retry/dead-letter.

closes #972

## Review

✅ 5/5 agents passed (correctness, testing, maintainability, reliability, adversarial)

| Agent | Verdict | Key Findings |
|-------|---------|-------------|
| correctness | Pass (2 fixed) | IncrementEnrichAttempt on success distorts metrics (P2, fixed); skip check only on Km>0 misses City/ImageURL (P2, fixed) |
| testing | Pass (accepted) | Missing Km=0 edge case test (added); IncrementEnrichAttempt failure after backfill (deferred to #980) |
| maintainability | Pass (limited) | Duplicated ItemDetails type (intentional — avoids coupling to yad2 package) |
| reliability | Pass (1 noted) | Wait blocks during 5min cooldown (accepted — consumer reclaim handles stalled batches) |
| adversarial | Pass (2 fixed) | Infinite Km=0 re-enrichment loop (fixed via multi-field skip check); double increment (fixed) |

## Test plan

- [x] 8 new worker tests: success, skip-enriched, skip-city-enriched, challenge backoff, fetch error, backfill error, lookup error, context cancellation
- [x] 9 existing rate limiter tests pass
- [x] `go build ./...` and `golangci-lint run ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)