### PR TITLE
feat!: change dedup key to per-search for independent search alerts

### DIFF
--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -194,7 +194,7 @@ func releaseDedupClaimsOnDeadLetter(dedup storage.DedupStore, logger *slog.Logge
 		}
 		for _, token := range alert.Tokens {
 			cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 5*time.Second)
-			err := dedup.ReleaseClaim(cleanupCtx, token, alert.ChatID)
+			err := dedup.ReleaseClaim(cleanupCtx, token, alert.ChatID, alert.SearchID)
 			cleanupCancel()
 			if err != nil {
 				return err

--- a/cmd/notifier/main_test.go
+++ b/cmd/notifier/main_test.go
@@ -160,7 +160,7 @@ type mockDedupStore struct {
 func (m *mockDedupStore) ClaimNew(context.Context, string, int64, int64) (bool, error) {
 	return false, nil
 }
-func (m *mockDedupStore) ReleaseClaim(_ context.Context, token string, chatID int64) error {
+func (m *mockDedupStore) ReleaseClaim(_ context.Context, token string, chatID int64, _ int64) error {
 	m.released = append(m.released, struct {
 		token  string
 		chatID int64

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -74,7 +74,7 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
 		for _, l := range sr.newListings {
-			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, l.Token, search.ChatID); relErr != nil {
+			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, l.Token, search.ChatID, search.ID); relErr != nil {
 				log.ErrorContext(ctx, "failed to release dedup claim after delivery failure",
 					"token", l.Token,
 					"error", relErr.Error(),
@@ -101,7 +101,7 @@ func (s *Scheduler) persistListings(ctx context.Context, records []storage.Listi
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
 		for _, rec := range records {
-			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, rec.Token, rec.ChatID); relErr != nil {
+			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, rec.Token, rec.ChatID, rec.SearchID); relErr != nil {
 				log.ErrorContext(ctx, "failed to release dedup claim after batch save failure, listing may be permanently lost",
 					"token", rec.Token,
 					"error", relErr.Error(),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -957,7 +957,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				filtered := make([]model.RawListing, 0, len(rawForPipeline))
 				for _, r := range rawForPipeline {
 					if r.Km > 0 && r.Km > acc.search.MaxKm {
-						if relErr := s.stores.Dedup.ReleaseClaim(ctx, r.Token, acc.search.ChatID); relErr != nil {
+						if relErr := s.stores.Dedup.ReleaseClaim(ctx, r.Token, acc.search.ChatID, acc.search.ID); relErr != nil {
 							s.logger.ErrorContext(searchCtx,
 								"failed to release dedup claim for km-filtered listing",
 								"token", r.Token, "error", relErr.Error())

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -51,11 +51,11 @@ func (m *errDedup) ClaimNew(ctx context.Context, token string, chatID int64, sea
 	return m.mockDedup.ClaimNew(ctx, token, chatID, searchID)
 }
 
-func (m *errDedup) ReleaseClaim(ctx context.Context, token string, chatID int64) error {
+func (m *errDedup) ReleaseClaim(ctx context.Context, token string, chatID int64, searchID int64) error {
 	if m.releaseErr != nil {
 		return m.releaseErr
 	}
-	return m.mockDedup.ReleaseClaim(ctx, token, chatID)
+	return m.mockDedup.ReleaseClaim(ctx, token, chatID, searchID)
 }
 
 func (m *errDedup) Prune(_ context.Context, _ time.Duration) (int64, error) {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -68,7 +68,7 @@ func (m *mockDedup) ClaimNew(_ context.Context, token string, chatID int64, _ in
 	return true, nil
 }
 
-func (m *mockDedup) ReleaseClaim(_ context.Context, token string, chatID int64) error {
+func (m *mockDedup) ReleaseClaim(_ context.Context, token string, chatID int64, _ int64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.seen, dedupKey{token, chatID})

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -97,7 +97,7 @@ type SearchStore interface {
 
 type DedupStore interface {
 	ClaimNew(ctx context.Context, token string, chatID int64, searchID int64) (bool, error)
-	ReleaseClaim(ctx context.Context, token string, chatID int64) error
+	ReleaseClaim(ctx context.Context, token string, chatID int64, searchID int64) error
 	Prune(ctx context.Context, olderThan time.Duration) (int64, error)
 }
 

--- a/internal/storage/postgres/dedup.go
+++ b/internal/storage/postgres/dedup.go
@@ -9,7 +9,7 @@ import (
 func (s *Store) ClaimNew(ctx context.Context, token string, chatID int64, searchID int64) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `
 		INSERT INTO seen_listings (token, chat_id, search_id) VALUES ($1, $2, $3)
-		ON CONFLICT (token, chat_id) DO NOTHING`,
+		ON CONFLICT (token, chat_id, search_id) DO NOTHING`,
 		token, chatID, searchID)
 	if err != nil {
 		return false, fmt.Errorf("claim new: %w", err)
@@ -21,10 +21,10 @@ func (s *Store) ClaimNew(ctx context.Context, token string, chatID int64, search
 	return rows > 0, nil
 }
 
-func (s *Store) ReleaseClaim(ctx context.Context, token string, chatID int64) error {
+func (s *Store) ReleaseClaim(ctx context.Context, token string, chatID int64, searchID int64) error {
 	_, err := s.db.ExecContext(ctx,
-		`DELETE FROM seen_listings WHERE token = $1 AND chat_id = $2`,
-		token, chatID)
+		`DELETE FROM seen_listings WHERE token = $1 AND chat_id = $2 AND search_id = $3`,
+		token, chatID, searchID)
 	if err != nil {
 		return fmt.Errorf("release claim: %w", err)
 	}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -591,7 +591,7 @@ func TestPostgres_Dedup(t *testing.T) {
 	}
 
 	// ReleaseClaim allows reclaim
-	if err := store.ReleaseClaim(ctx, "token1", 100); err != nil {
+	if err := store.ReleaseClaim(ctx, "token1", 100, 1); err != nil {
 		t.Fatalf("release: %v", err)
 	}
 	isNew, _ = store.ClaimNew(ctx, "token1", 100, 1)

--- a/migrations/000015_per_search_dedup.down.sql
+++ b/migrations/000015_per_search_dedup.down.sql
@@ -1,0 +1,8 @@
+-- Revert to per-user dedup by removing duplicates before restoring the old PK.
+DELETE FROM seen_listings a
+USING seen_listings b
+WHERE a.token = b.token AND a.chat_id = b.chat_id
+  AND a.ctid > b.ctid;
+
+ALTER TABLE seen_listings DROP CONSTRAINT seen_listings_pkey;
+ALTER TABLE seen_listings ADD PRIMARY KEY (token, chat_id);

--- a/migrations/000015_per_search_dedup.up.sql
+++ b/migrations/000015_per_search_dedup.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE seen_listings DROP CONSTRAINT seen_listings_pkey;
+ALTER TABLE seen_listings ADD PRIMARY KEY (token, chat_id, search_id);


### PR DESCRIPTION
## Review

✅ 1/1 agents passed (correctness)

- correctness-reviewer: passed — no findings

## Summary

**BREAKING CHANGE:** Dedup primary key changed from `(token, chat_id)` to `(token, chat_id, search_id)`.

Previously, if a user had two searches matching the same listing, only one search would trigger a notification (the first to claim). Now each search independently generates alerts, matching user expectations.

- Migration 000015 alters the `seen_listings` PK
- Down migration safely deduplicates rows before restoring the old constraint
- Updated `ReleaseClaim` interface to accept `searchID` for precise claim release
- All 9 callers across scheduler, notifier, and tests updated

closes #1009

## Test plan

- [x] `go build ./...` — compiles
- [x] All mock implementations updated
- [ ] CI integration tests with Postgres validate migration
- [ ] Manual: create 2 searches matching same listings, verify both trigger notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)