### PR TITLE
fix: backfill linked account data for pre-existing links (#1135)

### DIFF
--- a/cmd/bot-poller/main.go
+++ b/cmd/bot-poller/main.go
@@ -86,6 +86,12 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	}
 	defer func() { _ = store.Close() }()
 
+	if n, bfErr := store.BackfillLinkedData(ctx); bfErr != nil {
+		logger.Warn("backfill linked data failed", "error", bfErr)
+	} else if n > 0 {
+		logger.Info("backfilled linked account data", "rows_migrated", n)
+	}
+
 	fb, err := app.BuildFetchers(cfg, logger)
 	if err != nil {
 		return err

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -339,9 +339,15 @@ func (s *Store) BackfillLinkedData(ctx context.Context) (int, error) {
 }
 
 func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID int64) (int, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	var total int64
 
-	res, err := s.db.ExecContext(ctx, `
+	res, err := tx.ExecContext(ctx, `
 		UPDATE searches SET chat_id = $1
 		WHERE chat_id = $2
 		AND NOT EXISTS (
@@ -351,13 +357,14 @@ func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID i
 	if err != nil {
 		return 0, err
 	}
-	n, _ := res.RowsAffected()
-	total += n
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM searches WHERE chat_id = $1`, webChatID); err != nil {
-		return int(total), err
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM searches WHERE chat_id = $1`, webChatID); err != nil {
+		return 0, err
 	}
 
-	res, err = s.db.ExecContext(ctx, `
+	res, err = tx.ExecContext(ctx, `
 		UPDATE saved_listings SET chat_id = $1
 		WHERE chat_id = $2
 		AND NOT EXISTS (
@@ -365,15 +372,16 @@ func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID i
 			WHERE s2.chat_id = $1 AND s2.token = saved_listings.token
 		)`, telegramChatID, webChatID)
 	if err != nil {
-		return int(total), err
+		return 0, err
 	}
-	n, _ = res.RowsAffected()
-	total += n
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM saved_listings WHERE chat_id = $1`, webChatID); err != nil {
-		return int(total), err
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM saved_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return 0, err
 	}
 
-	res, err = s.db.ExecContext(ctx, `
+	res, err = tx.ExecContext(ctx, `
 		UPDATE hidden_listings SET chat_id = $1
 		WHERE chat_id = $2
 		AND NOT EXISTS (
@@ -381,14 +389,18 @@ func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID i
 			WHERE h2.chat_id = $1 AND h2.token = hidden_listings.token
 		)`, telegramChatID, webChatID)
 	if err != nil {
-		return int(total), err
+		return 0, err
 	}
-	n, _ = res.RowsAffected()
-	total += n
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM hidden_listings WHERE chat_id = $1`, webChatID); err != nil {
-		return int(total), err
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM hidden_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return 0, err
 	}
 
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
 	return int(total), nil
 }
 

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -302,6 +302,96 @@ func (s *Store) LinkTelegramToWeb(ctx context.Context, telegramChatID, webChatID
 	return nil
 }
 
+func (s *Store) BackfillLinkedData(ctx context.Context) (int, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT chat_id, linked_web_id FROM users
+		WHERE linked_web_id IS NOT NULL AND channel = 'telegram' AND active = true`)
+	if err != nil {
+		return 0, fmt.Errorf("query linked accounts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type link struct {
+		telegramID int64
+		webID      int64
+	}
+	var links []link
+	for rows.Next() {
+		var l link
+		if err := rows.Scan(&l.telegramID, &l.webID); err != nil {
+			return 0, fmt.Errorf("scan linked account: %w", err)
+		}
+		links = append(links, l)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	migrated := 0
+	for _, l := range links {
+		n, err := s.migrateUserData(ctx, l.telegramID, l.webID)
+		if err != nil {
+			return migrated, fmt.Errorf("migrate chat_id %d→%d: %w", l.webID, l.telegramID, err)
+		}
+		migrated += n
+	}
+	return migrated, nil
+}
+
+func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID int64) (int, error) {
+	var total int64
+
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE searches SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM searches s2
+			WHERE s2.chat_id = $1 AND s2.manufacturer = searches.manufacturer AND s2.model = searches.model
+		)`, telegramChatID, webChatID)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	total += n
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM searches WHERE chat_id = $1`, webChatID); err != nil {
+		return int(total), err
+	}
+
+	res, err = s.db.ExecContext(ctx, `
+		UPDATE saved_listings SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM saved_listings s2
+			WHERE s2.chat_id = $1 AND s2.token = saved_listings.token
+		)`, telegramChatID, webChatID)
+	if err != nil {
+		return int(total), err
+	}
+	n, _ = res.RowsAffected()
+	total += n
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM saved_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return int(total), err
+	}
+
+	res, err = s.db.ExecContext(ctx, `
+		UPDATE hidden_listings SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM hidden_listings h2
+			WHERE h2.chat_id = $1 AND h2.token = hidden_listings.token
+		)`, telegramChatID, webChatID)
+	if err != nil {
+		return int(total), err
+	}
+	n, _ = res.RowsAffected()
+	total += n
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM hidden_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return int(total), err
+	}
+
+	return int(total), nil
+}
+
 func (s *Store) GetLinkedTelegramUser(ctx context.Context, webChatID int64) (*storage.User, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT chat_id, username, state, state_data, created_at, active, language, tier, tier_expires_at, trial_used, channel, channel_id


### PR DESCRIPTION
## Summary

The sync PR (#1146) added migration logic inside `LinkTelegramToWeb`, but this only runs when accounts are **newly linked**. Accounts that were already linked before deployment have orphaned data under the web chatID, invisible to the bot's `/list`.

This PR adds:
- `BackfillLinkedData`: finds all active linked accounts, migrates searches/saved/hidden from web → Telegram chatID (idempotent, skips duplicates)
- Called once on `bot-poller` startup — zero-cost for already-migrated accounts

## Test plan
- [ ] Deploy → bot-poller logs "backfilled linked account data" with row count
- [ ] /list in bot now shows web-created searches
- [ ] Web dashboard still shows same searches (resolveCanonicalChatID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic data consolidation during system initialization to improve consistency across linked accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->