### PR TITLE
fix: filter removed listings from dashboard and enforce seller_filter in refresh

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -65,10 +65,7 @@ func matches(c model.FilterCriteria, l model.RawListing) bool {
 	}
 
 	sf := strings.ToLower(strings.TrimSpace(c.SellerFilter))
-	if sf != "" && sf != "any" {
-		if l.Commercial == nil {
-			return false
-		}
+	if sf != "" && sf != "any" && l.Commercial != nil {
 		isCommercial := *l.Commercial
 		if sf == "private" && isCommercial {
 			return false

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -64,6 +64,20 @@ func matches(c model.FilterCriteria, l model.RawListing) bool {
 		return false
 	}
 
+	sf := strings.ToLower(strings.TrimSpace(c.SellerFilter))
+	if sf != "" && sf != "any" {
+		if l.Commercial == nil {
+			return false
+		}
+		isCommercial := *l.Commercial
+		if sf == "private" && isCommercial {
+			return false
+		}
+		if (sf == "commercial" || sf == "dealer" || sf == "dealership") && !isCommercial {
+			return false
+		}
+	}
+
 	desc := strings.ToLower(l.Description + " " + l.SubModel)
 
 	for _, kw := range c.Keywords {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/dsionov/carwatch/internal/model"
 )
 
+func boolPtr(v bool) *bool { return &v }
+
 func TestApply(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -333,6 +335,81 @@ func TestApply(t *testing.T) {
 				{Token: "valid-year", Year: 2020},
 			},
 			want: []string{"valid-year"},
+		},
+		// --- SellerFilter tests ---
+		{
+			name:     "seller filter private rejects commercial",
+			criteria: model.FilterCriteria{SellerFilter: "private"},
+			listings: []model.RawListing{
+				{Token: "a", Commercial: boolPtr(false)},
+				{Token: "b", Commercial: boolPtr(true)},
+			},
+			want: []string{"a"},
+		},
+		{
+			name:     "seller filter commercial rejects private",
+			criteria: model.FilterCriteria{SellerFilter: "commercial"},
+			listings: []model.RawListing{
+				{Token: "a", Commercial: boolPtr(false)},
+				{Token: "b", Commercial: boolPtr(true)},
+			},
+			want: []string{"b"},
+		},
+		{
+			name:     "seller filter dealer synonym accepted",
+			criteria: model.FilterCriteria{SellerFilter: "dealer"},
+			listings: []model.RawListing{
+				{Token: "a", Commercial: boolPtr(true)},
+				{Token: "b", Commercial: boolPtr(false)},
+			},
+			want: []string{"a"},
+		},
+		{
+			name:     "seller filter nil Commercial passes through",
+			criteria: model.FilterCriteria{SellerFilter: "private"},
+			listings: []model.RawListing{
+				{Token: "a", Commercial: nil},
+				{Token: "b", Commercial: boolPtr(false)},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name:     "seller filter any passes all",
+			criteria: model.FilterCriteria{SellerFilter: "any"},
+			listings: []model.RawListing{
+				{Token: "a", Commercial: boolPtr(true)},
+				{Token: "b", Commercial: boolPtr(false)},
+				{Token: "c", Commercial: nil},
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name:     "seller filter empty passes all",
+			criteria: model.FilterCriteria{SellerFilter: ""},
+			listings: []model.RawListing{
+				{Token: "a", Commercial: boolPtr(true)},
+				{Token: "b", Commercial: boolPtr(false)},
+			},
+			want: []string{"a", "b"},
+		},
+		// --- SubModel keyword matching ---
+		{
+			name:     "keyword matches in SubModel",
+			criteria: model.FilterCriteria{Keywords: []string{"sport"}},
+			listings: []model.RawListing{
+				{Token: "a", Description: "clean car", SubModel: "Sport Edition"},
+				{Token: "b", Description: "clean car", SubModel: "Basic"},
+			},
+			want: []string{"a"},
+		},
+		{
+			name:     "exclude key matches in SubModel",
+			criteria: model.FilterCriteria{ExcludeKeys: []string{"basic"}},
+			listings: []model.RawListing{
+				{Token: "a", Description: "nice car", SubModel: "Sport"},
+				{Token: "b", Description: "nice car", SubModel: "Basic trim"},
+			},
+			want: []string{"a"},
 		},
 	}
 

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -12,17 +12,18 @@ import (
 // replaces both.
 func FilterCriteriaFromSearch(s *storage.Search) FilterCriteria {
 	criteria := FilterCriteria{
-		ModelID:     s.Model,
-		YearMin:     s.YearMin,
-		YearMax:     s.YearMax,
-		PriceMin:    s.PriceMin,
-		PriceMax:    s.PriceMax,
-		EngineMinCC: float64(s.EngineMinCC),
-		MaxKm:       s.MaxKm,
-		MaxHand:     s.MaxHand,
-		GearBox:     s.GearBox,
-		PriceOnly:   s.PriceOnly,
-		PhotoOnly:   s.PhotoOnly,
+		ModelID:      s.Model,
+		YearMin:      s.YearMin,
+		YearMax:      s.YearMax,
+		PriceMin:     s.PriceMin,
+		PriceMax:     s.PriceMax,
+		EngineMinCC:  float64(s.EngineMinCC),
+		MaxKm:        s.MaxKm,
+		MaxHand:      s.MaxHand,
+		GearBox:      s.GearBox,
+		SellerFilter: s.SellerFilter,
+		PriceOnly:    s.PriceOnly,
+		PhotoOnly:    s.PhotoOnly,
 	}
 
 	if s.Keywords != "" {
@@ -60,18 +61,19 @@ type SourceParams struct {
 // FilterCriteria defines the criteria used to filter raw listings
 // after they are fetched from a source.
 type FilterCriteria struct {
-	ModelID     int
-	YearMin     int
-	YearMax     int
-	PriceMin    int
-	PriceMax    int
-	EngineMinCC float64
-	EngineMaxCC float64
-	MaxKm       int
-	MaxHand     int
-	Keywords    []string
-	ExcludeKeys []string
-	GearBox     string
-	PriceOnly   bool
-	PhotoOnly   bool
+	ModelID      int
+	YearMin      int
+	YearMax      int
+	PriceMin     int
+	PriceMax     int
+	EngineMinCC  float64
+	EngineMaxCC  float64
+	MaxKm        int
+	MaxHand      int
+	Keywords     []string
+	ExcludeKeys  []string
+	GearBox      string
+	SellerFilter string
+	PriceOnly    bool
+	PhotoOnly    bool
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -225,10 +225,11 @@ type ListingFilter struct {
 	MaxKm    int
 	MaxHand  int
 	// Commercial: non-nil restricts to private (false) or commercial/dealer (true).
-	Commercial *bool
-	GearBox    string
-	PriceOnly  bool
-	PhotoOnly  bool
+	Commercial     *bool
+	GearBox        string
+	PriceOnly      bool
+	PhotoOnly      bool
+	IncludeRemoved bool // when true, include listings with removed_at set
 }
 
 // SearchStats holds aggregate market stats for a single search.

--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -17,6 +17,7 @@ func TestCountSearchListingsForChatQuery_Contract(t *testing.T) {
 		"s.seller_filter",
 		"WHEN 'dealer'",
 		"lh.is_commercial",
+		"lh.removed_at IS NULL",
 		"GROUP BY lh.search_id",
 	} {
 		if !strings.Contains(countSearchListingsForChatSQL, frag) {
@@ -47,8 +48,21 @@ func TestQuoteIdent(t *testing.T) {
 
 func TestBuildFilterClauses_Empty(t *testing.T) {
 	clause, args, nextParam := buildFilterClauses(storage.ListingFilter{}, 1)
+	if !strings.Contains(clause, "removed_at IS NULL") {
+		t.Errorf("expected removed_at IS NULL clause, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+	if nextParam != 1 {
+		t.Errorf("expected nextParam=1, got %d", nextParam)
+	}
+}
+
+func TestBuildFilterClauses_IncludeRemoved(t *testing.T) {
+	clause, args, nextParam := buildFilterClauses(storage.ListingFilter{IncludeRemoved: true}, 1)
 	if clause != "" {
-		t.Errorf("expected empty clause, got %q", clause)
+		t.Errorf("expected empty clause with IncludeRemoved, got %q", clause)
 	}
 	if len(args) != 0 {
 		t.Errorf("expected no args, got %v", args)

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -33,6 +33,7 @@ WHERE lh.chat_id = $1
   AND (COALESCE(s.gear_box, '') = '' OR LOWER(lh.gear_box) = LOWER(s.gear_box))
   AND (NOT s.price_only OR lh.price > 0)
   AND (NOT s.photo_only OR lh.image_url != '')
+  AND lh.removed_at IS NULL
 GROUP BY lh.search_id`
 
 const upsertListingSQL = `
@@ -287,7 +288,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 			engine_volume, horse_power, engine_type, gear_box, description,
 			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
 		FROM listing_history
-		WHERE chat_id = $1
+		WHERE chat_id = $1 AND removed_at IS NULL
 		ORDER BY first_seen_at DESC, token DESC
 		LIMIT $2 OFFSET $3`, chatID, limit, offset)
 	if err != nil {
@@ -310,7 +311,7 @@ func (s *Store) CountUserListings(ctx context.Context, chatID int64) (int64, err
 	var count int64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM listing_history
-		WHERE chat_id = $1`, chatID).Scan(&count)
+		WHERE chat_id = $1 AND removed_at IS NULL`, chatID).Scan(&count)
 	return count, err
 }
 
@@ -399,6 +400,9 @@ func buildFilterClauses(f storage.ListingFilter, paramStart int) (string, []any,
 	}
 	if f.PhotoOnly {
 		clauses = append(clauses, "image_url != ''")
+	}
+	if !f.IncludeRemoved {
+		clauses = append(clauses, "removed_at IS NULL")
 	}
 	if len(clauses) == 0 {
 		return "", nil, paramStart


### PR DESCRIPTION
## Summary

- Dashboard queries now exclude listings with `removed_at` set — sold/delisted cars no longer appear as active or inflate counts
- API refresh handler now enforces `seller_filter` — commercial listings no longer leak into private-only searches
- Added `IncludeRemoved` field to `ListingFilter` for opt-in access to removed listings (bookmarks)

## What was broken

1. **Stale listings in dashboard**: Listings removed from Yad2 kept showing in the dashboard with active counts. Users clicked through to Yad2 and found nothing.
2. **Seller filter bypass on refresh**: The percolator correctly filtered commercial listings for "private" searches, but the API refresh handler's `filter.Apply()` did not check `seller_filter` at all — so clicking refresh could surface dealer listings that should have been excluded.

## Changes

| File | Change |
|------|--------|
| `internal/storage/interfaces.go` | Add `IncludeRemoved` to `ListingFilter` |
| `internal/storage/postgres/listings.go` | Add `removed_at IS NULL` to `buildFilterClauses`, `countSearchListingsForChatSQL`, `CountUserListings`, `ListUserListings` |
| `internal/model/params.go` | Add `SellerFilter` to `FilterCriteria` and `FilterCriteriaFromSearch` |
| `internal/filter/filter.go` | Add seller filter check in `matches()` |
| `internal/storage/postgres/helpers_test.go` | Update tests for new default filter behavior, add `IncludeRemoved` test |

## Test plan

- [x] `go build ./...` compiles
- [x] `golangci-lint run ./...` — 0 issues
- [x] Unit tests pass (`TestBuildFilterClauses_*`, `TestCountSearchListingsForChatQuery_Contract`)
- [ ] Deploy and verify dashboard counts exclude removed listings
- [ ] Verify manual refresh doesn't surface commercial listings for private searches

closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seller-type filtering (private vs commercial) and expanded keyword matching to include submodel text.

* **Improvements**
  * Listings exclude soft-deleted/removed items by default and can optionally include removed entries.

* **Tests**
  * Added coverage for seller-type behavior and keyword/exclude matching across the extended fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->