### PR TITLE
fix(bot): bot audit phase 2 — error handling & UX polish (#1128-#1139)

### DIFF
--- a/internal/bot/history.go
+++ b/internal/bot/history.go
@@ -230,6 +230,8 @@ func (b *Bot) onSavedPage(ctx context.Context, chatID int64, data string) {
 	pageStr := strings.TrimPrefix(data, cbSavedPage)
 	page, err := strconv.Atoi(pageStr)
 	if err != nil {
+		b.logger.Warn("invalid saved page callback", "chat_id", chatID, "raw", pageStr, "error", err)
+		b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "error_generic"))
 		return
 	}
 	b.sendSavedPage(ctx, chatID, page)
@@ -317,6 +319,8 @@ func (b *Bot) onHiddenPage(ctx context.Context, chatID int64, data string) {
 	pageStr := strings.TrimPrefix(data, cbHiddenPage)
 	page, err := strconv.Atoi(pageStr)
 	if err != nil {
+		b.logger.Warn("invalid hidden page callback", "chat_id", chatID, "raw", pageStr, "error", err)
+		b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "error_generic"))
 		return
 	}
 	b.sendHiddenPage(ctx, chatID, page)

--- a/internal/bot/state.go
+++ b/internal/bot/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/dsionov/carwatch/internal/botcore"
+	"github.com/dsionov/carwatch/internal/locale"
 )
 
 const (
@@ -31,6 +32,21 @@ type WizardData = botcore.WizardData
 func (b *Bot) expectState(ctx context.Context, chatID int64, expected string) bool {
 	user, err := b.users.GetUser(ctx, chatID)
 	if err != nil || user == nil || user.State != expected {
+		return false
+	}
+	return true
+}
+
+func (b *Bot) expectStateOrNotify(ctx context.Context, chatID int64, expected string) bool {
+	lang := b.getUserLang(ctx, chatID)
+	user, err := b.users.GetUser(ctx, chatID)
+	if err != nil {
+		b.logger.Error("expectState: get user failed", "chat_id", chatID, "error", err)
+		b.send(ctx, chatID, locale.T(lang, "error_generic"))
+		return false
+	}
+	if user == nil || user.State != expected {
+		b.send(ctx, chatID, locale.T(lang, "callback_expired"))
 		return false
 	}
 	return true

--- a/internal/bot/state.go
+++ b/internal/bot/state.go
@@ -29,14 +29,6 @@ const (
 
 type WizardData = botcore.WizardData
 
-func (b *Bot) expectState(ctx context.Context, chatID int64, expected string) bool {
-	user, err := b.users.GetUser(ctx, chatID)
-	if err != nil || user == nil || user.State != expected {
-		return false
-	}
-	return true
-}
-
 func (b *Bot) expectStateOrNotify(ctx context.Context, chatID int64, expected string) bool {
 	lang := b.getUserLang(ctx, chatID)
 	user, err := b.users.GetUser(ctx, chatID)

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
@@ -644,7 +645,7 @@ func (b *Bot) handleKeywordsInput(ctx context.Context, chatID int64, text string
 	if strings.EqualFold(text, skip) || strings.EqualFold(text, "skip") || strings.EqualFold(text, "דלג") {
 		wd.Keywords = ""
 	} else {
-		if len(text) > maxKeywordsLen {
+		if utf8.RuneCountInString(text) > maxKeywordsLen {
 			b.send(ctx, chatID, locale.Tf(lang, "wizard_keywords_too_long", maxKeywordsLen))
 			return
 		}
@@ -667,7 +668,7 @@ func (b *Bot) handleExcludeKeysInput(ctx context.Context, chatID int64, text str
 	if strings.EqualFold(text, skip) || strings.EqualFold(text, "skip") || strings.EqualFold(text, "דלג") {
 		wd.ExcludeKeys = ""
 	} else {
-		if len(text) > maxKeywordsLen {
+		if utf8.RuneCountInString(text) > maxKeywordsLen {
 			b.send(ctx, chatID, locale.Tf(lang, "wizard_keywords_too_long", maxKeywordsLen))
 			return
 		}

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -136,7 +136,7 @@ func (b *Bot) onManufacturerSelected(ctx context.Context, chatID int64, data str
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskManufacturer) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskManufacturer) {
 		return
 	}
 	idStr := strings.TrimPrefix(data, cbPrefixMfr)
@@ -184,7 +184,7 @@ func (b *Bot) onModelSelected(ctx context.Context, chatID int64, data string) {
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskModel) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskModel) {
 		return
 	}
 	idStr := strings.TrimPrefix(data, cbPrefixModel)
@@ -210,7 +210,7 @@ func (b *Bot) onEngineSelected(ctx context.Context, chatID int64, data string) {
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskEngine) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskEngine) {
 		return
 	}
 	ccStr := strings.TrimPrefix(data, cbPrefixEngine)
@@ -236,7 +236,7 @@ func (b *Bot) onMaxKmSelected(ctx context.Context, chatID int64, data string) {
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskMaxKm) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskMaxKm) {
 		return
 	}
 	kmStr := strings.TrimPrefix(data, cbPrefixMaxKm)
@@ -260,7 +260,7 @@ func (b *Bot) onMaxHandSelected(ctx context.Context, chatID int64, data string) 
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskMaxHand) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskMaxHand) {
 		return
 	}
 	handStr := strings.TrimPrefix(data, cbPrefixMaxHand)
@@ -286,7 +286,7 @@ func (b *Bot) onSkipKeywords(ctx context.Context, chatID int64) {
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskKeywords) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskKeywords) {
 		return
 	}
 	wd := b.loadWizardData(ctx, chatID)
@@ -305,7 +305,7 @@ func (b *Bot) onSkipExcludeKeys(ctx context.Context, chatID int64) {
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskExcludeKeys) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskExcludeKeys) {
 		return
 	}
 	wd := b.loadWizardData(ctx, chatID)
@@ -597,7 +597,7 @@ func (b *Bot) onSkipPriceMin(ctx context.Context, chatID int64) {
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskPriceMin) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskPriceMin) {
 		return
 	}
 	wd := b.loadWizardData(ctx, chatID)
@@ -614,7 +614,7 @@ func (b *Bot) onGearBoxSelected(ctx context.Context, chatID int64, data string) 
 	unlock := b.lockChat(chatID)
 	defer unlock()
 
-	if !b.expectState(ctx, chatID, StateAskGearBox) {
+	if !b.expectStateOrNotify(ctx, chatID, StateAskGearBox) {
 		return
 	}
 	gearbox := strings.TrimPrefix(data, cbPrefixGearBox)

--- a/internal/bot/wizard.go
+++ b/internal/bot/wizard.go
@@ -82,7 +82,7 @@ func (b *Bot) onMfrPage(ctx context.Context, chatID int64, data string) {
 	page, err := strconv.Atoi(pageStr)
 	if err != nil {
 		b.logger.Warn("invalid manufacturer page callback", "chat_id", chatID, "raw", pageStr, "error", err)
-		b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "error_generic"))
+		b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "error_wrong_state"))
 		return
 	}
 	lang := b.getUserLang(ctx, chatID)
