### PR TITLE
fix: dead-letter alert messages for permanent failures and after max retries

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -332,6 +333,129 @@ func TestConsumerAcksUnsupportedChannelWithoutRetry(t *testing.T) {
 	}
 	if pending.Count != 0 {
 		t.Fatalf("expected 0 pending entries, got %d", pending.Count)
+	}
+}
+
+func TestConsumerAcksBlockedRecipientWithoutRetry(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	pub, err := NewPublisher(mr.Addr(), "", 0)
+	if err != nil {
+		t.Fatalf("new publisher: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+
+	alert := Alert{ChatID: 888, Message: "blocked recipient test"}
+	if err := pub.Publish(context.Background(), alert); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	var calls atomic.Int32
+	var hookCalls atomic.Int32
+	notify := func(_ context.Context, _ string, _ string) error {
+		calls.Add(1)
+		return fmt.Errorf("%w: chat not found", notifier.ErrRecipientBlocked)
+	}
+	cons, err := NewConsumer(mr.Addr(), "", 0, notify, slog.Default(), WithDeadLetterHook(func(_ context.Context, a Alert) error {
+		hookCalls.Add(1)
+		if a.ChatID != 888 {
+			t.Fatalf("dead-letter hook chat_id=%d, want 888", a.ChatID)
+		}
+		return nil
+	}))
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+	_ = cons.Run(ctx)
+
+	cons.reclaimPending(context.Background())
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("notify calls = %d, want 1 (should not retry blocked recipient)", got)
+	}
+	if got := hookCalls.Load(); got != 1 {
+		t.Fatalf("dead-letter hook calls = %d, want 1", got)
+	}
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+	pending, err := client.XPending(context.Background(), StreamName, GroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Fatalf("expected 0 pending entries, got %d", pending.Count)
+	}
+}
+
+func TestConsumerReclaimPendingDeadLettersAfterMaxRetries(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	pub, err := NewPublisher(mr.Addr(), "", 0)
+	if err != nil {
+		t.Fatalf("new publisher: %v", err)
+	}
+	defer func() { _ = pub.Close() }()
+
+	alert := Alert{ChatID: 999, Message: "transient failure test"}
+	if err := pub.Publish(context.Background(), alert); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	notify := func(_ context.Context, _ string, _ string) error {
+		return fmt.Errorf("temporary network error")
+	}
+
+	cons, err := NewConsumer(mr.Addr(), "", 0, notify, slog.Default())
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+	cons.reclaimIdleThreshold = 0
+
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+
+	// Initial read creates PEL entry (delivery count = 1).
+	streams, err := cons.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    GroupName,
+		Consumer: cons.consumer,
+		Streams:  []string{StreamName, ">"},
+		Count:    10,
+		Block:    time.Second,
+	}).Result()
+	if err != nil {
+		t.Fatalf("xreadgroup: %v", err)
+	}
+	for _, msg := range streams[0].Messages {
+		cons.processMessage(ctx, msg)
+	}
+
+	// Each reclaimPending XClaims (incrementing delivery count) and reprocesses.
+	for i := 0; i < MaxRetries+1; i++ {
+		cons.reclaimPending(ctx)
+	}
+
+	// Verify message was dead-lettered.
+	dlq, err := client.XRange(ctx, DeadLetterStream, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange dead-letter: %v", err)
+	}
+	if len(dlq) != 1 {
+		t.Fatalf("expected 1 dead-lettered message, got %d", len(dlq))
+	}
+
+	pending, err := client.XPending(ctx, StreamName, GroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Errorf("expected 0 pending after dead-letter, got %d", pending.Count)
 	}
 }
 

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -33,13 +33,14 @@ type DeadLetterHook func(ctx context.Context, alert Alert) error
 
 // Consumer reads alerts from the Redis Stream and delivers them.
 type Consumer struct {
-	client              *redis.Client
-	notify              NotifyFunc
-	deadLetterHook      DeadLetterHook
-	limiter             *rate.Limiter
-	logger              *slog.Logger
-	consumer            string
-	orphanIdleThreshold time.Duration
+	client               *redis.Client
+	notify               NotifyFunc
+	deadLetterHook       DeadLetterHook
+	limiter              *rate.Limiter
+	logger               *slog.Logger
+	consumer             string
+	reclaimIdleThreshold time.Duration
+	orphanIdleThreshold  time.Duration
 }
 
 // NewConsumer connects to Redis, creates the consumer group if needed,
