### PR TITLE
fix: fail closed when Firebase auth is missing on non-local bind

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -24,7 +24,7 @@ storage:
   prune_after: 720h
 
 http:
-  bind: "0.0.0.0:8080"
+  bind: "127.0.0.1:8080"
 
 redis:
   addr: "localhost:6379"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -123,11 +124,10 @@ type Config struct {
 }
 
 func New(c Config) *Server {
-	if c.FirebaseAuth == nil {
-		bind := c.Bind
-		if bind != "" && !strings.HasPrefix(bind, "127.0.0.1") && !strings.HasPrefix(bind, "localhost") {
+	if c.FirebaseAuth == nil && IsNonLocalBind(c.Bind) {
+		if c.Logger != nil {
 			c.Logger.Warn("firebase auth not configured — using dev auth mode on non-localhost bind address",
-				"bind", bind)
+				"bind", c.Bind)
 		}
 	}
 
@@ -160,6 +160,19 @@ func New(c Config) *Server {
 		cycleLog:       c.CycleLog,
 		vitals:         newVitalsRing(),
 	}
+}
+
+func IsNonLocalBind(bind string) bool {
+	b := strings.TrimSpace(bind)
+	if b == "" {
+		return false
+	}
+	host := b
+	if h, _, err := net.SplitHostPort(b); err == nil {
+		host = h
+	}
+	host = strings.Trim(strings.ToLower(host), "[]")
+	return host != "127.0.0.1" && host != "localhost" && host != "::1"
 }
 
 func requestIDMiddleware(next http.Handler) http.Handler {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,10 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
@@ -195,7 +193,7 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		}
 		firebaseAuth = v
 	}
-	if firebaseAuth == nil && isNonLocalBind(cfg.HTTP.Bind) {
+	if firebaseAuth == nil && api.IsNonLocalBind(cfg.HTTP.Bind) {
 		return nil, fmt.Errorf("firebase auth must be configured for non-local bind address %q", cfg.HTTP.Bind)
 	}
 
@@ -227,19 +225,6 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 	})
 
 	return apiServer, nil
-}
-
-func isNonLocalBind(bind string) bool {
-	b := strings.TrimSpace(bind)
-	if b == "" {
-		return false
-	}
-	host := b
-	if h, _, err := net.SplitHostPort(b); err == nil {
-		host = h
-	}
-	host = strings.Trim(strings.ToLower(host), "[]")
-	return host != "127.0.0.1" && host != "localhost" && host != "::1"
 }
 
 // BuildPriceListService creates the pricelist HTTP client and service.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
@@ -193,6 +195,9 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		}
 		firebaseAuth = v
 	}
+	if firebaseAuth == nil && isNonLocalBind(cfg.HTTP.Bind) {
+		return nil, fmt.Errorf("firebase auth must be configured for non-local bind address %q", cfg.HTTP.Bind)
+	}
 
 	cfg.API.AdminChatID = cfg.Telegram.AdminChatID
 	cfg.API.MaxSearches = cfg.Telegram.MaxSearches
@@ -222,6 +227,19 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 	})
 
 	return apiServer, nil
+}
+
+func isNonLocalBind(bind string) bool {
+	b := strings.TrimSpace(bind)
+	if b == "" {
+		return false
+	}
+	host := b
+	if h, _, err := net.SplitHostPort(b); err == nil {
+		host = h
+	}
+	host = strings.Trim(strings.ToLower(host), "[]")
+	return host != "127.0.0.1" && host != "localhost" && host != "::1"
 }
 
 // BuildPriceListService creates the pricelist HTTP client and service.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	apiinternal "github.com/dsionov/carwatch/internal/api"
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/fetcher"
 )
@@ -235,22 +236,49 @@ func TestBuildAPIRejectsMissingFirebaseOnNonLocalBind(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got nil (server=%v)", apiServer)
 	}
+	if !strings.Contains(err.Error(), "firebase auth must be configured") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "0.0.0.0:8080") {
+		t.Fatalf("error should include bind address, got: %v", err)
+	}
 }
 
