### PR TITLE
feat: add --migrate-only and --skip-migrate flags to all services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build build-api build-bot-poller build-scraper build-notifier build-enricher build-all \
        run test test-cover test-e2e lint ci clean docker-build docker-run \
-       dev dev-db dev-stop dev-reset dev-pg-shell \
+       dev dev-db dev-stop dev-reset dev-pg-shell migrate \
        vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-deploy vm-deploy-all vm-sync \
        vm-backup vm-backup-list vm-pg-shell \
        vm-setup-backup vm-backup-status \
@@ -98,6 +98,9 @@ dev-pg-shell:
 
 dev: build dev-db
 	./api-server -config config.dev.yaml
+
+migrate:
+	go run $(LDFLAGS) ./cmd/api-server -config config.yaml -migrate-only
 
 docker-build:
 	docker build -t carwatch .

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -27,6 +27,8 @@ var (
 func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
 	showVersion := flag.Bool("version", false, "print version and exit")
+	migrateOnly := flag.Bool("migrate-only", false, "run database migrations and exit")
+	skipMigrate := flag.Bool("skip-migrate", false, "skip auto-migration on startup")
 	flag.Parse()
 
 	if *showVersion {
@@ -34,15 +36,31 @@ func main() {
 		return
 	}
 
+	if *migrateOnly {
+		cfg, err := app.LoadConfig(*configPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load config: %v\n", err)
+			os.Exit(1)
+		}
+		store, err := app.OpenStore(cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+			os.Exit(1)
+		}
+		_ = store.Close()
+		fmt.Println("migrations complete")
+		return
+	}
+
 	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
 
-	if err := run(*configPath, logger); err != nil {
+	if err := run(*configPath, *skipMigrate, logger); err != nil {
 		logger.Error("fatal", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(configPath string, logger *slog.Logger) error {
+func run(configPath string, skipMigrate bool, logger *slog.Logger) error {
 	cfg, err := app.LoadConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -84,7 +102,7 @@ func run(configPath string, logger *slog.Logger) error {
 	}
 	defer func() { _ = telShutdown(context.Background()) }()
 
-	store, err := app.OpenStore(cfg)
+	store, err := app.OpenStore(cfg, skipMigrate)
 	if err != nil {
 		return fmt.Errorf("create store: %w", err)
 	}

--- a/cmd/bot-poller/main.go
+++ b/cmd/bot-poller/main.go
@@ -29,6 +29,7 @@ func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	healthBind := flag.String("health-bind", "0.0.0.0:8082", "health endpoint bind address")
+	skipMigrate := flag.Bool("skip-migrate", false, "skip auto-migration on startup")
 	flag.Parse()
 
 	if *showVersion {
@@ -38,13 +39,13 @@ func main() {
 
 	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
 
-	if err := run(*configPath, *healthBind, logger); err != nil {
+	if err := run(*configPath, *healthBind, *skipMigrate, logger); err != nil {
 		logger.Error("fatal", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(configPath, healthBind string, logger *slog.Logger) error {
+func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) error {
 	cfg, err := app.LoadConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -79,7 +80,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	}
 	defer func() { _ = telShutdown(context.Background()) }()
 
-	store, err := app.OpenStore(cfg)
+	store, err := app.OpenStore(cfg, skipMigrate)
 	if err != nil {
 		return fmt.Errorf("create store: %w", err)
 	}

--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -34,6 +34,7 @@ func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	healthBind := flag.String("health-bind", defaultHealthBind, "health endpoint bind address")
+	skipMigrate := flag.Bool("skip-migrate", false, "skip auto-migration on startup")
 	flag.Parse()
 
 	if *showVersion {
@@ -43,13 +44,13 @@ func main() {
 
 	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
 
-	if err := run(*configPath, *healthBind, logger); err != nil {
+	if err := run(*configPath, *healthBind, *skipMigrate, logger); err != nil {
 		logger.Error("fatal", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(configPath, healthBind string, logger *slog.Logger) error {
+func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) error {
 	cfg, err := app.LoadConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -88,7 +89,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	}
 	defer func() { _ = telShutdown(context.Background()) }()
 
-	store, err := app.OpenStore(cfg)
+	store, err := app.OpenStore(cfg, skipMigrate)
 	if err != nil {
 		return fmt.Errorf("create store: %w", err)
 	}

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -34,6 +34,7 @@ func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	healthBind := flag.String("health-bind", defaultHealthBind, "health endpoint bind address")
+	skipMigrate := flag.Bool("skip-migrate", false, "skip auto-migration on startup")
 	flag.Parse()
 
 	if *showVersion {
@@ -43,13 +44,13 @@ func main() {
 
 	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
 
-	if err := run(*configPath, *healthBind, logger); err != nil {
+	if err := run(*configPath, *healthBind, *skipMigrate, logger); err != nil {
 		logger.Error("fatal", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(configPath, healthBind string, logger *slog.Logger) error {
+func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) error {
 	cfg, err := app.LoadConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -90,7 +91,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 
 	// The notifier worker needs a user store for channel resolution and a
 	// push subscription store for WebPush delivery. Both come from PostgreSQL.
-	store, err := app.OpenStore(cfg)
+	store, err := app.OpenStore(cfg, skipMigrate)
 	if err != nil {
 		return fmt.Errorf("create store: %w", err)
 	}

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -32,6 +32,7 @@ func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	healthBind := flag.String("health-bind", "0.0.0.0:8081", "health endpoint bind address")
+	skipMigrate := flag.Bool("skip-migrate", false, "skip auto-migration on startup")
 	flag.Parse()
 
 	if *showVersion {
@@ -41,13 +42,13 @@ func main() {
 
 	logger := slog.New(app.NewLogHandler("auto", slog.LevelInfo))
 
-	if err := run(*configPath, *healthBind, logger); err != nil {
+	if err := run(*configPath, *healthBind, *skipMigrate, logger); err != nil {
 		logger.Error("fatal", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(configPath, healthBind string, logger *slog.Logger) error {
+func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) error {
 	cfg, err := app.LoadConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -87,7 +88,7 @@ func run(configPath, healthBind string, logger *slog.Logger) error {
 	}
 	defer func() { _ = telShutdown(context.Background()) }()
 
-	store, err := app.OpenStore(cfg)
+	store, err := app.OpenStore(cfg, skipMigrate)
 	if err != nil {
 		return fmt.Errorf("create store: %w", err)
 	}

--- a/cmd/scraper/main_test.go
+++ b/cmd/scraper/main_test.go
@@ -22,7 +22,7 @@ storage:
 		t.Fatal(err)
 	}
 	logger := slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1}))
-	err := run(path, "0.0.0.0:0", logger)
+	err := run(path, "0.0.0.0:0", false, logger)
 	if err == nil {
 		t.Fatal("expected error when redis.addr is empty")
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -41,9 +41,15 @@ func LoadConfig(path string) (*config.Config, error) {
 	return config.Load(path)
 }
 
-// OpenStore opens a PostgreSQL store using the configuration's DSN.
-func OpenStore(cfg *config.Config) (*postgres.Store, error) {
-	return postgres.New(cfg.Storage.DSN, cfg.Storage.MigrationsPath)
+// OpenStore opens a PostgreSQL store using the configuration's DSN and
+// runs pending migrations. Pass skipMigrate=true to connect without
+// running migrations (useful when a separate deploy step handles them).
+func OpenStore(cfg *config.Config, skipMigrate ...bool) (*postgres.Store, error) {
+	migrationsPath := cfg.Storage.MigrationsPath
+	if len(skipMigrate) > 0 && skipMigrate[0] {
+		migrationsPath = ""
+	}
+	return postgres.New(cfg.Storage.DSN, migrationsPath)
 }
 
 // FetcherBundle groups all fetcher-related objects returned by BuildFetchers.


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

- All 5 service binaries now accept `--skip-migrate` to connect to Postgres without running migrations
- api-server additionally accepts `--migrate-only` to run migrations and exit
- Added `make migrate` Makefile target
- Updated `app.OpenStore()` to accept optional `skipMigrate` parameter
- Backward compatible: default behavior unchanged (all services auto-migrate unless flagged)

closes #1013

## Test plan

- [x] `go build ./cmd/...` — all 5 binaries compile
- [x] `go vet ./cmd/...` — clean
- [x] `go test ./cmd/scraper/` — test updated for new signature
- [ ] Manual: `api-server --migrate-only` runs and exits with "migrations complete"
- [ ] Manual: `scraper --skip-migrate` starts without running migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)