### PR TITLE
feat: add global concurrency semaphore for guest instant search

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -132,6 +132,11 @@ func New(c Config) *Server {
 		}
 	}
 
+	fetchCap := c.API.MaxConcurrentFetches
+	if fetchCap <= 0 {
+		fetchCap = 10
+	}
+
 	return &Server{
 		catalog:        c.Catalog,
 		searches:       c.Searches,
@@ -160,7 +165,7 @@ func New(c Config) *Server {
 		logLevel:       c.LogLevel,
 		cycleLog:       c.CycleLog,
 		vitals:         newVitalsRing(),
-		fetchSem:       make(chan struct{}, c.API.MaxConcurrentFetches),
+		fetchSem:       make(chan struct{}, fetchCap),
 	}
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -160,7 +160,7 @@ func New(c Config) *Server {
 		logLevel:       c.LogLevel,
 		cycleLog:       c.CycleLog,
 		vitals:         newVitalsRing(),
-		fetchSem:       make(chan struct{}, 10),
+		fetchSem:       make(chan struct{}, c.API.MaxConcurrentFetches),
 	}
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -68,6 +68,7 @@ type Server struct {
 	vapidPublicKey   string
 	refreshMu        sync.Map
 	lastRefreshSweep atomic.Int64 // unix nano of last sweep
+	fetchSem         chan struct{}
 
 	logHub   *logstream.Hub
 	logLevel *slog.LevelVar
@@ -159,6 +160,7 @@ func New(c Config) *Server {
 		logLevel:       c.LogLevel,
 		cycleLog:       c.CycleLog,
 		vitals:         newVitalsRing(),
+		fetchSem:       make(chan struct{}, 10),
 	}
 }
 

--- a/internal/api/instant_search.go
+++ b/internal/api/instant_search.go
@@ -81,7 +81,6 @@ func (s *Server) instantSearch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "server too busy, try again later")
 		return
 	}
-	defer func() { <-s.fetchSem }()
 
 	sources := strings.Split(req.Source, ",")
 	var allRaw []model.RawListing
@@ -126,6 +125,7 @@ func (s *Server) instantSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		allRaw = append(allRaw, raw...)
 	}
+	<-s.fetchSem
 
 	criteria := model.FilterCriteria{
 		ModelID:     req.Model,

--- a/internal/api/instant_search.go
+++ b/internal/api/instant_search.go
@@ -75,6 +75,14 @@ func (s *Server) instantSearch(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
+	select {
+	case s.fetchSem <- struct{}{}:
+	case <-ctx.Done():
+		writeError(w, http.StatusServiceUnavailable, "server too busy, try again later")
+		return
+	}
+	defer func() { <-s.fetchSem }()
+
 	sources := strings.Split(req.Source, ",")
 	var allRaw []model.RawListing
 	for _, src := range sources {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,9 +68,10 @@ type APIConfig struct {
 	TrustForwardedFor bool   `yaml:"trust_forwarded_for"`
 	DevChatID         int64  `yaml:"dev_chat_id"`
 	AuthToken         string `yaml:"auth_token"`
-	AdminChatID       int64  `yaml:"-"`
-	AdminEmail        string `yaml:"admin_email"`
-	MaxSearches       int    `yaml:"-"`
+	AdminChatID          int64  `yaml:"-"`
+	AdminEmail           string `yaml:"admin_email"`
+	MaxSearches          int    `yaml:"-"`
+	MaxConcurrentFetches int    `yaml:"max_concurrent_fetches"`
 }
 
 type PollingConfig struct {
@@ -209,6 +210,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Enricher.BackfillInterval == 0 {
 		cfg.Enricher.BackfillInterval = 10 * time.Minute
+	}
+	if cfg.API.MaxConcurrentFetches <= 0 {
+		cfg.API.MaxConcurrentFetches = 10
 	}
 	var filtered []string
 	for _, o := range cfg.API.CORSOrigins {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,9 +65,9 @@ type APIConfig struct {
 	CORSOrigins []string `yaml:"cors_origins"`
 	// TrustForwardedFor, when true, uses X-Forwarded-For (leftmost hop) for IP rate limiting.
 	// Enable only behind a trusted reverse proxy that overwrites client-controlled forwarded headers.
-	TrustForwardedFor bool   `yaml:"trust_forwarded_for"`
-	DevChatID         int64  `yaml:"dev_chat_id"`
-	AuthToken         string `yaml:"auth_token"`
+	TrustForwardedFor    bool   `yaml:"trust_forwarded_for"`
+	DevChatID            int64  `yaml:"dev_chat_id"`
+	AuthToken            string `yaml:"auth_token"`
 	AdminChatID          int64  `yaml:"-"`
 	AdminEmail           string `yaml:"admin_email"`
 	MaxSearches          int    `yaml:"-"`


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

- Added a buffered channel semaphore (capacity 10) to the API Server struct
- Guest instant-search acquires a slot before fetching from Yad2, releases after
- If all slots are occupied, blocks until one frees or context times out (30s), returns 503
- Per-IP rate limiting (15 req/3min) still applies as first defense; semaphore adds global backpressure

closes #1023

## Test plan

- [x] `go build ./internal/api/` — compiles
- [x] Non-Docker API tests pass
- [ ] CI integration tests validate full behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Concurrency limits added for backend fetch operations with a configurable cap (default 10), reducing overload during peak traffic.
  * Under heavy load, requests may receive a "server too busy, try again later" (HTTP 503) and should be retried, improving overall stability and consistent performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->