### PR TITLE
fix: gearbox filter drops listings with empty gear_box field

### DIFF
--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -30,7 +30,7 @@ WHERE lh.chat_id = $1
     WHEN 'dealership' THEN lh.is_commercial = 1
     ELSE TRUE
   END
-  AND (COALESCE(s.gear_box, '') = '' OR LOWER(lh.gear_box) = LOWER(s.gear_box))
+  AND (COALESCE(s.gear_box, '') = '' OR lh.gear_box = '' OR LOWER(lh.gear_box) = LOWER(s.gear_box))
   AND (NOT s.price_only OR lh.price > 0)
   AND (NOT s.photo_only OR lh.image_url != '')
   AND lh.removed_at IS NULL
@@ -360,7 +360,7 @@ func buildFilterClauses(f storage.ListingFilter, paramStart int) (string, []any,
 		n++
 	}
 	if f.GearBox != "" {
-		clauses = append(clauses, fmt.Sprintf("LOWER(gear_box) = LOWER($%d)", n))
+		clauses = append(clauses, fmt.Sprintf("(gear_box = '' OR LOWER(gear_box) = LOWER($%d))", n))
 		args = append(args, f.GearBox)
 		n++
 	}


### PR DESCRIPTION
## Summary

**Root cause of Telegram-sends-but-web-doesn't-show bug.**

The Yad2 feed JSON does not include a top-level `gearbox` field — gearbox info is embedded in the sub-model text. As a result, all listings in `listing_history` have `gear_box = ''`.

The **percolator** (used by the scheduler for Telegram delivery) correctly handles this: `if s.GearBox != "" && l.GearBox != ""` — when the listing's gearbox is empty, it skips the check (unknown = pass through).

But the **DB filter** (used by the web API for listing queries) strictly matched: `LOWER(gear_box) = LOWER($N)` — empty gearbox fails the match, returning 0 results.

### Fix

Add `gear_box = ''` OR guard to both SQL filter paths:
- `buildFilterClauses` — used by `ListSearchListings`, `CountSearchListings`  
- `countSearchListingsForChatSQL` — used by dashboard batch counts

This matches the percolator's semantics: empty gearbox = unknown = pass through.

### Evidence from production DB

```
-- Search 38 (Toyota Corolla, gearbox=אוטומט):
-- 69 listings, all with gear_box = ''
-- Without fix: COUNT = 0  (web shows nothing)
-- With fix:    COUNT = 69 (matches Telegram delivery)
```

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listing search filtering to better handle cases where transmission type is unspecified, providing more accurate and flexible matching results with case-insensitive comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->