### PR TITLE
fix: dead-letter enrichment messages after max retries

### DIFF
--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -27,10 +27,11 @@ type EnrichFunc func(ctx context.Context, req EnrichRequest) error
 // Redis Stream, sorts each batch by priority, and processes them via
 // a caller-provided EnrichFunc.
 type EnrichConsumer struct {
-	client   *redis.Client
-	enrich   EnrichFunc
-	logger   *slog.Logger
-	consumer string
+	client               *redis.Client
+	enrich               EnrichFunc
+	logger               *slog.Logger
+	consumer             string
+	reclaimIdleThreshold time.Duration
 }
 
 // NewEnrichConsumer connects to Redis, creates the consumer group if
@@ -58,10 +59,11 @@ func NewEnrichConsumer(addr, password string, db int, fn EnrichFunc, logger *slo
 		hostname = fmt.Sprintf("enricher-%d", time.Now().UnixNano())
 	}
 	return &EnrichConsumer{
-		client:   client,
-		enrich:   fn,
-		logger:   logger,
-		consumer: hostname,
+		client:               client,
+		enrich:               fn,
+		logger:               logger,
+		consumer:             hostname,
+		reclaimIdleThreshold: 30 * time.Second,
 	}, nil
 }
 
@@ -151,6 +153,7 @@ func (c *EnrichConsumer) processBatch(ctx context.Context, msgs []redis.XMessage
 }
 
 func (c *EnrichConsumer) reclaimPending(ctx context.Context) {
+	idle := c.reclaimIdleThreshold
 	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
 		Stream:   EnrichStreamName,
 		Group:    EnrichGroupName,
@@ -158,24 +161,38 @@ func (c *EnrichConsumer) reclaimPending(ctx context.Context) {
 		Start:    "-",
 		End:      "+",
 		Count:    50,
-		Idle:     30 * time.Second,
+		Idle:     idle,
 	}).Result()
 	if err != nil || len(pending) == 0 {
 		return
 	}
 
 	c.logger.Info("reclaiming pending enrich messages", "count", len(pending))
+
+	var retryIDs []string
 	for _, p := range pending {
 		if p.RetryCount >= int64(enrichMaxRetries) {
 			c.deadLetter(ctx, p.ID)
 			continue
 		}
-		msgs, err := c.client.XRangeN(ctx, EnrichStreamName, p.ID, p.ID, 1).Result()
-		if err != nil || len(msgs) == 0 {
-			continue
-		}
-		c.processBatch(ctx, msgs)
+		retryIDs = append(retryIDs, p.ID)
 	}
+	if len(retryIDs) == 0 {
+		return
+	}
+
+	claimed, err := c.client.XClaim(ctx, &redis.XClaimArgs{
+		Stream:   EnrichStreamName,
+		Group:    EnrichGroupName,
+		Consumer: c.consumer,
+		MinIdle:  idle,
+		Messages: retryIDs,
+	}).Result()
+	if err != nil {
+		c.logger.Error("xclaim pending enrich messages failed", "error", err)
+		return
+	}
+	c.processBatch(ctx, claimed)
 }
 
 func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
@@ -188,17 +205,26 @@ func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
 		c.ack(ctx, id)
 		return
 	}
+
+	token := ""
+	if data, ok := msgs[0].Values["data"].(string); ok {
+		var req EnrichRequest
+		if err := json.Unmarshal([]byte(data), &req); err == nil {
+			token = req.Token
+		}
+	}
+
 	if err := c.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: EnrichDeadLetterStream,
 		MaxLen: enrichDeadLetterMaxLen,
 		Approx: true,
 		Values: msgs[0].Values,
 	}).Err(); err != nil {
-		c.logger.Error("enrich dead-letter failed, leaving message pending", "id", id, "error", err)
+		c.logger.Error("enrich dead-letter failed, leaving message pending", "id", id, "token", token, "error", err)
 		return
 	}
 	c.logger.Warn("enrich message dead-lettered after max retries",
-		"id", id, "max_retries", enrichMaxRetries)
+		"id", id, "token", token, "max_retries", enrichMaxRetries)
 	c.ack(ctx, id)
 }
 

