### PR TITLE
feat(bot): bot audit phase 3 — notification UX (#1130-#1137)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -258,6 +258,12 @@ func (b *Bot) send(ctx context.Context, chatID int64, text string) {
 	}
 }
 
+func (b *Bot) sendTyping(ctx context.Context, chatID int64) {
+	if err := b.msg.SendChatAction(ctx, chatID, "typing"); err != nil {
+		b.logger.Debug("send typing action failed", "chat_id", chatID, "error", err)
+	}
+}
+
 func (b *Bot) sendMarkdown(ctx context.Context, chatID int64, text string) {
 	b.logger.Debug("sending markdown message", "chat_id", chatID, "text_len", len(text))
 	if err := b.msg.SendMessage(ctx, chatID, text, "Markdown", nil); err != nil {

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -211,6 +211,7 @@ func (b *Bot) handleList(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	if !b.ensureUser(ctx, chatID, update.Message.From.Username) {
 		return
 	}
+	b.sendTyping(ctx, chatID)
 	lang := b.getUserLang(ctx, chatID)
 
 	searches, err := b.searches.ListSearches(ctx, chatID)
@@ -388,6 +389,7 @@ func (b *Bot) handleSettings(ctx context.Context, _ *tgbot.Bot, update *tgmodels
 	if !b.ensureUser(ctx, chatID, update.Message.From.Username) {
 		return
 	}
+	b.sendTyping(ctx, chatID)
 	lang := b.getUserLang(ctx, chatID)
 
 	count, err := b.searches.CountSearches(ctx, chatID)
@@ -413,6 +415,7 @@ func (b *Bot) handleStats(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 		b.send(ctx, chatID, locale.T(lang, "unknown_command"))
 		return
 	}
+	b.sendTyping(ctx, chatID)
 
 	users, _ := b.users.CountUsers(ctx)
 	searches, _ := b.searches.CountAllSearches(ctx)
@@ -539,6 +542,7 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 	if !b.ensureUser(ctx, chatID, update.Message.From.Username) {
 		return
 	}
+	b.sendTyping(ctx, chatID)
 	lang := b.getUserLang(ctx, chatID)
 
 	parts := strings.Fields(update.Message.Text)

--- a/internal/bot/history.go
+++ b/internal/bot/history.go
@@ -25,6 +25,7 @@ func (b *Bot) handleHistory(ctx context.Context, _ *tgbot.Bot, update *tgmodels.
 	if !b.ensureUser(ctx, chatID, update.Message.From.Username) {
 		return
 	}
+	b.sendTyping(ctx, chatID)
 	b.sendHistoryPage(ctx, chatID, 0)
 }
 
@@ -142,6 +143,7 @@ func (b *Bot) handleSaved(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Up
 	if !b.ensureUser(ctx, chatID, update.Message.From.Username) {
 		return
 	}
+	b.sendTyping(ctx, chatID)
 	b.sendSavedPage(ctx, chatID, 0)
 }
 
@@ -248,6 +250,7 @@ func (b *Bot) handleHidden(ctx context.Context, _ *tgbot.Bot, update *tgmodels.U
 	if !b.ensureUser(ctx, chatID, update.Message.From.Username) {
 		return
 	}
+	b.sendTyping(ctx, chatID)
 	b.sendHiddenPage(ctx, chatID, 0)
 }
 

--- a/internal/bot/messenger.go
+++ b/internal/bot/messenger.go
@@ -13,6 +13,7 @@ type messenger interface {
 	SendMessage(ctx context.Context, chatID int64, text string, parseMode string, kb *tgmodels.InlineKeyboardMarkup) error
 	SendPhoto(ctx context.Context, chatID int64, photoPath string, caption string, parseMode string, kb *tgmodels.InlineKeyboardMarkup) error
 	AnswerCallback(ctx context.Context, callbackID string) error
+	SendChatAction(ctx context.Context, chatID int64, action string) error
 }
 
 type telegramMessenger struct {
@@ -53,6 +54,14 @@ func (t *telegramMessenger) SendPhoto(ctx context.Context, chatID int64, photoPa
 		params.ReplyMarkup = kb
 	}
 	_, err = t.bot.SendPhoto(ctx, params)
+	return err
+}
+
+func (t *telegramMessenger) SendChatAction(ctx context.Context, chatID int64, action string) error {
+	_, err := t.bot.SendChatAction(ctx, &tgbot.SendChatActionParams{
+		ChatID: chatID,
+		Action: tgmodels.ChatAction(action),
+	})
 	return err
 }
 

--- a/internal/bot/testhelpers_test.go
+++ b/internal/bot/testhelpers_test.go
@@ -58,6 +58,10 @@ func (m *mockMessenger) AnswerCallback(_ context.Context, _ string) error {
 	return nil
 }
 
+func (m *mockMessenger) SendChatAction(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+
 func (m *mockMessenger) last() sentMessage {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/locale/commands.go
+++ b/internal/locale/commands.go
@@ -211,6 +211,7 @@ var heCommands = map[string]string{
 	"fmt_price_drop":             "💰 *ירידת מחיר!* %s: ₪%s → ₪%s (-₪%s)\n",
 	"fmt_batch_header":           "🚗 *%d מודעות חדשות*\n",
 	"fmt_batch_item":             "*[%d/%d]*\n",
+	"fmt_batch_overflow":          "\n...ו-%d מודעות נוספות. השתמש ב /history כדי לראות הכל.",
 	"fmt_digest_header":          "*סיכום יומי (%d פריטים):*\n",
 
 	// fitness scoring
@@ -494,6 +495,7 @@ var enCommands = map[string]string{
 	"fmt_price_drop":             "💰 *Price Drop!* %s: ₪%s → ₪%s (-₪%s)\n",
 	"fmt_batch_header":           "🚗 *%d New Listings Found*\n",
 	"fmt_batch_item":             "*[%d/%d]*\n",
+	"fmt_batch_overflow":          "\n...and %d more new listings. Use /history to see all.",
 	"fmt_digest_header":          "*Digest Summary (%d items):*\n",
 
 	// fitness scoring

--- a/internal/locale/commands.go
+++ b/internal/locale/commands.go
@@ -211,7 +211,7 @@ var heCommands = map[string]string{
 	"fmt_price_drop":             "💰 *ירידת מחיר!* %s: ₪%s → ₪%s (-₪%s)\n",
 	"fmt_batch_header":           "🚗 *%d מודעות חדשות*\n",
 	"fmt_batch_item":             "*[%d/%d]*\n",
-	"fmt_batch_overflow":          "\n...ו-%d מודעות נוספות. השתמש ב /history כדי לראות הכל.",
+	"fmt_batch_overflow":         "\n...ו-%d מודעות נוספות. השתמש ב /history כדי לראות הכל.",
 	"fmt_digest_header":          "*סיכום יומי (%d פריטים):*\n",
 
 	// fitness scoring
@@ -495,7 +495,7 @@ var enCommands = map[string]string{
 	"fmt_price_drop":             "💰 *Price Drop!* %s: ₪%s → ₪%s (-₪%s)\n",
 	"fmt_batch_header":           "🚗 *%d New Listings Found*\n",
 	"fmt_batch_item":             "*[%d/%d]*\n",
-	"fmt_batch_overflow":          "\n...and %d more new listings. Use /history to see all.",
+	"fmt_batch_overflow":         "\n...and %d more new listings. Use /history to see all.",
 	"fmt_digest_header":          "*Digest Summary (%d items):*\n",
 
 	// fitness scoring

--- a/internal/notifier/multi.go
+++ b/internal/notifier/multi.go
@@ -60,8 +60,6 @@ func (m *MultiNotifier) Disconnect() error {
 	return errors.Join(errs...)
 }
 
-var errNoNotifier = fmt.Errorf("no notifiers registered")
-
 var ErrNoChannelNotifier = fmt.Errorf("no notifier for user channel")
 
 func normalizeChannel(channel string) string {
@@ -76,7 +74,7 @@ func normalizeChannel(channel string) string {
 func (m *MultiNotifier) Notify(ctx context.Context, recipient string, listings []model.Listing, lang locale.Lang) error {
 	targets := m.resolveAll(ctx, recipient)
 	if len(targets) == 0 {
-		return errNoNotifier
+		return ErrNoChannelNotifier
 	}
 
 	var errs []error
@@ -98,7 +96,7 @@ func (m *MultiNotifier) Notify(ctx context.Context, recipient string, listings [
 func (m *MultiNotifier) NotifyRaw(ctx context.Context, recipient string, message string) error {
 	targets := m.resolveAll(ctx, recipient)
 	if len(targets) == 0 {
-		return errNoNotifier
+		return ErrNoChannelNotifier
 	}
 
 	var errs []error
@@ -159,6 +157,12 @@ func (m *MultiNotifier) resolveAll(ctx context.Context, recipient string) map[st
 	}
 
 	if len(result) == 0 {
+		channel := ""
+		if user != nil {
+			channel = user.Channel
+		}
+		m.logger.Warn("no notification channel resolved for user",
+			"recipient", recipient, "channel", channel)
 		if n := m.notifiers[m.fallback]; n != nil {
 			result[m.fallback] = n
 		}

--- a/internal/notifier/multi_test.go
+++ b/internal/notifier/multi_test.go
@@ -184,8 +184,8 @@ func TestMultiNotifier_NoRegisteredNotifier(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when no notifiers registered")
 	}
-	if !errors.Is(err, errNoNotifier) {
-		t.Errorf("expected errNoNotifier, got %v", err)
+	if !errors.Is(err, ErrNoChannelNotifier) {
+		t.Errorf("expected ErrNoChannelNotifier, got %v", err)
 	}
 }
 

--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -82,11 +82,30 @@ func (n *Notifier) Connect(ctx context.Context) error {
 
 func (n *Notifier) Notify(ctx context.Context, chatID string, listings []model.Listing, lang locale.Lang) error {
 	n.throttleChat(chatID)
-	if len(listings) == 1 && listings[0].ImageURL != "" {
-		return n.sendListingWithPhoto(ctx, chatID, listings[0], lang)
+	if len(listings) == 1 {
+		kb := listingActionKeyboard(listings[0].Token, lang)
+		if listings[0].ImageURL != "" {
+			return n.sendListingWithPhotoAndKeyboard(ctx, chatID, listings[0], lang, kb)
+		}
+		msg := notifier.FormatBatch(listings, lang)
+		return n.sendMessageMarkdownWithKeyboard(ctx, chatID, msg, kb)
 	}
 	msg := notifier.FormatBatch(listings, lang)
 	return n.sendMessageMarkdown(ctx, chatID, msg)
+}
+
+func listingActionKeyboard(token string, lang locale.Lang) *tgmodels.InlineKeyboardMarkup {
+	if token == "" {
+		return nil
+	}
+	return &tgmodels.InlineKeyboardMarkup{
+		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
+			{
+				{Text: locale.T(lang, "btn_save"), CallbackData: "save:" + token},
+				{Text: locale.T(lang, "btn_hide"), CallbackData: "hide:" + token},
+			},
+		},
+	}
 }
 
 func (n *Notifier) NotifyRaw(ctx context.Context, chatID string, message string) error {
@@ -121,7 +140,7 @@ func (n *Notifier) throttleChat(chatID string) {
 	n.lastSendTime.Store(chatID, time.Now())
 }
 
-func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, listing model.Listing, lang locale.Lang) error {
+func (n *Notifier) sendListingWithPhotoAndKeyboard(ctx context.Context, chatID string, listing model.Listing, lang locale.Lang, kb *tgmodels.InlineKeyboardMarkup) error {
 	id, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid chat ID %q: %w", chatID, err)
@@ -143,15 +162,19 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 		captionForPhoto = truncateTelegramCaption(captionForPhoto, maxCaptionLen)
 	}
 
-	err = n.sendPhotoWithRetry(ctx, chatID, &tgbot.SendPhotoParams{
+	params := &tgbot.SendPhotoParams{
 		ChatID:    id,
 		Photo:     &tgmodels.InputFileString{Data: listing.ImageURL},
 		Caption:   captionForPhoto,
 		ParseMode: tgmodels.ParseModeMarkdownV1,
-	})
+	}
+	if kb != nil {
+		params.ReplyMarkup = kb
+	}
+	err = n.sendPhotoWithRetry(ctx, chatID, params)
 	if err != nil {
 		n.logger.Warn("sendPhoto failed, falling back to text", "chat_id", chatID, "error", err)
-		return n.sendMessageMarkdown(ctx, chatID, caption)
+		return n.sendMessageMarkdownWithKeyboard(ctx, chatID, caption, kb)
 	}
 
 	n.logger.Info("sent telegram photo", "chat_id", chatID)
@@ -159,10 +182,14 @@ func (n *Notifier) sendListingWithPhoto(ctx context.Context, chatID string, list
 }
 
 func (n *Notifier) sendMessageMarkdown(ctx context.Context, chatID string, text string) error {
-	return n.sendMessageWithParseMode(ctx, chatID, text, tgmodels.ParseModeMarkdownV1)
+	return n.sendMessageWithParseModeAndKeyboard(ctx, chatID, text, tgmodels.ParseModeMarkdownV1, nil)
 }
 
-func (n *Notifier) sendMessageWithParseMode(ctx context.Context, chatID string, text string, parseMode tgmodels.ParseMode) error {
+func (n *Notifier) sendMessageMarkdownWithKeyboard(ctx context.Context, chatID string, text string, kb *tgmodels.InlineKeyboardMarkup) error {
+	return n.sendMessageWithParseModeAndKeyboard(ctx, chatID, text, tgmodels.ParseModeMarkdownV1, kb)
+}
+
+func (n *Notifier) sendMessageWithParseModeAndKeyboard(ctx context.Context, chatID string, text string, parseMode tgmodels.ParseMode, kb *tgmodels.InlineKeyboardMarkup) error {
 	id, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid chat ID %q: %w", chatID, err)
@@ -188,6 +215,9 @@ func (n *Notifier) sendMessageWithParseMode(ctx context.Context, chatID string, 
 		}
 		if parseMode != "" {
 			params.ParseMode = parseMode
+		}
+		if kb != nil && i == len(chunks)-1 {
+			params.ReplyMarkup = kb
 		}
 		err = n.sendMessageWithRetry(ctx, chatID, params)
 		if err != nil {

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -16,6 +16,8 @@ import (
 
 var errMalformedMessage = errors.New("blocked malformed message")
 
+const maxBatchSize = 10
+
 type DeliveryStrategy interface {
 	DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error
 	DeliverRaw(ctx context.Context, chatID int64, message string) error
@@ -64,8 +66,17 @@ func WithSearchContext(id int64, name string) func(*InstantDelivery) {
 }
 
 func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {
+	truncated := 0
+	if len(listings) > maxBatchSize {
+		truncated = len(listings) - maxBatchSize
+		listings = listings[:maxBatchSize]
+	}
+
 	if d.publisher != nil {
 		msg := notifier.FormatBatch(listings, d.lang)
+		if truncated > 0 {
+			msg += locale.Tf(d.lang, "fmt_batch_overflow", truncated)
+		}
 		if notifier.IsMalformedMessage(msg) {
 			d.logger.ErrorContext(ctx, "blocked delivery of malformed batch message, skipping to prevent Telegram API errors",
 				"chat_id", chatID, "msg_len", len(msg))
@@ -149,7 +160,15 @@ func NewDigestDelivery(s storage.DigestStore, lang locale.Lang) *DigestDelivery 
 }
 
 func (d *DigestDelivery) DeliverBatch(ctx context.Context, chatID int64, listings []model.Listing) error {
+	truncated := 0
+	if len(listings) > maxBatchSize {
+		truncated = len(listings) - maxBatchSize
+		listings = listings[:maxBatchSize]
+	}
 	msg := notifier.FormatBatch(listings, d.lang)
+	if truncated > 0 {
+		msg += locale.Tf(d.lang, "fmt_batch_overflow", truncated)
+	}
 	if notifier.IsMalformedMessage(msg) {
 		return errMalformedMessage
 	}


### PR DESCRIPTION
## Summary

Phase 3 of the bot audit plan — 4 notification UX improvements:

- **Typing indicators** (#1130): Bot shows "typing..." while processing DB-heavy commands (/list, /history, /saved, /hidden, /settings, /stats, /edit). Added `SendChatAction` to messenger interface.
- **Save/hide buttons** (#1131): Single-listing Telegram notifications now include inline save/hide buttons. Attached to both photo and text formats, including fallback. Batch notifications skip keyboard.
- **Batch size cap** (#1132): Both InstantDelivery and DigestDelivery enforce `maxBatchSize=10`. Overflow appends "...and N more. Use /history to see all."
- **Web-only notification logging** (#1137): `resolveAll` now logs a warning when no channel resolves. Unified `Notify`/`NotifyRaw` to return `ErrNoChannelNotifier` for consistent dead-letter handling.

## Review

Self-reviewed: all interfaces updated, mock implementations extended, locale keys added in both HE/EN, lint clean.

## Test plan

- [ ] /list, /history, /saved → "typing..." appears briefly before response
- [ ] Single listing notification → save/hide inline buttons visible
- [ ] Batch of >10 listings → only 10 shown + overflow footer
- [ ] Web user with no webpush → warning logged, error handled as dead-letter

closes #1130
closes #1131
closes #1132
closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)