### PR TITLE
ci: add post-deploy smoke test script and vm-smoke Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build build-api build-bot-poller build-scraper build-notifier build-enricher build-all \
        run test test-cover test-e2e lint ci clean docker-build docker-run \
        dev dev-db dev-stop dev-reset dev-pg-shell \
-       vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-deploy vm-deploy-all vm-sync \
+       vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-smoke vm-deploy vm-deploy-all vm-sync \
        vm-backup vm-backup-list vm-pg-shell \
        vm-setup-backup vm-backup-status \
        web-install web-dev web-build \
@@ -154,6 +154,10 @@ VM_COMPOSE := cd $(VM_DIR) && docker compose -f docker-compose.prod.yaml
 vm-sync: vm-check-env
 	$(SSH) "mkdir -p $(VM_DIR)"
 	$(SCP) docker-compose.prod.yaml $(VM_USER)@$(VM_IP):$(VM_DIR)/docker-compose.prod.yaml
+
+vm-smoke: vm-check-env
+	$(SCP) scripts/smoke-test.sh $(VM_USER)@$(VM_IP):$(VM_DIR)/scripts/smoke-test.sh
+	$(SSH) "chmod +x $(VM_DIR)/scripts/smoke-test.sh && $(VM_DIR)/scripts/smoke-test.sh $(VM_DIR)"
 
 vm-deploy: vm-sync
 	$(SSH) "$(VM_COMPOSE) pull carwatch && $(VM_COMPOSE) up -d --force-recreate carwatch \

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post-deploy smoke test for CarWatch production.
+# Verifies all services are healthy and core functionality works.
+# Exit 0 on success, non-zero on any failure.
+
+COMPOSE_DIR="${1:-/home/ubuntu/carwatch}"
+COMPOSE="docker compose -f ${COMPOSE_DIR}/docker-compose.prod.yaml"
+
+SERVICES=(api bot-poller scraper notifier enricher)
+HEALTH_PORTS=(8080 8082 8081 8083 8084)
+
+fail=0
+
+echo "=== CarWatch Post-Deploy Smoke Test ==="
+
+# 1. Check all containers are running
+echo ""
+echo "--- Container status ---"
+for svc in "${SERVICES[@]}"; do
+  container="carwatch-${svc}"
+  if docker inspect --format='{{.State.Status}}' "$container" 2>/dev/null | grep -q running; then
+    echo "  ✓ ${container} running"
+  else
+    echo "  ✗ ${container} NOT running"
+    fail=1
+  fi
+done
+
+# 2. Health endpoint checks
+echo ""
+echo "--- Health checks ---"
+for i in "${!SERVICES[@]}"; do
+  svc="${SERVICES[$i]}"
+  port="${HEALTH_PORTS[$i]}"
+  container="carwatch-${svc}"
+  if docker exec "$container" wget -qO- --timeout=5 "http://localhost:${port}/healthz" >/dev/null 2>&1; then
+    echo "  ✓ ${svc} :${port}/healthz OK"
+  else
+    echo "  ✗ ${svc} :${port}/healthz FAILED"
+    fail=1
+  fi
+done
+
+# 3. Database connectivity (via API catalog endpoint)
+echo ""
+echo "--- Database connectivity ---"
+if docker exec carwatch-api wget -qO- --timeout=5 "http://localhost:8080/api/v1/catalog/manufacturers" | grep -q '"id"'; then
+  echo "  ✓ API catalog returns data (DB connected)"
+else
+  echo "  ✗ API catalog empty or unreachable (DB issue?)"
+  fail=1
+fi
+
+# 4. Redis connectivity (check stream exists)
+echo ""
+echo "--- Redis connectivity ---"
+REDIS_PASS=$(grep -oP 'REDIS_PASSWORD=\K[^\s]+' "${COMPOSE_DIR}/.env" 2>/dev/null || echo "")
+if [ -n "$REDIS_PASS" ]; then
+  if docker exec carwatch-redis redis-cli -a "$REDIS_PASS" --no-auth-warning ping 2>/dev/null | grep -q PONG; then
+    echo "  ✓ Redis PONG"
+  else
+    echo "  ✗ Redis not responding"
+    fail=1
+  fi
+else
+  echo "  - Redis password not found in .env, skipping"
+fi
+
+# 5. Version check
+echo ""
+echo "--- Service versions ---"
+for svc in "${SERVICES[@]}"; do
+  container="carwatch-${svc}"
+  binary="${svc}"
+  [ "$svc" = "api" ] && binary="api-server"
+  version=$(docker exec "$container" "${binary}" -version 2>/dev/null | head -1 || echo "unknown")
+  echo "  ${svc}: ${version}"
+done
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "=== ALL SMOKE TESTS PASSED ==="
+  exit 0
+else
+  echo "=== SMOKE TESTS FAILED ==="
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Added `scripts/smoke-test.sh` with comprehensive checks: container status, health endpoints, DB connectivity (catalog API), Redis ping, version info
- Added `make vm-smoke` target to deploy and run the script on the VM

closes #1018

## Test plan

- [x] Script passes shellcheck
- [ ] Run `make vm-smoke` against production VM after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)