### PR TITLE
docs: split config examples into dev and production

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,5 @@
-# CarWatch v3 — Multi-Tenant Telegram Bot Configuration
+# CarWatch v3 — Local Development Configuration
+# For production, see config.prod.example.yaml.
 # Users manage their searches via Telegram commands (/watch, /list, /stop)
 # No per-search config needed here — it's all in the database.
 

--- a/config.prod.example.yaml
+++ b/config.prod.example.yaml
@@ -1,0 +1,63 @@
+# CarWatch v3 — Production Configuration
+# Copy to config.yaml on the VM and fill in secrets from .env.
+
+log_level: info
+log_format: json
+
+telegram:
+  token: "${TELEGRAM_BOT_TOKEN}"
+  admin_chat_id: 0
+  max_searches: 3
+  # bot_username: "YourBotUsername"
+
+polling:
+  interval: 15m
+  jitter: 5m
+  active_hours:
+    start: "08:00"
+    end: "22:00"
+  timezone: "Asia/Jerusalem"
+
+storage:
+  dsn: "postgres://carwatch:${POSTGRES_PASSWORD}@postgres:5432/carwatch?sslmode=disable"
+  migrations_path: "./migrations"
+  prune_after: 720h
+
+http:
+  bind: "0.0.0.0:8080"
+  user_agents:
+    - "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+    - "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+
+redis:
+  addr: "redis:6379"
+  password: "${REDIS_PASSWORD}"
+  db: 0
+
+telemetry:
+  traces_exporter: none
+  metrics_path: /metrics
+  auth_token: "${TELEMETRY_AUTH_TOKEN}"
+
+api:
+  cors_origins:
+    - "https://${CARWATCH_DOMAIN}"
+  admin_email: ""
+  trust_forwarded_for: true
+
+# Firebase authentication (required for web UI)
+# firebase:
+#   project_id: "your-project-id"
+#   credentials_json: '${FIREBASE_CREDENTIALS_JSON}'
+
+# Web push notifications (VAPID keys)
+# push:
+#   vapid_public_key: "${VAPID_PUBLIC_KEY}"
+#   vapid_private_key: "${VAPID_PRIVATE_KEY}"
+#   vapid_subject: "mailto:admin@example.com"
+
+# Enricher rate limiting
+# enricher:
+#   min_delay: 3s
+#   max_delay: 30s
+#   cooldown: 10m


### PR DESCRIPTION
## Summary

- Added `config.prod.example.yaml` with all production-required sections (redis, telemetry, firebase, push, enricher)
- Updated `config.example.yaml` header to clarify it is for local development

closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)