### PR TITLE
fix: protect telemetry endpoints and enforce auth defaults

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -15,5 +15,8 @@ REDIS_PASSWORD=changeme-redis-password
 #   addr: "redis:6379"
 #   password: "${REDIS_PASSWORD}"
 
+# Metrics endpoint auth token (required for non-local API bind)
+TELEMETRY_AUTH_TOKEN=changeme-telemetry-token
+
 # Telegram bot token (@BotFather)
 TELEGRAM_BOT_TOKEN=your-bot-token-here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           POSTGRES_PASSWORD=test-postgres \
           REDIS_PASSWORD=test-redis \
+          TELEMETRY_AUTH_TOKEN=test-telemetry \
           CARWATCH_DOMAIN=example.com \
           TELEGRAM_BOT_TOKEN=test-token \
           docker compose -f docker-compose.prod.yaml config >/dev/null
@@ -88,6 +89,7 @@ jobs:
         run: |
           set +e
           POSTGRES_PASSWORD=test-postgres \
+          TELEMETRY_AUTH_TOKEN=test-telemetry \
           CARWATCH_DOMAIN=example.com \
           TELEGRAM_BOT_TOKEN=test-token \
           docker compose -f docker-compose.prod.yaml config >/dev/null 2>&1
@@ -95,6 +97,20 @@ jobs:
           set -e
           if [ "$rc" -eq 0 ]; then
             echo "Expected docker compose config to fail without REDIS_PASSWORD"
+            exit 1
+          fi
+      - name: Verify TELEMETRY_AUTH_TOKEN is required in production compose
+        run: |
+          set +e
+          POSTGRES_PASSWORD=test-postgres \
+          REDIS_PASSWORD=test-redis \
+          CARWATCH_DOMAIN=example.com \
+          TELEGRAM_BOT_TOKEN=test-token \
+          docker compose -f docker-compose.prod.yaml config >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "Expected docker compose config to fail without TELEMETRY_AUTH_TOKEN"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,15 @@ jobs:
               echo "config.yaml must include redis.password: \"\${REDIS_PASSWORD}\" before deploy"
               exit 1
             fi
+            if ! awk '
+              /^[[:space:]]*telemetry:[[:space:]]*$/ { in_telemetry=1; next }
+              in_telemetry && /^[^[:space:]]/ { in_telemetry=0 }
+              in_telemetry && /^[[:space:]]*auth_token:[[:space:]]*"\$\{TELEMETRY_AUTH_TOKEN\}"[[:space:]]*$/ { found=1 }
+              END { exit found ? 0 : 1 }
+            ' config.yaml; then
+              echo "config.yaml must include telemetry.auth_token: \"\${TELEMETRY_AUTH_TOKEN}\" before deploy"
+              exit 1
+            fi
 
             # Ensure the shared network exists
             docker network create carwatch-net 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ redis:
   db: 0
 ```
 
+Also set `TELEMETRY_AUTH_TOKEN` in `.env` and configure:
+
+```yaml
+telemetry:
+  auth_token: "${TELEMETRY_AUTH_TOKEN}"
+```
+
+This is required when binding the API on a non-localhost address.
+
 ## Configuration
 
 See [`config.example.yaml`](config.example.yaml) for all options.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ telemetry:
   auth_token: "${TELEMETRY_AUTH_TOKEN}"
 ```
 
-This is required when binding the API on a non-localhost address.
+This token protects `/metrics` when binding the API on a non-localhost address.
+`POST /api/v1/vitals` uses normal API authentication (Firebase in production, `api.auth_token` in local dev mode).
 
 ## Configuration
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,6 +42,7 @@ http:
 #   traces_exporter: none  # none | stdout | otlp
 #   otlp_endpoint: ""      # e.g. localhost:4317
 #   metrics_path: /metrics
