### PR TITLE
feat(bot): bot audit phase 4a — config & edit preview (#1138, #1140)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -27,29 +27,29 @@ type PollTrigger interface {
 var wizardTimeout = 30 * time.Minute
 
 type Bot struct {
-	bot          *tgbot.Bot
-	msg          messenger
-	users        storage.UserStore
-	linkTokens   storage.LinkTokenStore
-	searches     storage.SearchStore
-	listings     storage.ListingStore
-	digests      storage.DigestStore
-	saved        storage.SavedListingStore
-	hidden       storage.HiddenListingStore
-	dailyDigests storage.DailyDigestStore
-	catalog      catalog.Catalog
+	bot                    *tgbot.Bot
+	msg                    messenger
+	users                  storage.UserStore
+	linkTokens             storage.LinkTokenStore
+	searches               storage.SearchStore
+	listings               storage.ListingStore
+	digests                storage.DigestStore
+	saved                  storage.SavedListingStore
+	hidden                 storage.HiddenListingStore
+	dailyDigests           storage.DailyDigestStore
+	catalog                catalog.Catalog
 	adminChatID            int64
 	maxSearches            int
-	botUsername             string
+	botUsername            string
 	pollInterval           time.Duration
 	quickStartManufacturer int
 	quickStartModel        int
-	logger       *slog.Logger
-	health       *health.Status
-	chatMu       sync.Map
-	pollTrigger  PollTrigger
-	rateLimiter  sync.Map
-	nowFunc      func() time.Time // overridable clock for testing; nil means time.Now
+	logger                 *slog.Logger
+	health                 *health.Status
+	chatMu                 sync.Map
+	pollTrigger            PollTrigger
+	rateLimiter            sync.Map
+	nowFunc                func() time.Time // overridable clock for testing; nil means time.Now
 }
 
 type chatMuEntry struct {
@@ -104,7 +104,7 @@ func (b *Bot) isRateLimited(chatID int64) bool {
 type Config struct {
 	AdminChatID            int64
 	MaxSearches            int
-	BotUsername             string
+	BotUsername            string
 	PollInterval           time.Duration
 	QuickStartManufacturer int
 	QuickStartModel        int
@@ -140,25 +140,25 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 		msg = &telegramMessenger{bot: b}
 	}
 	return &Bot{
-		bot:          b,
-		msg:          msg,
-		users:        users,
-		linkTokens:   cfg.LinkTokens,
-		searches:     searches,
-		listings:     cfg.Listings,
-		digests:      cfg.Digests,
-		saved:        cfg.Saved,
-		hidden:       cfg.Hidden,
-		dailyDigests: cfg.DailyDigests,
-		catalog:      cat,
+		bot:                    b,
+		msg:                    msg,
+		users:                  users,
+		linkTokens:             cfg.LinkTokens,
+		searches:               searches,
+		listings:               cfg.Listings,
+		digests:                cfg.Digests,
+		saved:                  cfg.Saved,
+		hidden:                 cfg.Hidden,
+		dailyDigests:           cfg.DailyDigests,
+		catalog:                cat,
 		adminChatID:            cfg.AdminChatID,
 		maxSearches:            cfg.MaxSearches,
-		botUsername:             cfg.BotUsername,
+		botUsername:            cfg.BotUsername,
 		pollInterval:           cfg.PollInterval,
 		quickStartManufacturer: cfg.QuickStartManufacturer,
 		quickStartModel:        cfg.QuickStartModel,
-		logger:       logger,
-		health:       cfg.Health,
+		logger:                 logger,
+		health:                 cfg.Health,
 	}
 }
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -38,10 +38,12 @@ type Bot struct {
 	hidden       storage.HiddenListingStore
 	dailyDigests storage.DailyDigestStore
 	catalog      catalog.Catalog
-	adminChatID  int64
-	maxSearches  int
-	botUsername  string
-	pollInterval time.Duration
+	adminChatID            int64
+	maxSearches            int
+	botUsername             string
+	pollInterval           time.Duration
+	quickStartManufacturer int
+	quickStartModel        int
 	logger       *slog.Logger
 	health       *health.Status
 	chatMu       sync.Map
@@ -100,18 +102,20 @@ func (b *Bot) isRateLimited(chatID int64) bool {
 }
 
 type Config struct {
-	AdminChatID  int64
-	MaxSearches  int
-	BotUsername  string
-	PollInterval time.Duration
-	Health       *health.Status
-	Digests      storage.DigestStore
-	Listings     storage.ListingStore
-	Saved        storage.SavedListingStore
-	Hidden       storage.HiddenListingStore
-	DailyDigests storage.DailyDigestStore
-	Catalog      catalog.Catalog
-	LinkTokens   storage.LinkTokenStore
+	AdminChatID            int64
+	MaxSearches            int
+	BotUsername             string
+	PollInterval           time.Duration
+	QuickStartManufacturer int
+	QuickStartModel        int
+	Health                 *health.Status
+	Digests                storage.DigestStore
+	Listings               storage.ListingStore
+	Saved                  storage.SavedListingStore
+	Hidden                 storage.HiddenListingStore
+	DailyDigests           storage.DailyDigestStore
+	Catalog                catalog.Catalog
+	LinkTokens             storage.LinkTokenStore
 }
 
 func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cfg Config, logger *slog.Logger) *Bot {
@@ -120,6 +124,12 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 	}
 	if cfg.PollInterval == 0 {
 		cfg.PollInterval = 15 * time.Minute
+	}
+	if cfg.QuickStartManufacturer == 0 {
+		cfg.QuickStartManufacturer = DefaultQuickStartManufacturer
+	}
+	if cfg.QuickStartModel == 0 {
+		cfg.QuickStartModel = DefaultQuickStartModel
 	}
 	cat := cfg.Catalog
 	if cat == nil {
@@ -141,10 +151,12 @@ func New(b *tgbot.Bot, users storage.UserStore, searches storage.SearchStore, cf
 		hidden:       cfg.Hidden,
 		dailyDigests: cfg.DailyDigests,
 		catalog:      cat,
-		adminChatID:  cfg.AdminChatID,
-		maxSearches:  cfg.MaxSearches,
-		botUsername:  cfg.BotUsername,
-		pollInterval: cfg.PollInterval,
+		adminChatID:            cfg.AdminChatID,
+		maxSearches:            cfg.MaxSearches,
+		botUsername:             cfg.BotUsername,
+		pollInterval:           cfg.PollInterval,
+		quickStartManufacturer: cfg.QuickStartManufacturer,
+		quickStartModel:        cfg.QuickStartModel,
 		logger:       logger,
 		health:       cfg.Health,
 	}

--- a/internal/bot/callbacks.go
+++ b/internal/bot/callbacks.go
@@ -15,8 +15,6 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-// DefaultQuickStartManufacturer and DefaultQuickStartModel are catalog IDs for the quick-start preset (Toyota Corolla).
-// TODO: these should eventually come from config instead of hardcoding.
 const (
 	DefaultQuickStartManufacturer = 19
 	DefaultQuickStartModel        = 8640
@@ -216,12 +214,16 @@ func (b *Bot) onQuickStart(ctx context.Context, chatID int64) {
 		return
 	}
 
+	mfr := b.catalog.ManufacturerName(b.quickStartManufacturer)
+	mdl := b.modelDisplayName(b.quickStartManufacturer, b.quickStartModel)
+	name := fmt.Sprintf("%s-%s", strings.ToLower(mfr), strings.ToLower(mdl))
+
 	id, err := b.searches.CreateSearch(ctx, storage.Search{
 		ChatID:       chatID,
-		Name:         "toyota-corolla",
+		Name:         name,
 		Source:       "yad2",
-		Manufacturer: DefaultQuickStartManufacturer,
-		Model:        DefaultQuickStartModel,
+		Manufacturer: b.quickStartManufacturer,
+		Model:        b.quickStartModel,
 		YearMin:      2018,
 		YearMax:      time.Now().Year() + 2,
 		PriceMax:     200000,

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -11,6 +11,7 @@ import (
 	tgbot "github.com/go-telegram/bot"
 	tgmodels "github.com/go-telegram/bot/models"
 
+	"github.com/dsionov/carwatch/internal/botcore"
 	"github.com/dsionov/carwatch/internal/format"
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/storage"
@@ -586,6 +587,23 @@ func (b *Bot) handleEdit(ctx context.Context, _ *tgbot.Bot, update *tgmodels.Upd
 		PriceOnly:        search.PriceOnly,
 		PhotoOnly:        search.PhotoOnly,
 		EditSearchID:     search.ID,
+		OriginalSearch: &botcore.OriginalSearch{
+			Source:           search.Source,
+			Manufacturer:     search.Manufacturer,
+			ManufacturerName: mfr,
+			Model:            search.Model,
+			ModelName:        mdl,
+			YearMin:          search.YearMin,
+			YearMax:          search.YearMax,
+			PriceMin:         search.PriceMin,
+			PriceMax:         search.PriceMax,
+			GearBox:          search.GearBox,
+			EngineMinCC:      search.EngineMinCC,
+			MaxKm:            search.MaxKm,
+			MaxHand:          search.MaxHand,
+			Keywords:         search.Keywords,
+			ExcludeKeys:      search.ExcludeKeys,
+		},
 	}
 	if !b.saveWizardStateOrAbort(ctx, chatID, StateAskSource, wd) {
 		return

--- a/internal/bot/coverage_test.go
+++ b/internal/bot/coverage_test.go
@@ -28,19 +28,21 @@ func newTestBotFull(t *testing.T) *testBot {
 	logger := slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	b := &Bot{
-		msg:          mm,
-		users:        store,
-		searches:     store,
-		listings:     store,
-		digests:      store,
-		saved:        store,
-		hidden:       store,
-		dailyDigests: store,
-		catalog:      catalog.NewStatic(),
-		adminChatID:  999,
-		maxSearches:  defaultMaxSearches,
-		botUsername:  "test_bot",
-		logger:       logger,
+		msg:                    mm,
+		users:                  store,
+		searches:               store,
+		listings:               store,
+		digests:                store,
+		saved:                  store,
+		hidden:                 store,
+		dailyDigests:           store,
+		catalog:                catalog.NewStatic(),
+		adminChatID:            999,
+		maxSearches:            defaultMaxSearches,
+		botUsername:            "test_bot",
+		quickStartManufacturer: DefaultQuickStartManufacturer,
+		quickStartModel:        DefaultQuickStartModel,
+		logger:                 logger,
 	}
 
 	return &testBot{bot: b, msg: mm, store: store}

--- a/internal/bot/keyboards.go
+++ b/internal/bot/keyboards.go
@@ -8,6 +8,7 @@ import (
 
 	tgmodels "github.com/go-telegram/bot/models"
 
+	"github.com/dsionov/carwatch/internal/botcore"
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/format"
 	"github.com/dsionov/carwatch/internal/locale"
@@ -407,6 +408,13 @@ func confirmKeyboard(data WizardData, lang locale.Lang) (*tgmodels.InlineKeyboar
 		summary += locale.Tf(lang, "wizard_confirm_exclude_keys", format.EscapeMarkdown(data.ExcludeKeys))
 	}
 
+	if data.OriginalSearch != nil {
+		diff := formatEditDiff(data, *data.OriginalSearch, lang)
+		if diff != "" {
+			summary += diff
+		}
+	}
+
 	kb := &tgmodels.InlineKeyboardMarkup{
 		InlineKeyboard: [][]tgmodels.InlineKeyboardButton{
 			{
@@ -418,6 +426,53 @@ func confirmKeyboard(data WizardData, lang locale.Lang) (*tgmodels.InlineKeyboar
 	}
 
 	return kb, summary
+}
+
+func formatEditDiff(current WizardData, orig botcore.OriginalSearch, lang locale.Lang) string {
+	var changes []string
+
+	add := func(label string, oldVal, newVal string) {
+		if oldVal != newVal {
+			changes = append(changes, fmt.Sprintf("%s: %s → %s", label, format.EscapeMarkdown(oldVal), format.EscapeMarkdown(newVal)))
+		}
+	}
+	addInt := func(label string, oldVal, newVal int) {
+		if oldVal != newVal {
+			changes = append(changes, fmt.Sprintf("%s: %d → %d", label, oldVal, newVal))
+		}
+	}
+	addPrice := func(label string, oldVal, newVal int) {
+		if oldVal != newVal {
+			changes = append(changes, fmt.Sprintf("%s: %s → %s", label, format.Number(oldVal), format.Number(newVal)))
+		}
+	}
+
+	add(locale.T(lang, "edit_diff_source"), sourceDisplayName(orig.Source), sourceDisplayName(current.Source))
+	if orig.Manufacturer != current.Manufacturer || orig.Model != current.Model {
+		oldCar := orig.ManufacturerName + " " + orig.ModelName
+		newCar := current.ManufacturerName + " " + current.ModelName
+		add(locale.T(lang, "edit_diff_car"), oldCar, newCar)
+	}
+	addInt(locale.T(lang, "edit_diff_year_min"), orig.YearMin, current.YearMin)
+	addInt(locale.T(lang, "edit_diff_year_max"), orig.YearMax, current.YearMax)
+	addPrice(locale.T(lang, "edit_diff_price_max"), orig.PriceMax, current.PriceMax)
+	addPrice(locale.T(lang, "edit_diff_price_min"), orig.PriceMin, current.PriceMin)
+	add(locale.T(lang, "edit_diff_gearbox"), gearboxDisplayName(lang, orig.GearBox), gearboxDisplayName(lang, current.GearBox))
+	addInt(locale.T(lang, "edit_diff_engine"), orig.EngineMinCC, current.EngineMinCC)
+	addInt(locale.T(lang, "edit_diff_km"), orig.MaxKm, current.MaxKm)
+	addInt(locale.T(lang, "edit_diff_hand"), orig.MaxHand, current.MaxHand)
+	add(locale.T(lang, "edit_diff_keywords"), orig.Keywords, current.Keywords)
+	add(locale.T(lang, "edit_diff_exclude"), orig.ExcludeKeys, current.ExcludeKeys)
+
+	if len(changes) == 0 {
+		return "\n\n" + locale.T(lang, "edit_diff_no_changes")
+	}
+
+	result := "\n\n" + locale.T(lang, "edit_diff_header")
+	for _, c := range changes {
+		result += "\n• " + c
+	}
+	return result
 }
 
 func ListingActionKeyboard(token string, lang locale.Lang) *tgmodels.InlineKeyboardMarkup {

--- a/internal/bot/testhelpers_test.go
+++ b/internal/bot/testhelpers_test.go
@@ -91,15 +91,17 @@ func newTestBot(t *testing.T) *testBot {
 	logger := slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	b := &Bot{
-		msg:         mm,
-		users:       store,
-		searches:    store,
-		listings:    store,
-		catalog:     catalog.NewStatic(),
-		adminChatID: 999,
-		maxSearches: defaultMaxSearches,
-		botUsername: "test_bot",
-		logger:      logger,
+		msg:                    mm,
+		users:                  store,
+		searches:               store,
+		listings:               store,
+		catalog:                catalog.NewStatic(),
+		adminChatID:            999,
+		maxSearches:            defaultMaxSearches,
+		botUsername:            "test_bot",
+		quickStartManufacturer: DefaultQuickStartManufacturer,
+		quickStartModel:        DefaultQuickStartModel,
+		logger:                 logger,
 	}
 
 	return &testBot{bot: b, msg: mm, store: store}
@@ -142,16 +144,18 @@ func newTestBotWithDigests(t *testing.T) *testBot {
 	logger := slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	b := &Bot{
-		msg:         mm,
-		users:       store,
-		searches:    store,
-		listings:    store,
-		digests:     store,
-		catalog:     catalog.NewStatic(),
-		adminChatID: 999,
-		maxSearches: defaultMaxSearches,
-		botUsername: "test_bot",
-		logger:      logger,
+		msg:                    mm,
+		users:                  store,
+		searches:               store,
+		listings:               store,
+		digests:                store,
+		catalog:                catalog.NewStatic(),
+		adminChatID:            999,
+		maxSearches:            defaultMaxSearches,
+		botUsername:            "test_bot",
+		quickStartManufacturer: DefaultQuickStartManufacturer,
+		quickStartModel:        DefaultQuickStartModel,
+		logger:                 logger,
 	}
 
 	return &testBot{bot: b, msg: mm, store: store}

--- a/internal/botcore/state.go
+++ b/internal/botcore/state.go
@@ -21,6 +21,32 @@ const (
 )
 
 type WizardData struct {
+	Source           string          `json:"source,omitempty"`
+	Manufacturer     int             `json:"manufacturer,omitempty"`
+	ManufacturerName string          `json:"manufacturer_name,omitempty"`
+	Model            int             `json:"model,omitempty"`
+	ModelName        string          `json:"model_name,omitempty"`
+	YearMin          int             `json:"year_min,omitempty"`
+	YearMax          int             `json:"year_max,omitempty"`
+	PriceMax         int             `json:"price_max,omitempty"`
+	PriceMin         int             `json:"price_min,omitempty"`
+	GearBox          string          `json:"gear_box,omitempty"`
+	EngineMinCC      int             `json:"engine_min_cc,omitempty"`
+	MaxKm            int             `json:"max_km,omitempty"`
+	MaxHand          int             `json:"max_hand,omitempty"`
+	Keywords         string          `json:"keywords,omitempty"`
+	ExcludeKeys      string          `json:"exclude_keys,omitempty"`
+	SellerFilter     string          `json:"seller_filter,omitempty"`
+	PriceOnly        bool            `json:"price_only,omitempty"`
+	PhotoOnly        bool            `json:"photo_only,omitempty"`
+	EditSearchID     int64           `json:"edit_search_id,omitempty"`
+	OriginalSearch   *OriginalSearch `json:"original_search,omitempty"`
+	// UpdatedAt tracks when the wizard state was last modified (Unix seconds).
+	// Used to auto-cancel stale wizard sessions.
+	UpdatedAt int64 `json:"updated_at,omitempty"`
+}
+
+type OriginalSearch struct {
 	Source           string `json:"source,omitempty"`
 	Manufacturer     int    `json:"manufacturer,omitempty"`
 	ManufacturerName string `json:"manufacturer_name,omitempty"`
@@ -36,11 +62,4 @@ type WizardData struct {
 	MaxHand          int    `json:"max_hand,omitempty"`
 	Keywords         string `json:"keywords,omitempty"`
 	ExcludeKeys      string `json:"exclude_keys,omitempty"`
-	SellerFilter     string `json:"seller_filter,omitempty"`
-	PriceOnly        bool   `json:"price_only,omitempty"`
-	PhotoOnly        bool   `json:"photo_only,omitempty"`
-	EditSearchID     int64  `json:"edit_search_id,omitempty"`
-	// UpdatedAt tracks when the wizard state was last modified (Unix seconds).
-	// Used to auto-cancel stale wizard sessions.
-	UpdatedAt int64 `json:"updated_at,omitempty"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,10 +88,12 @@ type ActiveHours struct {
 }
 
 type TelegramConfig struct {
-	Token       string `yaml:"token"`
-	AdminChatID int64  `yaml:"admin_chat_id"`
-	MaxSearches int    `yaml:"max_searches"`
-	BotUsername string `yaml:"bot_username"`
+	Token                  string `yaml:"token"`
+	AdminChatID            int64  `yaml:"admin_chat_id"`
+	MaxSearches            int    `yaml:"max_searches"`
+	BotUsername             string `yaml:"bot_username"`
+	QuickStartManufacturer int    `yaml:"quick_start_manufacturer"`
+	QuickStartModel        int    `yaml:"quick_start_model"`
 }
 
 type StorageConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,7 +91,7 @@ type TelegramConfig struct {
 	Token                  string `yaml:"token"`
 	AdminChatID            int64  `yaml:"admin_chat_id"`
 	MaxSearches            int    `yaml:"max_searches"`
-	BotUsername             string `yaml:"bot_username"`
+	BotUsername            string `yaml:"bot_username"`
 	QuickStartManufacturer int    `yaml:"quick_start_manufacturer"`
 	QuickStartModel        int    `yaml:"quick_start_model"`
 }

--- a/internal/locale/wizard.go
+++ b/internal/locale/wizard.go
@@ -66,6 +66,22 @@ var heWizard = map[string]string{
 	"wizard_save_failed":          "שמירת החיפוש נכשלה. אנא נסה שוב.",
 	"wizard_session_expired":      "הסשן פג. השתמש ב /watch כדי להתחיל חיפוש חדש.",
 
+	// edit diff
+	"edit_diff_header":     "*שינויים:*",
+	"edit_diff_no_changes": "אין שינויים.",
+	"edit_diff_source":     "מקור",
+	"edit_diff_car":        "רכב",
+	"edit_diff_year_min":   "שנה מינימלית",
+	"edit_diff_year_max":   "שנה מקסימלית",
+	"edit_diff_price_max":  "מחיר מקסימלי",
+	"edit_diff_price_min":  "מחיר מינימלי",
+	"edit_diff_gearbox":    "תיבת הילוכים",
+	"edit_diff_engine":     "מנוע",
+	"edit_diff_km":         "ק\"מ מקסימלי",
+	"edit_diff_hand":       "יד מקסימלית",
+	"edit_diff_keywords":   "מילות מפתח",
+	"edit_diff_exclude":    "מילות החרגה",
+
 	// /watch
 }
 
@@ -134,6 +150,22 @@ var enWizard = map[string]string{
 	"wizard_search_updated":       "Search #%d updated!\n\nUse /list to see your searches.",
 	"wizard_save_failed":          "Failed to save search. Please try again.",
 	"wizard_session_expired":      "Session expired. Use /watch to start a new search.",
+
+	// edit diff
+	"edit_diff_header":     "*Changes:*",
+	"edit_diff_no_changes": "No changes detected.",
+	"edit_diff_source":     "Source",
+	"edit_diff_car":        "Car",
+	"edit_diff_year_min":   "Year min",
+	"edit_diff_year_max":   "Year max",
+	"edit_diff_price_max":  "Max price",
+	"edit_diff_price_min":  "Min price",
+	"edit_diff_gearbox":    "Gearbox",
+	"edit_diff_engine":     "Engine",
+	"edit_diff_km":         "Max km",
+	"edit_diff_hand":       "Max hand",
+	"edit_diff_keywords":   "Keywords",
+	"edit_diff_exclude":    "Exclude",
 
 	// /watch
 }


### PR DESCRIPTION
## Summary

Phase 4a of the bot audit plan — 2 polish fixes:

- **Configurable quick-start** (#1138): Quick-start manufacturer/model IDs now come from config (`telegram.quick_start_manufacturer` / `quick_start_model`). Defaults to Toyota Corolla (19/8640). Search name derived from catalog instead of hardcoded string.
- **Edit change preview** (#1140): `/edit` confirmation screen now shows a diff section highlighting what changed. Original search params are snapshotted in `WizardData.OriginalSearch` on `/edit` start, then compared field by field. Shows "No changes detected" when nothing differs, or "Changes:" with bullet list of "Field: old → new" for each modified field.

## Review

Self-reviewed: all locale keys added in both HE/EN, OriginalSearch struct cleanly serializes/deserializes, lint clean, build passes.

## Test plan

- [ ] Quick-start with default config → creates Toyota Corolla search
- [ ] /edit 1 → change year min → confirmation shows "Year min: 2018 → 2020"
- [ ] /edit 1 → change nothing → confirmation shows "No changes detected"
- [ ] /edit 1 → change multiple fields → all listed in diff section

closes #1138
closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Start feature now respects custom manufacturer and model configuration instead of using hardcoded presets
  * Edit search now displays a summary of which fields changed when modifying saved searches
  * Added automatic expiration for stale editing sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->