-func TestBuildAPIAllowsMissingFirebaseOnLocalBind(t *testing.T) {
-	cfg := &config.Config{
-		HTTP: config.HTTPConfig{
-			Bind: "127.0.0.1:8080",
-		},
-	}
+func TestBuildAPIFirebaseRequirementByBind(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+	tests := []struct {
+		name    string
+		bind    string
+		wantErr bool
+	}{
+		{name: "loopback v4", bind: "127.0.0.1:8080", wantErr: false},
+		{name: "localhost", bind: "localhost:8080", wantErr: false},
+		{name: "loopback v6", bind: "[::1]:8080", wantErr: false},
+		{name: "all interfaces short", bind: ":8080", wantErr: true},
+		{name: "all interfaces v4", bind: "0.0.0.0:8080", wantErr: true},
 	}
-	if apiServer == nil {
-		t.Fatalf("expected api server, got nil")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				HTTP: config.HTTPConfig{
+					Bind: tt.bind,
+				},
+			}
+			apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (server=%v)", apiServer)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if apiServer == nil {
+				t.Fatalf("expected api server, got nil")
+			}
+		})
 	}
 }
 
@@ -264,14 +292,16 @@ func TestIsNonLocalBind(t *testing.T) {
 		{name: "localhost", bind: "localhost:8080", want: false},
 		{name: "loopback", bind: "127.0.0.1:8080", want: false},
 		{name: "ipv6 loopback", bind: "[::1]:8080", want: false},
+		{name: "empty", bind: "", want: false},
+		{name: "whitespace", bind: "   ", want: false},
 		{name: "all interfaces short", bind: ":8080", want: true},
 		{name: "all interfaces v4", bind: "0.0.0.0:8080", want: true},
 		{name: "public host", bind: "192.168.1.10:8080", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isNonLocalBind(tt.bind); got != tt.want {
-				t.Fatalf("isNonLocalBind(%q) = %v, want %v", tt.bind, got, tt.want)
+			if got := apiinternal.IsNonLocalBind(tt.bind); got != tt.want {
+				t.Fatalf("IsNonLocalBind(%q) = %v, want %v", tt.bind, got, tt.want)
 			}
 		})
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,12 +1,14 @@
 package app
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/fetcher"
 )
 
@@ -218,5 +220,59 @@ storage:
 	}
 	if _, ok := fb.Caching.(*fetcher.CircuitBreaker); !ok {
 		t.Errorf("FetcherBundle.Caching should be *fetcher.CircuitBreaker, got %T", fb.Caching)
+	}
+}
+
+func TestBuildAPIRejectsMissingFirebaseOnNonLocalBind(t *testing.T) {
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			Bind: "0.0.0.0:8080",
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error, got nil (server=%v)", apiServer)
+	}
+}
+
+func TestBuildAPIAllowsMissingFirebaseOnLocalBind(t *testing.T) {
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			Bind: "127.0.0.1:8080",
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if apiServer == nil {
+		t.Fatalf("expected api server, got nil")
+	}
+}
+
+func TestIsNonLocalBind(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		bind string
+		want bool
+	}{
+		{name: "localhost", bind: "localhost:8080", want: false},
+		{name: "loopback", bind: "127.0.0.1:8080", want: false},
+		{name: "ipv6 loopback", bind: "[::1]:8080", want: false},
+		{name: "all interfaces short", bind: ":8080", want: true},
+		{name: "all interfaces v4", bind: "0.0.0.0:8080", want: true},
+		{name: "public host", bind: "192.168.1.10:8080", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNonLocalBind(tt.bind); got != tt.want {
+				t.Fatalf("isNonLocalBind(%q) = %v, want %v", tt.bind, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- fail API startup when Firebase auth is missing on non-local binds
- centralize bind classification via `api.IsNonLocalBind` and reuse in startup + warnings
- keep local developer workflow working by binding `config.dev.yaml` to loopback
- add coverage for bind matrix and startup guard behavior

## Review
✅ 5/5 agents passed (correctness, security, reliability, maintainability, testing).

## Test plan
- [x] `go test ./internal/app`
- [x] `go test ./internal/api -run TestDoesNotExist` (compile check)
- [ ] CI checks green

closes #1004

Made with [Cursor](https://cursor.com)