### PR TITLE
fix: backend reliability bugs from production audit

### DIFF
--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -198,7 +198,8 @@ func (c *EnrichConsumer) reclaimPending(ctx context.Context) {
 func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
 	msgs, err := c.client.XRangeN(ctx, EnrichStreamName, id, id, 1).Result()
 	if err != nil {
-		c.logger.Error("read enrich message for dead-letter failed", "id", id, "error", err)
+		c.logger.Error("read enrich message for dead-letter failed, acking to prevent stuck loop", "id", id, "error", err)
+		c.ack(ctx, id)
 		return
 	}
 	if len(msgs) == 0 {

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -107,6 +107,15 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		return err
 	}
 
+	// Count toward the enrich_attempts cap when km is genuinely unavailable
+	// on the source page, so backfill stops re-queuing this token.
+	if details.Km <= 0 {
+		if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
+			w.logger.ErrorContext(ctx, "failed to increment enrich attempt for km-unavailable listing",
+				"token", req.Token, "error", incErr.Error())
+		}
+	}
+
 	if telemetry.EnrichSuccesses != nil {
 		telemetry.EnrichSuccesses.Add(ctx, 1)
 	}

--- a/internal/scheduler/digest.go
+++ b/internal/scheduler/digest.go
@@ -110,9 +110,6 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 		return
 	}
 
-	// Delivery succeeded; clear the failure marker.
-	s.digestFailures.Delete(chatID)
-
 	if err := s.stores.Digests.AckDigest(ctx, chatID, cutoff); err != nil {
 		s.logger.Error("digest ack failed after successful send, items may be resent",
 			"chat_id", chatID,
@@ -120,7 +117,10 @@ func (s *Scheduler) flushAndSendDigest(ctx context.Context, chatID int64) {
 			"items", len(payloads),
 			"error", err,
 		)
+		s.digestFailures.Store(chatID, time.Now())
+		return
 	}
+	s.digestFailures.Delete(chatID)
 
 	s.logger.Info("digest sent",
 		"chat_id", chatID,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -748,8 +748,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	// cycles get that data before matching.
 	prefilled := false
 	if s.stores.Listings != nil {
-		s.prefillFromDB(ctx, raw)
-		prefilled = true
+		prefilled = s.prefillFromDB(ctx, raw)
 	}
 
 	// 4. Build a per-search accumulator to collect results across listings.
@@ -956,7 +955,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			if acc.search.MaxKm > 0 {
 				filtered := make([]model.RawListing, 0, len(rawForPipeline))
 				for _, r := range rawForPipeline {
-					if r.Km > 0 && r.Km > acc.search.MaxKm {
+					if r.Km <= 0 || r.Km > acc.search.MaxKm {
 						if relErr := s.stores.Dedup.ReleaseClaim(ctx, r.Token, acc.search.ChatID, acc.search.ID); relErr != nil {
 							s.logger.ErrorContext(searchCtx,
 								"failed to release dedup claim for km-filtered listing",
@@ -1105,7 +1104,7 @@ type cycleStats struct {
 // prefillFromDB fills in km/city/image from listing_history for listings
 // that the enricher could not reach this cycle. Once a listing's km is
 // learned in any previous cycle, it is remembered here.
-func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListing) {
+func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListing) bool {
 	var tokens []string
 	for i := range listings {
 		if listings[i].Km <= 0 || listings[i].City == "" || listings[i].ImageURL == "" {
@@ -1113,7 +1112,7 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 		}
 	}
 	if len(tokens) == 0 {
-		return
+		return true
 	}
 
 	prefillStart := time.Now()
@@ -1121,10 +1120,10 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to look up enrichment data from database for prefill",
 			"error", err, "looked_up", len(tokens))
-		return
+		return false
 	}
 	if len(data) == 0 {
-		return
+		return true
 	}
 
 	filled := 0
@@ -1155,6 +1154,7 @@ func (s *Scheduler) prefillFromDB(ctx context.Context, listings []model.RawListi
 			"filled", filled, "looked_up", len(tokens),
 			"duration_ms", time.Since(prefillStart).Milliseconds())
 	}
+	return true
 }
 
 // backfillEnrichedListings upserts listing_history for listings that gained


### PR DESCRIPTION
## Summary

Five fixes from adversarial-reviewed backend reliability audit, triggered by production incident where Mazda vehicles received notifications without km enrichment data.

- **Post-enrichment MaxKm filter** now rejects `Km<=0` listings when `MaxKm` is set, preventing unenriched vehicles from bypassing km constraints
- **prefillFromDB** returns bool indicating success; pipeline's own prefill runs as fallback when scheduler prefill fails instead of being unconditionally skipped
- **Digest flush** moves `digestFailures.Delete` after successful `AckDigest` and sets failure marker on ack failure, preventing duplicate digest sends
- **Enricher** increments `enrich_attempts` on successful fetch with `Km=0`, so backfill stops re-queuing tokens whose source pages genuinely lack km data
- **Dead-letter** acks message on `XRangeN` read failure to prevent stuck 30-second retry loop

## Audit Context

Full audit found 16 potential bugs. Each was independently verified by an adversarial review agent reading the actual source code:
- **4 confirmed** → fixed here
- **2 partial** (downgraded) → 1 fixed here (BUG-007), 1 deferred as self-correcting (BUG-013)
- **10 refuted** → closed with explanations

Parent epic: #1166

closes #1151
closes #1154
closes #1155
closes #1156
closes #1158

## Test plan

- [x] All unit tests pass (`make test` — 3 Docker-dependent tests fail without Docker, pre-existing)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Post-enrichment MaxKm filter: verified by `TestPostEnrichmentKmFilter_*` tests
- [x] Enricher worker: verified by `TestWorker_*` tests (18 pass)
- [x] Broker consumer: verified by `TestConsumer*` tests (all pass)
- [x] Digest delivery: verified by `TestDigestDelivery_*` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a potential retry loop condition in enrichment error handling

* **Improvements**
  * Enhanced enrichment attempt tracking to ensure all requests are properly counted against system limits
  * Improved digest acknowledgment failure detection for more reliable retry interval scheduling
  * Refined post-enrichment listing filtering to appropriately handle items missing critical data during processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->