### PR TITLE
fix(a11y): WCAG AA compliance batch — 6 accessibility fixes

### DIFF
--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -4,7 +4,7 @@ import { Bookmark, AlertTriangle, Clock, Flame, TrendingDown, TrendingUp, Minus 
 import { formatPrice, formatKm, relativeTime, cn, marketComparison, listingSource } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { MatchScoreBox } from "@/components/ui/MatchScoreBox";
-import { scoreHsl } from "@/lib/scoringAlgorithm";
+import { scoreHsl, scoreLabel } from "@/lib/scoringAlgorithm";
 import { manufacturerLogoSrc } from "@/lib/manufacturerLogo";
 
 function dealInfo(listing: Listing): {
@@ -202,7 +202,7 @@ export function ListingCardBody({
             <>
               <MatchScoreBox score={listing.fitness_score} size="sm" />
               <span className="text-xs font-semibold" style={{ color: scoreHsl(listing.fitness_score) }}>
-                {listing.fitness_score.toFixed(1)}
+                {listing.fitness_score.toFixed(1)} · {scoreLabel(listing.fitness_score)}
               </span>
             </>
           ) : null}

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useNavigate, Link } from "react-router";
 import {
   Play,
@@ -36,9 +37,14 @@ export function SearchCard({
   onCancelDelete,
 }: SearchCardProps) {
   const navigate = useNavigate();
+  const confirmRef = useRef<HTMLButtonElement>(null);
   const isActive = search.active;
   const listingsPath = `/searches/${search.id}/listings`;
   const { data: stats } = useSearchStats(search.id);
+
+  useEffect(() => {
+    if (isConfirmingDelete) confirmRef.current?.focus();
+  }, [isConfirmingDelete]);
 
   const mfrLogo =
     manufacturerLogoSrcFromCatalogId(search.manufacturer_id) ??
@@ -232,8 +238,9 @@ export function SearchCard({
       </Link>
 
       {isConfirmingDelete ? (
-        <div className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3">
+        <div className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3" role="alertdialog" aria-label="אישור מחיקת חיפוש">
           <Button
+            ref={confirmRef}
             type="button"
             variant="destructive"
             size="md"

--- a/web/src/components/SearchFormFields.tsx
+++ b/web/src/components/SearchFormFields.tsx
@@ -312,6 +312,7 @@ export function BudgetFields({
             value={form.maxKm}
             onChange={(v) => set("maxKm", v)}
             formatLabel={formatKmLabel}
+            aria-label='ק"מ מקסימלי'
           />
         </FormField>
 

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -184,6 +184,12 @@ export function Shell() {
 
   return (
     <div className="min-h-screen bg-background">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:right-4 focus:z-[60] focus:rounded-xl focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg"
+      >
+        דלג לתוכן
+      </a>
       <ConnectionBanner status={connectionStatus} />
 
       {/* ── Desktop Sidebar ── */}
@@ -296,7 +302,7 @@ export function Shell() {
       </aside>
 
       {/* ── Main Content ── */}
-      <main className="h-[100dvh] overflow-y-auto scroll-smooth pb-[var(--bottom-nav-h)] landscape:pb-16 md:mr-60 md:pb-0">
+      <main id="main-content" className="h-[100dvh] overflow-y-auto scroll-smooth pb-[var(--bottom-nav-h)] landscape:pb-16 md:mr-60 md:pb-0">
         <div className="mx-auto max-w-5xl px-4 py-6 landscape:py-4 sm:px-6 md:py-8 lg:px-8">
           <div key={location.pathname} className="animate-fade-in">
             <Outlet />

--- a/web/src/components/ui/RangeSlider.tsx
+++ b/web/src/components/ui/RangeSlider.tsx
@@ -8,6 +8,7 @@ export interface RangeSliderProps {
   onChange: (value: number) => void;
   formatLabel?: (value: number) => string;
   className?: string;
+  "aria-label"?: string;
 }
 
 export function RangeSlider({
@@ -18,6 +19,7 @@ export function RangeSlider({
   onChange,
   formatLabel,
   className,
+  "aria-label": ariaLabel,
 }: RangeSliderProps) {
   const label = formatLabel ? formatLabel(value) : String(value);
   const percent = ((value - min) / (max - min)) * 100;
@@ -36,6 +38,8 @@ export function RangeSlider({
         step={step}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
+        aria-label={ariaLabel}
+        aria-valuetext={label}
         className="range-slider w-full"
         style={
           { "--range-percent": `${percent}%` } as React.CSSProperties

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -268,6 +268,7 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
                 onBlur={() => setTouched((p) => ({ ...p, email: true }))}
                 required
                 aria-invalid={!!emailErr}
+                aria-describedby={emailErr ? "auth-email-error" : undefined}
                 className={cn(
                   "w-full rounded-lg border bg-secondary px-3.5 py-2.5 text-sm text-foreground outline-none transition-all",
                   "placeholder:text-muted-foreground/50",
@@ -276,7 +277,7 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
                 )}
                 placeholder="you@example.com"
               />
-              {emailErr && <p className="mt-1 text-xs text-destructive">{emailErr}</p>}
+              {emailErr && <p id="auth-email-error" className="mt-1 text-xs text-destructive">{emailErr}</p>}
             </div>
 
             <div>
@@ -295,6 +296,7 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
                   onBlur={() => setTouched((p) => ({ ...p, password: true }))}
                   required
                   aria-invalid={!!passwordErr}
+                  aria-describedby={passwordErr ? "auth-password-error" : undefined}
                   className={cn(
                     "w-full rounded-lg border bg-secondary py-2.5 ps-10 pe-3.5 text-sm text-foreground outline-none transition-all",
                     "placeholder:text-muted-foreground/50",
@@ -314,7 +316,7 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
                 </button>
               </div>
               {tab === "login" && passwordErr && (
-                <p className="mt-1 text-xs text-destructive">{passwordErr}</p>
+                <p id="auth-password-error" className="mt-1 text-xs text-destructive">{passwordErr}</p>
               )}
               {tab === "signup" && touched.password && password.length > 0 && (
                 <ul className="mt-2 space-y-0.5">
@@ -352,6 +354,7 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
                   onChange={(e) => setConfirm(e.target.value)}
                   onBlur={() => setTouched((p) => ({ ...p, confirm: true }))}
                   required
+                  aria-describedby={confirmErr ? "auth-confirm-error" : undefined}
                   className={cn(
                     "w-full rounded-lg border bg-secondary px-3.5 py-2.5 text-sm text-foreground outline-none transition-all",
                     "placeholder:text-muted-foreground/50",
@@ -360,7 +363,7 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
                   )}
                   placeholder="••••••••"
                 />
-                {confirmErr && <p className="mt-1 text-xs text-destructive">{confirmErr}</p>}
+                {confirmErr && <p id="auth-confirm-error" className="mt-1 text-xs text-destructive">{confirmErr}</p>}
                 {touched.confirm && confirm.length > 0 && confirm === password && (
                   <p className="mt-1 flex items-center gap-1 text-xs text-success">
                     <Check className="h-3 w-3" />

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, memo, useMemo } from "react";
-import { useParams, useNavigate, Link } from "react-router";
+import { useParams, Link } from "react-router";
 import {
   ExternalLink,
   Bookmark,
@@ -36,11 +36,6 @@ const SORT_OPTIONS = [
 ];
 
 const REFRESH_COOLDOWN_S = 60;
-
-function isInteractiveTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false;
-  return target.closest("button,a,input,select,textarea") != null;
-}
 
 function RefreshButton({ searchId }: { searchId: number }) {
   const { toast } = useToast();
@@ -312,27 +307,15 @@ export function ListingsPage() {
 }
 
 const ListingCard = memo(function ListingCard({ listing }: { listing: Listing }) {
-  const navigate = useNavigate();
   const { saved, seen, toggleSaved, toggleSeen } = useListingActions(listing);
   const { toast } = useToast();
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <Link
+      to={`/listings/${listing.token}`}
+      state={{ listing }}
       aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
-      onClick={(e) => {
-        if (isInteractiveTarget(e.target)) return;
-        navigate(`/listings/${listing.token}`, { state: { listing } });
-      }}
-      onKeyDown={(e) => {
-        if (isInteractiveTarget(e.target)) return;
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          navigate(`/listings/${listing.token}`, { state: { listing } });
-        }
-      }}
-      className="group block cursor-pointer rounded-2xl border border-border/40 bg-card overflow-hidden shadow-sm transition-all duration-300 ease-out hover:border-primary/20 hover:shadow-[0_16px_48px_-12px_var(--color-glow-primary)] hover:-translate-y-1 dir-rtl"
+      className="group block rounded-2xl border border-border/40 bg-card overflow-hidden shadow-sm transition-all duration-300 ease-out hover:border-primary/20 hover:shadow-[0_16px_48px_-12px_var(--color-glow-primary)] hover:-translate-y-1 dir-rtl"
     >
       <ListingCardBody
         listing={listing}
@@ -397,6 +380,6 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
           </>
         }
       />
-    </div>
+    </Link>
   );
 });

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -305,6 +305,7 @@ export default function TrySearchPage() {
                 value={form.maxKm}
                 onChange={(v) => set("maxKm", v)}
                 formatLabel={formatKmLabel}
+                aria-label='ק"מ מקסימלי'
               />
             </FormField>
 


### PR DESCRIPTION
## Summary
Six accessibility fixes toward WCAG AA compliance:

1. **ListingCard semantic restructure** (#1085): Replace `div[role=button]` with semantic `<Link>`. Removes `isInteractiveTarget` guard — screen readers now correctly announce cards as links with independently focusable action buttons.

2. **Skip-to-content link** (#1086): Add visually-hidden "skip to content" link as first focusable element in Shell layout. Visible on Tab focus. Targets `#main-content` on the `<main>` element.

3. **Delete confirmation focus** (#1087): Auto-focus the confirm button when delete confirmation appears in SearchCard. Added `role="alertdialog"` to the confirmation container.

4. **Score non-color indicator** (#1088): Show `scoreLabel()` text (e.g., "good", "excellent") next to the numeric score in listing cards, providing color-independent quality indication.

5. **RangeSlider aria** (#1089): Add `aria-label` and `aria-valuetext` props to the native range input. Applied in SearchFormFields and TrySearchPage.

6. **Auth form aria-describedby** (#1090): Bind error messages to inputs via `aria-describedby` for email, password, and confirm fields.

## Test plan
- [ ] Tab through the app from the top — skip link should appear and focus main content
- [ ] Listing cards navigable via keyboard (Enter on card = navigate)
- [ ] Action buttons (bookmark, seen) independently focusable and functional
- [ ] Delete confirmation auto-focuses the confirm button
- [ ] Screen reader announces score label text alongside numeric score
- [ ] RangeSlider announces current value text (e.g., "120,000 km")
- [ ] Auth form error messages announced when inputs are focused

closes #1085, #1086, #1087, #1088, #1089, #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)