### PR TITLE
fix: targeted fetches bypass circuit breaker to prevent cross-model blocking

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -147,6 +147,7 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 		Prices:           store,
 		ConfigPath:       configPath,
 		FetcherFactory:   fb.Factory,
+		TargetedFetcher:  fb.Targeted,
 		ListingStore:     store,
 		SearchStore:      store,
 		UserStore:        store,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -54,10 +54,11 @@ func OpenStore(cfg *config.Config, skipMigrate ...bool) (*postgres.Store, error)
 
 // FetcherBundle groups all fetcher-related objects returned by BuildFetchers.
 type FetcherBundle struct {
-	Yad2    *yad2.Yad2Fetcher
-	Caching fetcher.Fetcher
-	Factory *fetcher.Factory
-	Pool    *fetcher.ProxyPool
+	Yad2     *yad2.Yad2Fetcher
+	Caching  fetcher.Fetcher // full chain: CircuitBreaker → Cache → Paginator → Yad2
+	Targeted fetcher.Fetcher // without circuit breaker: Cache → Paginator → Yad2
+	Factory  *fetcher.Factory
+	Pool     *fetcher.ProxyPool
 }
 
 // BuildFetchers creates the Yad2 fetcher, paginating/caching wrappers,
@@ -89,10 +90,11 @@ func BuildFetchers(cfg *config.Config, logger *slog.Logger) (*FetcherBundle, err
 	fetcherFactory.Register("yad2", yad2CB)
 
 	return &FetcherBundle{
-		Yad2:    yad2Fetcher,
-		Caching: yad2CB,
-		Factory: fetcherFactory,
-		Pool:    proxyPool,
+		Yad2:     yad2Fetcher,
+		Caching:  yad2CB,
+		Targeted: cachingFetcher,
+		Factory:  fetcherFactory,
+		Pool:     proxyPool,
 	}, nil
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -54,6 +54,7 @@ type Scheduler struct {
 	cfg             *config.Config
 	configPath      string
 	fetcher         fetcher.Fetcher
+	targetedFetcher fetcher.Fetcher // bypasses circuit breaker for per-model fetches
 	stores          Stores
 	notifier        notifier.Notifier
 	logger          *slog.Logger
@@ -120,6 +121,7 @@ type Options struct {
 	Prices           storage.PriceTracker
 	ConfigPath       string
 	FetcherFactory   *fetcher.Factory
+	TargetedFetcher  fetcher.Fetcher // bypasses circuit breaker for per-model fetches
 	ListingStore     storage.ListingStore
 	SearchStore      storage.SearchStore
 	UserStore        storage.UserStore
@@ -176,10 +178,16 @@ func NewWithOptions(
 		mcTTL = defaultMarketCacheTTL
 	}
 
+	tf := opts.TargetedFetcher
+	if tf == nil {
+		tf = f
+	}
+
 	return &Scheduler{
-		cfg:        cfg,
-		configPath: opts.ConfigPath,
-		fetcher:    f,
+		cfg:             cfg,
+		configPath:      opts.ConfigPath,
+		fetcher:         f,
+		targetedFetcher: tf,
 		stores: Stores{
 			Dedup:        d,
 			Prices:       opts.Prices,
@@ -717,7 +725,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 
 	// 1b. Targeted fetches for specific manufacturer/model pairs that
 	// are unlikely to appear in the global feed's 200 most recent listings.
-	raw = s.fetchTargetedListings(ctx, searches, raw, activeFetcher)
+	raw = s.fetchTargetedListings(ctx, searches, raw, s.targetedFetcher)
 	stats.listingsFetched = len(raw)
 
 	// 2. Catalog ingestion.


### PR DESCRIPTION
## Summary

**Root cause fix for the missing Mazda listing (#1209).**

The circuit breaker wraps the entire Yad2 fetcher chain. When Honda Civic returns 400 Bad Request, the circuit breaker opens and blocks ALL other model fetches (Mazda 3, Toyota Corolla, Honda Accord) for 10 minutes. Production showed only 1 of 4 search models fetched per cycle.

### Fix

Add a `TargetedFetcher` that uses `Cache → Paginator → Yad2` without the `CircuitBreaker` wrapper:
- **Global feed:** Still protected by circuit breaker (total Yad2 outage detection)
- **Per-model targeted fetches:** Use the targeted fetcher directly, isolated from each other

3 files changed:
- `internal/app/app.go` — Expose `Targeted` fetcher in `FetcherBundle`
- `internal/scheduler/scheduler.go` — Add `targetedFetcher` field, use it for `fetchTargetedListings`
- `cmd/scraper/main.go` — Wire `fb.Targeted` into scheduler options

### Before/After

| Metric | Before | After |
|--------|--------|-------|
| Models fetched per cycle | 1/4 (75% skipped) | 4/4 |
| Circuit breaker scope | Global (all models) | Global feed only |
| Honda Civic 400 impact | Blocks Mazda, Toyota, Honda Accord | Blocks only Honda Civic |

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] Existing tests pass (targetedFetcher defaults to main fetcher when nil)
- [ ] CI

closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)