### PR TITLE
feat: create enricher binary and add to Docker build/compose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
 
             # Only manage app + infra services; watchtower and caddy are
             # long-lived infrastructure that must not be recreated on every deploy.
-            APP_SERVICES="postgres redis api bot-poller scraper notifier"
+            APP_SERVICES="postgres redis api bot-poller scraper notifier enricher"
 
             echo "==> Pulling latest image..."
             docker compose -f docker-compose.prod.yaml pull $APP_SERVICES

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,14 @@ ENV LDFLAGS="-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X
 RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/api-server ./cmd/api-server && \
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/bot-poller ./cmd/bot-poller && \
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/scraper ./cmd/scraper && \
-    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier && \
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/enricher ./cmd/enricher
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata \
     && adduser -D -u 1000 carwatch
 USER carwatch
-COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /usr/local/bin/
+COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /bin/enricher /usr/local/bin/
 COPY --from=builder /app/migrations /migrations
 HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
   CMD wget -q --spider http://localhost:8080/healthz || exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-api build-bot-poller build-scraper build-notifier build-all \
+.PHONY: all build build-api build-bot-poller build-scraper build-notifier build-enricher build-all \
        run test test-cover test-e2e lint ci clean docker-build docker-run \
        dev dev-db dev-stop dev-reset dev-pg-shell \
        vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-deploy vm-deploy-all vm-sync \
@@ -37,7 +37,10 @@ build-scraper:
 build-notifier:
 	go build $(LDFLAGS) -o notifier-worker ./cmd/notifier
 
-build-all: build build-bot-poller build-scraper build-notifier
+build-enricher:
+	go build $(LDFLAGS) -o enricher ./cmd/enricher
+
+build-all: build build-bot-poller build-scraper build-notifier build-enricher
 
 catalog-refresh:
 	go run ./cmd/catalog-gen -output internal/catalog/catalog_data.json

