### PR TITLE
fix: scraper rate limit delays and enrichment UI improvements

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -657,10 +657,19 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 			if errors.Is(err, context.Canceled) {
 				return raw
 			}
+			delay := 3 * time.Second
+			if errors.Is(err, fetcher.ErrRateLimited) {
+				delay = 5 * time.Second
+			}
 			s.logger.WarnContext(ctx, "targeted fetch failed, skipping pair",
 				"manufacturer", pair.Manufacturer, "model", pair.Model,
 				"car", s.carName(pair.Manufacturer, pair.Model),
-				"error", err)
+				"error", err, "cooldown", delay.String())
+			select {
+			case <-ctx.Done():
+				return raw
+			case <-time.After(delay):
+			}
 			continue
 		}
 		fetched++
@@ -678,7 +687,7 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 		select {
 		case <-ctx.Done():
 			return raw
-		case <-time.After(2 * time.Second):
+		case <-time.After(3 * time.Second):
 		}
 	}
 
@@ -722,6 +731,14 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		"active_searches", len(searches),
 		"duration_ms", fetchDuration.Milliseconds(),
 	)
+
+	// Cooldown after global feed before targeted fetches to let
+	// Yad2's rate limiter reset.
+	select {
+	case <-ctx.Done():
+		return stats, ctx.Err()
+	case <-time.After(5 * time.Second):
+	}
 
 	// 1b. Targeted fetches for specific manufacturer/model pairs that
 	// are unlikely to appear in the global feed's 200 most recent listings.

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -223,10 +223,10 @@ export function ListingCardBody({
         <div className="flex flex-wrap gap-1.5">
           <SpecChip label="ק״מ" value={listing.km > 0 ? formatKm(listing.km) : undefined} enriching={listing.km <= 0} />
           <SpecChip label="יד" value={listing.hand > 0 ? String(listing.hand) : undefined} />
-          {listing.gear_box ? <SpecChip label="הילוכים" value={listing.gear_box} /> : null}
-          {listing.engine_type ? <SpecChip label="דלק" value={listing.engine_type} /> : null}
+          <SpecChip label="הילוכים" value={listing.gear_box || undefined} enriching={!listing.gear_box} />
+          <SpecChip label="דלק" value={listing.engine_type || undefined} enriching={!listing.engine_type} />
           {listing.engine_volume ? <SpecChip label="נפח" value={`${(listing.engine_volume / 1000).toFixed(1)}L`} /> : null}
-          {listing.horse_power ? <SpecChip label="כ״ס" value={String(listing.horse_power)} /> : null}
+          <SpecChip label="כ״ס" value={listing.horse_power ? String(listing.horse_power) : undefined} enriching={!listing.horse_power} />
         </div>
 
         {/* Description */}
@@ -266,13 +266,19 @@ export function ListingCardBody({
 
 function SpecChip({ label, value, enriching }: { label: string; value?: string; enriching?: boolean }) {
   return (
-    <div className="rounded-lg bg-secondary/70 px-2.5 py-1.5 text-center min-w-[3.5rem]">
+    <div className={cn(
+      "rounded-lg px-2.5 py-1.5 text-center min-w-[3.5rem] transition-colors",
+      enriching ? "bg-amber-500/5 border border-amber-500/10" : "bg-secondary/70",
+    )}>
       <p className="text-[10px] text-muted-foreground/70">{label}</p>
       <p className="text-xs font-semibold text-foreground truncate tabular-nums">
         {value ?? (enriching ? (
-          <span className="inline-flex items-center gap-0.5 text-muted-foreground/50">
-            <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
-            <span className="text-[9px]">מעשיר</span>
+          <span className="inline-flex items-center gap-1 text-amber-500/60">
+            <span className="flex gap-0.5">
+              <span className="h-1 w-1 rounded-full bg-amber-400 animate-pulse" />
+              <span className="h-1 w-1 rounded-full bg-amber-400 animate-pulse [animation-delay:150ms]" />
+              <span className="h-1 w-1 rounded-full bg-amber-400 animate-pulse [animation-delay:300ms]" />
+            </span>
           </span>
         ) : "—")}
       </p>

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -231,6 +231,33 @@ export function ListingsPage() {
         </div>
       </div>
 
+      {/* Enrichment progress banner */}
+      {!showSkeletons && allListings.length > 0 && (() => {
+        const unenriched = allListings.filter(l => l.km <= 0 || !l.horse_power || !l.gear_box).length;
+        if (unenriched === 0) return null;
+        const pct = Math.round(((allListings.length - unenriched) / allListings.length) * 100);
+        return (
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 px-4 py-3 flex items-center gap-3">
+            <div className="flex gap-0.5 shrink-0">
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse [animation-delay:150ms]" />
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse [animation-delay:300ms]" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                מעשיר נתונים עבור {unenriched} מודעות ({pct}% הושלם)
+              </p>
+              <p className="text-[10px] text-amber-600/70 dark:text-amber-500/60">
+                קילומטראז׳, כ״ס והילוכים יתעדכנו תוך דקות
+              </p>
+            </div>
+            <div className="h-1.5 w-20 rounded-full bg-amber-500/20 overflow-hidden shrink-0">
+              <div className="h-full rounded-full bg-amber-400 transition-all duration-500" style={{ width: `${pct}%` }} />
+            </div>
+          </div>
+        );
+      })()}
+
       {/* Grid */}
       {showSkeletons ? (
         <div className="grid gap-5 sm:gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary

### Scraper Performance

Production logs showed targeted fetches still getting rate-limited despite the 2s delay from #1211. Root cause: the `continue` on error **skipped the delay entirely**, so rate-limited fetches fired back-to-back:

```
Honda Accord page 2 → 400 (rate limited)
Honda Civic → 400 (266ms later, no delay!)
Toyota Corolla → 400 (266ms later)
Mazda 3 → 400 (266ms later)
```

Fixes:
- **5s cooldown between global feed and targeted fetches** — lets Yad2's rate limiter reset after 5 global pages
- **Delay after failed fetches too** — 5s for rate-limited, 3s for other errors (was 0s due to `continue`)
- **Increase inter-fetch delay to 3s** — more breathing room between models

### Enrichment UI

- **SpecChip enriching state for all fields** — HP, gearbox, fuel type now show three-dot pulsing animation (was only km)
- **Enrichment progress banner** — shows above listing grid when data is being enriched: count of pending listings, completion %, and animated progress bar
- **Auto-hides** when all listings are fully enriched

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added enrichment progress banner showing status and completion percentage
  - Enhanced enrichment state indicators in listing cards with improved visual feedback

* **Improvements**
  - Optimized data fetching reliability and responsiveness between requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->