### PR TITLE
fix: recover dedup claims from dead-lettered listing alerts

### DIFF
--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/logstream"
+	"github.com/dsionov/carwatch/internal/storage"
 )
 
 var (
@@ -120,21 +121,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	cons, err := broker.NewConsumer(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB,
 		multi.NotifyRaw,
 		logger.With("component", "broker-consumer"),
-		broker.WithDeadLetterHook(func(ctx context.Context, alert broker.Alert) error {
-			if len(alert.Tokens) == 0 {
-				return nil
-			}
-			for _, token := range alert.Tokens {
-				if err := store.ReleaseClaim(ctx, token, alert.ChatID); err != nil {
-					return err
-				}
-			}
-			logger.Warn("released dedup claims for dead-lettered alert",
-				"chat_id", alert.ChatID,
-				"tokens", len(alert.Tokens),
-				"search_id", alert.SearchID)
-			return nil
-		}),
+		broker.WithDeadLetterHook(releaseDedupClaimsOnDeadLetter(store, logger)),
 	)
 	if err != nil {
 		return fmt.Errorf("create redis consumer: %w", err)
@@ -196,5 +183,26 @@ func consumerLoopWithConfig(ctx context.Context, cons runner, logger *slog.Logge
 			}
 			backoff = min(backoff*2, bo.max)
 		}
+	}
+}
+
+func releaseDedupClaimsOnDeadLetter(dedup storage.DedupStore, logger *slog.Logger) broker.DeadLetterHook {
+	return func(ctx context.Context, alert broker.Alert) error {
+		if dedup == nil || len(alert.Tokens) == 0 {
+			return nil
+		}
+		for _, token := range alert.Tokens {
+			cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 5*time.Second)
+			err := dedup.ReleaseClaim(cleanupCtx, token, alert.ChatID)
+			cleanupCancel()
+			if err != nil {
+				return err
+			}
+		}
+		logger.Warn("released dedup claims for dead-lettered alert",
+			"chat_id", alert.ChatID,
+			"tokens", len(alert.Tokens),
+			"search_id", alert.SearchID)
+		return nil
 	}
 }

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -118,7 +118,24 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	}()
 
 	cons, err := broker.NewConsumer(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB,
-		multi.NotifyRaw, logger.With("component", "broker-consumer"))
+		multi.NotifyRaw,
+		logger.With("component", "broker-consumer"),
+		broker.WithDeadLetterHook(func(ctx context.Context, alert broker.Alert) error {
+			if len(alert.Tokens) == 0 {
+				return nil
+			}
+			for _, token := range alert.Tokens {
+				if err := store.ReleaseClaim(ctx, token, alert.ChatID); err != nil {
+					return err
+				}
+			}
+			logger.Warn("released dedup claims for dead-lettered alert",
+				"chat_id", alert.ChatID,
+				"tokens", len(alert.Tokens),
+				"search_id", alert.SearchID)
+			return nil
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("create redis consumer: %w", err)
 	}

--- a/cmd/notifier/main_test.go
+++ b/cmd/notifier/main_test.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/dsionov/carwatch/internal/broker"
 )
 
 func TestDefaultHealthBind(t *testing.T) {
@@ -144,5 +146,74 @@ func TestConsumerLoop_ShutdownOnContextCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("consumerLoop did not exit after context cancel")
+	}
+}
+
+type mockDedupStore struct {
+	released []struct {
+		token  string
+		chatID int64
+	}
+	releaseErr error
+}
+
+func (m *mockDedupStore) ClaimNew(context.Context, string, int64, int64) (bool, error) { return false, nil }
+func (m *mockDedupStore) ReleaseClaim(_ context.Context, token string, chatID int64) error {
+	m.released = append(m.released, struct {
+		token  string
+		chatID int64
+	}{token: token, chatID: chatID})
+	return m.releaseErr
+}
+func (m *mockDedupStore) Prune(context.Context, time.Duration) (int64, error) { return 0, nil }
+
+func TestReleaseDedupClaimsOnDeadLetter_ReleasesAllTokens(t *testing.T) {
+	dedup := &mockDedupStore{}
+	hook := releaseDedupClaimsOnDeadLetter(dedup, testLogger())
+
+	err := hook(context.Background(), broker.Alert{
+		ChatID:   101,
+		SearchID: 7,
+		Tokens:   []string{"a", "b", "c"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dedup.released) != 3 {
+		t.Fatalf("expected 3 release calls, got %d", len(dedup.released))
+	}
+	for i, tok := range []string{"a", "b", "c"} {
+		if dedup.released[i].token != tok || dedup.released[i].chatID != 101 {
+			t.Fatalf("unexpected release call at %d: %+v", i, dedup.released[i])
+		}
+	}
+}
+
+func TestReleaseDedupClaimsOnDeadLetter_SkipsWhenNoTokens(t *testing.T) {
+	dedup := &mockDedupStore{}
+	hook := releaseDedupClaimsOnDeadLetter(dedup, testLogger())
+
+	err := hook(context.Background(), broker.Alert{ChatID: 77})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dedup.released) != 0 {
+		t.Fatalf("expected no release calls, got %d", len(dedup.released))
+	}
+}
+
+func TestReleaseDedupClaimsOnDeadLetter_ReturnsReleaseError(t *testing.T) {
+	dedup := &mockDedupStore{releaseErr: errors.New("db down")}
+	hook := releaseDedupClaimsOnDeadLetter(dedup, testLogger())
+
+	err := hook(context.Background(), broker.Alert{
+		ChatID: 22,
+		Tokens: []string{"x", "y"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(dedup.released) != 1 {
+		t.Fatalf("expected hook to stop after first failure, got %d calls", len(dedup.released))
 	}
 }

--- a/cmd/notifier/main_test.go
+++ b/cmd/notifier/main_test.go
@@ -157,7 +157,9 @@ type mockDedupStore struct {
 	releaseErr error
 }
 
-func (m *mockDedupStore) ClaimNew(context.Context, string, int64, int64) (bool, error) { return false, nil }
+func (m *mockDedupStore) ClaimNew(context.Context, string, int64, int64) (bool, error) {
+	return false, nil
+}
 func (m *mockDedupStore) ReleaseClaim(_ context.Context, token string, chatID int64) error {
 	m.released = append(m.released, struct {
 		token  string

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -10,13 +10,13 @@ import (
 
 // Alert represents a notification to be delivered via Redis Streams.
 type Alert struct {
-	ChatID     int64  `json:"chat_id"`
-	SearchID   int64  `json:"search_id"`
-	SearchName string `json:"search_name"`
+	ChatID     int64    `json:"chat_id"`
+	SearchID   int64    `json:"search_id"`
+	SearchName string   `json:"search_name"`
 	Tokens     []string `json:"tokens,omitempty"`
-	Message    string `json:"message"`
-	Language   string `json:"language"`
-	Timestamp  string `json:"timestamp"`
+	Message    string   `json:"message"`
+	Language   string   `json:"language"`
+	Timestamp  string   `json:"timestamp"`
 }
 
 // StreamName is the Redis Stream key for alert delivery.

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -13,6 +13,7 @@ type Alert struct {
 	ChatID     int64  `json:"chat_id"`
 	SearchID   int64  `json:"search_id"`
 	SearchName string `json:"search_name"`
+	Tokens     []string `json:"tokens,omitempty"`
 	Message    string `json:"message"`
 	Language   string `json:"language"`
 	Timestamp  string `json:"timestamp"`

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -17,6 +17,7 @@ func TestAlertSerializationRoundtrip(t *testing.T) {
 		ChatID:     12345,
 		SearchID:   42,
 		SearchName: "Toyota Corolla 2021",
+		Tokens:     []string{"tok-1", "tok-2"},
 		Message:    "New listing found!",
 		Language:   "he",
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
@@ -40,6 +41,14 @@ func TestAlertSerializationRoundtrip(t *testing.T) {
 	}
 	if decoded.SearchName != original.SearchName {
 		t.Errorf("SearchName = %q, want %q", decoded.SearchName, original.SearchName)
+	}
+	if len(decoded.Tokens) != len(original.Tokens) {
+		t.Fatalf("Tokens len = %d, want %d", len(decoded.Tokens), len(original.Tokens))
+	}
+	for i := range original.Tokens {
+		if decoded.Tokens[i] != original.Tokens[i] {
+			t.Fatalf("Tokens[%d] = %q, want %q", i, decoded.Tokens[i], original.Tokens[i])
+		}
 	}
 	if decoded.Message != original.Message {
 		t.Errorf("Message = %q, want %q", decoded.Message, original.Message)
@@ -265,5 +274,117 @@ func TestConsumerConnectionFailure(t *testing.T) {
 	_, err := NewConsumer("localhost:1", "", 0, notify, slog.Default())
 	if err == nil {
 		t.Fatal("expected error for unreachable Redis")
+	}
+}
+
+func TestDeadLetterCallsHookAndAcks(t *testing.T) {
+	mr := miniredis.RunT(t)
+	pub, err := NewPublisher(mr.Addr(), "", 0)
+	if err != nil {
+		t.Fatalf("new publisher: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+
+	alert := Alert{
+		ChatID:   42,
+		SearchID: 7,
+		Tokens:   []string{"abc", "def"},
+		Message:  "msg",
+	}
+	if err := pub.Publish(context.Background(), alert); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	var got Alert
+	notify := func(_ context.Context, _ string, _ string) error { return nil }
+	cons, err := NewConsumer(mr.Addr(), "", 0, notify, slog.Default(), WithDeadLetterHook(func(_ context.Context, a Alert) error {
+		got = a
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+	msgs, err := client.XRange(context.Background(), StreamName, "-", "+").Result()
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("xrange: %v len=%d", err, len(msgs))
+	}
+	cons.deadLetter(context.Background(), msgs[0].ID)
+
+	if got.ChatID != 42 || len(got.Tokens) != 2 {
+		t.Fatalf("unexpected hook alert: %+v", got)
+	}
+	deadMsgs, err := client.XRange(context.Background(), DeadLetterStream, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("dead xrange: %v", err)
+	}
+	if len(deadMsgs) != 1 {
+		t.Fatalf("expected 1 dead-letter message, got %d", len(deadMsgs))
+	}
+	pending, err := client.XPending(context.Background(), StreamName, GroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Fatalf("expected 0 pending after dead-letter ack, got %d", pending.Count)
+	}
+}
+
+func TestDeadLetterHookFailureDoesNotAckOrMoveMessage(t *testing.T) {
+	mr := miniredis.RunT(t)
+	pub, err := NewPublisher(mr.Addr(), "", 0)
+	if err != nil {
+		t.Fatalf("new publisher: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+	if err := pub.Publish(context.Background(), Alert{ChatID: 7, Tokens: []string{"x"}, Message: "msg"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	notify := func(_ context.Context, _ string, _ string) error { return nil }
+	cons, err := NewConsumer(mr.Addr(), "", 0, notify, slog.Default(), WithDeadLetterHook(func(_ context.Context, _ Alert) error {
+		return context.DeadlineExceeded
+	}))
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+	msgs, err := client.XRange(context.Background(), StreamName, "-", "+").Result()
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("xrange: %v len=%d", err, len(msgs))
+	}
+	// Create a pending entry so XPending can observe it.
+	_, err = client.XReadGroup(context.Background(), &redis.XReadGroupArgs{
+		Group:    GroupName,
+		Consumer: "hook-fail-consumer",
+		Streams:  []string{StreamName, ">"},
+		Count:    1,
+		Block:    time.Second,
+	}).Result()
+	if err != nil {
+		t.Fatalf("xreadgroup: %v", err)
+	}
+
+	cons.deadLetter(context.Background(), msgs[0].ID)
+
+	deadMsgs, err := client.XRange(context.Background(), DeadLetterStream, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("dead xrange: %v", err)
+	}
+	if len(deadMsgs) != 0 {
+		t.Fatalf("expected 0 dead-letter messages on hook failure, got %d", len(deadMsgs))
+	}
+	pending, err := client.XPending(context.Background(), StreamName, GroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count == 0 {
+		t.Fatalf("expected pending message to remain after hook failure")
 	}
 }

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -24,11 +24,13 @@ const (
 
 // NotifyFunc delivers a single notification to a recipient.
 type NotifyFunc func(ctx context.Context, recipient string, message string) error
+type DeadLetterHook func(ctx context.Context, alert Alert) error
 
 // Consumer reads alerts from the Redis Stream and delivers them.
 type Consumer struct {
 	client              *redis.Client
 	notify              NotifyFunc
+	deadLetterHook      DeadLetterHook
 	limiter             *rate.Limiter
 	logger              *slog.Logger
 	consumer            string
@@ -37,7 +39,7 @@ type Consumer struct {
 
 // NewConsumer connects to Redis, creates the consumer group if needed,
 // and returns a Consumer ready to process alerts.
-func NewConsumer(addr, password string, db int, notify NotifyFunc, logger *slog.Logger) (*Consumer, error) {
+func NewConsumer(addr, password string, db int, notify NotifyFunc, logger *slog.Logger, opts ...func(*Consumer)) (*Consumer, error) {
 	client := redis.NewClient(&redis.Options{
 		Addr:     addr,
 		Password: password,
@@ -60,14 +62,24 @@ func NewConsumer(addr, password string, db int, notify NotifyFunc, logger *slog.
 	if err != nil {
 		hostname = fmt.Sprintf("consumer-%d", time.Now().UnixNano())
 	}
-	return &Consumer{
+	c := &Consumer{
 		client:              client,
 		notify:              notify,
 		limiter:             rate.NewLimiter(rate.Limit(30), 30), // 30 msg/sec Telegram limit
 		logger:              logger,
 		consumer:            hostname,
 		orphanIdleThreshold: orphanIdleThreshold,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+func WithDeadLetterHook(h DeadLetterHook) func(*Consumer) {
+	return func(c *Consumer) {
+		c.deadLetterHook = h
+	}
 }
 
 // Run reads and processes alerts in a loop until the context is cancelled.
@@ -154,6 +166,16 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 		c.ack(ctx, id)
 		return
 	}
+	alert, alertErr := parseAlert(msgs[0])
+	if alertErr != nil {
+		c.logger.Error("dead-letter alert parse failed", "id", id, "error", alertErr)
+	}
+	if c.deadLetterHook != nil && alertErr == nil {
+		if err := c.deadLetterHook(ctx, alert); err != nil {
+			c.logger.Error("dead-letter hook failed", "id", id, "error", err)
+			return
+		}
+	}
 	if err := c.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: DeadLetterStream,
 		MaxLen: 10000,
@@ -161,6 +183,7 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 		Values: msgs[0].Values,
 	}).Err(); err != nil {
 		c.logger.Error("dead-letter failed", "id", id, "error", err)
+		return
 	} else {
 		c.logger.Warn("message dead-lettered after max retries", "id", id, "max_retries", MaxRetries)
 	}
@@ -168,14 +191,8 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 }
 
 func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
-	data, ok := msg.Values["data"].(string)
-	if !ok {
-		c.ack(ctx, msg.ID)
-		return
-	}
-
-	var alert Alert
-	if err := json.Unmarshal([]byte(data), &alert); err != nil {
+	alert, err := parseAlert(msg)
+	if err != nil {
 		c.logger.Error("unmarshal alert", "id", msg.ID, "error", err)
 		c.ack(ctx, msg.ID)
 		return
@@ -194,6 +211,18 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 
 	c.ack(ctx, msg.ID)
 	c.logger.Info("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
+}
+
+func parseAlert(msg redis.XMessage) (Alert, error) {
+	data, ok := msg.Values["data"].(string)
+	if !ok {
+		return Alert{}, fmt.Errorf("missing data field")
+	}
+	var alert Alert
+	if err := json.Unmarshal([]byte(data), &alert); err != nil {
+		return Alert{}, err
+	}
+	return alert, nil
 }
 
 func (c *Consumer) ack(ctx context.Context, id string) {

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -71,10 +71,15 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 				"chat_id", chatID, "msg_len", len(msg))
 			return errMalformedMessage
 		}
+		tokens := make([]string, 0, len(listings))
+		for _, l := range listings {
+			tokens = append(tokens, l.Token)
+		}
 		alert := broker.Alert{
 			ChatID:     chatID,
 			SearchID:   d.searchID,
 			SearchName: d.searchName,
+			Tokens:     tokens,
 			Message:    msg,
 			Language:   string(d.lang),
 			Timestamp:  time.Now().UTC().Format(time.RFC3339),

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -2,10 +2,14 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
 )
@@ -41,6 +45,55 @@ func TestInstantDelivery_DeliverBatch_NotifyFails(t *testing.T) {
 	err := d.DeliverBatch(context.Background(), 100, listings)
 	if err == nil {
 		t.Fatal("expected error when notifier fails")
+	}
+}
+
+func TestInstantDelivery_DeliverBatch_WithPublisherIncludesTokens(t *testing.T) {
+	mr := miniredis.RunT(t)
+	pub, err := broker.NewPublisher(mr.Addr(), "", 0)
+	if err != nil {
+		t.Fatalf("new publisher: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+
+	n := &mockNotifier{}
+	d := NewInstantDelivery(
+		n,
+		locale.English,
+		WithPublisher(pub),
+		WithSearchContext(55, "Search 55"),
+	)
+
+	listings := []model.Listing{
+		{RawListing: model.RawListing{Token: "tok-a", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 100000}},
+		{RawListing: model.RawListing{Token: "tok-b", Manufacturer: "Honda", Model: "Civic", Year: 2020, Price: 90000}},
+	}
+	if err := d.DeliverBatch(context.Background(), 100, listings); err != nil {
+		t.Fatalf("deliver batch: %v", err)
+	}
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+	msgs, err := client.XRange(context.Background(), broker.StreamName, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 queued message, got %d", len(msgs))
+	}
+	data, ok := msgs[0].Values["data"].(string)
+	if !ok {
+		t.Fatal("missing data field in queued message")
+	}
+	var queued broker.Alert
+	if err := json.Unmarshal([]byte(data), &queued); err != nil {
+		t.Fatalf("unmarshal queued alert: %v", err)
+	}
+	if queued.ChatID != 100 || queued.SearchID != 55 || queued.SearchName != "Search 55" {
+		t.Fatalf("unexpected queued metadata: %+v", queued)
+	}
+	if len(queued.Tokens) != 2 || queued.Tokens[0] != "tok-a" || queued.Tokens[1] != "tok-b" {
+		t.Fatalf("unexpected queued tokens: %+v", queued.Tokens)
 	}
 }
 

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/redis/go-redis/v9"
 	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/redis/go-redis/v9"
 )
 
 func TestInstantDelivery_DeliverBatch_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- carry listing tokens in queued broker alerts for batch listing deliveries
- add dead-letter hook support in the notifier consumer and run claim recovery before DLQ ack
- wire notifier hook to release dedup claims per token/chat on dead-letter
- add tests for scheduler token publishing, broker dead-letter semantics, and notifier claim-release hook behavior

## Review
✅ 5/5 agents passed (correctness, security, reliability, maintainability, testing).

## Test plan
- [x] `go test ./internal/broker`
- [x] `go test ./internal/scheduler -run TestInstantDelivery_DeliverBatch_WithPublisherIncludesTokens`
- [x] `go test ./cmd/notifier -run TestReleaseDedupClaimsOnDeadLetter`
- [ ] CI checks green

closes #1007

Made with [Cursor](https://cursor.com)