### PR TITLE
fix: enforce route-level auth guards and align mobile nav visibility

### DIFF
--- a/web/src/components/ProtectedRoute.test.tsx
+++ b/web/src/components/ProtectedRoute.test.tsx
@@ -40,10 +40,10 @@ describe("ProtectedRoute", () => {
     expect(screen.getByText("טוען...")).toBeInTheDocument();
   });
 
-  it("renders content for unauthenticated guests (no redirect)", () => {
+  it("redirects unauthenticated users to login", () => {
     authState = { user: null, loading: false };
     renderWithRoute();
-    expect(screen.getByText("Protected Content")).toBeInTheDocument();
-    expect(screen.queryByText("Login Page")).not.toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(screen.getByText("Login Page")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ProtectedRoute.tsx
+++ b/web/src/components/ProtectedRoute.tsx
@@ -1,9 +1,9 @@
-import { Outlet } from "react-router";
+import { Navigate, Outlet } from "react-router";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 
 export function ProtectedRoute() {
-  const { loading } = useAuth();
+  const { user, loading } = useAuth();
 
   if (loading) {
     return (
@@ -15,6 +15,10 @@ export function ProtectedRoute() {
         />
       </div>
     );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
   }
 
   return <Outlet />;

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -57,14 +57,15 @@ interface MobileNavItem {
   icon: typeof LayoutDashboard;
   badge?: boolean;
   fab?: boolean;
+  authOnly?: boolean;
 }
 
 const mobileNav: MobileNavItem[] = [
-  { path: "/dashboard", label: "ראשי", icon: LayoutDashboard },
-  { path: "/saved", label: "מועדפים", icon: Bookmark },
-  { path: "/searches/new", label: "חדש", icon: Plus, fab: true },
-  { path: "/notifications", label: "התראות", icon: Bell, badge: true },
-  { path: "/settings", label: "הגדרות", icon: Settings },
+  { path: "/dashboard", label: "ראשי", icon: LayoutDashboard, authOnly: true },
+  { path: "/saved", label: "מועדפים", icon: Bookmark, authOnly: true },
+  { path: "/searches/new", label: "חדש", icon: Plus, fab: true, authOnly: true },
+  { path: "/notifications", label: "התראות", icon: Bell, badge: true, authOnly: true },
+  { path: "/settings", label: "הגדרות", icon: Settings, authOnly: true },
 ];
 
 function isNavActive(pathname: string, path: string): boolean {
@@ -309,7 +310,7 @@ export function Shell() {
         className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/90 shadow-[0_-2px_16px_-6px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_24px_-8px_rgba(0,0,0,0.4)] backdrop-blur-xl backdrop-saturate-150 pb-[env(safe-area-inset-bottom,0px)] md:hidden"
       >
         <div className="flex items-end justify-around px-2 py-1.5 landscape:py-1">
-          {mobileNav.map((item) => {
+          {mobileNav.filter((item) => !item.authOnly || !!user).map((item) => {
             const Icon = item.icon;
             const isActive = isNavActive(location.pathname, item.path);
             const showBadge = item.badge && unread > 0;


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

- **ProtectedRoute** was only checking Firebase loading state — unauthenticated guests could access all protected routes. Now redirects to `/login` when `user` is null.
- **Mobile bottom nav** was static and always showed all items. Added `authOnly` flag and filtering so guests don't see dashboard, saved, notifications, or settings links.
- Updated test to verify redirect-to-login behavior.

closes #1010

## Test plan

- [x] `npm --prefix web run test -- --run src/components/ProtectedRoute.test.tsx` — 3 tests pass
- [x] `npm --prefix web run lint` — no errors
- [ ] Manual: visit `/dashboard` as guest → expect redirect to `/login`
- [ ] Manual: verify mobile nav hides auth-only items for guests

🤖 Generated with [Claude Code](https://claude.com/claude-code)