+#   auth_token: "${TELEMETRY_AUTH_TOKEN}"  # required when binding non-localhost
 
 # Redis (optional; enabled in production compose for stream-based workers)
 # For local dev, use localhost and empty password:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -80,6 +80,7 @@ services:
       - CARWATCH_DOMAIN=${CARWATCH_DOMAIN}
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+      - TELEMETRY_AUTH_TOKEN=${TELEMETRY_AUTH_TOKEN:?TELEMETRY_AUTH_TOKEN must be set}
     restart: unless-stopped
     labels:
       - "com.centurylinklabs.watchtower.enable=true"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -207,6 +207,7 @@ func (s *Server) Routes() http.Handler {
 
 	authMux.HandleFunc("GET /api/v1/catalog/manufacturers", s.listManufacturers)
 	authMux.HandleFunc("GET /api/v1/catalog/manufacturers/{id}/models", s.listModels)
+	authMux.HandleFunc("POST /api/v1/vitals", s.receiveVitals)
 
 	authMux.HandleFunc("POST /api/v1/searches", s.createSearch)
 	authMux.HandleFunc("GET /api/v1/searches/{id}", s.getSearch)
@@ -312,7 +313,6 @@ func (s *Server) Routes() http.Handler {
 	// --- Top-level router ---
 	// More-specific prefixes are matched first by net/http.ServeMux.
 	top := http.NewServeMux()
-	top.HandleFunc("POST /api/v1/vitals", s.receiveVitals)
 	top.Handle("/api/v1/guest/", guestChain)
 	top.Handle("/api/v1/catalog/", catalogChain)
 	top.Handle("GET /api/v1/me", optAuthChain)

--- a/internal/api/vitals_test.go
+++ b/internal/api/vitals_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/config"
+)
+
+func TestVitalsRequiresAuthToken(t *testing.T) {
+	srv := New(Config{
+		Logger: slog.Default(),
+		API: config.APIConfig{
+			CORSOrigins: []string{"http://localhost:5173"},
+			DevChatID:   999,
+			AuthToken:   "secret-token",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/vitals", strings.NewReader(`{"name":"LCP","value":1000}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestVitalsAcceptsAuthorizedRequest(t *testing.T) {
+	srv := New(Config{
+		Logger: slog.Default(),
+		API: config.APIConfig{
+			CORSOrigins: []string{"http://localhost:5173"},
+			DevChatID:   999,
+			AuthToken:   "secret-token",
+		},
+	})
+
+	body := []byte(`{"name":"LCP","value":1234.5,"rating":"good","delta":3.1,"id":"v1","navigationType":"navigate"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/vitals", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -185,6 +185,10 @@ func BuildDynamicCatalog(ctx context.Context, yad2Fetcher *yad2.Yad2Fetcher, log
 
 // BuildAPI creates the API server with all REST endpoints.
 func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, logger *slog.Logger, fetcherFactory *fetcher.Factory, plSvc *pricelist.Service, logHub *logstream.Hub, logLevel *slog.LevelVar) (*api.Server, error) {
+	if api.IsNonLocalBind(cfg.HTTP.Bind) && cfg.Telemetry.AuthToken == "" {
+		return nil, fmt.Errorf("telemetry.auth_token must be configured for non-local bind address %q", cfg.HTTP.Bind)
+	}
+
 	var firebaseAuth api.TokenVerifier
 	if cfg.Firebase.ProjectID != "" {
 		v, err := api.NewFirebaseVerifier(cfg.Firebase.CredentialsFile, cfg.Firebase.CredentialsJSON, cfg.Firebase.ProjectID)
@@ -251,7 +255,7 @@ func BuildHTTPServer(cfg *config.Config, h *health.Status, apiServer *api.Server
 	if err != nil {
 		logger.Error("metrics handler setup failed", "error", err)
 	} else {
-		mux.Handle(cfg.Telemetry.MetricsPath, metricsHandler)
+		mux.Handle(cfg.Telemetry.MetricsPath, metricsAuthMiddleware(cfg.HTTP.Bind, cfg.Telemetry.AuthToken, metricsHandler))
 	}
 
 	srv := &http.Server{

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -229,6 +229,9 @@ func TestBuildAPIRejectsMissingFirebaseOnNonLocalBind(t *testing.T) {
 		HTTP: config.HTTPConfig{
 			Bind: "0.0.0.0:8080",
 		},
+		Telemetry: config.TelemetryConfig{
+			AuthToken: "telemetry-secret",
+		},
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
@@ -264,6 +267,9 @@ func TestBuildAPIFirebaseRequirementByBind(t *testing.T) {
 				HTTP: config.HTTPConfig{
 					Bind: tt.bind,
 				},
+				Telemetry: config.TelemetryConfig{
+					AuthToken: "telemetry-secret",
+				},
 			}
 			apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
 			if tt.wantErr {
@@ -279,6 +285,24 @@ func TestBuildAPIFirebaseRequirementByBind(t *testing.T) {
 				t.Fatalf("expected api server, got nil")
 			}
 		})
+	}
+}
+
+func TestBuildAPIRejectsMissingTelemetryAuthOnNonLocalBind(t *testing.T) {
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			Bind: "0.0.0.0:8080",
+		},
+		Telemetry: config.TelemetryConfig{},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error, got nil (server=%v)", apiServer)
+	}
+	if !strings.Contains(err.Error(), "telemetry.auth_token must be configured") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/app/metrics_auth.go
+++ b/internal/app/metrics_auth.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/dsionov/carwatch/internal/api"
+)
+
+func metricsAuthMiddleware(bind, token string, next http.Handler) http.Handler {
+	nonLocal := api.IsNonLocalBind(bind)
+	requiredToken := strings.TrimSpace(token)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !nonLocal {
+			next.ServeHTTP(w, r)
+			return
+		}
+		candidate := strings.TrimSpace(r.Header.Get("X-CarWatch-Telemetry-Token"))
+		if candidate == "" {
+			candidate = bearerFromHeader(r.Header.Get("Authorization"))
+		}
+		if requiredToken == "" || subtle.ConstantTimeCompare([]byte(candidate), []byte(requiredToken)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func bearerFromHeader(value string) string {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(value, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(value, prefix))
+}

--- a/internal/app/metrics_auth_test.go
+++ b/internal/app/metrics_auth_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMetricsAuthMiddleware_LocalBindAllowsWithoutToken(t *testing.T) {
+	called := false
+	h := metricsAuthMiddleware("127.0.0.1:8080", "", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !called {
+		t.Fatal("expected wrapped handler to be called")
+	}
+}
+
+func TestMetricsAuthMiddleware_NonLocalRequiresToken(t *testing.T) {
+	h := metricsAuthMiddleware("0.0.0.0:8080", "secret-token", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestMetricsAuthMiddleware_NonLocalAcceptsTelemetryHeader(t *testing.T) {
+	h := metricsAuthMiddleware("0.0.0.0:8080", "secret-token", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("X-CarWatch-Telemetry-Token", "secret-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestMetricsAuthMiddleware_NonLocalAcceptsBearerToken(t *testing.T) {
+	h := metricsAuthMiddleware("0.0.0.0:8080", "secret-token", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type TelemetryConfig struct {
 	TracesExporter string `yaml:"traces_exporter"` // "none" (default), "stdout", "otlp"
 	OTLPEndpoint   string `yaml:"otlp_endpoint"`   // e.g. "localhost:4317"
 	MetricsPath    string `yaml:"metrics_path"`    // default "/metrics"
+	AuthToken      string `yaml:"auth_token"`      // required for non-local metrics exposure
 }
 
 type PushConfig struct {

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ import { onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { useQueryClient } from "@tanstack/react-query";
 import { auth } from "@/lib/firebase";
 import { setAuthTokenGetter } from "@/lib/auth-token";
+import { reportWebVitals } from "@/lib/webVitals";
 
 type AuthContextValue = {
   user: User | null;
@@ -28,6 +29,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const queryClient = useQueryClient();
   const prevUidRef = useRef<string | null>(null);
+  const vitalsStartedRef = useRef(false);
 
   useEffect(() => {
     setAuthTokenGetter(async (forceRefresh?: boolean) => {
@@ -35,6 +37,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (!u) return null;
       return u.getIdToken(forceRefresh);
     });
+    if (!vitalsStartedRef.current) {
+      vitalsStartedRef.current = true;
+      void reportWebVitals();
+    }
     return () => {
       setAuthTokenGetter(async () => null);
     };

--- a/web/src/lib/webVitals.test.ts
+++ b/web/src/lib/webVitals.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./auth-token", () => ({
+  getAuthToken: vi.fn(),
+}));
+
+import { getAuthToken } from "./auth-token";
+import { sendVitalsToServer } from "./webVitals";
+
+const mockedGetAuthToken = vi.mocked(getAuthToken);
+
+describe("sendVitalsToServer", () => {
+  beforeEach(() => {
+    mockedGetAuthToken.mockReset();
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(null))));
+  });
+
+  it("sends an authorized vitals payload when a token exists", async () => {
+    mockedGetAuthToken.mockResolvedValue("firebase-token");
+
+    await sendVitalsToServer({
+      name: "LCP",
+      value: 1200,
+      rating: "good",
+      delta: 10,
+      id: "vital-1",
+      navigationType: "navigate",
+    } as never);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/v1/vitals",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer firebase-token",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("skips sending vitals when no token exists", async () => {
+    mockedGetAuthToken.mockResolvedValue(null);
+
+    await sendVitalsToServer({
+      name: "TTFB",
+      value: 100,
+      rating: "good",
+      delta: 3,
+      id: "vital-2",
+      navigationType: "reload",
+    } as never);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/webVitals.ts
+++ b/web/src/lib/webVitals.ts
@@ -10,7 +10,7 @@ import { getAuthToken } from "./auth-token";
 
 const VITALS_ENDPOINT = "/api/v1/vitals";
 
-async function sendToServer(metric: Metric) {
+export async function sendVitalsToServer(metric: Metric) {
   const body = JSON.stringify({
     name: metric.name,
     value: metric.value,
@@ -50,7 +50,7 @@ function logToConsole(metric: Metric) {
 export async function reportWebVitals() {
   const { onCLS, onFCP, onINP, onLCP, onTTFB } = await import("web-vitals");
 
-  const report = import.meta.env.DEV ? logToConsole : sendToServer;
+  const report = import.meta.env.DEV ? logToConsole : sendVitalsToServer;
 
   onCLS(report);
   onFCP(report);

--- a/web/src/lib/webVitals.ts
+++ b/web/src/lib/webVitals.ts
@@ -1,4 +1,5 @@
 import type { Metric } from "web-vitals";
+import { getAuthToken } from "./auth-token";
 
 /**
  * Beacon web-vitals to the server when the API endpoint exists,
@@ -9,7 +10,7 @@ import type { Metric } from "web-vitals";
 
 const VITALS_ENDPOINT = "/api/v1/vitals";
 
-function sendToServer(metric: Metric) {
+async function sendToServer(metric: Metric) {
   const body = JSON.stringify({
     name: metric.name,
     value: metric.value,
@@ -18,17 +19,17 @@ function sendToServer(metric: Metric) {
     id: metric.id,
     navigationType: metric.navigationType,
   });
-
-  if (navigator.sendBeacon) {
-    const blob = new Blob([body], { type: "application/json" });
-    if (navigator.sendBeacon(VITALS_ENDPOINT, blob)) return;
-  }
+  const token = await getAuthToken();
+  if (!token) return;
 
   fetch(VITALS_ENDPOINT, {
     body,
     method: "POST",
     keepalive: true,
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
   }).catch(() => {});
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,7 +8,6 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ToastProvider, showGlobalToast } from "./components/ui/Toast";
 import { errorToHebrew } from "./lib/error-messages";
-import { reportWebVitals } from "./lib/webVitals";
 import "./index.css";
 
 if ('serviceWorker' in navigator) {
@@ -31,8 +30,6 @@ const queryClient = new QueryClient({
     },
   }),
 });
-
-reportWebVitals();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
## Review

✅ 5/5 agents passed (correctness, security, reliability, maintainability, testing)

## Summary
- Protect `GET /metrics` for non-local binds with telemetry token auth and fail closed at startup when `telemetry.auth_token` is missing.
- Move `POST /api/v1/vitals` behind API auth middleware so unauthenticated requests are denied.
- Wire telemetry auth through production/deploy contracts (`docker-compose.prod.yaml`, CI compose validation, and release preflight config checks).
- Update frontend vitals reporting to send authenticated requests and initialize vitals only after auth token getter is registered.
- Add regression tests for metrics middleware auth behavior, vitals auth enforcement, startup guardrails, and frontend vitals authorization headers.

## Test plan
- [x] `go test ./internal/app ./internal/api -run 'MetricsAuth|Vitals|BuildAPIRejectsMissingTelemetryAuthOnNonLocalBind|BuildAPIFirebaseRequirementByBind|BuildAPIRejectsMissingFirebaseOnNonLocalBind'`
- [x] `npm test -- src/lib/webVitals.test.ts`
- [x] Review swarm pass (correctness/security/reliability/maintainability/testing)
- [ ] GitHub Actions CI green on this PR

closes #1006

Made with [Cursor](https://cursor.com)