### PR TITLE
fix: treat Yad2 400/429 as rate limiting, not infra failure

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -150,7 +150,7 @@ func TestE2E_FullPipeline(t *testing.T) {
 		t.Fatalf("create scheduler: %v", err)
 	}
 
-	schedCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	schedCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	_ = sched.Run(schedCtx)
 

--- a/internal/fetcher/circuitbreaker.go
+++ b/internal/fetcher/circuitbreaker.go
@@ -103,7 +103,7 @@ func (cb *CircuitBreaker) Fetch(ctx context.Context, params model.SourceParams) 
 		if errors.Is(err, ErrPartialResults) && len(listings) > 0 {
 			return listings, err
 		}
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, ErrRateLimited) {
 			cb.failures++
 			if cb.failures >= cb.failureThreshold || cb.state == StateHalfOpen {
 				prev := cb.state

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -219,6 +219,9 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 			}
 			return nil, fmt.Errorf("yad2: %w", fetcher.ErrChallenge)
 		}
+		if result.StatusCode == http.StatusBadRequest || result.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("yad2 status %d: %w", result.StatusCode, fetcher.ErrRateLimited)
+		}
 		body := string(result.Body)
 		if len(body) > 512 {
 			body = body[:512] + "…"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -380,7 +380,7 @@ func (s *Scheduler) fetchWithRetryUsing(ctx context.Context, f fetcher.Fetcher, 
 			return listings, nil
 		}
 
-		if errors.Is(err, fetcher.ErrChallenge) || errors.Is(err, fetcher.ErrCircuitOpen) || errors.Is(err, context.Canceled) {
+		if errors.Is(err, fetcher.ErrChallenge) || errors.Is(err, fetcher.ErrRateLimited) || errors.Is(err, fetcher.ErrCircuitOpen) || errors.Is(err, context.Canceled) {
 			return nil, err
 		}
 
@@ -674,11 +674,11 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 			added++
 		}
 
-		// Brief pause between fetches to reduce rate-limit risk.
+		// Pause between targeted fetches to avoid Yad2 rate limiting.
 		select {
 		case <-ctx.Done():
 			return raw
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(2 * time.Second):
 		}
 	}
 


### PR DESCRIPTION
## Summary

**Root cause of why the circuit breaker was tripping (#1209 follow-up).**

Production logs show Yad2 returning 400 Bad Request when the scraper makes rapid sequential targeted fetches (~2s apart). The scraper treated these as generic errors:

1. **Retried 3 times** — each retry is another request into the rate-limited window, making it worse
2. **Circuit breaker counted them** — 5 rate-limited responses = circuit breaker opens for 10 minutes

### Timeline from production

```
00:06:34 Honda Accord page 1 → 200 ✓
00:06:36 Honda Accord page 2 → 400 ← rate limited
00:06:38 Honda Civic page 1  → 400 (retry 1)
00:06:40 Honda Civic page 1  → 400 (retry 2)
00:06:44 Honda Civic page 1  → 400 (retry 3, gives up)
00:06:45 Toyota Corolla      → 400 (retry 1)
00:06:47 Toyota Corolla      → 400 → circuit breaker OPENS
```

### Fixes

| Component | Before | After |
|-----------|--------|-------|
| Yad2 fetcher | 400 → generic error | 400/429 → `ErrRateLimited` |
| Scheduler retry | Retries 3x (wastes budget) | Doesn't retry rate-limited (like challenge) |
| Circuit breaker | Counts rate limits as failures | Excludes rate limits from count |
| Inter-fetch delay | 500ms | 2s |

**Net effect:** Instead of 4 wasted requests + circuit breaker trip per 400, the scraper fails fast, skips to the next model, and the circuit breaker stays closed for models that actually work.

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] All existing fetcher + circuit breaker tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)