### PR TITLE
fix: secure production Redis with auth and deploy guards

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -8,5 +8,8 @@ CARWATCH_DOMAIN=your-subdomain.duckdns.org
 # PostgreSQL password (required by docker-compose)
 POSTGRES_PASSWORD=changeme-in-production
 
+# Redis password (required by docker-compose and app services)
+REDIS_PASSWORD=changeme-redis-password
+
 # Telegram bot token (@BotFather)
 TELEGRAM_BOT_TOKEN=your-bot-token-here

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -10,6 +10,10 @@ POSTGRES_PASSWORD=changeme-in-production
 
 # Redis password (required by docker-compose and app services)
 REDIS_PASSWORD=changeme-redis-password
+# Ensure config.yaml uses:
+# redis:
+#   addr: "redis:6379"
+#   password: "${REDIS_PASSWORD}"
 
 # Telegram bot token (@BotFather)
 TELEGRAM_BOT_TOKEN=your-bot-token-here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
         with:
           version: v2.4
           args: --timeout=5m
+      - name: Validate production compose env contract
+        run: |
+          POSTGRES_PASSWORD=test-postgres \
+          REDIS_PASSWORD=test-redis \
+          CARWATCH_DOMAIN=example.com \
+          TELEGRAM_BOT_TOKEN=test-token \
+          docker compose -f docker-compose.prod.yaml config >/dev/null
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,19 @@ jobs:
           CARWATCH_DOMAIN=example.com \
           TELEGRAM_BOT_TOKEN=test-token \
           docker compose -f docker-compose.prod.yaml config >/dev/null
+      - name: Verify REDIS_PASSWORD is required in production compose
+        run: |
+          set +e
+          POSTGRES_PASSWORD=test-postgres \
+          CARWATCH_DOMAIN=example.com \
+          TELEGRAM_BOT_TOKEN=test-token \
+          docker compose -f docker-compose.prod.yaml config >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "Expected docker compose config to fail without REDIS_PASSWORD"
+            exit 1
+          fi
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,9 +180,23 @@ jobs:
             set -euo pipefail
             cd "$HOME/carwatch"
 
-            # Source .env if present (CARWATCH_DOMAIN, TELEGRAM_BOT_TOKEN, etc.)
+            # Source .env if present (CARWATCH_DOMAIN, TELEGRAM_BOT_TOKEN, REDIS_PASSWORD, etc.)
             if [ -f .env ]; then
               set -a; source .env; set +a
+            fi
+            : "${REDIS_PASSWORD:?REDIS_PASSWORD must be set in ~/carwatch/.env}"
+            if [ ! -f config.yaml ]; then
+              echo "config.yaml is missing in ~/carwatch"
+              exit 1
+            fi
+            if ! awk '
+              /^[[:space:]]*redis:[[:space:]]*$/ { in_redis=1; next }
+              in_redis && /^[^[:space:]]/ { in_redis=0 }
+              in_redis && /^[[:space:]]*password:[[:space:]]*"\$\{REDIS_PASSWORD\}"[[:space:]]*$/ { found=1 }
+              END { exit found ? 0 : 1 }
+            ' config.yaml; then
+              echo "config.yaml must include redis.password: \"\${REDIS_PASSWORD}\" before deploy"
+              exit 1
             fi
 
             # Ensure the shared network exists
@@ -211,19 +225,40 @@ jobs:
               if docker exec carwatch-api wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
                 echo "==> Health check passed!"
                 docker exec carwatch-api api-server -version
-                exit 0
+                break
               fi
               echo "    attempt $i/15 — waiting 5s..."
               sleep 5
             done
+            if ! docker exec carwatch-api wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
+              echo "==> API health check failed after 75s"
+              exit 1
+            fi
 
-            echo "==> Health check failed after 75s"
-            for svc in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier; do
-              echo "--- $svc ---"
-              docker inspect "$svc" --format 'status={{.State.Status}} exit={{.State.ExitCode}} started={{.State.StartedAt}}' 2>/dev/null || echo "(not found)"
-              docker logs "$svc" --tail 20 2>&1 || true
+            echo "==> Waiting for worker health checks..."
+            for svc in bot-poller scraper notifier enricher; do
+              container="carwatch-$svc"
+              port=$(case "$svc" in
+                bot-poller) echo 8082 ;;
+                scraper) echo 8081 ;;
+                notifier) echo 8083 ;;
+                enricher) echo 8084 ;;
+              esac)
+              ok=0
+              for i in $(seq 1 15); do
+                if docker exec "$container" wget -q --spider "http://localhost:${port}/healthz" 2>/dev/null; then
+                  ok=1
+                  break
+                fi
+                echo "    $container attempt $i/15 — waiting 5s..."
+                sleep 5
+              done
+              if [ "$ok" -ne 1 ]; then
+                echo "==> Worker health check failed: $container"
+                exit 1
+              fi
             done
-            exit 1
+            echo "==> Worker health checks passed!"
 
       - name: Rollback on failure
         if: failure()
