### PR TITLE
fix: fix vm-logs variable escaping in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,14 +128,14 @@ vm-ssh: vm-check-env
 	$(SSH)
 
 vm-logs: vm-check-env
-	$(SSH) "for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 200 -f $$c 2>&1 | sed \"s/^/[$$c] /\" & done; wait"
+	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 200 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait'
 
 LOGS_FILTER ?=
 logs: vm-check-env
 ifdef LOGS_FILTER
-	$(SSH) "for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 500 -f $$c 2>&1 | sed \"s/^/[$$c] /\" & done; wait" | grep -iF --line-buffered -- "$(LOGS_FILTER)"
+	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 500 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait' | grep -iF --line-buffered -- "$(LOGS_FILTER)"
 else
-	$(SSH) "for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 200 -f $$c 2>&1 | sed \"s/^/[$$c] /\" & done; wait"
+	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 200 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait'
 endif
 
 vm-status: vm-check-env


### PR DESCRIPTION
## Summary

`make vm-logs` was broken — the `$c` loop variable was expanded by the local shell (empty) before SSH sent the command to the remote. All 5 container names resolved to empty strings, producing `docker logs` errors.

Fix: switch SSH argument from double quotes to single quotes so `$c` is passed literally to the remote shell.

## Test plan

- [x] `make -n vm-logs` shows correct command with `$c` preserved
- [x] `make vm-logs` streams logs with correct `[container-name]` prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of logging command execution through updated shell script handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->