### PR TITLE
fix(mobile): coordinate sticky bar positioning via CSS variable

### DIFF
--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -296,7 +296,7 @@ export function Shell() {
       </aside>
 
       {/* ── Main Content ── */}
-      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[calc(4.5rem+env(safe-area-inset-bottom,0px))] landscape:pb-16 md:mr-60 md:pb-0">
+      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[var(--bottom-nav-h)] landscape:pb-16 md:mr-60 md:pb-0">
         <div className="mx-auto max-w-5xl px-4 py-6 landscape:py-4 sm:px-6 md:py-8 lg:px-8">
           <div key={location.pathname} className="animate-fade-in">
             <Outlet />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -87,6 +87,11 @@
   --animate-pulse-glow: pulse-glow 2.5s ease-in-out infinite;
 }
 
+/* ═══ Layout ═══ */
+:root {
+  --bottom-nav-h: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+}
+
 /* ═══ Light Mode — Clean, bright, professional ═══ */
 :root {
   --primary: #1D4ED8;

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -396,7 +396,7 @@ function ListingDetailContent({
       </div>
 
       {/* Mobile sticky action bar */}
-      <div className="fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))] z-40 border-t border-border/50 bg-card/95 px-4 py-3 backdrop-blur-xl md:hidden">
+      <div className="fixed inset-x-0 bottom-[var(--bottom-nav-h)] z-40 border-t border-border/50 bg-card/95 px-4 py-3 backdrop-blur-xl md:hidden">
         <div className="flex items-center gap-2">
           <Button
             type="button"

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -135,7 +135,7 @@ function ScrollToTopButton() {
     <button
       type="button"
       onClick={() => document.querySelector("main")?.scrollTo({ top: 0, behavior: "smooth" })}
-      className="fixed bottom-[calc(5.5rem+env(safe-area-inset-bottom,0px))] left-4 z-40 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white shadow-lg transition-all duration-150 hover:opacity-90 active:scale-95 md:bottom-6"
+      className="fixed bottom-[calc(var(--bottom-nav-h)+1rem)] left-4 z-40 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white shadow-lg transition-all duration-150 hover:opacity-90 active:scale-95 md:bottom-6"
       aria-label="חזרה למעלה"
     >
       <ArrowUp className="h-4 w-4" />

--- a/web/src/pages/NewSearchPage.tsx
+++ b/web/src/pages/NewSearchPage.tsx
@@ -217,7 +217,7 @@ export function NewSearchPage() {
       </div>
 
       {/* Navigation */}
-      <div className="sticky bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))] landscape:bottom-14 md:bottom-0 z-40 -mx-4 px-4 py-3 bg-background/90 backdrop-blur-xl border-t border-border/30 md:static md:mx-0 md:px-0 md:py-0 md:bg-transparent md:backdrop-blur-none md:border-0">
+      <div className="sticky bottom-[var(--bottom-nav-h)] landscape:bottom-14 md:bottom-0 z-40 -mx-4 px-4 py-3 bg-background/90 backdrop-blur-xl border-t border-border/30 md:static md:mx-0 md:px-0 md:py-0 md:bg-transparent md:backdrop-blur-none md:border-0">
         <div className="flex items-center gap-3">
           {step > 0 && (
             <button


### PR DESCRIPTION
## Summary
- Introduce `--bottom-nav-h` CSS variable to centralize the bottom navigation height calculation
- Replace hardcoded `calc(4.5rem+env(...))` in ListingDetailPage, NewSearchPage, and ScrollToTopButton with `var(--bottom-nav-h)`
- All sticky footers now share a single source of truth

## Test plan
- [ ] Verify ListingDetailPage mobile action bar doesn't overlap bottom nav
- [ ] Verify NewSearchPage step navigation doesn't collide with bottom nav
- [ ] Verify ScrollToTopButton floats correctly above bottom nav
- [ ] Test on iPhone SE (375px) and landscape mode

closes #1066
closes #1067
closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)