### PR TITLE
fix: schema improvements from codebase audit

### DIFF
--- a/migrations/000017_schema_audit_fixes.down.sql
+++ b/migrations/000017_schema_audit_fixes.down.sql
@@ -1,0 +1,12 @@
+-- Remove FK on push_subscriptions.
+ALTER TABLE push_subscriptions DROP CONSTRAINT IF EXISTS fk_push_subs_user;
+
+-- Restore original stale index on search_name.
+CREATE INDEX IF NOT EXISTS idx_listing_history_chat_search
+  ON listing_history (chat_id, search_name);
+
+-- Restore narrow unenriched index (km-only).
+DROP INDEX IF EXISTS idx_listing_history_unenriched;
+CREATE INDEX idx_listing_history_unenriched
+  ON listing_history (first_seen_at DESC)
+  WHERE km <= 0;

--- a/migrations/000017_schema_audit_fixes.up.sql
+++ b/migrations/000017_schema_audit_fixes.up.sql
@@ -1,0 +1,15 @@
+-- Add missing FK on push_subscriptions to cascade user deletion.
+ALTER TABLE push_subscriptions
+  ADD CONSTRAINT fk_push_subs_user
+  FOREIGN KEY (chat_id) REFERENCES users(chat_id) ON DELETE CASCADE;
+
+-- Drop stale index on search_name (all queries use search_id).
+DROP INDEX IF EXISTS idx_listing_history_chat_search;
+
+-- Replace narrow unenriched index (km-only) with broader partial index
+-- covering all enrichment criteria checked by the enricher worker.
+DROP INDEX IF EXISTS idx_listing_history_unenriched;
+CREATE INDEX idx_listing_history_unenriched
+  ON listing_history (first_seen_at DESC)
+  WHERE (km <= 0 OR COALESCE(city, '') = '' OR COALESCE(image_url, '') = '')
+    AND enrich_attempts < 10;


### PR DESCRIPTION
## Summary

Database schema fixes from the comprehensive codebase audit (#1190, #1194, #1196).

Migration 000017:
- **FK on `push_subscriptions`:** Add `REFERENCES users(chat_id) ON DELETE CASCADE` — orphaned subscriptions were surviving user deletion
- **Drop stale index:** Remove `idx_listing_history_chat_search` (indexed `search_name` text column, but all queries use `search_id` integer)
- **Broader unenriched index:** Replace narrow km-only partial index with one covering all enrichment criteria (`km`, `city`, `image_url`) plus `enrich_attempts`, matching the enricher's actual WHERE clause

## Test plan

- [x] Up/down migration SQL validates
- [ ] CI migration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)