### PR TITLE
refactor: enrich logs with car identity, search context, and queue stats

### DIFF
--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/health"
 	"github.com/dsionov/carwatch/internal/logstream"
+	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/redis/go-redis/v9"
 )
 
 var (
@@ -126,6 +128,15 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 		}
 	}()
 
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:     cfg.Redis.Addr,
+		Password: cfg.Redis.Password,
+		DB:       cfg.Redis.DB,
+	})
+	defer func() { _ = redisClient.Close() }()
+
+	enrichPub := broker.NewEnrichPublisher(redisClient)
+
 	cons, err := broker.NewEnrichConsumer(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB,
 		worker.HandleRequest, logger.With("component", "enrich-consumer"))
 	if err != nil {
@@ -140,6 +151,8 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 		"max_delay", cfg.Enricher.MaxDelay,
 		"cooldown", cfg.Enricher.CooldownDuration,
 	)
+
+	go enrichmentStatsLoop(ctx, store, enrichPub, logger)
 
 	consumerLoop(ctx, cons, logger)
 	return nil
@@ -210,4 +223,28 @@ func (a *yad2ItemFetcherAdapter) FetchItem(ctx context.Context, token string) (e
 		City:     details.City,
 		Area:     details.Area,
 	}, nil
+}
+
+func enrichmentStatsLoop(ctx context.Context, store storage.ListingStore, pub *broker.EnrichPublisher, logger *slog.Logger) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	log := logger.With("component", "enricher-stats")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			attrs := []any{}
+			if queueLen, err := pub.EnrichQueueLen(ctx); err == nil {
+				attrs = append(attrs, "queue_depth", queueLen)
+			}
+			if unenriched, err := store.CountUnenrichedTokens(ctx); err == nil {
+				attrs = append(attrs, "unenriched_total", unenriched)
+			}
+			if len(attrs) > 0 {
+				log.InfoContext(ctx, "enrichment stats", attrs...)
+			}
+		}
+	}
 }

--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -152,9 +153,15 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 		"cooldown", cfg.Enricher.CooldownDuration,
 	)
 
-	go enrichmentStatsLoop(ctx, store, enrichPub, logger)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		enrichmentStatsLoop(ctx, store, enrichPub, logger)
+	}()
 
 	consumerLoop(ctx, cons, logger)
+	wg.Wait()
 	return nil
 }
 

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -47,35 +47,30 @@ func NewWorker(f ItemFetcher, ls storage.ListingStore, rl *AdaptiveRateLimiter, 
 // enrichment request: checks if already enriched, waits for rate limit,
 // fetches the item page, and updates the database.
 func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) error {
-	// Check if already enriched (idempotent skip).
-	// A listing is considered fully enriched only when all key fields exist.
-	// If one field is missing (for example only image exists), keep trying.
+	// Resolve car identity for structured logging. LookupEnrichmentData
+	// only matches rows that already have some enrichment data; fall back
+	// to LookupListingIdentity for brand-new unenriched listings.
 	existing, err := w.listings.LookupEnrichmentData(ctx, []string{req.Token})
 	if err != nil {
 		w.logger.ErrorContext(ctx, "failed to check enrichment status",
 			"token", req.Token, "error", err.Error())
 		return err
 	}
+
+	carAttrs := w.carAttrs(ctx, req, existing)
+
 	if rec, ok := existing[req.Token]; ok && rec.Km > 0 && rec.City != "" && rec.ImageURL != "" {
-		hasKm := rec.Km > 0
-		hasCity := rec.City != ""
-		hasImage := rec.ImageURL != ""
-		w.logger.DebugContext(ctx, "listing already enriched, skipping",
-			"token", req.Token, "km", rec.Km, "city", rec.City,
-			"has_km", hasKm, "has_city", hasCity, "has_image", hasImage,
-			"skip_reason", "already_fully_enriched")
+		w.logger.DebugContext(ctx, "listing already enriched, skipping", carAttrs...)
 		if telemetry.EnrichSkipped != nil {
 			telemetry.EnrichSkipped.Add(ctx, 1)
 		}
 		return nil
 	}
 
-	// Wait for rate limiter.
 	if !w.limiter.Wait(ctx) {
 		return ctx.Err()
 	}
 
-	// Fetch item detail page.
 	details, fetchErr := w.fetcher.FetchItem(ctx, req.Token)
 	if fetchErr != nil {
 		if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
@@ -89,19 +84,17 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 				telemetry.EnrichChallenges.Add(ctx, 1)
 			}
 			w.logger.WarnContext(ctx, "bot challenge during enrichment, backing off",
-				"token", req.Token, "cooldown", w.limiter.InCooldown(),
-				"current_delay", w.limiter.CurrentDelay())
+				append(carAttrs, "cooldown", w.limiter.InCooldown(), "current_delay", w.limiter.CurrentDelay())...)
 			return fetchErr
 		}
 
 		w.logger.WarnContext(ctx, "failed to fetch listing detail page",
-			"token", req.Token, "error", fetchErr.Error())
+			append(carAttrs, "error", fetchErr.Error())...)
 		return fetchErr
 	}
 
 	w.limiter.RecordSuccess()
 
