### PR TITLE
fix: resolve 4 CodeRabbit review comments from past PRs

### DIFF
--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -7,11 +7,12 @@ type notifCountResponse struct {
 }
 
 func (s *Server) notificationCount(w http.ResponseWriter, r *http.Request) {
-	chatID, ok := s.requireResolvedChatID(w, r)
-	if !ok {
+	chatID, ok := chatIDFromContext(r.Context())
+	if !ok || chatID == 0 {
 		writeJSON(w, http.StatusOK, notifCountResponse{Count: 0})
 		return
 	}
+	chatID = s.resolveCanonicalChatID(r.Context(), chatID)
 
 	log := s.handlerLogger(r, "op", "notification_count")
 

--- a/internal/api/searches.go
+++ b/internal/api/searches.go
@@ -564,9 +564,6 @@ func (s *Server) setSearchActive(w http.ResponseWriter, r *http.Request, active 
 	if !okChat {
 		return
 	}
-	if active {
-		s.ensureUserActive(r.Context(), chatID)
-	}
 	id, ok := parsePathID(r)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid search id")
@@ -585,5 +582,8 @@ func (s *Server) setSearchActive(w http.ResponseWriter, r *http.Request, active 
 		return
 	}
 
+	if active {
+		s.ensureUserActive(r.Context(), chatID)
+	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -110,18 +110,20 @@ type BotBundle struct {
 // multi-notifier (Telegram + optional WebPush).
 func BuildBot(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, h *health.Status, logger *slog.Logger) (*BotBundle, error) {
 	botHandler := cwbot.New(nil, store, store, cwbot.Config{
-		AdminChatID:  cfg.Telegram.AdminChatID,
-		MaxSearches:  cfg.Telegram.MaxSearches,
-		BotUsername:  cfg.Telegram.BotUsername,
-		PollInterval: cfg.Polling.Interval,
-		Health:       h,
-		Digests:      store,
-		Listings:     store,
-		Saved:        store,
-		Hidden:       store,
-		DailyDigests: store,
-		Catalog:      dynCatalog,
-		LinkTokens:   store,
+		AdminChatID:            cfg.Telegram.AdminChatID,
+		MaxSearches:            cfg.Telegram.MaxSearches,
+		BotUsername:            cfg.Telegram.BotUsername,
+		PollInterval:           cfg.Polling.Interval,
+		QuickStartManufacturer: cfg.Telegram.QuickStartManufacturer,
+		QuickStartModel:        cfg.Telegram.QuickStartModel,
+		Health:                 h,
+		Digests:                store,
+		Listings:               store,
+		Saved:                  store,
+		Hidden:                 store,
+		DailyDigests:           store,
+		Catalog:                dynCatalog,
+		LinkTokens:             store,
 	}, logger.With("component", "bot"))
 
 	tgNotif, err := telegram.New(cfg.Telegram.Token, logger.With("component", "telegram"),

--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -155,8 +155,8 @@ func TestBuildFilterClauses_Commercial(t *testing.T) {
 	tVal := true
 	f := storage.ListingFilter{Commercial: &tVal}
 	clause, args, next := buildFilterClauses(f, 2)
-	if !strings.Contains(clause, "is_commercial = $2") {
-		t.Fatalf("expected is_commercial placeholder, got %q", clause)
+	if !strings.Contains(clause, "COALESCE(is_commercial, 0) = $2") {
+		t.Fatalf("expected COALESCE is_commercial placeholder, got %q", clause)
 	}
 	if len(args) != 1 || next != 3 {
 		t.Fatalf("args=%v next=%d", args, next)
@@ -165,7 +165,7 @@ func TestBuildFilterClauses_Commercial(t *testing.T) {
 	fVal := false
 	f2 := storage.ListingFilter{Commercial: &fVal}
 	clause2, args2, next2 := buildFilterClauses(f2, 1)
-	if !strings.Contains(clause2, "is_commercial = $1") {
+	if !strings.Contains(clause2, "COALESCE(is_commercial, 0) = $1") {
 		t.Fatalf("expected private clause, got %q", clause2)
 	}
 	if len(args2) != 1 || next2 != 2 {

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -24,10 +24,10 @@ WHERE lh.chat_id = $1
   AND (s.max_km <= 0 OR lh.km <= s.max_km OR lh.km = 0)
   AND (s.max_hand <= 0 OR lh.hand <= s.max_hand)
   AND CASE LOWER(TRIM(COALESCE(NULLIF(s.seller_filter, ''), 'any')))
-    WHEN 'private' THEN lh.is_commercial = 0
-    WHEN 'commercial' THEN lh.is_commercial = 1
-    WHEN 'dealer' THEN lh.is_commercial = 1
-    WHEN 'dealership' THEN lh.is_commercial = 1
+    WHEN 'private' THEN COALESCE(lh.is_commercial, 0) = 0
+    WHEN 'commercial' THEN COALESCE(lh.is_commercial, 0) = 1
+    WHEN 'dealer' THEN COALESCE(lh.is_commercial, 0) = 1
+    WHEN 'dealership' THEN COALESCE(lh.is_commercial, 0) = 1
     ELSE TRUE
   END
   AND (COALESCE(s.gear_box, '') = '' OR lh.gear_box = '' OR LOWER(lh.gear_box) = LOWER(s.gear_box))
@@ -351,10 +351,10 @@ func buildFilterClauses(f storage.ListingFilter, paramStart int) (string, []any,
 	}
 	if f.Commercial != nil {
 		if *f.Commercial {
-			clauses = append(clauses, fmt.Sprintf("is_commercial = $%d", n))
+			clauses = append(clauses, fmt.Sprintf("COALESCE(is_commercial, 0) = $%d", n))
 			args = append(args, 1)
 		} else {
-			clauses = append(clauses, fmt.Sprintf("is_commercial = $%d", n))
+			clauses = append(clauses, fmt.Sprintf("COALESCE(is_commercial, 0) = $%d", n))
 			args = append(args, 0)
 		}
 		n++


### PR DESCRIPTION
## Summary

Reviewed all CodeRabbit comments from the last 20 merged PRs. Found 4 still-open issues:

1. **PR #1201 — ensureUserActive fires before validation** (searches.go:568) — Moved after `SetSearchActive` succeeds so invalid/nonexistent search IDs don't trigger user reactivation
2. **PR #1189 — NULL is_commercial excluded from counts** (listings.go:27) — Wrapped with `COALESCE(is_commercial, 0)` so NULL rows are treated as private, matching percolator behavior
3. **PR #1187 — notificationCount double-write for guests** (notifications.go:10) — Replaced `requireResolvedChatID` (which writes 401) with direct `chatIDFromContext` to cleanly return `{count:0}` for unauthenticated users
4. **PR #1145 — QuickStart config not wired** (app.go:112) — Added `QuickStartManufacturer` and `QuickStartModel` to `cwbot.Config` initialization

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)