### PR TITLE
refactor: extract shared listingSource and useListingActions hook

### DIFF
--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -1,18 +1,11 @@
 import type { ReactNode } from "react";
 import { useState, useEffect } from "react";
 import { Bookmark, AlertTriangle, Clock, Flame, TrendingDown, TrendingUp, Minus } from "lucide-react";
-import { formatPrice, formatKm, relativeTime, cn, marketComparison } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, cn, marketComparison, listingSource } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
 import { scoreHsl } from "@/lib/scoringAlgorithm";
 import { manufacturerLogoSrc } from "@/lib/manufacturerLogo";
-
-function listingSource(pageLink: string): "Yad2" | null {
-  if (!pageLink) return null;
-  const lower = pageLink.toLowerCase();
-  if (lower.includes("yad2")) return "Yad2";
-  return null;
-}
 
 function dealInfo(listing: Listing): {
   label: string;

--- a/web/src/hooks/useListingActions.ts
+++ b/web/src/hooks/useListingActions.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Listing } from "@/lib/api";
+import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
+import { useMarkListingSeen, useUnmarkListingSeen } from "@/hooks/useListingSeen";
+
+export function useListingActions(listing: Listing) {
+  const saveBookmark = useSaveBookmark();
+  const removeBookmark = useRemoveBookmark();
+  const markSeen = useMarkListingSeen();
+  const unmarkSeen = useUnmarkListingSeen();
+
+  const [saved, setSaved] = useState(() => listing.saved ?? false);
+  const [seen, setSeen] = useState(() => listing.seen ?? false);
+
+  useEffect(() => {
+    setSaved(listing.saved ?? false);
+  }, [listing.token, listing.saved]);
+
+  useEffect(() => {
+    setSeen(listing.seen ?? false);
+  }, [listing.token, listing.seen]);
+
+  const toggleSaved = useCallback(
+    (opts?: { onSuccess?: (next: boolean) => void }) => {
+      const next = !saved;
+      setSaved(next);
+      const mutation = next ? saveBookmark : removeBookmark;
+      mutation.mutate(listing.token, {
+        onSuccess: () => opts?.onSuccess?.(next),
+        onError: () => setSaved(!next),
+      });
+    },
+    [saved, listing.token, saveBookmark, removeBookmark],
+  );
+
+  const toggleSeen = useCallback(
+    (opts?: { onSuccess?: (next: boolean) => void }) => {
+      const next = !seen;
+      setSeen(next);
+      const mutation = next ? markSeen : unmarkSeen;
+      mutation.mutate(listing.token, {
+        onSuccess: () => opts?.onSuccess?.(next),
+        onError: () => setSeen(!next),
+      });
+    },
+    [seen, listing.token, markSeen, unmarkSeen],
+  );
+
+  return {
+    saved,
+    seen,
+    toggleSaved,
+    toggleSeen,
+    isSaving: saveBookmark.isPending || removeBookmark.isPending,
+    isTogglingSeen: markSeen.isPending || unmarkSeen.isPending,
+  };
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -98,6 +98,12 @@ export function marketComparison(
   return null;
 }
 
+export function listingSource(pageLink: string): string | null {
+  if (!pageLink) return null;
+  if (pageLink.toLowerCase().includes("yad2")) return "Yad2";
+  return null;
+}
+
 export function relativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   if (Number.isNaN(date.getTime())) return "—";

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useLocation, Link, useNavigate, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
-import { useState, useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   ArrowRight,
   ExternalLink,
@@ -22,25 +22,17 @@ import {
   Store,
   User,
 } from "lucide-react";
-import { formatPrice, formatKm, relativeTime, safeHref, marketComparison, cn } from "@/lib/utils";
+import { formatPrice, formatKm, relativeTime, safeHref, marketComparison, cn, listingSource } from "@/lib/utils";
 import { api, ApiError } from "@/lib/api";
 import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
 import { scoreHsl, scoreLabel } from "@/lib/scoringAlgorithm";
-import { useMarkListingSeen, useUnmarkListingSeen } from "@/hooks/useListingSeen";
-import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
+import { useListingActions } from "@/hooks/useListingActions";
 import { manufacturerLogoSrc } from "@/lib/manufacturerLogo";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { PriceHistoryChart } from "@/components/PriceHistoryChart";
-
-function listingSource(pageLink: string): string | null {
-  if (!pageLink) return null;
-  const lower = pageLink.toLowerCase();
-  if (lower.includes("yad2")) return "Yad2";
-  return null;
-}
 
 export function ListingDetailPage() {
   const location = useLocation();
@@ -163,17 +155,7 @@ function ListingDetailContent({
   listing: Listing;
   backButton: ReactNode;
 }) {
-  const markSeen = useMarkListingSeen();
-  const unmarkSeen = useUnmarkListingSeen();
-  const saveBookmark = useSaveBookmark();
-  const removeBookmark = useRemoveBookmark();
-  const [seen, setSeen] = useState(() => listing.seen ?? false);
-  const [saved, setSaved] = useState(() => listing.saved ?? false);
-
-  useEffect(() => {
-    setSeen(listing.seen ?? false);
-    setSaved(listing.saved ?? false);
-  }, [listing.token, listing.seen, listing.saved]);
+  const { saved, seen, toggleSaved, toggleSeen, isSaving, isTogglingSeen } = useListingActions(listing);
 
   const detailLogoSrc = manufacturerLogoSrc(listing.manufacturer);
   const source = listingSource(listing.page_link);
@@ -348,13 +330,8 @@ function ListingDetailContent({
           type="button"
           variant={saved ? "secondary" : "primary"}
           size="lg"
-          disabled={saved ? removeBookmark.isPending : saveBookmark.isPending}
-          onClick={() => {
-            const next = !saved;
-            setSaved(next);
-            const mutation = next ? saveBookmark : removeBookmark;
-            mutation.mutate(listing.token, { onError: () => setSaved(!next) });
-          }}
+          disabled={isSaving}
+          onClick={() => toggleSaved()}
         >
           {saved ? (
             <><BookmarkCheck className="h-4 w-4" />שמור</>
@@ -366,13 +343,8 @@ function ListingDetailContent({
           type="button"
           variant="secondary"
           size="lg"
-          disabled={seen ? unmarkSeen.isPending : markSeen.isPending}
-          onClick={() => {
-            const next = !seen;
-            setSeen(next);
-            const mutation = next ? markSeen : unmarkSeen;
-            mutation.mutate(listing.token, { onError: () => setSeen(!next) });
-          }}
+          disabled={isTogglingSeen}
+          onClick={() => toggleSeen()}
         >
           {seen ? (
             <><EyeOff className="h-4 w-4" />החזר לחדשות</>
@@ -403,13 +375,8 @@ function ListingDetailContent({
             variant={saved ? "secondary" : "primary"}
             size="md"
             className="flex-1"
-            disabled={saved ? removeBookmark.isPending : saveBookmark.isPending}
-            onClick={() => {
-              const next = !saved;
-              setSaved(next);
-              const mutation = next ? saveBookmark : removeBookmark;
-              mutation.mutate(listing.token, { onError: () => setSaved(!next) });
-            }}
+            disabled={isSaving}
+            onClick={() => toggleSaved()}
           >
             {saved ? (
               <><BookmarkCheck className="h-4 w-4" />שמור</>
@@ -421,13 +388,8 @@ function ListingDetailContent({
             type="button"
             variant="secondary"
             size="md"
-            disabled={seen ? unmarkSeen.isPending : markSeen.isPending}
-            onClick={() => {
-              const next = !seen;
-              setSeen(next);
-              const mutation = next ? markSeen : unmarkSeen;
-              mutation.mutate(listing.token, { onError: () => setSeen(!next) });
-            }}
+            disabled={isTogglingSeen}
+            onClick={() => toggleSeen()}
           >
             {seen ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
           </Button>

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -13,8 +13,7 @@ import {
 import { AnimatePresence, motion } from "motion/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useInfiniteListings } from "@/hooks/useInfiniteListings";
-import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
-import { useMarkListingSeen, useUnmarkListingSeen } from "@/hooks/useListingSeen";
+import { useListingActions } from "@/hooks/useListingActions";
 import { safeHref, cn, formatPrice } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing, RefreshResponse } from "@/lib/api";
@@ -314,21 +313,8 @@ export function ListingsPage() {
 
 const ListingCard = memo(function ListingCard({ listing }: { listing: Listing }) {
   const navigate = useNavigate();
-  const saveBookmark = useSaveBookmark();
-  const removeBookmark = useRemoveBookmark();
-  const markListingSeen = useMarkListingSeen();
-  const unmarkListingSeen = useUnmarkListingSeen();
+  const { saved, seen, toggleSaved, toggleSeen } = useListingActions(listing);
   const { toast } = useToast();
-  const [saved, setSaved] = useState(() => listing.saved ?? false);
-  const [seen, setSeen] = useState(() => listing.seen ?? false);
-
-  useEffect(() => {
-    setSaved(listing.saved ?? false);
-  }, [listing.token, listing.saved]);
-
-  useEffect(() => {
-    setSeen(listing.seen ?? false);
-  }, [listing.token, listing.seen]);
 
   return (
     <div
@@ -360,12 +346,7 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
               aria-pressed={seen}
               onClick={(e) => {
                 e.stopPropagation();
-                const next = !seen;
-                setSeen(next);
-                const mutation = next ? markListingSeen : unmarkListingSeen;
-                mutation.mutate(listing.token, {
-                  onError: () => setSeen(!next),
-                });
+                toggleSeen();
               }}
               className={cn(
                 "rounded-lg p-2.5 min-h-[44px] min-w-[44px] flex items-center justify-center transition-all duration-150",
@@ -386,18 +367,8 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
               aria-pressed={saved}
               onClick={(e) => {
                 e.stopPropagation();
-                const next = !saved;
-                setSaved(next);
-                const mutation = next ? saveBookmark : removeBookmark;
-                mutation.mutate(listing.token, {
-                  onSuccess: () => {
-                    if (next) {
-                      toast("נשמר בהצלחה", "success");
-                    } else {
-                      toast("הוסר מהשמורים", "info");
-                    }
-                  },
-                  onError: () => setSaved(!next),
+                toggleSaved({
+                  onSuccess: (next) => toast(next ? "נשמר בהצלחה" : "הוסר מהשמורים", next ? "success" : "info"),
                 });
               }}
               className={cn(


### PR DESCRIPTION
## Summary
- Move duplicated `listingSource()` from `ListingCardBody.tsx` and `ListingDetailPage.tsx` to shared `lib/utils.ts`
- Create `useListingActions` hook that encapsulates the saved/seen optimistic toggle pattern
- Net reduction: 81 lines added, 92 removed — the new hook replaces ~100 lines of duplicated state management

## Changes
- `web/src/lib/utils.ts` — add `listingSource()` export
- `web/src/hooks/useListingActions.ts` — new hook returning `{ saved, seen, toggleSaved, toggleSeen, isSaving, isTogglingSeen }`
- `web/src/components/ListingCardBody.tsx` — import `listingSource` from utils
- `web/src/pages/ListingDetailPage.tsx` — use `useListingActions` hook, import `listingSource` from utils
- `web/src/pages/ListingsPage.tsx` — use `useListingActions` hook

## Test plan
- [ ] Verify bookmark toggle works on listing cards (save + unsave)
- [ ] Verify seen toggle works on listing cards
- [ ] Verify bookmark/seen works on listing detail page (desktop + mobile action bar)
- [ ] All 241 existing tests pass

closes #1097
closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)