### PR TITLE
feat: add user-facing price history endpoint for listing detail

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -220,6 +220,7 @@ func (s *Server) Routes() http.Handler {
 	authMux.HandleFunc("GET /api/v1/searches/{id}/listings", s.listListings)
 	authMux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
 	authMux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
+	authMux.HandleFunc("GET /api/v1/listings/{token}/price-history", s.listingPriceHistory)
 
 	if s.admin != nil {
 		authMux.HandleFunc("GET /api/v1/admin/stats", s.requireAdmin(s.adminStats))

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -288,6 +288,47 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+func (s *Server) listingPriceHistory(w http.ResponseWriter, r *http.Request) {
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "missing token")
+		return
+	}
+
+	l, err := s.listings.GetListing(r.Context(), chatID, token)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to verify listing ownership")
+		return
+	}
+	if l == nil {
+		writeError(w, http.StatusNotFound, "listing not found")
+		return
+	}
+
+	points, err := s.prices.GetPriceHistory(r.Context(), token)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get price history")
+		return
+	}
+
+	type priceRecord struct {
+		Price      int    `json:"price"`
+		ObservedAt string `json:"observed_at"`
+	}
+	items := make([]priceRecord, 0, len(points))
+	for _, p := range points {
+		items = append(items, priceRecord{
+			Price:      p.Price,
+			ObservedAt: p.ObservedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
 func listingFilterFromSearch(sr *storage.Search) storage.ListingFilter {
 	f := storage.ListingFilter{
 		PriceMin:  sr.PriceMin,

--- a/web/src/components/PriceHistoryChart.tsx
+++ b/web/src/components/PriceHistoryChart.tsx
@@ -9,7 +9,7 @@ import {
   ReferenceDot,
 } from "recharts";
 import { TrendingDown, TrendingUp, Minus } from "lucide-react";
-import { adminApi, type AdminPriceRecord } from "@/lib/api";
+import { api } from "@/lib/api";
 import { formatPrice } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/Skeleton";
 
@@ -42,7 +42,7 @@ export function PriceHistoryChart({
   token,
   currentPrice,
 }: PriceHistoryChartProps) {
-  const [records, setRecords] = useState<AdminPriceRecord[]>([]);
+  const [records, setRecords] = useState<{ price: number; observed_at: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
@@ -50,8 +50,8 @@ export function PriceHistoryChart({
     let cancelled = false;
     setLoading(true);
     setError(false);
-    adminApi
-      .priceHistory({ token, limit: 100 })
+    api
+      .priceHistory(token)
       .then((res) => {
         if (!cancelled) {
           setRecords(res.items);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -205,6 +205,8 @@ export const api = {
       fetchAPI<SearchStatsResponse>(`/searches/${id}/stats`),
   },
   listing: (token: string) => fetchAPI<Listing>(`/listings/${encodeURIComponent(token)}`),
+  priceHistory: (token: string) =>
+    fetchAPI<{ items: { price: number; observed_at: string }[] }>(`/listings/${encodeURIComponent(token)}/price-history`),
   markListingSeen: (token: string) =>
     fetchAPI<void>(`/listings/${encodeURIComponent(token)}/seen`, {
       method: "POST",


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

- **Backend:** Added `GET /api/v1/listings/{token}/price-history` under auth middleware. Verifies listing ownership via chatID before returning price data.
- **Frontend:** Updated `PriceHistoryChart` to call user-scoped endpoint (`api.priceHistory`) instead of admin-only (`adminApi.priceHistory`). Non-admin users now see price history on listing detail pages.
- Added `priceHistory` method to the user-facing `api` object in `api.ts`.

closes #1011

## Test plan

- [x] `go build ./internal/api/` — compiles
- [x] `npm --prefix web run build` — builds successfully
- [ ] Manual: view listing detail as non-admin user → price chart loads
- [ ] Manual: view listing detail as admin → price chart still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)