--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -180,6 +180,10 @@ func consumerLoop(ctx context.Context, cons runner, logger *slog.Logger) {
 			logger.Error("enrich consumer exited, restarting", "backoff", backoff.String(), "error", err)
 			select {
 			case <-ctx.Done():
+				logger.Info("enricher worker draining in-flight requests")
+				drainCtx2, drainCancel2 := context.WithTimeout(context.Background(), 10*time.Second)
+				cons.Drain(drainCtx2)
+				drainCancel2()
 				logger.Info("enricher worker shut down")
 				return
 			case <-time.After(backoff):

--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -1,0 +1,208 @@
+// Command enricher runs a standalone worker that consumes enrichment
+// requests from the carwatch:enrich Redis stream and fetches individual
+// listing pages from Yad2 to fill in missing km/city/image data.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/app"
+	"github.com/dsionov/carwatch/internal/broker"
+	"github.com/dsionov/carwatch/internal/cwlog"
+	"github.com/dsionov/carwatch/internal/enricher"
+	"github.com/dsionov/carwatch/internal/fetcher/yad2"
+	"github.com/dsionov/carwatch/internal/health"
+	"github.com/dsionov/carwatch/internal/logstream"
+)
+
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
+const defaultHealthBind = "0.0.0.0:8084"
+
+func main() {
+	configPath := flag.String("config", "config.yaml", "path to config file")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	healthBind := flag.String("health-bind", defaultHealthBind, "health endpoint bind address")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("enricher %s (commit: %s, built: %s)\n", version, gitCommit, buildTime)
+		return
+	}
+
+	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
+
+	if err := run(*configPath, *healthBind, logger); err != nil {
+		logger.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(configPath, healthBind string, logger *slog.Logger) error {
+	cfg, err := app.LoadConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	logger, _, err = app.SetupLogger(cfg)
+	if err != nil {
+		return err
+	}
+
+	baseHandler := logger.Handler()
+	if cfg.Redis.Addr != "" {
+		logPub, pubErr := logstream.NewRedisPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
+		if pubErr != nil {
+			logger.Warn("redis log publisher failed", "error", pubErr)
+		} else {
+			defer func() { _ = logPub.Close() }()
+			baseHandler = logstream.NewTeeHandler(baseHandler, logPub, "enricher")
+		}
+	}
+	logger = slog.New(cwlog.NewContextHandler(baseHandler))
+	slog.SetDefault(logger)
+
+	logger.Info("config loaded", "log_level", cfg.LogLevel, "log_format", cfg.LogFormat, "version", version)
+
+	if cfg.Redis.Addr == "" {
+		return fmt.Errorf("redis.addr is required for the enricher worker")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	telShutdown, err := app.InitTelemetry(ctx, "carwatch-enricher", version, cfg, logger)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = telShutdown(context.Background()) }()
+
+	store, err := app.OpenStore(cfg)
+	if err != nil {
+		return fmt.Errorf("create store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Build fetcher for item detail pages.
+	fb, err := app.BuildFetchers(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	// Wrap Yad2Fetcher to satisfy enricher.ItemFetcher interface.
+	itemFetcher := &yad2ItemFetcherAdapter{fetcher: fb.Yad2}
+
+	// Create adaptive rate limiter.
+	rl := enricher.NewAdaptiveRateLimiter(
+		cfg.Enricher.BaseDelay,
+		cfg.Enricher.MaxDelay,
+		cfg.Enricher.CooldownDuration,
+	)
+
+	// Create the enrichment worker.
+	worker := enricher.NewWorker(itemFetcher, store, rl, logger.With("component", "enricher"))
+
+	h := health.New()
+	h.SetVersion(version)
+
+	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := healthSrv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("health server shutdown failed", "error", err)
+		}
+	}()
+
+	cons, err := broker.NewEnrichConsumer(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB,
+		worker.HandleRequest, logger.With("component", "enrich-consumer"))
+	if err != nil {
+		return fmt.Errorf("create enrich consumer: %w", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	logger.Info("enricher worker started",
+		"redis", cfg.Redis.Addr,
+		"health", "http://"+healthBind+"/healthz",
+		"base_delay", cfg.Enricher.BaseDelay,
+		"max_delay", cfg.Enricher.MaxDelay,
+		"cooldown", cfg.Enricher.CooldownDuration,
+	)
+
+	consumerLoop(ctx, cons, logger)
+	return nil
+}
+
+type runner interface {
+	Run(ctx context.Context) error
+	Drain(ctx context.Context)
+}
+
+type consumerBackoff struct {
+	initial        time.Duration
+	max            time.Duration
+	resetThreshold time.Duration
+}
+
+var defaultConsumerBackoff = consumerBackoff{
+	initial:        time.Second,
+	max:            30 * time.Second,
+	resetThreshold: 30 * time.Second,
+}
+
+func consumerLoop(ctx context.Context, cons runner, logger *slog.Logger) {
+	backoff := defaultConsumerBackoff.initial
+	for {
+		start := time.Now()
+		if err := cons.Run(ctx); err != nil {
+			if ctx.Err() != nil {
+				logger.Info("enricher worker draining in-flight requests")
+				drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				cons.Drain(drainCtx)
+				drainCancel()
+				logger.Info("enricher worker shut down")
+				return
+			}
+			if time.Since(start) >= defaultConsumerBackoff.resetThreshold {
+				backoff = defaultConsumerBackoff.initial
+			}
+			logger.Error("enrich consumer exited, restarting", "backoff", backoff.String(), "error", err)
+			select {
+			case <-ctx.Done():
+				logger.Info("enricher worker shut down")
+				return
+			case <-time.After(backoff):
+			}
+			backoff = min(backoff*2, defaultConsumerBackoff.max)
+		}
+	}
+}
+
+// yad2ItemFetcherAdapter adapts yad2.Yad2Fetcher to the enricher.ItemFetcher interface.
+type yad2ItemFetcherAdapter struct {
+	fetcher *yad2.Yad2Fetcher
+}
+
+func (a *yad2ItemFetcherAdapter) FetchItem(ctx context.Context, token string) (enricher.ItemDetails, error) {
+	details, err := a.fetcher.FetchItem(ctx, token)
+	if err != nil {
+		return enricher.ItemDetails{}, err
+	}
+	return enricher.ItemDetails{
+		Km:       details.Km,
+		ImageURL: details.ImageURL,
+		City:     details.City,
+		Area:     details.Area,
+	}, nil
+}

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -185,6 +185,40 @@ services:
         limits:
           memory: 256M
 
+  enricher:
+    image: ghcr.io/danielsio/carwatch:latest
+    container_name: carwatch-enricher
+    entrypoint: ["/usr/local/bin/enricher"]
+    networks:
+      - carwatch-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./config.yaml:/config.yaml:ro
+      - ./migrations:/migrations:ro
+    environment:
+      - TZ=Asia/Jerusalem
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8084/healthz"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
   caddy:
     image: caddy:2-alpine
     container_name: caddy

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -217,7 +217,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 512M
 
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
## Summary

Adds the standalone enricher worker binary and integrates it into the Docker build/deploy pipeline.

- **`cmd/enricher/main.go`** — new binary modeled on `cmd/notifier`, consuming from `carwatch:enrich` Redis stream
- Adapter wraps `yad2.Yad2Fetcher` to satisfy `enricher.ItemFetcher` interface
- Consumer loop with exponential backoff and graceful drain on shutdown
- Health endpoint on port 8084
- Added to Dockerfile, docker-compose.prod.yaml (512M memory), release.yml deploy script, and Makefile

closes #974
closes #975

## Review

✅ 5/5 agents passed (correctness, testing, maintainability, reliability, adversarial)

| Agent | Verdict | Key Findings |
|-------|---------|-------------|
| correctness | Pass (1 fixed) | Missing drain during backoff shutdown (P1, fixed) |
| testing | Pass (accepted) | Consumer loop untested — follows same pattern as notifier which is tested. Deferred to #980. |
| maintainability | Pass | Consumer loop duplication with notifier (P2, accepted — extract to shared package later) |
| reliability | Pass | Redis fatal on startup (accepted — docker restart policy handles it). Memory bumped to 512M. |
| adversarial | Pass | Shared proxy pool contention with scraper (P2 advisory — noted for future). Memory limit fixed. |

## Test plan

- [x] `go build ./cmd/enricher/` — compiles clean
- [x] `golangci-lint run ./cmd/enricher/` — 0 issues
- [x] All existing tests pass
- [x] Dockerfile builds with enricher binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new enricher microservice to the application. The service is fully integrated into production deployments with health monitoring, automatic restarts, memory limits (512MB), and container management. It is now included in the standard release workflow and deployment pipeline for consistent deployment across all environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->