### PR TITLE
fix: security hardening from codebase audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           TELEGRAM_BOT_TOKEN=test \
           docker compose -f docker-compose.prod.yaml config > /tmp/compose-full.yaml
           for svc in $APP_SERVICES; do
-            if ! grep -A20 "^  ${svc}:" /tmp/compose-full.yaml | grep -q "healthcheck:"; then
+            if ! grep -A40 "^  ${svc}:" /tmp/compose-full.yaml | grep -q "healthcheck:"; then
               echo "::error::Service ${svc} is missing a healthcheck"
               exit 1
             fi

--- a/Caddyfile
+++ b/Caddyfile
@@ -6,6 +6,7 @@
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
 		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+		Content-Security-Policy "default-src 'self'; script-src 'self' https://*.googleapis.com https://*.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; frame-src https://*.firebaseapp.com"
 	}
 	reverse_proxy api:8080
 }

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -64,6 +64,13 @@ services:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-api
     entrypoint: ["/usr/local/bin/api-server"]
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
     networks:
       - carwatch-net
     depends_on:
@@ -101,6 +108,13 @@ services:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-bot-poller
     entrypoint: ["/usr/local/bin/bot-poller"]
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
     networks:
       - carwatch-net
     depends_on:
@@ -133,6 +147,13 @@ services:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-scraper
     entrypoint: ["/usr/local/bin/scraper"]
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
     networks:
       - carwatch-net
     depends_on:
@@ -167,6 +188,13 @@ services:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-notifier
     entrypoint: ["/usr/local/bin/notifier"]
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
     networks:
       - carwatch-net
     depends_on:
@@ -200,6 +228,13 @@ services:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
     container_name: carwatch-enricher
     entrypoint: ["/usr/local/bin/enricher"]
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
     networks:
       - carwatch-net
     depends_on:

--- a/internal/api/accesslog.go
+++ b/internal/api/accesslog.go
@@ -57,11 +57,6 @@ func (s *Server) withAccessLog(next http.Handler) http.Handler {
 		if chatID > 0 {
 			fields = append(fields, "chat_id", chatID)
 		}
-		if rec.status >= 400 {
-			if detail := rec.Header().Get("X-Error-Detail"); detail != "" {
-				fields = append(fields, "error", detail)
-			}
-		}
 		s.logger.Info("http_request", fields...)
 	})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -550,7 +550,6 @@ func (s *Server) handlerLogger(r *http.Request, extras ...any) *slog.Logger {
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("X-Error-Detail", msg)
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 

--- a/internal/api/push.go
+++ b/internal/api/push.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -34,6 +35,10 @@ func (s *Server) pushSubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Endpoint == "" || req.Keys.P256DH == "" || req.Keys.Auth == "" {
 		writeError(w, http.StatusBadRequest, "endpoint, keys.p256dh, and keys.auth are required")
+		return
+	}
+	if len(req.Endpoint) > 2048 || !strings.HasPrefix(req.Endpoint, "https://") {
+		writeError(w, http.StatusBadRequest, "endpoint must be an HTTPS URL (max 2048 chars)")
 		return
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,14 +141,24 @@ func warnHardcodedSecrets(raw string) {
 	if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
 		return
 	}
-	tg, ok := doc["telegram"].(map[string]any)
-	if !ok {
-		return
+	checkSecret := func(path, envHint string, section map[string]any, key string) {
+		val, _ := section[key].(string)
+		val = strings.TrimSpace(val)
+		if val != "" && !strings.Contains(val, "${") {
+			slog.Warn(path + " appears hardcoded in config; use ${" + envHint + "} for production")
+		}
 	}
-	token, _ := tg["token"].(string)
-	token = strings.TrimSpace(token)
-	if token != "" && !strings.Contains(token, "${") {
-		slog.Warn("telegram.token appears hardcoded in config; use ${TELEGRAM_BOT_TOKEN} for production")
+	if tg, ok := doc["telegram"].(map[string]any); ok {
+		checkSecret("telegram.token", "TELEGRAM_BOT_TOKEN", tg, "token")
+	}
+	if redis, ok := doc["redis"].(map[string]any); ok {
+		checkSecret("redis.password", "REDIS_PASSWORD", redis, "password")
+	}
+	if push, ok := doc["push"].(map[string]any); ok {
+		checkSecret("push.vapid_private_key", "VAPID_PRIVATE", push, "vapid_private_key")
+	}
+	if storage, ok := doc["storage"].(map[string]any); ok {
+		checkSecret("storage.dsn", "DATABASE_URL", storage, "dsn")
 	}
 }
 


### PR DESCRIPTION
## Summary

Security hardening fixes from the comprehensive codebase audit (#1190, #1194).

- **Remove `X-Error-Detail` header:** Internal error messages were exposed via response headers; removed from both `writeError` and access log reader
- **Push subscription URL validation:** Enforce `https://` scheme and 2048-char limit on WebPush endpoints
- **Extend hardcoded secret detection:** `warnHardcodedSecrets` now checks `redis.password`, `push.vapid_private_key`, and `storage.dsn` (was only `telegram.token`)
- **Content-Security-Policy header:** Added to Caddyfile restricting script/connect/style/img/font/frame sources to self + Firebase domains
- **Container hardening:** All 5 app services now run with `read_only`, `no-new-privileges`, `cap_drop: [ALL]`, `tmpfs: [/tmp]`

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added Content-Security-Policy header to enhance browser security.
  * Hardened production containers with read-only filesystems, privilege restrictions, and capability dropping.
  * Enhanced validation for push subscription endpoints to require HTTPS.
  * Expanded detection of hardcoded secrets in configuration files.

* **Bug Fixes**
  * Simplified API error responses and refined access logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->