### PR TITLE
fix: harden production deploy flow with immutable tags

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -5,6 +5,10 @@
 # Public domain for Caddy TLS and CORS (change to switch domains)
 CARWATCH_DOMAIN=your-subdomain.duckdns.org
 
+# Immutable application image tag used by docker-compose.prod.yaml.
+# Release automation updates this value during deploy/rollback.
+CARWATCH_IMAGE_TAG=0.0.0
+
 # PostgreSQL password (required by docker-compose)
 POSTGRES_PASSWORD=changeme-in-production
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,32 @@ jobs:
           args: --timeout=5m
       - name: Validate production compose env contract
         run: |
+          CARWATCH_IMAGE_TAG=1.2.3 \
           POSTGRES_PASSWORD=test-postgres \
           REDIS_PASSWORD=test-redis \
           TELEMETRY_AUTH_TOKEN=test-telemetry \
           CARWATCH_DOMAIN=example.com \
           TELEGRAM_BOT_TOKEN=test-token \
           docker compose -f docker-compose.prod.yaml config >/dev/null
+      - name: Verify CARWATCH_IMAGE_TAG is required in production compose
+        run: |
+          set +e
+          POSTGRES_PASSWORD=test-postgres \
+          REDIS_PASSWORD=test-redis \
+          TELEMETRY_AUTH_TOKEN=test-telemetry \
+          CARWATCH_DOMAIN=example.com \
+          TELEGRAM_BOT_TOKEN=test-token \
+          docker compose -f docker-compose.prod.yaml config >/dev/null 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "Expected docker compose config to fail without CARWATCH_IMAGE_TAG"
+            exit 1
+          fi
       - name: Verify REDIS_PASSWORD is required in production compose
         run: |
           set +e
+          CARWATCH_IMAGE_TAG=1.2.3 \
           POSTGRES_PASSWORD=test-postgres \
           TELEMETRY_AUTH_TOKEN=test-telemetry \
           CARWATCH_DOMAIN=example.com \
@@ -102,6 +119,7 @@ jobs:
       - name: Verify TELEMETRY_AUTH_TOKEN is required in production compose
         run: |
           set +e
+          CARWATCH_IMAGE_TAG=1.2.3 \
           POSTGRES_PASSWORD=test-postgres \
           REDIS_PASSWORD=test-redis \
           CARWATCH_DOMAIN=example.com \
@@ -111,6 +129,25 @@ jobs:
           set -e
           if [ "$rc" -eq 0 ]; then
             echo "Expected docker compose config to fail without TELEMETRY_AUTH_TOKEN"
+            exit 1
+          fi
+      - name: Enforce immutable image tags in production compose
+        run: |
+          if grep -n "ghcr.io/danielsio/carwatch:latest" docker-compose.prod.yaml; then
+            echo "docker-compose.prod.yaml must not pin app services to :latest"
+            exit 1
+          fi
+      - name: Ensure watchtower does not auto-update app containers
+        run: |
+          if grep -n "com.centurylinklabs.watchtower.enable=true" docker-compose.prod.yaml; then
+            echo "watchtower auto-update labels must be removed from app services"
+            exit 1
+          fi
+      - name: Ensure all app services use CARWATCH_IMAGE_TAG
+        run: |
+          count=$(grep -c "ghcr.io/danielsio/carwatch:\${CARWATCH_IMAGE_TAG" docker-compose.prod.yaml || true)
+          if [ "$count" -ne 5 ]; then
+            echo "Expected api/bot-poller/scraper/notifier/enricher to use CARWATCH_IMAGE_TAG (found $count)"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,16 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: release-prod
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Version, Build & Push
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -113,7 +119,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/danielsio/carwatch:${{ steps.version.outputs.version }}
-            ghcr.io/danielsio/carwatch:latest
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             GIT_COMMIT=${{ github.sha }}
@@ -158,16 +163,39 @@ jobs:
           source: "docker-compose.prod.yaml,migrations"
           target: ~/carwatch/
 
-      - name: Save previous image tag
+      - name: Prepare immutable deploy tag and rollback marker
         uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