@@ -68,12 +69,13 @@ func NewConsumer(addr, password string, db int, notify NotifyFunc, logger *slog.
 		hostname = fmt.Sprintf("consumer-%d", time.Now().UnixNano())
 	}
 	c := &Consumer{
-		client:              client,
-		notify:              notify,
-		limiter:             rate.NewLimiter(rate.Limit(30), 30), // 30 msg/sec Telegram limit
-		logger:              logger,
-		consumer:            hostname,
-		orphanIdleThreshold: orphanIdleThreshold,
+		client:               client,
+		notify:               notify,
+		limiter:              rate.NewLimiter(rate.Limit(30), 30), // 30 msg/sec Telegram limit
+		logger:               logger,
+		consumer:             hostname,
+		reclaimIdleThreshold: 30 * time.Second,
+		orphanIdleThreshold:  orphanIdleThreshold,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -142,6 +144,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 // reclaimPending reclaims messages that were delivered but not acked
 // (failed deliveries). Messages exceeding MaxRetries are dead-lettered.
 func (c *Consumer) reclaimPending(ctx context.Context) {
+	idle := c.reclaimIdleThreshold
 	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
 		Stream:   StreamName,
 		Group:    GroupName,
@@ -149,23 +152,39 @@ func (c *Consumer) reclaimPending(ctx context.Context) {
 		Start:    "-",
 		End:      "+",
 		Count:    50,
-		Idle:     30 * time.Second,
+		Idle:     idle,
 	}).Result()
 	if err != nil || len(pending) == 0 {
 		return
 	}
 
 	c.logger.Info("reclaiming pending messages", "count", len(pending))
+
+	var retryIDs []string
 	for _, p := range pending {
 		if p.RetryCount >= int64(MaxRetries) {
 			c.deadLetter(ctx, p.ID)
 			continue
 		}
-		msgs, err := c.client.XRangeN(ctx, StreamName, p.ID, p.ID, 1).Result()
-		if err != nil || len(msgs) == 0 {
-			continue
-		}
-		c.processMessage(ctx, msgs[0])
+		retryIDs = append(retryIDs, p.ID)
+	}
+	if len(retryIDs) == 0 {
+		return
+	}
+
+	claimed, err := c.client.XClaim(ctx, &redis.XClaimArgs{
+		Stream:   StreamName,
+		Group:    GroupName,
+		Consumer: c.consumer,
+		MinIdle:  idle,
+		Messages: retryIDs,
+	}).Result()
+	if err != nil {
+		c.logger.Error("xclaim pending messages failed", "error", err)
+		return
+	}
+	for _, msg := range claimed {
+		c.processMessage(ctx, msg)
 	}
 }
 
@@ -215,14 +234,14 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 
 	recipient := fmt.Sprintf("%d", alert.ChatID)
 	if err := c.notify(ctx, recipient, alert.Message); err != nil {
-		if errors.Is(err, notifier.ErrNoChannelNotifier) {
+		if errors.Is(err, notifier.ErrNoChannelNotifier) || errors.Is(err, notifier.ErrRecipientBlocked) {
 			if c.deadLetterHook != nil {
 				if hookErr := c.deadLetterHook(ctx, alert); hookErr != nil {
 					c.logger.Error("drop alert cleanup failed", "id", msg.ID, "chat_id", alert.ChatID, "error", hookErr)
 					return
 				}
 			}
-			c.logger.Warn("dropping alert due to unsupported user channel",
+			c.logger.Warn("dropping alert for permanently undeliverable recipient",
 				"id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
 			c.ack(ctx, msg.ID)
 			return


### PR DESCRIPTION
## Summary

- Handle `ErrRecipientBlocked` (chat not found, bot blocked, user deactivated) as a permanent failure — immediately ack and dead-letter instead of retrying forever
- Fix `reclaimPending` to use `XClaim` instead of `XRangeN` so the Redis delivery counter increments and messages eventually reach `MaxRetries` for dead-lettering
- Add `reclaimIdleThreshold` field to `Consumer` struct (matching `EnrichConsumer` pattern) for testability

## Context

7 alert messages for `chat_id: 2000000000000` were stuck in infinite retry every ~30 seconds because:
1. Telegram returned "chat not found" → wrapped as `ErrRecipientBlocked` → not checked → treated as transient
2. Even if it were transient, `reclaimPending` used `XRangeN` which doesn't increment the delivery counter, so `MaxRetries` was unreachable

## Test plan

- [x] `TestConsumerAcksBlockedRecipientWithoutRetry` — verifies `ErrRecipientBlocked` is immediately acked with dead-letter hook called, no retry
- [x] `TestConsumerReclaimPendingDeadLettersAfterMaxRetries` — verifies delivery count increments via `XClaim` and message is dead-lettered after `MaxRetries`
- [x] All 21 existing broker tests pass
- [x] `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and handling of blocked alert recipients, now properly marked as permanently undeliverable without further retry attempts.
  * Enhanced processing and dead-lettering of messages that exceed the maximum configured retry thresholds.
  * Optimized batch processing of pending messages for increased system performance and reduced delivery latency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->