### PR TITLE
feat: instrument queue depth, pending count, and delivery lag SLIs

### DIFF
--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -9,7 +9,11 @@ import (
 	"os"
 	"time"
 
+	"strconv"
+	"strings"
+
 	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/telemetry"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/time/rate"
 )
@@ -92,6 +96,9 @@ func (c *Consumer) Run(ctx context.Context) error {
 	orphanTicker := time.NewTicker(60 * time.Second)
 	defer orphanTicker.Stop()
 
+	metricsTicker := time.NewTicker(30 * time.Second)
+	defer metricsTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -100,6 +107,8 @@ func (c *Consumer) Run(ctx context.Context) error {
 			c.reclaimPending(ctx)
 		case <-orphanTicker.C:
 			c.reclaimOrphans(ctx)
+		case <-metricsTicker.C:
+			c.reportQueueMetrics(ctx)
 		default:
 		}
 
@@ -224,6 +233,12 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 
 	c.ack(ctx, msg.ID)
 	c.logger.Info("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
+
+	if telemetry.QueueLag != nil {
+		if lag := messageAge(msg.ID); lag > 0 {
+			telemetry.QueueLag.Record(ctx, lag.Seconds())
+		}
+	}
 }
 
 func parseAlert(msg redis.XMessage) (Alert, error) {
@@ -242,6 +257,31 @@ func (c *Consumer) ack(ctx context.Context, id string) {
 	if err := c.client.XAck(ctx, StreamName, GroupName, id).Err(); err != nil {
 		c.logger.Error("ack failed", "id", id, "error", err)
 	}
+}
+
+func (c *Consumer) reportQueueMetrics(ctx context.Context) {
+	if telemetry.QueueDepth != nil {
+		if depth, err := c.client.XLen(ctx, StreamName).Result(); err == nil {
+			telemetry.QueueDepth.Record(ctx, depth)
+		}
+	}
+	if telemetry.QueuePending != nil {
+		if info, err := c.client.XPending(ctx, StreamName, GroupName).Result(); err == nil {
+			telemetry.QueuePending.Record(ctx, info.Count)
+		}
+	}
+}
+
+func messageAge(id string) time.Duration {
+	parts := strings.SplitN(id, "-", 2)
+	if len(parts) == 0 {
+		return 0
+	}
+	ms, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return time.Since(time.UnixMilli(ms))
 }
 
 const orphanIdleThreshold = 5 * time.Minute

--- a/internal/telemetry/app_metrics.go
+++ b/internal/telemetry/app_metrics.go
@@ -31,6 +31,13 @@ var (
 	EnrichChallenges metric.Int64Counter
 	// EnrichSkipped counts enrichment requests skipped (already enriched).
 	EnrichSkipped metric.Int64Counter
+
+	// QueueDepth reports the current number of messages in the alerts stream.
+	QueueDepth metric.Int64Gauge
+	// QueuePending reports the number of messages claimed but not yet acked.
+	QueuePending metric.Int64Gauge
+	// QueueLag records the time between message publish and delivery.
+	QueueLag metric.Float64Histogram
 )
 
 // InitMetrics creates all application-level OTel metric instruments.
@@ -101,6 +108,25 @@ func InitMetrics() error {
 
 	EnrichSkipped, err = meter.Int64Counter("carwatch.enrich.skipped",
 		metric.WithDescription("Enrichment requests skipped (already enriched)"))
+	if err != nil {
+		return err
+	}
+
+	QueueDepth, err = meter.Int64Gauge("carwatch.queue.depth",
+		metric.WithDescription("Messages in alerts stream"))
+	if err != nil {
+		return err
+	}
+
+	QueuePending, err = meter.Int64Gauge("carwatch.queue.pending",
+		metric.WithDescription("Messages claimed but not yet acked"))
+	if err != nil {
+		return err
+	}
+
+	QueueLag, err = meter.Float64Histogram("carwatch.queue.lag",
+		metric.WithDescription("Time from message publish to delivery"),
+		metric.WithUnit("s"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

- Added 3 new OTel metric instruments: `carwatch.queue.depth` (gauge), `carwatch.queue.pending` (gauge), `carwatch.queue.lag` (histogram)
- Consumer reports depth/pending every 30s via XLEN/XPENDING
- Delivery lag computed from Redis stream message ID timestamp (milliseconds-sequence format)
- All metrics are no-ops when OTel is not configured

closes #1016

## Test plan

- [x] `go build ./internal/...` — compiles
- [ ] CI tests pass
- [ ] Verify metrics appear in Prometheus when OTel is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)