### PR TITLE
feat: sync searches and bookmarks between linked accounts (#1135, #1136)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -489,6 +489,21 @@ func chatIDFromContext(ctx context.Context) (int64, bool) {
 	return id, true
 }
 
+func (s *Server) resolveCanonicalChatID(ctx context.Context, webChatID int64) int64 {
+	if s.users == nil {
+		return webChatID
+	}
+	linked, err := s.users.GetLinkedTelegramUser(ctx, webChatID)
+	if err != nil {
+		s.logger.Warn("resolve canonical chatID: lookup failed", "web_chat_id", webChatID, "error", err)
+		return webChatID
+	}
+	if linked == nil {
+		return webChatID
+	}
+	return linked.ChatID
+}
+
 func emailFromContext(ctx context.Context) string {
 	e, ok := ctx.Value(emailKey).(string)
 	if !ok {
@@ -504,6 +519,14 @@ func requireChatID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+func (s *Server) requireResolvedChatID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, ok := requireChatID(w, r)
+	if !ok {
+		return 0, false
+	}
+	return s.resolveCanonicalChatID(r.Context(), id), true
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -14,7 +14,7 @@ const (
 )
 
 func (s *Server) saveListing(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -45,7 +45,7 @@ func (s *Server) saveListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) unsaveListing(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -65,7 +65,7 @@ func (s *Server) unsaveListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -105,7 +105,7 @@ func (s *Server) listSaved(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) hideListing(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -136,7 +136,7 @@ func (s *Server) hideListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) unhideListing(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -156,7 +156,7 @@ func (s *Server) unhideListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}

--- a/internal/api/listing_seen.go
+++ b/internal/api/listing_seen.go
@@ -3,7 +3,7 @@ package api
 import "net/http"
 
 func (s *Server) markListingSeen(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -22,7 +22,7 @@ func (s *Server) markListingSeen(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) unmarkListingSeen(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -66,7 +66,7 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -215,7 +215,7 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -289,7 +289,7 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listingPriceHistory(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -379,7 +379,7 @@ func (s *Server) sweepRefreshCooldowns() {
 }
 
 func (s *Server) listListings(w http.ResponseWriter, r *http.Request) {
-	chatID, okChat := requireChatID(w, r)
+	chatID, okChat := s.requireResolvedChatID(w, r)
 	if !okChat {
 		return
 	}

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -34,7 +34,7 @@ func (s *Server) notificationCount(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listNotifications(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -78,7 +78,7 @@ func (s *Server) listNotifications(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) markNotificationsSeen(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -186,10 +186,10 @@ func (s *Server) searchResponseWithListingCount(ctx context.Context, chatID int6
 func (s *Server) listSearches(w http.ResponseWriter, r *http.Request) {
 	chatID, ok := chatIDFromContext(r.Context())
 	if !ok {
-		// Guest user — return empty list.
 		writeJSON(w, http.StatusOK, []searchResponse{})
 		return
 	}
+	chatID = s.resolveCanonicalChatID(r.Context(), chatID)
 	log := s.handlerLogger(r, "op", "list_searches")
 
 	searches, err := s.searches.ListSearches(r.Context(), chatID)
@@ -341,7 +341,7 @@ func (s *Server) writeCreatedSearch(w http.ResponseWriter, r *http.Request, chat
 }
 
 func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := requireChatID(w, r)
+	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
 		return
 	}
@@ -388,7 +388,7 @@ func (s *Server) createSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getSearch(w http.ResponseWriter, r *http.Request) {
-	chatID, okChat := requireChatID(w, r)
+	chatID, okChat := s.requireResolvedChatID(w, r)
 	if !okChat {
 		return
 	}
@@ -415,7 +415,7 @@ func (s *Server) getSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
-	chatID, okChat := requireChatID(w, r)
+	chatID, okChat := s.requireResolvedChatID(w, r)
 	if !okChat {
 		return
 	}
@@ -486,7 +486,7 @@ func (s *Server) updateSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) deleteSearch(w http.ResponseWriter, r *http.Request) {
-	chatID, okChat := requireChatID(w, r)
+	chatID, okChat := s.requireResolvedChatID(w, r)
 	if !okChat {
 		return
 	}
@@ -513,7 +513,7 @@ func (s *Server) deleteSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) searchStats(w http.ResponseWriter, r *http.Request) {
-	chatID, okChat := requireChatID(w, r)
+	chatID, okChat := s.requireResolvedChatID(w, r)
 	if !okChat {
 		return
 	}
@@ -564,7 +564,7 @@ func (s *Server) resumeSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) setSearchActive(w http.ResponseWriter, r *http.Request, active bool) {
-	chatID, okChat := requireChatID(w, r)
+	chatID, okChat := s.requireResolvedChatID(w, r)
 	if !okChat {
 		return
 	}

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -253,6 +253,49 @@ func (s *Store) LinkTelegramToWeb(ctx context.Context, telegramChatID, webChatID
 	if n == 0 {
 		return storage.ErrNotFound
 	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE searches SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM searches s2
+			WHERE s2.chat_id = $1 AND s2.manufacturer = searches.manufacturer AND s2.model = searches.model
+		)`,
+		telegramChatID, webChatID); err != nil {
+		return fmt.Errorf("migrate searches: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM searches WHERE chat_id = $1`, webChatID); err != nil {
+		return fmt.Errorf("cleanup duplicate searches: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE saved_listings SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM saved_listings s2
+			WHERE s2.chat_id = $1 AND s2.token = saved_listings.token
+		)`,
+		telegramChatID, webChatID); err != nil {
+		return fmt.Errorf("migrate saved listings: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM saved_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return fmt.Errorf("cleanup duplicate saved: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE hidden_listings SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM hidden_listings h2
+			WHERE h2.chat_id = $1 AND h2.token = hidden_listings.token
+		)`,
+		telegramChatID, webChatID); err != nil {
+		return fmt.Errorf("migrate hidden listings: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM hidden_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return fmt.Errorf("cleanup duplicate hidden: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
@@ -263,7 +306,7 @@ func (s *Store) GetLinkedTelegramUser(ctx context.Context, webChatID int64) (*st
 	row := s.db.QueryRowContext(ctx, `
 		SELECT chat_id, username, state, state_data, created_at, active, language, tier, tier_expires_at, trial_used, channel, channel_id
 		FROM users
-		WHERE linked_web_id = $1 AND channel = 'telegram'
+		WHERE linked_web_id = $1 AND channel = 'telegram' AND active = true
 		LIMIT 1`,
 		webChatID)
 


### PR DESCRIPTION
## Summary

Phase 4b of the bot audit plan — web-bot data sync:

- **Search sync** (#1135): When accounts are linked, web user's searches are migrated to the Telegram user's chatID. API reads use the linked Telegram chatID, so both interfaces see the same searches.
- **Bookmark sync** (#1136): Same pattern for saved/hidden listings. Migrated on link, resolved on read.

### Key implementation details

**Storage (`LinkTelegramToWeb`):**
- Transactional migration of searches, saved_listings, and hidden_listings from web → Telegram chatID
- Duplicate-safe: skips entries where the Telegram user already has a matching search (same manufacturer+model) or bookmark (same token)
- Cleans up remaining web-only entries after migration

**API (`resolveCanonicalChatID`):**
- If authenticated web user has a linked **active** Telegram user, returns the Telegram chatID
- Falls back to web chatID when no link exists or linked user is inactive/deleted
- Applied to all data-access endpoints (searches, bookmarks, listings, notifications)
- Identity endpoints (webpush, link tokens) intentionally use raw chatID

**`GetLinkedTelegramUser`:**
- Now adds `AND active = true` to prevent resolving deleted/deactivated Telegram users

## Test plan

- [ ] Link accounts → web dashboard shows bot-created searches
- [ ] Link accounts → /list in bot shows web-created searches
- [ ] Create search on web after linking → visible in bot
- [ ] Save listing on web after linking → appears in /saved
- [ ] Linked Telegram user deleted → web API falls back to own chatID
- [ ] Unlink → searches stay with Telegram user, web sees empty list

closes #1135
closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for linked Telegram and web accounts with proper data migration across searches, saved listings, and history when accounts are linked.

* **Improvements**
  * Standardized chat ID resolution across all API endpoints for consistent and reliable account access regardless of authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->