-            PREV=$(docker inspect carwatch-api --format='{{.Config.Image}}' 2>/dev/null || echo 'none')
-            echo "$PREV" > ~/carwatch/prev_image_tag
-            echo "Saved previous image tag: $PREV"
+            set -euo pipefail
+            cd "$HOME/carwatch"
+            if [ ! -f .env ]; then
+              echo ".env is missing in ~/carwatch"
+              exit 1
+            fi
+
+            if [ -f .deploy_recreate_started ] && [ -s prev_image_tag ]; then
+              PREV_TAG=$(cat prev_image_tag)
+              PREV_TAG="${PREV_TAG##*:}"
+            else
+              PREV_TAG=$(awk -F= '/^CARWATCH_IMAGE_TAG=/{print $2}' .env | tail -1 | tr -d '"' || true)
+              if [ -z "$PREV_TAG" ]; then
+                PREV_TAG=$(docker exec carwatch-api api-server -version 2>/dev/null | awk '{print $2}' || true)
+              fi
+              if [ -z "$PREV_TAG" ]; then
+                PREV_TAG=none
+              fi
+            fi
+            echo "$PREV_TAG" > prev_image_tag
+
+            NEW_TAG="${{ needs.release.outputs.version }}"
+            echo "$NEW_TAG" > next_image_tag
+
+            echo "Saved previous image tag: $PREV_TAG"
+            echo "Prepared new image tag: $NEW_TAG"
 
       - name: Pull, recreate and health-check
         uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
@@ -179,13 +207,33 @@ jobs:
           script: |
             set -euo pipefail
             cd "$HOME/carwatch"
-            rm -f .deploy_recreate_started
-
-            # Source .env if present (CARWATCH_DOMAIN, TELEGRAM_BOT_TOKEN, REDIS_PASSWORD, etc.)
             if [ -f .env ]; then
               set -a; source .env; set +a
+            else
+              echo ".env is missing in ~/carwatch"
+              exit 1
             fi
+            APP_SERVICES="postgres redis api bot-poller scraper notifier enricher"
+            if [ -f .deploy_recreate_started ]; then
+              echo "==> Found stale deploy marker; restoring previously known-good services before continuing"
+              RECOVERY_TAG=$(cat prev_image_tag 2>/dev/null || echo 'none')
+              RECOVERY_TAG="${RECOVERY_TAG##*:}"
+              if [ "$RECOVERY_TAG" = "none" ] || [ -z "$RECOVERY_TAG" ]; then
+                RECOVERY_TAG=$(awk -F= '/^CARWATCH_IMAGE_TAG=/{print $2}' .env | tail -1 | tr -d '"' || true)
+              fi
+              if [ -n "$RECOVERY_TAG" ] && [ "$RECOVERY_TAG" != "none" ]; then
+                CARWATCH_IMAGE_TAG="$RECOVERY_TAG" docker compose -f docker-compose.prod.yaml pull $APP_SERVICES || true
+                CARWATCH_IMAGE_TAG="$RECOVERY_TAG" docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES || true
+              fi
+              rm -f .deploy_recreate_started
+            fi
+
             : "${REDIS_PASSWORD:?REDIS_PASSWORD must be set in ~/carwatch/.env}"
+            NEW_TAG=$(cat next_image_tag 2>/dev/null || true)
+            if [ -z "$NEW_TAG" ]; then
+              echo "next_image_tag is missing"
+              exit 1
+            fi
             if [ ! -f config.yaml ]; then
               echo "config.yaml is missing in ~/carwatch"
               exit 1
@@ -218,10 +266,9 @@ jobs:
 
             # Only manage app + infra services; watchtower and caddy are
             # long-lived infrastructure that must not be recreated on every deploy.
-            APP_SERVICES="postgres redis api bot-poller scraper notifier enricher"
 
-            echo "==> Pulling latest image..."
-            docker compose -f docker-compose.prod.yaml pull $APP_SERVICES
+            echo "==> Pulling release image tag: $NEW_TAG"
+            CARWATCH_IMAGE_TAG="$NEW_TAG" docker compose -f docker-compose.prod.yaml pull $APP_SERVICES
 
             # NOTE: Migrations run automatically on app startup.
             # The postgres.New() constructor runs golang-migrate/migrate before
@@ -229,7 +276,7 @@ jobs:
 
             echo "==> Recreating containers..."
             touch .deploy_recreate_started
-            docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES
+            CARWATCH_IMAGE_TAG="$NEW_TAG" docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES
 
             echo "==> Waiting for API health check..."
             for i in $(seq 1 15); do
@@ -271,6 +318,15 @@ jobs:
             done
             echo "==> Worker health checks passed!"
 
