### PR TITLE
perf(api): bundle search stats into list searches endpoint

### DIFF
--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -49,29 +49,36 @@ type updateSearchRequest struct {
 }
 
 type searchResponse struct {
-	ID               int64  `json:"id"`
-	Name             string `json:"name"`
-	Source           string `json:"source"`
-	ManufacturerID   int    `json:"manufacturer_id"`
-	ManufacturerName string `json:"manufacturer_name"`
-	ModelID          int    `json:"model_id"`
-	ModelName        string `json:"model_name"`
-	YearMin          int    `json:"year_min"`
-	YearMax          int    `json:"year_max"`
-	PriceMin         int    `json:"price_min,omitempty"`
-	PriceMax         int    `json:"price_max"`
-	EngineMinCC      int    `json:"engine_min_cc"`
-	MaxKm            int    `json:"max_km"`
-	MaxHand          int    `json:"max_hand"`
-	Keywords         string `json:"keywords,omitempty"`
-	ExcludeKeys      string `json:"exclude_keys,omitempty"`
-	SellerFilter     string `json:"seller_filter,omitempty"`
-	GearBox          string `json:"gear_box,omitempty"`
-	PriceOnly        bool   `json:"price_only,omitempty"`
-	PhotoOnly        bool   `json:"photo_only,omitempty"`
-	Active           bool   `json:"active"`
-	CreatedAt        string `json:"created_at"`
-	ListingsCount    int64  `json:"listings_count"`
+	ID               int64              `json:"id"`
+	Name             string             `json:"name"`
+	Source           string             `json:"source"`
+	ManufacturerID   int                `json:"manufacturer_id"`
+	ManufacturerName string             `json:"manufacturer_name"`
+	ModelID          int                `json:"model_id"`
+	ModelName        string             `json:"model_name"`
+	YearMin          int                `json:"year_min"`
+	YearMax          int                `json:"year_max"`
+	PriceMin         int                `json:"price_min,omitempty"`
+	PriceMax         int                `json:"price_max"`
+	EngineMinCC      int                `json:"engine_min_cc"`
+	MaxKm            int                `json:"max_km"`
+	MaxHand          int                `json:"max_hand"`
+	Keywords         string             `json:"keywords,omitempty"`
+	ExcludeKeys      string             `json:"exclude_keys,omitempty"`
+	SellerFilter     string             `json:"seller_filter,omitempty"`
+	GearBox          string             `json:"gear_box,omitempty"`
+	PriceOnly        bool               `json:"price_only,omitempty"`
+	PhotoOnly        bool               `json:"photo_only,omitempty"`
+	Active           bool               `json:"active"`
+	CreatedAt        string             `json:"created_at"`
+	ListingsCount    int64              `json:"listings_count"`
+	Stats            *searchStatsInline `json:"stats,omitempty"`
+}
+
+type searchStatsInline struct {
+	Total    int64   `json:"total"`
+	New24h   int64   `json:"new_24h"`
+	AvgPrice float64 `json:"avg_price"`
 }
 
 func (s *Server) ensureUserActive(ctx context.Context, chatID int64) {
@@ -202,15 +209,33 @@ func (s *Server) listSearches(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	statsMap := make(map[int64]*storage.SearchStats, len(searches))
+	if s.listings != nil {
+		for i := range searches {
+			sr := &searches[i]
+			st, err := s.listings.SearchStats(r.Context(), chatID, sr.ID, listingFilterFromSearch(sr))
+			if err != nil {
+				log.Error("search stats failed", "search_id", sr.ID, "error", err)
+				continue
+			}
+			statsMap[sr.ID] = st
+		}
+	}
+
 	resp := make([]searchResponse, 0, len(searches))
 	for _, sr := range searches {
+		item := s.toSearchResponse(sr)
 		if counts != nil {
-			item := s.toSearchResponse(sr)
 			item.ListingsCount = counts[sr.ID]
-			resp = append(resp, item)
-			continue
 		}
-		resp = append(resp, s.searchResponseWithListingCount(r.Context(), chatID, sr))
+		if st := statsMap[sr.ID]; st != nil {
+			item.Stats = &searchStatsInline{
+				Total:    st.Total,
+				New24h:   st.New24h,
+				AvgPrice: st.AvgPrice,
+			}
+		}
+		resp = append(resp, item)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -15,7 +15,6 @@ import {
   manufacturerLogoSrc,
   manufacturerLogoSrcFromCatalogId,
 } from "@/lib/manufacturerLogo";
-import { useSearchStats } from "@/hooks/useSearchStats";
 
 export type SearchCardProps = {
   search: Search;
@@ -40,7 +39,7 @@ export function SearchCard({
   const confirmRef = useRef<HTMLButtonElement>(null);
   const isActive = search.active;
   const listingsPath = `/searches/${search.id}/listings`;
-  const { data: stats } = useSearchStats(search.id);
+  const stats = search.stats;
 
   useEffect(() => {
     if (isConfirmingDelete) confirmRef.current?.focus();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -86,6 +86,11 @@ export interface Search {
   photo_only?: boolean;
   /** Total listings found for this search; from API when supported. */
   listings_count?: number;
+  stats?: {
+    total: number;
+    new_24h: number;
+    avg_price: number;
+  };
 }
 
 export interface CreateSearchRequest {


### PR DESCRIPTION
## Summary
Eliminate the N+1 query pattern on the dashboard where each SearchCard independently fetched stats.

**Backend:**
- Call `SearchStats` per search within the `listSearches` handler
- Include stats (total, new_24h, avg_price) as optional `stats` field in the search response

**Frontend:**
- Add `stats` field to the `Search` TypeScript interface
- Remove `useSearchStats` hook import from SearchCard — use `search.stats` from the list response
- Dashboard now makes 3 requests instead of N+3 (searches, notifications, notification-count)

## Test plan
- [ ] Dashboard shows stats (listing count, new today, avg price) on search cards
- [ ] Stats update when navigating back to dashboard
- [ ] Go linter passes
- [ ] Frontend builds and all 241 tests pass

closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search statistics (total listings, new listings in 24 hours, and average price) are now displayed inline with search results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->