@@ -238,7 +273,7 @@ jobs:
             if [ "$PREV" != 'none' ]; then
               echo "==> Rolling back to previous image: $PREV"
               docker tag "$PREV" ghcr.io/danielsio/carwatch:latest
-              docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier
+              docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier enricher
               echo "==> Rolled back to previous version"
             else
               echo "==> No previous image tag found, skipping rollback"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
           script: |
             set -euo pipefail
             cd "$HOME/carwatch"
+            rm -f .deploy_recreate_started
 
             # Source .env if present (CARWATCH_DOMAIN, TELEGRAM_BOT_TOKEN, REDIS_PASSWORD, etc.)
             if [ -f .env ]; then
@@ -218,6 +219,7 @@ jobs:
             # returning, so no explicit migration step is needed here.
 
             echo "==> Recreating containers..."
+            touch .deploy_recreate_started
             docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES
 
             echo "==> Waiting for API health check..."
@@ -268,13 +270,19 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
+            set -euo pipefail
             cd "$HOME/carwatch"
+            if [ ! -f .deploy_recreate_started ]; then
+              echo "==> Skipping rollback (deploy failed before container recreation)"
+              exit 0
+            fi
             PREV=$(cat prev_image_tag 2>/dev/null || echo 'none')
             if [ "$PREV" != 'none' ]; then
               echo "==> Rolling back to previous image: $PREV"
               docker tag "$PREV" ghcr.io/danielsio/carwatch:latest
               docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier enricher
               echo "==> Rolled back to previous version"
