### PR TITLE
feat: add enrichment observability metrics and admin endpoint

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -725,3 +725,16 @@ func (s *Server) adminSetLogLevel(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("log level changed", "level", body.Level)
 	writeJSON(w, http.StatusOK, map[string]string{"level": s.logLevel.Level().String()})
 }
+
+func (s *Server) adminEnrichmentStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	unenriched, err := s.listings.CountUnenrichedTokens(ctx)
+	if err != nil {
+		s.logger.Error("admin: count unenriched tokens", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to count unenriched tokens")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"unenriched_count": unenriched,
+	})
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -225,6 +225,7 @@ func (s *Server) Routes() http.Handler {
 		if s.cycleLog != nil {
 			authMux.HandleFunc("GET /api/v1/admin/cycles", s.requireAdmin(s.adminCycles))
 		}
+		authMux.HandleFunc("GET /api/v1/admin/enrichment-status", s.requireAdmin(s.adminEnrichmentStatus))
 		if s.logHub != nil {
 			authMux.HandleFunc("GET /api/v1/admin/logs", s.requireAdmin(s.adminLogs))
 			authMux.HandleFunc("GET /api/v1/admin/logs/stream", s.requireAdmin(s.adminLogStream))

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/telemetry"
 )
 
 // ItemDetails holds enrichment data fetched from an individual listing page.
@@ -58,6 +59,9 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 	if rec, ok := existing[req.Token]; ok && (rec.Km > 0 || rec.City != "" || rec.ImageURL != "") {
 		w.logger.DebugContext(ctx, "listing already enriched, skipping",
 			"token", req.Token, "km", rec.Km, "city", rec.City)
+		if telemetry.EnrichSkipped != nil {
+			telemetry.EnrichSkipped.Add(ctx, 1)
+		}
 		return nil
 	}
 
@@ -76,6 +80,9 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 
 		if errors.Is(fetchErr, fetcher.ErrChallenge) {
 			w.limiter.RecordChallenge()
+			if telemetry.EnrichChallenges != nil {
+				telemetry.EnrichChallenges.Add(ctx, 1)
+			}
 			w.logger.WarnContext(ctx, "bot challenge during enrichment, backing off",
 				"token", req.Token, "cooldown", w.limiter.InCooldown(),
 				"current_delay", w.limiter.CurrentDelay())
@@ -100,6 +107,10 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		w.logger.ErrorContext(ctx, "failed to backfill enriched data to database",
 			"token", req.Token, "error", err.Error())
 		return err
+	}
+
+	if telemetry.EnrichSuccesses != nil {
+		telemetry.EnrichSuccesses.Add(ctx, 1)
 	}
 
 	w.logger.InfoContext(ctx, "enriched listing",

--- a/internal/telemetry/app_metrics.go
+++ b/internal/telemetry/app_metrics.go
@@ -22,6 +22,15 @@ var (
 	ActiveSearches metric.Int64Gauge
 	// ActiveUsers reports the current number of active users.
 	ActiveUsers metric.Int64Gauge
+
+	// EnrichRequests counts enrichment requests published to the stream.
+	EnrichRequests metric.Int64Counter
+	// EnrichSuccesses counts successful enrichments.
+	EnrichSuccesses metric.Int64Counter
+	// EnrichChallenges counts bot challenge responses during enrichment.
+	EnrichChallenges metric.Int64Counter
+	// EnrichSkipped counts enrichment requests skipped (already enriched).
+	EnrichSkipped metric.Int64Counter
 )
 
 // InitMetrics creates all application-level OTel metric instruments.
@@ -68,6 +77,30 @@ func InitMetrics() error {
 
 	ActiveUsers, err = meter.Int64Gauge("carwatch.users.active",
 		metric.WithDescription("Number of active users"))
+	if err != nil {
+		return err
+	}
+
+	EnrichRequests, err = meter.Int64Counter("carwatch.enrich.requests",
+		metric.WithDescription("Enrichment requests published to stream"))
+	if err != nil {
+		return err
+	}
+
+	EnrichSuccesses, err = meter.Int64Counter("carwatch.enrich.successes",
+		metric.WithDescription("Successful enrichments"))
+	if err != nil {
+		return err
+	}
+
+	EnrichChallenges, err = meter.Int64Counter("carwatch.enrich.challenges",
+		metric.WithDescription("Bot challenge responses during enrichment"))
+	if err != nil {
+		return err
+	}
+
+	EnrichSkipped, err = meter.Int64Counter("carwatch.enrich.skipped",
+		metric.WithDescription("Enrichment requests skipped (already enriched)"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Adds 4 OTel metrics to `app_metrics.go`: `EnrichRequests`, `EnrichSuccesses`, `EnrichChallenges`, `EnrichSkipped`
- Emits metrics from the enricher worker on success, skip (already enriched), and bot challenge
- Adds `GET /api/v1/admin/enrichment-status` endpoint returning `unenriched_count` for dashboard visibility

closes #978

## Review

✅ Metrics follow existing OTel pattern. Endpoint follows existing admin handler pattern. No review agents needed for 58-line additive change.

## Test plan

- [x] `go build ./...` and `golangci-lint run ./...` — clean
- [x] All enricher and telemetry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)