### PR TITLE
fix: skip VM deploy when release is superseded by a newer commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,20 @@ jobs:
             echo "Saved previous image tag: $PREV_TAG"
             echo "Prepared new image tag: $NEW_TAG"
 
+      - name: Skip deploy if superseded by a newer release
+        id: stale-check
+        run: |
+          git fetch origin main --quiet
+          LATEST=$(git rev-parse origin/main)
+          if [ "$LATEST" != "$GITHUB_SHA" ]; then
+            echo "This release ($GITHUB_SHA) is superseded by $LATEST — skipping deploy"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Pull, recreate and health-check
+        if: steps.stale-check.outputs.skip != 'true'
         uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
         with:
           host: ${{ secrets.DEPLOY_HOST }}


### PR DESCRIPTION
## Summary

When multiple PRs merge to main in quick succession, each triggers a release workflow. Previously all would deploy sequentially, meaning an older version could briefly overwrite a newer one before the latest deploy re-deploys.

Now: before the SSH deploy step, the workflow checks if `GITHUB_SHA` is still HEAD of main. If a newer commit exists, the deploy is skipped — build and image push still complete (they're idempotent), but container recreation is avoided.

- `cancel-in-progress` stays `false` (safe: no mid-deploy cancellation)
- Stale releases build their image (available for rollback) but skip the VM deploy
- Rollback step only triggers on `failure()`, unaffected by skip

## Test plan

- [ ] Merge 2 PRs within ~1 minute, verify only the latest version deploys
- [x] Rollback step is guarded by `if: failure()` — unaffected by skip logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)