+            if grep -q '^CARWATCH_IMAGE_TAG=' .env; then
+              sed -i "s/^CARWATCH_IMAGE_TAG=.*/CARWATCH_IMAGE_TAG=${NEW_TAG}/" .env
+            else
+              echo "CARWATCH_IMAGE_TAG=${NEW_TAG}" >> .env
+            fi
+            rm -f .deploy_recreate_started
+            rm -f next_image_tag
+            echo "==> Persisted CARWATCH_IMAGE_TAG=${NEW_TAG} in .env"
+
       - name: Rollback on failure
         if: failure()
         uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
@@ -281,17 +337,63 @@ jobs:
           script: |
             set -euo pipefail
             cd "$HOME/carwatch"
+            if [ -f .env ]; then
+              set -a; source .env; set +a
+            fi
             if [ ! -f .deploy_recreate_started ]; then
               echo "==> Skipping rollback (deploy failed before container recreation)"
               exit 0
             fi
             PREV=$(cat prev_image_tag 2>/dev/null || echo 'none')
+            PREV="${PREV##*:}"
             if [ "$PREV" != 'none' ]; then
-              echo "==> Rolling back to previous image: $PREV"
-              docker tag "$PREV" ghcr.io/danielsio/carwatch:latest
-              docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier enricher
-              echo "==> Rolled back to previous version"
+              echo "==> Rolling back to previous image tag: $PREV"
+              APP_SERVICES="postgres redis api bot-poller scraper notifier enricher"
+              CARWATCH_IMAGE_TAG="$PREV" docker compose -f docker-compose.prod.yaml pull $APP_SERVICES
+              CARWATCH_IMAGE_TAG="$PREV" docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES
+
+              for i in $(seq 1 15); do
+                if docker exec carwatch-api wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
+                  break
+                fi
+                sleep 5
+              done
+              if ! docker exec carwatch-api wget -q --spider http://localhost:8080/healthz 2>/dev/null; then
+                echo "==> Rollback API health check failed"
+                exit 1
+              fi
+              for svc in bot-poller scraper notifier enricher; do
+                container="carwatch-$svc"
+                port=$(case "$svc" in
+                  bot-poller) echo 8082 ;;
+                  scraper) echo 8081 ;;
+                  notifier) echo 8083 ;;
+                  enricher) echo 8084 ;;
+                esac)
+                ok=0
+                for i in $(seq 1 15); do
+                  if docker exec "$container" wget -q --spider "http://localhost:${port}/healthz" 2>/dev/null; then
+                    ok=1
+                    break
+                  fi
+                  sleep 5
+                done
+                if [ "$ok" -ne 1 ]; then
+                  echo "==> Rollback worker health check failed: $container"
+                  exit 1
+                fi
+              done
+
+              if grep -q '^CARWATCH_IMAGE_TAG=' .env; then
+                sed -i "s/^CARWATCH_IMAGE_TAG=.*/CARWATCH_IMAGE_TAG=${PREV}/" .env
+              else
+                echo "CARWATCH_IMAGE_TAG=${PREV}" >> .env
+              fi
+              echo "==> Rolled back to previous version and restored .env"
               rm -f .deploy_recreate_started
+              rm -f next_image_tag
             else
               echo "==> No previous image tag found, skipping rollback"
+              rm -f .deploy_recreate_started
+              rm -f next_image_tag
             fi

--- a/README.md
+++ b/README.md
@@ -44,6 +44,46 @@ telemetry:
 This token protects `/metrics` when binding the API on a non-localhost address.
 `POST /api/v1/vitals` uses normal API authentication (Firebase in production, `api.auth_token` in local dev mode).
 