@@ -110,7 +110,7 @@ func (b *Bot) onMdlPage(ctx context.Context, chatID int64, data string) {
 	page, err := strconv.Atoi(pageStr)
 	if err != nil {
 		b.logger.Warn("invalid model page callback", "chat_id", chatID, "raw", pageStr, "error", err)
-		b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "error_generic"))
+		b.send(ctx, chatID, locale.T(b.getUserLang(ctx, chatID), "error_wrong_state"))
 		return
 	}
 	wd := b.loadWizardData(ctx, chatID)
@@ -645,7 +645,7 @@ func (b *Bot) handleKeywordsInput(ctx context.Context, chatID int64, text string
 		wd.Keywords = ""
 	} else {
 		if len(text) > maxKeywordsLen {
-			b.send(ctx, chatID, locale.T(lang, "error_generic"))
+			b.send(ctx, chatID, locale.Tf(lang, "wizard_keywords_too_long", maxKeywordsLen))
 			return
 		}
 		wd.Keywords = normalizeKeywords(text)
@@ -668,7 +668,7 @@ func (b *Bot) handleExcludeKeysInput(ctx context.Context, chatID int64, text str
 		wd.ExcludeKeys = ""
 	} else {
 		if len(text) > maxKeywordsLen {
-			b.send(ctx, chatID, locale.T(lang, "error_generic"))
+			b.send(ctx, chatID, locale.Tf(lang, "wizard_keywords_too_long", maxKeywordsLen))
 			return
 		}
 		wd.ExcludeKeys = normalizeKeywords(text)

--- a/internal/locale/wizard.go
+++ b/internal/locale/wizard.go
@@ -1,7 +1,7 @@
 package locale
 
 var heWizard = map[string]string{
-	"wizard_source_prompt": "באילו אתרים לחפש? (בחר אחד או שניהם)",
+	"wizard_source_prompt": "באילו אתרים לחפש? (בחר אחד או שניהם)\n\n⏱ ההגדרה תפוג אחרי 30 דקות של חוסר פעילות.",
 	"wizard_source_empty":  "אנא בחר לפחות אתר אחד.",
 	"wizard_start_over":    "בוא נתחיל מחדש. באילו אתרים?",
 
@@ -70,7 +70,7 @@ var heWizard = map[string]string{
 }
 
 var enWizard = map[string]string{
-	"wizard_source_prompt": "Which marketplaces do you want to search? (select one or both)",
+	"wizard_source_prompt": "Which marketplaces do you want to search? (select one or both)\n\n⏱ This setup expires after 30 minutes of inactivity.",
 	"wizard_source_empty":  "Please select at least one marketplace.",
 	"wizard_start_over":    "Let's start over. Which marketplaces?",
 

--- a/internal/locale/wizard.go
+++ b/internal/locale/wizard.go
@@ -46,6 +46,7 @@ var heWizard = map[string]string{
 	"wizard_keywords_prompt":     "מילות מפתח לחיפוש בתיאור? (מופרדות בפסיק, או הקלד 'דלג')\nלדוגמה: אוטומטי, שמור",
 	"wizard_exclude_keys_prompt": "מילות מפתח להחרגה מהתיאור? (מופרדות בפסיק, או הקלד 'דלג')\nלדוגמה: תאונה, חורף",
 	"wizard_keywords_skip":       "דלג",
+	"wizard_keywords_too_long":   "מילות מפתח ארוכות מדי (מקסימום %d תווים). אנא קצר ונסה שוב.",
 
 	// wizard - confirm
 	"wizard_confirm_summary": "*החיפוש שלך:*\n" +
@@ -114,6 +115,7 @@ var enWizard = map[string]string{
 	"wizard_keywords_prompt":     "Any keywords to require in the description? (comma-separated, or type 'skip')\nExample: automatic, well-kept",
 	"wizard_exclude_keys_prompt": "Any keywords to exclude? (comma-separated, or type 'skip')\nExample: accident, damaged",
 	"wizard_keywords_skip":       "skip",
+	"wizard_keywords_too_long":   "Keywords are too long (max %d characters). Please shorten and try again.",
 
 	// wizard - confirm
 	"wizard_confirm_summary": "*Your search:*\n" +


### PR DESCRIPTION
## Summary

Phase 2 of the bot audit plan — 4 error handling and UX polish fixes:

- **Stale callback feedback** (#1128): Added `expectStateOrNotify` helper that sends "callback expired" when users click buttons from an old wizard session, instead of silently ignoring. All 9 call sites migrated. Removed unused `expectState`.
- **Specific error messages** (#1133): Replaced generic "Something went wrong" with actionable messages — keywords-too-long now shows the 500-char limit, invalid page callbacks show "use /cancel". Only the onConfirm DB error retains the generic message (appropriate there).
- **Pagination consistency** (#1139): `onSavedPage` and `onHiddenPage` now log and send error messages on parse failure, matching the existing `onHistoryPage` pattern.
- **Timeout warning** (#1134): The first wizard message now mentions the 30-minute inactivity timeout so users aren't surprised by auto-cancellation.

## Review

Self-reviewed: verified all locale keys exist in both HE/EN, no test files reference removed `expectState`, all 9 call sites migrated, linter clean.

## Test plan

- [ ] Click an old wizard button after starting a new /watch → user sees "callback expired" message
- [ ] Enter >500 chars as keywords → user sees "Keywords are too long (max 500 characters)"  
- [ ] /watch → first message includes timeout note
- [ ] Corrupt saved_pg/hidden_pg callback data → user sees error message (not silent ignore)

closes #1128
closes #1133
closes #1139
closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 30-minute inactivity expiration notice to wizard prompts.
  * Added localized error message for oversized keyword input.

* **Bug Fixes**
  * Improved error handling in callback validation with user notifications.
  * Enhanced wizard flow with localized error messages instead of generic responses.
  * Added callback expiration notification for invalid session states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->