-	// Build a minimal listing record for backfill.
 	rec := storage.ListingRecord{
 		Token:    req.Token,
 		Km:       details.Km,
@@ -110,7 +103,7 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 	}
 	if err := w.listings.BackfillListings(ctx, []storage.ListingRecord{rec}); err != nil {
 		w.logger.ErrorContext(ctx, "failed to backfill enriched data to database",
-			"token", req.Token, "error", err.Error())
+			append(carAttrs, "error", err.Error())...)
 		return err
 	}
 
@@ -119,8 +112,29 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 	}
 
 	w.logger.InfoContext(ctx, "enriched listing",
-		"token", req.Token, "km", details.Km, "city", details.City,
-		"has_image", details.ImageURL != "", "priority", req.Priority)
+		append(carAttrs, "km", details.Km, "city", details.City, "has_image", details.ImageURL != "")...)
 
 	return nil
+}
+
+// carAttrs builds a reusable slog attribute slice with car-identifying fields.
+func (w *Worker) carAttrs(ctx context.Context, req broker.EnrichRequest, existing map[string]storage.EnrichmentRecord) []any {
+	attrs := []any{"token", req.Token, "source", req.Source, "priority", req.Priority}
+	if len(req.SearchIDs) > 0 {
+		attrs = append(attrs, "search_ids", req.SearchIDs)
+	}
+
+	if rec, ok := existing[req.Token]; ok {
+		return append(attrs,
+			"manufacturer", rec.Manufacturer, "model", rec.Model,
+			"year", rec.Year, "price", rec.Price, "search_name", rec.SearchName)
+	}
+
+	id, err := w.listings.LookupListingIdentity(ctx, req.Token)
+	if err != nil {
+		return attrs
+	}
+	return append(attrs,
+		"manufacturer", id.Manufacturer, "model", id.Model,
+		"year", id.Year, "price", id.Price, "search_name", id.SearchName)
 }

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -132,6 +132,9 @@ func (w *Worker) carAttrs(ctx context.Context, req broker.EnrichRequest, existin
 
 	id, err := w.listings.LookupListingIdentity(ctx, req.Token)
 	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			w.logger.WarnContext(ctx, "failed to lookup listing identity", "token", req.Token, "error", err.Error())
+		}
 		return attrs
 	}
 	return append(attrs,

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -114,6 +114,9 @@ func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (in
 func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
 }
+func (m *mockListingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
+	return &storage.ListingIdentity{}, nil
+}
 
 func testWorkerLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError + 1}))

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -61,6 +61,9 @@ func (s *prefillTrackingStore) ListUnenrichedTokens(_ context.Context, _ int) ([
 }
 func (s *prefillTrackingStore) CountUnenrichedTokens(_ context.Context) (int64, error)   { return 0, nil }
 func (s *prefillTrackingStore) IncrementEnrichAttempt(_ context.Context, _ string) error { return nil }
+func (s *prefillTrackingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
+	return &storage.ListingIdentity{}, nil
+}
 
 func pipelineTestLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1}))

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -316,3 +316,6 @@ func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]str
 }
 func (m *mockListingStore) CountUnenrichedTokens(_ context.Context) (int64, error)   { return 0, nil }
 func (m *mockListingStore) IncrementEnrichAttempt(_ context.Context, _ string) error { return nil }
