### PR TITLE
fix: sanitize external URL navigation in guest search and push notifications

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -35,7 +35,14 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = event.notification.data?.url || '/dashboard';
+  const rawUrl = event.notification.data?.url || '/dashboard';
+  let url = '/dashboard';
+  try {
+    const parsed = new URL(rawUrl, self.location.origin);
+    if (parsed.origin === self.location.origin) {
+      url = parsed.pathname + parsed.search;
+    }
+  } catch { /* keep default */ }
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
       for (const client of windowClients) {

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -9,7 +9,7 @@ import {
   type Manufacturer,
   type Model,
 } from "@/lib/api";
-import { formatPrice } from "@/lib/utils";
+import { formatPrice, safeHref } from "@/lib/utils";
 import { ChipButton } from "@/components/ui/ChipButton";
 import { Input } from "@/components/ui/Input";
 import { RangeSlider } from "@/components/ui/RangeSlider";
@@ -384,17 +384,27 @@ export default function TrySearchPage() {
           </h2>
 
           <div className="grid gap-4 sm:grid-cols-2">
-            {results.map((listing) => (
-              <a
-                key={listing.token}
-                href={listing.page_link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group rounded-2xl border border-border/50 bg-card overflow-hidden transition-all hover:border-primary/30 hover:shadow-lg"
-              >
-                <ListingCardBody listing={listing} hoverScale />
-              </a>
-            ))}
+            {results.map((listing) => {
+              const href = safeHref(listing.page_link);
+              return href ? (
+                <a
+                  key={listing.token}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group rounded-2xl border border-border/50 bg-card overflow-hidden transition-all hover:border-primary/30 hover:shadow-lg"
+                >
+                  <ListingCardBody listing={listing} hoverScale />
+                </a>
+              ) : (
+                <div
+                  key={listing.token}
+                  className="group rounded-2xl border border-border/50 bg-card overflow-hidden"
+                >
+                  <ListingCardBody listing={listing} />
+                </div>
+              );
+            })}
           </div>
 
           {/* CTA banner */}


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

- TrySearchPage: validate listing `page_link` with `safeHref()` before rendering as clickable anchor; render as non-clickable card if URL is invalid
- Service worker: enforce same-origin URL validation on notification click navigation to prevent open-redirect via malicious push payloads

closes #1012

## Test plan

- [x] `npm --prefix web run test -- --run src/pages/TrySearchPage.test.tsx` — 6 tests pass
- [x] `npm --prefix web run lint` — no errors
- [ ] Manual: click a push notification and verify it navigates within the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)