### PR TITLE
fix: add targeted per-search fetching for specific manufacturer/model pairs

### DIFF
--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -159,8 +159,9 @@ func TestRunMultiTenantCycle_SharedScraping(t *testing.T) {
 	fetchCalls := f.calls
 	f.mu.Unlock()
 
-	if fetchCalls != 1 {
-		t.Errorf("fetcher called %d times, want 1 (shared scraping)", fetchCalls)
+	// 1 global feed + 1 targeted fetch for the shared (27, 10332) pair.
+	if fetchCalls != 2 {
+		t.Errorf("fetcher called %d times, want 2 (global + targeted)", fetchCalls)
 	}
 
 	n.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -588,6 +588,87 @@ func (s *Scheduler) writeCycleLog(ctx context.Context, entry storage.CycleLogEnt
 	}
 }
 
+// targetedFetchCoverageThreshold is the minimum number of listings for a
+// manufacturer/model pair in the global feed before targeted fetch is skipped.
+const targetedFetchCoverageThreshold = 5
+
+// fetchTargetedListings supplements the global feed with targeted fetches for
+// specific manufacturer/model pairs from active searches. Models that rarely
+// appear in the top-200 global feed would otherwise never match.
+func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storage.Search, raw []model.RawListing, f fetcher.Fetcher) []model.RawListing {
+	type mfrModel struct{ Manufacturer, Model int }
+	pairs := make(map[mfrModel]struct{})
+	for _, sr := range searches {
+		if sr.Manufacturer > 0 {
+			pairs[mfrModel{sr.Manufacturer, sr.Model}] = struct{}{}
+		}
+	}
+	if len(pairs) == 0 {
+		return raw
+	}
+
+	// Count how many global-feed listings already cover each pair.
+	coverage := make(map[mfrModel]int, len(pairs))
+	for _, l := range raw {
+		key := mfrModel{l.ManufacturerID, l.ModelID}
+		if _, needed := pairs[key]; needed {
+			coverage[key]++
+		}
+	}
+
+	// Build the dedup set from existing tokens.
+	seen := make(map[string]struct{}, len(raw))
+	for _, l := range raw {
+		seen[l.Token] = struct{}{}
+	}
+
+	var fetched, added int
+	for pair := range pairs {
+		if coverage[pair] >= targetedFetchCoverageThreshold {
+			continue
+		}
+
+		targetCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+		params := model.SourceParams{Manufacturer: pair.Manufacturer, Model: pair.Model}
+		targeted, err := s.fetchWithRetryUsing(targetCtx, f, params, s.logger)
+		cancel()
+
+		if err != nil {
+			s.logger.WarnContext(ctx, "targeted fetch failed, skipping pair",
+				"manufacturer", pair.Manufacturer, "model", pair.Model,
+				"car", s.carName(pair.Manufacturer, pair.Model),
+				"error", err)
+			continue
+		}
+		fetched++
+
+		for _, l := range targeted {
+			if _, dup := seen[l.Token]; dup {
+				continue
+			}
+			seen[l.Token] = struct{}{}
+			raw = append(raw, l)
+			added++
+		}
+
+		// Brief pause between fetches to reduce rate-limit risk.
+		select {
+		case <-ctx.Done():
+			return raw
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	if fetched > 0 {
+		s.logger.InfoContext(ctx, "fetched targeted listings for search-specific models",
+			"pairs_fetched", fetched,
+			"pairs_skipped", len(pairs)-fetched,
+			"new_listings_added", added,
+		)
+	}
+	return raw
+}
+
 // fetchGlobalAndMatch fetches the global Yad2 feed once, matches each listing
 // against all active searches via the percolator, then enriches only the
 // matched listings to minimize API calls. Per-user dedup, pipeline processing,
@@ -618,6 +699,11 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		"active_searches", len(searches),
 		"duration_ms", fetchDuration.Milliseconds(),
 	)
+
+	// 1b. Targeted fetches for specific manufacturer/model pairs that
+	// are unlikely to appear in the global feed's 200 most recent listings.
+	raw = s.fetchTargetedListings(ctx, searches, raw, activeFetcher)
+	stats.listingsFetched = len(raw)
 
 	// 2. Catalog ingestion.
 	if s.catalogIngester != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -624,6 +624,12 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 
 	var fetched, added int
 	for pair := range pairs {
+		select {
+		case <-ctx.Done():
+			return raw
+		default:
+		}
+
 		if coverage[pair] >= targetedFetchCoverageThreshold {
 			continue
 		}
@@ -634,6 +640,9 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 		cancel()
 
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return raw
+			}
 			s.logger.WarnContext(ctx, "targeted fetch failed, skipping pair",
 				"manufacturer", pair.Manufacturer, "model", pair.Model,
 				"car", s.carName(pair.Manufacturer, pair.Model),

--- a/internal/scheduler/targeted_fetch_test.go
+++ b/internal/scheduler/targeted_fetch_test.go
@@ -1,0 +1,254 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// paramAwareFetcher returns different listings based on SourceParams.
+type paramAwareFetcher struct {
+	mu       sync.Mutex
+	calls    []model.SourceParams
+	results  map[paramKey][]model.RawListing
+	errors   map[paramKey]error
+	fallback []model.RawListing
+}
+
+type paramKey struct{ Manufacturer, Model int }
+
+func (f *paramAwareFetcher) Fetch(_ context.Context, p model.SourceParams) ([]model.RawListing, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, p)
+	key := paramKey{p.Manufacturer, p.Model}
+	if err, ok := f.errors[key]; ok {
+		return nil, err
+	}
+	if res, ok := f.results[key]; ok {
+		return res, nil
+	}
+	return f.fallback, nil
+}
+
+func newTestSchedulerWithFetcher(f fetcher.Fetcher) *Scheduler {
+	cfg := testConfig()
+	s, _ := NewWithOptions(cfg, f, newMockDedup(), &mockNotifier{}, testLogger(), Options{})
+	return s
+}
+
+func TestFetchTargetedListings_NoPairsNoFetch(t *testing.T) {
+	f := &paramAwareFetcher{}
+	s := newTestSchedulerWithFetcher(f)
+
+	searches := []storage.Search{
+		{ID: 1, Manufacturer: 0, Model: 0},
+	}
+	global := []model.RawListing{{Token: "g1"}}
+	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 listing (unchanged), got %d", len(result))
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) != 0 {
+		t.Errorf("expected 0 fetch calls for wildcard-only searches, got %d", len(f.calls))
+	}
+}
+
+func TestFetchTargetedListings_FetchesUncoveredPair(t *testing.T) {
+	f := &paramAwareFetcher{
+		results: map[paramKey][]model.RawListing{
+			{0, 0}: {{Token: "g1", ManufacturerID: 99, ModelID: 999}},
+			{27, 10332}: {
+				{Token: "t1", ManufacturerID: 27, ModelID: 10332},
+				{Token: "t2", ManufacturerID: 27, ModelID: 10332},
+			},
+		},
+	}
+	s := newTestSchedulerWithFetcher(f)
+
+	searches := []storage.Search{
+		{ID: 1, Manufacturer: 27, Model: 10332},
+	}
+	global := []model.RawListing{{Token: "g1", ManufacturerID: 99, ModelID: 999}}
+	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 listings (1 global + 2 targeted), got %d", len(result))
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) != 1 {
+		t.Fatalf("expected 1 targeted fetch call, got %d", len(f.calls))
+	}
+	if f.calls[0].Manufacturer != 27 || f.calls[0].Model != 10332 {
+		t.Errorf("targeted fetch used wrong params: %+v", f.calls[0])
+	}
+}
+
+func TestFetchTargetedListings_SkipsWellCoveredPair(t *testing.T) {
+	f := &paramAwareFetcher{}
+	s := newTestSchedulerWithFetcher(f)
+
+	searches := []storage.Search{
+		{ID: 1, Manufacturer: 27, Model: 10332},
+	}
+	// Global feed already has 5 listings for this pair.
+	global := make([]model.RawListing, 5)
+	for i := range global {
+		global[i] = model.RawListing{
+			Token:          "g" + string(rune('0'+i)),
+			ManufacturerID: 27,
+			ModelID:        10332,
+		}
+	}
+
+	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+
+	if len(result) != 5 {
+		t.Errorf("expected 5 listings (no targeted fetch), got %d", len(result))
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) != 0 {
+		t.Errorf("expected 0 fetch calls (pair well-covered), got %d", len(f.calls))
+	}
+}
+
+func TestFetchTargetedListings_DeduplicatesTokens(t *testing.T) {
+	f := &paramAwareFetcher{
+		results: map[paramKey][]model.RawListing{
+			{17, 10182}: {
+				{Token: "shared", ManufacturerID: 17, ModelID: 10182},
+				{Token: "new1", ManufacturerID: 17, ModelID: 10182},
+			},
+		},
+	}
+	s := newTestSchedulerWithFetcher(f)
+
+	searches := []storage.Search{
+		{ID: 1, Manufacturer: 17, Model: 10182},
+	}
+	global := []model.RawListing{{Token: "shared", ManufacturerID: 17, ModelID: 10182}}
+
+	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 listings (1 shared deduped + 1 new), got %d", len(result))
+	}
+	tokens := make(map[string]int)
+	for _, l := range result {
+		tokens[l.Token]++
+	}
+	if tokens["shared"] != 1 {
+		t.Errorf("token 'shared' appeared %d times, want 1", tokens["shared"])
+	}
+	if tokens["new1"] != 1 {
+		t.Errorf("token 'new1' appeared %d times, want 1", tokens["new1"])
+	}
+}
+
+func TestFetchTargetedListings_FetchErrorContinues(t *testing.T) {
+	f := &paramAwareFetcher{
+		results: map[paramKey][]model.RawListing{
+			{19, 10222}: {{Token: "ok1", ManufacturerID: 19, ModelID: 10222}},
+		},
+		errors: map[paramKey]error{
+			{27, 10332}: fetcher.ErrChallenge,
+		},
+	}
+	s := newTestSchedulerWithFetcher(f)
+
+	searches := []storage.Search{
+		{ID: 1, Manufacturer: 27, Model: 10332},
+		{ID: 2, Manufacturer: 19, Model: 10222},
+	}
+	global := []model.RawListing{{Token: "g1"}}
+
+	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+
+	// Should have global + successful targeted fetch, despite first pair failing.
+	hasOk1 := false
+	for _, l := range result {
+		if l.Token == "ok1" {
+			hasOk1 = true
+		}
+	}
+	if !hasOk1 {
+		t.Error("expected targeted listing 'ok1' from successful pair, not found")
+	}
+}
+
+func TestFetchTargetedListings_SharedPairFetchedOnce(t *testing.T) {
+	f := &paramAwareFetcher{
+		results: map[paramKey][]model.RawListing{
+			{27, 10332}: {{Token: "t1", ManufacturerID: 27, ModelID: 10332}},
+		},
+	}
+	s := newTestSchedulerWithFetcher(f)
+
+	// Two searches for the same manufacturer/model pair.
+	searches := []storage.Search{
+		{ID: 1, ChatID: 100, Manufacturer: 27, Model: 10332},
+		{ID: 2, ChatID: 200, Manufacturer: 27, Model: 10332},
+	}
+	global := []model.RawListing{{Token: "g1"}}
+
+	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	targetedCalls := 0
+	for _, c := range f.calls {
+		if c.Manufacturer == 27 && c.Model == 10332 {
+			targetedCalls++
+		}
+	}
+	if targetedCalls != 1 {
+		t.Errorf("expected 1 targeted fetch for shared pair, got %d", targetedCalls)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 listings (1 global + 1 targeted), got %d", len(result))
+	}
+}
+
+func TestFetchTargetedListings_ContextCanceled(t *testing.T) {
+	f := &paramAwareFetcher{
+		results: map[paramKey][]model.RawListing{
+			{27, 10332}: {{Token: "t1"}},
+			{19, 10222}: {{Token: "t2"}},
+		},
+	}
+	s := newTestSchedulerWithFetcher(f)
+
+	searches := []storage.Search{
+		{ID: 1, Manufacturer: 27, Model: 10332},
+		{ID: 2, Manufacturer: 19, Model: 10222},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	global := []model.RawListing{{Token: "g1"}}
+	result := s.fetchTargetedListings(ctx, searches, global, f)
+
+	// With context already cancelled, the method should return early.
+	// Global listings must always be preserved.
+	hasGlobal := false
+	for _, l := range result {
+		if l.Token == "g1" {
+			hasGlobal = true
+		}
+	}
+	if !hasGlobal {
+		t.Error("global listing 'g1' missing from result after context cancellation")
+	}
+}

--- a/internal/scheduler/targeted_fetch_test.go
+++ b/internal/scheduler/targeted_fetch_test.go
@@ -37,7 +37,10 @@ func (f *paramAwareFetcher) Fetch(_ context.Context, p model.SourceParams) ([]mo
 
 func newTestSchedulerWithFetcher(f fetcher.Fetcher) *Scheduler {
 	cfg := testConfig()
-	s, _ := NewWithOptions(cfg, f, newMockDedup(), &mockNotifier{}, testLogger(), Options{})
+	s, err := NewWithOptions(cfg, f, newMockDedup(), &mockNotifier{}, testLogger(), Options{})
+	if err != nil {
+		panic(err)
+	}
 	return s
 }
 
@@ -241,14 +244,22 @@ func TestFetchTargetedListings_ContextCanceled(t *testing.T) {
 	result := s.fetchTargetedListings(ctx, searches, global, f)
 
 	// With context already cancelled, the method should return early.
-	// Global listings must always be preserved.
-	hasGlobal := false
+	// Only global listings should be present — no targeted tokens.
+	if len(result) != len(global) {
+		t.Errorf("expected %d listings (global only), got %d", len(global), len(result))
+	}
 	for _, l := range result {
-		if l.Token == "g1" {
-			hasGlobal = true
+		if l.Token == "t1" || l.Token == "t2" {
+			t.Errorf("targeted token %q should not appear after context cancellation", l.Token)
 		}
 	}
-	if !hasGlobal {
+	if result[0].Token != "g1" {
 		t.Error("global listing 'g1' missing from result after context cancellation")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) != 0 {
+		t.Errorf("expected 0 fetch calls after context cancellation, got %d", len(f.calls))
 	}
 }


### PR DESCRIPTION
## Summary

- The V3 global feed (200 most recent listings) rarely contains specific models like Honda Civic or Mazda 3, causing searches with manufacturer/model filters to match 0 listings
- Adds targeted fetches for each unique (manufacturer, model) pair from active searches, merged with the global feed before percolator matching
- Pairs already well-represented in the global feed (≥5 listings) are skipped to avoid redundant requests
- Fetches are sequential with 500ms delays to avoid Yad2 rate limiting

## Review

✅ 9/9 agents passed (correctness, testing, maintainability, project-standards, agent-native, learnings-researcher, performance, reliability, adversarial)

P1 finding (missing tests) was addressed before PR creation. Remaining findings are advisory (P2-P3).

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] 7 new unit tests for `fetchTargetedListings`:
  - NoPairsNoFetch, FetchesUncoveredPair, SkipsWellCoveredPair
  - DeduplicatesTokens, FetchErrorContinues, SharedPairFetchedOnce
  - ContextCanceled
- [x] Existing `TestRunMultiTenantCycle_SharedScraping` updated for new call count
- [ ] Deploy and verify `listing_history` has entries for searches 25, 26, 32, 33, 34

closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduler now performs targeted supplemental fetching for specific manufacturer/model pairs when global feed coverage is insufficient; targeted results are deduplicated and merged with global listings.

* **Tests**
  * Added comprehensive tests for targeted fetching behavior: coverage thresholds, deduplication, error handling, single-fetch-per-pair, and context cancellation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->