+              rm -f .deploy_recreate_started
             else
               echo "==> No previous image tag found, skipping rollback"
             fi

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ make build
 docker compose -f docker-compose.prod.yaml up -d
 ```
 
+For production compose, set `REDIS_PASSWORD` in `.env` and configure Redis in `config.yaml`:
+
+```yaml
+redis:
+  addr: "redis:6379"
+  password: "${REDIS_PASSWORD}"
+  db: 0
+```
+
 ## Configuration
 
 See [`config.example.yaml`](config.example.yaml) for all options.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,11 +43,12 @@ http:
 #   otlp_endpoint: ""      # e.g. localhost:4317
 #   metrics_path: /metrics
 
-# Redis (required in production compose for alert/enrichment brokers)
-redis:
-  addr: "redis:6379"
-  password: "${REDIS_PASSWORD}"
-  db: 0
+# Redis (optional; enabled in production compose for stream-based workers)
+# For local dev, use localhost and empty password:
+# redis:
+#   addr: "localhost:6379"
+#   password: ""
+#   db: 0
 
 # REST API settings (for web frontend)
 api:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,10 +43,10 @@ http:
 #   otlp_endpoint: ""      # e.g. localhost:4317
 #   metrics_path: /metrics
 
-# Redis (optional, enables stream-based notification delivery with rate limiting)
+# Redis (required in production compose for alert/enrichment brokers)
 # redis:
-#   addr: "localhost:6379"   # leave empty or omit to disable Redis broker
-#   password: ""
+#   addr: "localhost:6379"
+#   password: "${REDIS_PASSWORD}"
 #   db: 0
 
 # REST API settings (for web frontend)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,10 +44,10 @@ http:
 #   metrics_path: /metrics
 
 # Redis (required in production compose for alert/enrichment brokers)
-# redis:
-#   addr: "localhost:6379"
-#   password: "${REDIS_PASSWORD}"
-#   db: 0
+redis:
+  addr: "redis:6379"
+  password: "${REDIS_PASSWORD}"
+  db: 0
 
 # REST API settings (for web frontend)
 api:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -30,13 +30,22 @@ services:
   redis:
     image: redis:7-alpine
     container_name: carwatch-redis
-    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --requirepass
+      - ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     networks:
       - carwatch-net
     volumes:
       - redis-data:/data
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli -a \"$REDIS_PASSWORD\" ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -70,6 +79,7 @@ services:
       - TZ=Asia/Jerusalem
       - CARWATCH_DOMAIN=${CARWATCH_DOMAIN}
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     restart: unless-stopped
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
@@ -98,6 +108,7 @@ services:
     environment:
       - TZ=Asia/Jerusalem
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8082/healthz"]
       interval: 60s
@@ -133,6 +144,7 @@ services:
     environment:
       - TZ=Asia/Jerusalem
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081/healthz"]
       interval: 60s
@@ -167,6 +179,7 @@ services:
     environment:
       - TZ=Asia/Jerusalem
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8083/healthz"]
       interval: 60s
@@ -201,6 +214,7 @@ services:
       - ./migrations:/migrations:ro
     environment:
       - TZ=Asia/Jerusalem
+      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8084/healthz"]
       interval: 60s

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -288,6 +288,16 @@ func TestPublisherWithRedisAuth(t *testing.T) {
 	defer func() { _ = pub.Close() }()
 }
 
+func TestPublisherWithRedisAuthWrongPassword(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.RequireAuth("secret")
+
+	_, err := NewPublisher(mr.Addr(), "wrong", 0)
+	if err == nil {
+		t.Fatal("expected auth error for wrong Redis password")
+	}
+}
+
 func TestConsumerWithRedisAuth(t *testing.T) {
 	mr := miniredis.RunT(t)
 	mr.RequireAuth("secret")
@@ -298,6 +308,83 @@ func TestConsumerWithRedisAuth(t *testing.T) {
 		t.Fatalf("new consumer with auth: %v", err)
 	}
 	defer func() { _ = cons.Close() }()
+}
+
+func TestConsumerWithRedisAuthWrongPassword(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.RequireAuth("secret")
+
+	notify := func(_ context.Context, _ string, _ string) error { return nil }
+	_, err := NewConsumer(mr.Addr(), "wrong", 0, notify, slog.Default())
+	if err == nil {
+		t.Fatal("expected auth error for wrong Redis password")
+	}
+}
+
+func TestPublishAndConsumeWithRedisAuth(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.RequireAuth("secret")
+
+	pub, err := NewPublisher(mr.Addr(), "secret", 0)
+	if err != nil {
+		t.Fatalf("new publisher with auth: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+
+	alert := Alert{
+		ChatID:   123,
+		Message:  "auth-protected message",
+		Language: "en",
+	}
+	if err := pub.Publish(context.Background(), alert); err != nil {
+		t.Fatalf("publish with auth: %v", err)
+	}
+
+	var mu sync.Mutex
+	var delivered []string
+	notify := func(_ context.Context, _ string, message string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		delivered = append(delivered, message)
+		return nil
+	}
+	cons, err := NewConsumer(mr.Addr(), "secret", 0, notify, slog.Default())
+	if err != nil {
+		t.Fatalf("new consumer with auth: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- cons.Run(ctx) }()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(delivered)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for authenticated delivery")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(delivered) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(delivered))
+	}
+	if delivered[0] != "auth-protected message" {
+		t.Fatalf("message = %q, want %q", delivered[0], "auth-protected message")
+	}
 }
 
 func TestDeadLetterCallsHookAndAcks(t *testing.T) {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -277,6 +277,29 @@ func TestConsumerConnectionFailure(t *testing.T) {
 	}
 }
 
+func TestPublisherWithRedisAuth(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.RequireAuth("secret")
+
+	pub, err := NewPublisher(mr.Addr(), "secret", 0)
+	if err != nil {
+		t.Fatalf("new publisher with auth: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+}
+
+func TestConsumerWithRedisAuth(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.RequireAuth("secret")
+
+	notify := func(_ context.Context, _ string, _ string) error { return nil }
+	cons, err := NewConsumer(mr.Addr(), "secret", 0, notify, slog.Default())
+	if err != nil {
+		t.Fatalf("new consumer with auth: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+}
+
 func TestDeadLetterCallsHookAndAcks(t *testing.T) {
 	mr := miniredis.RunT(t)
 	pub, err := NewPublisher(mr.Addr(), "", 0)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -164,6 +164,25 @@ http:
 	}
 }
 
+func TestLoad_EnvVarInterpolationRedisPassword(t *testing.T) {
+	t.Setenv("REDIS_PASSWORD", "redis-secret")
+
+	yaml := `
+telegram:
+  token: "test-token"
+storage:
+  dsn: "postgres://localhost/test"
+redis:
+  addr: "localhost:6379"
+  password: "${REDIS_PASSWORD}"
+`
+	cfg := loadFromString(t, yaml)
+
+	if cfg.Redis.Password != "redis-secret" {
+		t.Errorf("redis.password = %q, want redis-secret", cfg.Redis.Password)
+	}
+}
+
 func TestParseLogLevel(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Review

✅ 5/5 agents passed (correctness, security, reliability, maintainability, testing)

## Summary
- Enable authenticated Redis in `docker-compose.prod.yaml` with `--requirepass`, authenticated healthchecks, and required `REDIS_PASSWORD` env wiring for app containers.
- Add rollout safety gates: CI now validates the compose env contract (including fail-closed behavior when `REDIS_PASSWORD` is missing), and release deploy preflight now validates VM `.env` + `config.yaml` Redis contract before recreation.
- Strengthen deployment reliability with worker health checks (`bot-poller`, `scraper`, `notifier`, `enricher`) and a rollback guard that skips rollback if deploy fails before container recreation.
- Expand test coverage for Redis auth: broker auth success/failure paths and authenticated publish/consume flow, plus config env interpolation for `redis.password`.
- Document production Redis wiring in `.env.prod.example` and `README.md` while keeping `config.example.yaml` dev-friendly.

## Test plan
- [x] `go test ./internal/broker ./internal/config`
- [x] Review swarm pass (correctness/security/reliability/maintainability/testing)
- [ ] GitHub Actions CI green on this PR
- [ ] Release workflow verifies preflight + worker health checks on next main deploy

closes #1005

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Redis authentication for production deployments, requiring a password to be set via environment variable.
  * Added automated validation in CI/CD to ensure required Redis password configuration is present.
  * Enhanced health checks for all worker services during deployment to verify successful startup.

* **Documentation**
  * Added production configuration guidance and examples for setting up Redis with password authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->