### PR TITLE
docs: document derived API config fields and close dead-knobs audit

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,9 +68,9 @@ type APIConfig struct {
 	TrustForwardedFor bool   `yaml:"trust_forwarded_for"`
 	DevChatID         int64  `yaml:"dev_chat_id"`
 	AuthToken         string `yaml:"auth_token"`
-	AdminChatID       int64  `yaml:"-"`
-	AdminEmail        string `yaml:"admin_email"`
-	MaxSearches       int    `yaml:"-"`
+	AdminChatID int64  `yaml:"-"` // derived from telegram.admin_chat_id at startup
+	AdminEmail  string `yaml:"admin_email"`
+	MaxSearches int    `yaml:"-"` // derived from telegram.max_searches at startup
 }
 
 type PollingConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,9 +68,9 @@ type APIConfig struct {
 	TrustForwardedFor bool   `yaml:"trust_forwarded_for"`
 	DevChatID         int64  `yaml:"dev_chat_id"`
 	AuthToken         string `yaml:"auth_token"`
-	AdminChatID int64  `yaml:"-"` // derived from telegram.admin_chat_id at startup
-	AdminEmail  string `yaml:"admin_email"`
-	MaxSearches int    `yaml:"-"` // derived from telegram.max_searches at startup
+	AdminChatID       int64  `yaml:"-"` // derived from telegram.admin_chat_id at startup
+	AdminEmail        string `yaml:"admin_email"`
+	MaxSearches       int    `yaml:"-"` // derived from telegram.max_searches at startup
 }
 
 type PollingConfig struct {


### PR DESCRIPTION
## Summary

- Added inline comments on `APIConfig.AdminChatID` and `MaxSearches` clarifying they are derived from `telegram.*` at startup (`yaml:"-"`)
- Audit confirmed no dead config knobs: all fields are used or derived

closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration documentation for improved code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->