### PR TITLE
fix: include listing_history in linked account data migration

### DIFF
--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -296,6 +296,20 @@ func (s *Store) LinkTelegramToWeb(ctx context.Context, telegramChatID, webChatID
 		return fmt.Errorf("cleanup duplicate hidden: %w", err)
 	}
 
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE listing_history SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM listing_history lh2
+			WHERE lh2.chat_id = $1 AND lh2.token = listing_history.token
+		)`,
+		telegramChatID, webChatID); err != nil {
+		return fmt.Errorf("migrate listing history: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM listing_history WHERE chat_id = $1`, webChatID); err != nil {
+		return fmt.Errorf("cleanup duplicate listing history: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
@@ -395,6 +409,23 @@ func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID i
 		total += n
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM hidden_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return 0, err
+	}
+
+	res, err = tx.ExecContext(ctx, `
+		UPDATE listing_history SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM listing_history lh2
+			WHERE lh2.chat_id = $1 AND lh2.token = listing_history.token
+		)`, telegramChatID, webChatID)
+	if err != nil {
+		return 0, err
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM listing_history WHERE chat_id = $1`, webChatID); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
## Summary

The account linking migration moved searches, saved listings, and hidden listings but missed `listing_history`. After linking, the dashboard showed all searches with 0 results because listing records were still under the web chatID.

Adds `listing_history` migration to both `LinkTelegramToWeb` (future links) and `migrateUserData` (backfill). Same duplicate-safe pattern as the other tables.

Already applied the fix manually to production DB (117 rows migrated).

## Test plan
- [ ] Dashboard shows listing counts after linking
- [ ] /history in bot shows web-discovered listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)