### PR TITLE
perf(fonts): reduce render-blocking Google Fonts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,9 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" />
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" /></noscript>
     <title>CarWatch — מעקב חכם אחרי רכבים</title>
     <meta name="description" content="CarWatch — מעקב חכם אחרי מודעות רכב מיד2 ו-WinWin. קבלו התראות מיידיות, ניתוח מחירים וציון התאמה אוטומטי." />
     <meta property="og:title" content="CarWatch — מעקב חכם אחרי רכבים" />


### PR DESCRIPTION
## Summary
- Remove unused weight 300 from both Heebo and Inter font families (never used — `font-light` has 0 occurrences)
- Load fonts non-blocking using `preload` + `media="print"` pattern with noscript fallback
- Saves ~20KB font data transfer and unblocks rendering (improves LCP)

## Test plan
- [ ] Verify fonts still render correctly for weights 400, 500, 600, 700
- [ ] Verify no FOUT (Flash of Unstyled Text) — `display=swap` is preserved
- [ ] Check landing page LCP in Lighthouse

closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)