--- a/internal/broker/enrich_consumer_test.go
+++ b/internal/broker/enrich_consumer_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -113,6 +114,80 @@ func TestEnrichConsumer_AcksOnSuccess(t *testing.T) {
 	}
 	if pending.Count != 0 {
 		t.Errorf("expected 0 pending after ack, got %d", pending.Count)
+	}
+}
+
+func TestEnrichConsumer_DeadLettersAfterMaxRetries(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req := EnrichRequest{Token: "stuck-token", Priority: 3, Source: "test"}
+	if err := pub.PublishEnrich(ctx, req); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	fn := func(_ context.Context, _ EnrichRequest) error {
+		return fmt.Errorf("anti-bot challenge detected")
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+	cons.reclaimIdleThreshold = 0
+
+	// Initial read creates PEL entry (delivery count = 1).
+	streams, err := cons.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    EnrichGroupName,
+		Consumer: cons.consumer,
+		Streams:  []string{EnrichStreamName, ">"},
+		Count:    10,
+		Block:    time.Second,
+	}).Result()
+	if err != nil {
+		t.Fatalf("xreadgroup: %v", err)
+	}
+	cons.processBatch(ctx, streams[0].Messages)
+
+	// Each reclaimPending call XClaims (incrementing delivery count) and reprocesses.
+	// After enrichMaxRetries deliveries, the message should be dead-lettered.
+	for i := 0; i < enrichMaxRetries+1; i++ {
+		cons.reclaimPending(ctx)
+	}
+
+	// Verify message was dead-lettered.
+	dlq, err := client.XRange(ctx, EnrichDeadLetterStream, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange dead-letter: %v", err)
+	}
+	if len(dlq) != 1 {
+		t.Fatalf("expected 1 dead-lettered message, got %d", len(dlq))
+	}
+
+	var dlqReq EnrichRequest
+	data, ok := dlq[0].Values["data"].(string)
+	if !ok {
+		t.Fatal("dead-lettered message missing data field")
+	}
+	if err := json.Unmarshal([]byte(data), &dlqReq); err != nil {
+		t.Fatalf("unmarshal DLQ message: %v", err)
+	}
+	if dlqReq.Token != "stuck-token" {
+		t.Errorf("DLQ token = %q, want stuck-token", dlqReq.Token)
+	}
+
+	// Verify no more pending messages.
+	pending, err := client.XPending(ctx, EnrichStreamName, EnrichGroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Errorf("expected 0 pending after dead-letter, got %d", pending.Count)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `reclaimPending()` used `XRangeN` to re-read pending messages. `XRangeN` does not go through the consumer group mechanism, so Redis `RetryCount` never incremented. Messages stuck on anti-bot challenges were retried every 30 seconds indefinitely — `RetryCount` stayed at 1 and never reached the dead-letter threshold of 5.
- **Fix:** Switched to `XClaim` (same as `reclaimOrphans` already uses). Each reclaim now increments `RetryCount`, and after 5 deliveries (~2.5 min) the message is dead-lettered. The DB-level guard (`enrich_attempts < 10` + 1-hour cooldown in `unenrichedBacklogWhereSQL`) prevents re-enqueuing permanently-failing tokens.
- **Also:** Dead-letter log now includes the listing token for debugging. Reclaim idle threshold extracted to a struct field for testability.

## Changes

| File | What |
|------|------|
| `internal/broker/enrich_consumer.go` | `reclaimPending`: XRangeN → XClaim; `deadLetter`: parse + log token; add `reclaimIdleThreshold` field |
| `internal/broker/enrich_consumer_test.go` | New `TestEnrichConsumer_DeadLettersAfterMaxRetries` — verifies full cycle: publish → read → fail → reclaim × N → DLQ |

## Test plan

- [x] `go test ./internal/broker/ -v` — all 19 tests pass (including new dead-letter test)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — clean
- [ ] Deploy and verify VM logs stop showing infinite retry spam for stuck tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging for dead-lettered messages to include tracking token information.

* **Refactor**
  * Optimized pending message reclamation with batch processing and configurable idle timeout handling.

* **Tests**
  * Added test coverage for dead-lettering behavior after maximum retry attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->