+Set an immutable application image tag in `.env` and use release tags for deploys:
+
+```dotenv
+CARWATCH_IMAGE_TAG=9.16.11
+```
+
+### Production deploy verification
+
+After deployment, verify every runtime service is healthy:
+
+```bash
+docker exec carwatch-api wget -q --spider http://localhost:8080/healthz
+docker exec carwatch-bot-poller wget -q --spider http://localhost:8082/healthz
+docker exec carwatch-scraper wget -q --spider http://localhost:8081/healthz
+docker exec carwatch-notifier wget -q --spider http://localhost:8083/healthz
+docker exec carwatch-enricher wget -q --spider http://localhost:8084/healthz
+```
+
+If any check fails, rollback deterministically to the last known-good image tag:
+
+```bash
+cd ~/carwatch
+set -a; source .env; set +a
+PREV_TAG=$(cat prev_image_tag)
+if grep -q '^CARWATCH_IMAGE_TAG=' .env; then
+  sed -i "s/^CARWATCH_IMAGE_TAG=.*/CARWATCH_IMAGE_TAG=${PREV_TAG}/" .env
+else
+  echo "CARWATCH_IMAGE_TAG=${PREV_TAG}" >> .env
+fi
+CARWATCH_IMAGE_TAG="${PREV_TAG}" docker compose -f docker-compose.prod.yaml pull postgres redis api bot-poller scraper notifier enricher
+CARWATCH_IMAGE_TAG="${PREV_TAG}" docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier enricher
+
+# verify rollback health
+docker exec carwatch-api wget -q --spider http://localhost:8080/healthz
+docker exec carwatch-bot-poller wget -q --spider http://localhost:8082/healthz
+docker exec carwatch-scraper wget -q --spider http://localhost:8081/healthz
+docker exec carwatch-notifier wget -q --spider http://localhost:8083/healthz
+docker exec carwatch-enricher wget -q --spider http://localhost:8084/healthz
+```
+
 ## Configuration
 
 See [`config.example.yaml`](config.example.yaml) for all options.

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -61,7 +61,7 @@ services:
           memory: 256M
 
   api:
-    image: ghcr.io/danielsio/carwatch:latest
+    image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-api
     entrypoint: ["/usr/local/bin/api-server"]
     networks:
@@ -82,8 +82,6 @@ services:
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
       - TELEMETRY_AUTH_TOKEN=${TELEMETRY_AUTH_TOKEN:?TELEMETRY_AUTH_TOKEN must be set}
     restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     logging:
       driver: json-file
       options:
@@ -95,7 +93,7 @@ services:
           memory: 512M
 
   bot-poller:
-    image: ghcr.io/danielsio/carwatch:latest
+    image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-bot-poller
     entrypoint: ["/usr/local/bin/bot-poller"]
     networks:
@@ -116,8 +114,6 @@ services:
       timeout: 5s
       retries: 3
     restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     logging:
       driver: json-file
       options:
@@ -129,7 +125,7 @@ services:
           memory: 256M
 
   scraper:
-    image: ghcr.io/danielsio/carwatch:latest
+    image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-scraper
     entrypoint: ["/usr/local/bin/scraper"]
     networks:
@@ -152,8 +148,6 @@ services:
       timeout: 5s
       retries: 3
     restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     logging:
       driver: json-file
       options:
@@ -165,7 +159,7 @@ services:
           memory: 512M
 
   notifier:
-    image: ghcr.io/danielsio/carwatch:latest
+    image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-notifier
     entrypoint: ["/usr/local/bin/notifier"]
     networks:
@@ -187,8 +181,6 @@ services:
       timeout: 5s
       retries: 3
     restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     logging:
       driver: json-file
       options:
@@ -200,7 +192,7 @@ services:
           memory: 256M
 
   enricher:
-    image: ghcr.io/danielsio/carwatch:latest
+    image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-enricher
     entrypoint: ["/usr/local/bin/enricher"]
     networks:
@@ -222,8 +214,6 @@ services:
       timeout: 5s
       retries: 3
     restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Review

✅ 3/3 agents passed (reliability, correctness, testing)

- reliability-reviewer: passed after rollback state-machine hardening
- correctness-reviewer: passed after legacy marker/tag normalization updates
- testing-reviewer: passed after CI contract guards for immutable tags/watchtower race prevention

## Summary

- remove watchtower app-service auto-update labels to eliminate dual deploy actors
- switch production app services from `:latest` to required `CARWATCH_IMAGE_TAG`
- make release deploy/rollback run with explicit immutable tags and serialized workflow concurrency
- harden rollback path: deterministic previous-tag markers, stale-marker recovery, full-stack health gates, and rollback image pull
- add CI guards for immutable tag contract and forbidden watchtower auto-update labels
- document production verification/rollback commands with full service health checks

## Test plan

- [x] `go test ./internal/enricher ./internal/api ./internal/storage/postgres -run TestDoesNotExist`
- [x] `npm --prefix web run build`
- [x] CI compose contract checks updated in `.github/workflows/ci.yml` for tag + env requirements

## Notes

- local environment does not have Docker CLI (`docker: command not found`), so compose validation was implemented in CI guards
- local environment does not have `golangci-lint` binary (`command not found`)

closes #1001
closes #1002
closes #1003

Made with [Cursor](https://cursor.com)