+func (m *mockListingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
+	return &storage.ListingIdentity{}, nil
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -193,11 +193,26 @@ type DBPoolStats struct {
 	WaitDuration       string `json:"wait_duration"`
 }
 
-// EnrichmentRecord holds km/city/image data previously learned for a listing token.
+// EnrichmentRecord holds km/city/image data previously learned for a listing token,
+// along with car-identifying fields for log context.
 type EnrichmentRecord struct {
-	Km       int
-	City     string
-	ImageURL string
+	Manufacturer string
+	Model        string
+	Year         int
+	Price        int
+	SearchName   string
+	Km           int
+	City         string
+	ImageURL     string
+}
+
+// ListingIdentity holds car-identifying fields for a listing token.
+type ListingIdentity struct {
+	Manufacturer string
+	Model        string
+	Year         int
+	Price        int
+	SearchName   string
 }
 
 // ListingFilter restricts which listing_history rows are returned.
@@ -241,6 +256,7 @@ type ListingStore interface {
 	SearchStats(ctx context.Context, chatID int64, searchID int64, f ListingFilter) (*SearchStats, error)
 	ListUnenrichedTokens(ctx context.Context, limit int) ([]string, error)
 	CountUnenrichedTokens(ctx context.Context) (int64, error)
+	LookupListingIdentity(ctx context.Context, token string) (*ListingIdentity, error)
 	IncrementEnrichAttempt(ctx context.Context, token string) error
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -252,6 +252,9 @@ func (s *Store) LookupListingIdentity(ctx context.Context, token string) (*stora
 		 ORDER BY first_seen_at DESC LIMIT 1`, token).
 		Scan(&id.Manufacturer, &id.Model, &id.Year, &id.Price, &id.SearchName)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, storage.ErrNotFound
+		}
 		return nil, fmt.Errorf("lookup listing identity: %w", err)
 	}
 	return &id, nil

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -213,7 +213,7 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 			placeholders[i] = fmt.Sprintf("$%d", i+1)
 		}
 
-		q := `SELECT DISTINCT ON (token) token, km, city, image_url
+		q := `SELECT DISTINCT ON (token) token, manufacturer, model, year, price, search_name, km, city, image_url
 			FROM listing_history
 			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
 			ORDER BY token, first_seen_at DESC`
@@ -224,13 +224,16 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 		}
 
 		for rows.Next() {
-			var tok, city, img string
-			var km int
-			if err := rows.Scan(&tok, &km, &city, &img); err != nil {
+			var tok, manufacturer, model, searchName, city, img string
+			var year, price, km int
+			if err := rows.Scan(&tok, &manufacturer, &model, &year, &price, &searchName, &km, &city, &img); err != nil {
 				_ = rows.Close()
 				return nil, fmt.Errorf("scan enrichment data: %w", err)
 			}
-			out[tok] = storage.EnrichmentRecord{Km: km, City: city, ImageURL: img}
+			out[tok] = storage.EnrichmentRecord{
+				Manufacturer: manufacturer, Model: model, Year: year, Price: price, SearchName: searchName,
+				Km: km, City: city, ImageURL: img,
+			}
 		}
 		if err := rows.Err(); err != nil {
 			_ = rows.Close()
@@ -239,6 +242,19 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 		_ = rows.Close()
 	}
 	return out, nil
+}
+
+func (s *Store) LookupListingIdentity(ctx context.Context, token string) (*storage.ListingIdentity, error) {
+	var id storage.ListingIdentity
+	err := s.db.QueryRowContext(ctx,
+		`SELECT manufacturer, model, year, price, search_name
+		 FROM listing_history WHERE token = $1
+		 ORDER BY first_seen_at DESC LIMIT 1`, token).
+		Scan(&id.Manufacturer, &id.Model, &id.Year, &id.Price, &id.SearchName)
+	if err != nil {
+		return nil, fmt.Errorf("lookup listing identity: %w", err)
+	}
+	return &id, nil
 }
 
 func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*storage.ListingRecord, error) {


### PR DESCRIPTION
## Summary

- Every enricher log line now includes **manufacturer, model, year, price, search_name** so you can identify the car at a glance
- **source** and **search_ids** from the enrich request are logged for traceability
- Added **periodic stats logging** (every 60s): `queue_depth` and `unenriched_total` for backlog visibility
- Extended `EnrichmentRecord` with car-identifying fields; added `LookupListingIdentity` fallback for brand-new unenriched listings

### Example log output

```json
{"level":"INFO","msg":"enriched listing","token":"abc123","source":"scheduler","priority":1,"search_ids":[5,12],"manufacturer":"Honda","model":"Civic","year":2020,"price":85000,"km":45000,"city":"Tel Aviv","search_name":"honda-civic","has_image":true}
{"level":"INFO","msg":"enrichment stats","queue_depth":42,"unenriched_total":318}
```

## Test plan

- [x] All enricher tests pass
- [x] All broker tests pass
- [x] All scheduler tests pass (except 2 pre-existing Docker-dependent tests)
- [x] `golangci-lint run ./...` clean
- [ ] Deploy to VM, verify logs show car identity via `make vm-logs LOGS_FILTER=enricher`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enricher worker now periodically logs enrichment metrics every 60 seconds, reporting queue status and unenriched listing counts.
  * Enhanced enrichment event logging with additional contextual details including kilometers, city, and image information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Danielsio/carwatch/pull/1123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->