### PR TITLE
feat(listing-card): enrich specs with engine/HP/fuel + PWA best practices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,9 @@
     <meta property="og:title" content="CarWatch — מעקב חכם אחרי רכבים" />
     <meta property="og:description" content="מעקב אוטומטי אחרי מודעות רכב. התראות מיידיות, ניתוח מחירים וציון התאמה חכם." />
     <meta property="og:type" content="website" />
+    <meta property="og:image" content="/logo-512.png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
     <meta property="og:locale" content="he_IL" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="CarWatch" />
@@ -26,7 +29,7 @@
   </head>
   <body>
     <noscript>
-      <div style="text-align:center;padding:2rem;font-family:sans-serif;direction:rtl">
+      <div style="text-align:center;padding:2rem;font-family:sans-serif;direction:rtl;min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;background-color:var(--bg,#F4F6FA);color:var(--fg,#0C1222)">
         <h1>CarWatch</h1>
         <p>יש להפעיל JavaScript כדי להשתמש באפליקציה.</p>
       </div>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -38,5 +38,18 @@
       "type": "image/png",
       "purpose": "any maskable"
     }
+  ],
+  "categories": ["auto", "shopping", "lifestyle"],
+  "shortcuts": [
+    {
+      "name": "חיפוש חדש",
+      "url": "/searches/new",
+      "icons": [{ "src": "/favicon.svg", "sizes": "any" }]
+    },
+    {
+      "name": "התראות",
+      "url": "/notifications",
+      "icons": [{ "src": "/favicon.svg", "sizes": "any" }]
+    }
   ]
 }

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,14 @@
+User-agent: *
+Allow: /
+Allow: /login
+Allow: /signup
+Allow: /try
+Disallow: /dashboard
+Disallow: /admin
+Disallow: /searches/
+Disallow: /listings/
+Disallow: /saved
+Disallow: /history
+Disallow: /notifications
+Disallow: /settings
+Disallow: /api/

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -72,9 +72,25 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Navigation requests and hashed assets (e.g. /assets/Foo-abc123.js):
-  // always go network-first so deploys take effect immediately.
-  if (event.request.mode === 'navigate' || url.pathname.startsWith('/assets/')) {
+  // Hashed assets are immutable (hash changes on rebuild) — cache-first.
+  if (url.pathname.startsWith('/assets/')) {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(event.request).then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
+          return response;
+        });
+      })
+    );
+    return;
+  }
+
+  // Navigation requests: network-first so deploys take effect immediately.
+  if (event.request.mode === 'navigate') {
     event.respondWith(
       fetch(event.request).catch(() => caches.match(event.request))
     );

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -225,30 +225,13 @@ export function ListingCardBody({
         </div>
 
         {/* Specs grid */}
-        <div className="grid grid-cols-3 gap-1.5">
-          <div className="rounded-lg bg-secondary/70 px-2.5 py-1.5 text-center">
-            <p className="text-[10px] text-muted-foreground/70">ק״מ</p>
-            <p className="text-xs font-semibold tabular-nums text-foreground">
-              {listing.km > 0 ? formatKm(listing.km) : (
-                <span className="inline-flex items-center gap-0.5 text-muted-foreground/50">
-                  <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
-                  <span className="text-[9px]">מעשיר</span>
-                </span>
-              )}
-            </p>
-          </div>
-          <div className="rounded-lg bg-secondary/70 px-2.5 py-1.5 text-center">
-            <p className="text-[10px] text-muted-foreground/70">יד</p>
-            <p className="text-xs font-semibold text-foreground">
-              {listing.hand > 0 ? listing.hand : "—"}
-            </p>
-          </div>
-          <div className="rounded-lg bg-secondary/70 px-2.5 py-1.5 text-center">
-            <p className="text-[10px] text-muted-foreground/70">תיבת הילוכים</p>
-            <p className="text-xs font-semibold text-foreground truncate">
-              {listing.gear_box || "—"}
-            </p>
-          </div>
+        <div className="flex flex-wrap gap-1.5">
+          <SpecChip label="ק״מ" value={listing.km > 0 ? formatKm(listing.km) : undefined} enriching={listing.km <= 0} />
+          <SpecChip label="יד" value={listing.hand > 0 ? String(listing.hand) : undefined} />
+          {listing.gear_box ? <SpecChip label="הילוכים" value={listing.gear_box} /> : null}
+          {listing.engine_type ? <SpecChip label="דלק" value={listing.engine_type} /> : null}
+          {listing.engine_volume ? <SpecChip label="נפח" value={`${(listing.engine_volume / 1000).toFixed(1)}L`} /> : null}
+          {listing.horse_power ? <SpecChip label="כ״ס" value={String(listing.horse_power)} /> : null}
         </div>
 
         {/* Description */}
@@ -283,5 +266,21 @@ export function ListingCardBody({
         </div>
       </div>
     </>
+  );
+}
+
+function SpecChip({ label, value, enriching }: { label: string; value?: string; enriching?: boolean }) {
+  return (
+    <div className="rounded-lg bg-secondary/70 px-2.5 py-1.5 text-center min-w-[3.5rem]">
+      <p className="text-[10px] text-muted-foreground/70">{label}</p>
+      <p className="text-xs font-semibold text-foreground truncate tabular-nums">
+        {value ?? (enriching ? (
+          <span className="inline-flex items-center gap-0.5 text-muted-foreground/50">
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
+            <span className="text-[9px]">מעשיר</span>
+          </span>
+        ) : "—")}
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Listing card enrichment**: Spec grid now shows engine volume (formatted as "1.6L"), horsepower, and fuel type when available. Uses dynamic flex-wrap layout — only renders fields with data.
- **robots.txt**: Allow crawling of public pages, disallow authenticated routes
- **PWA manifest**: Add `categories` and `shortcuts` for richer install experience
- **og:image**: Add meta tag for social sharing previews
- **noscript**: Dark mode support via CSS variables
- **Service worker**: Cache hashed `/assets/` files with cache-first strategy (immutable due to content hashes)

## Test plan
- [ ] Verify listing cards show engine/HP/fuel when data is available
- [ ] Verify cards with missing data gracefully show only available specs
- [ ] Verify robots.txt is served at `/robots.txt`
- [ ] Verify og:image shows in social share previews
- [ ] Test PWA install — shortcuts should appear
- [ ] Verify noscript fallback uses dark background on dark-mode devices

closes #1106, #1100, #1101, #1076, #1102, #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)