### PR TITLE
fix: add human-readable context to logs across all services

### DIFF
--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -201,9 +201,13 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 	}
 	if c.deadLetterHook != nil && alertErr == nil {
 		if err := c.deadLetterHook(ctx, alert); err != nil {
-			c.logger.Error("dead-letter hook failed", "id", id, "error", err)
+			c.logger.Error("dead-letter hook failed", "id", id, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
 			return
 		}
+	}
+	dlAttrs := []any{"id", id, "max_retries", MaxRetries}
+	if alertErr == nil {
+		dlAttrs = append(dlAttrs, "chat_id", alert.ChatID, "search_name", alert.SearchName)
 	}
 	if err := c.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: DeadLetterStream,
@@ -211,10 +215,10 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 		Approx: true,
 		Values: msgs[0].Values,
 	}).Err(); err != nil {
-		c.logger.Error("dead-letter failed", "id", id, "error", err)
+		c.logger.Error("dead-letter failed", append(dlAttrs, "error", err)...)
 		return
 	} else {
-		c.logger.Warn("message dead-lettered after max retries", "id", id, "max_retries", MaxRetries)
+		c.logger.Warn("message dead-lettered after max retries", dlAttrs...)
 	}
 	c.ack(ctx, id)
 }

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -119,6 +119,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 				if challengeRetries >= maxChallengeRetries {
 					e.logger.WarnContext(ctx, "halting enrichment pass, source is rate-limiting with bot challenges",
 						"token", listings[i].Token,
+						"car", listings[i].Manufacturer+" "+listings[i].Model,
 						"challenges", challengeRetries,
 						"impact", fmt.Sprintf("%d remaining listings will not be enriched this cycle", len(candidates)-attempts),
 						"action_taken", "aborting enrichment, will retry unenriched listings next cycle",
@@ -129,6 +130,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 				}
 				e.logger.WarnContext(ctx, "bot challenge detected during enrichment, backing off before retry",
 					"token", listings[i].Token,
+					"car", listings[i].Manufacturer+" "+listings[i].Model,
 					"challenge_count", challengeRetries,
 					"backoff", e.cfg.ChallengeBackoff,
 				)
@@ -142,6 +144,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			consecutiveFailures++
 			e.logger.WarnContext(ctx, "failed to fetch detailed listing data for mileage enrichment",
 				"token", listings[i].Token,
+				"car", listings[i].Manufacturer+" "+listings[i].Model,
 				"error", err.Error(),
 				"impact", "listing will appear without km/city data until next cycle",
 				"action_taken", "continuing with remaining candidates",
@@ -150,6 +153,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			if consecutiveFailures >= maxConsecutiveFailures {
 				e.logger.WarnContext(ctx, "halting enrichment pass after consecutive fetch failures",
 					"token", listings[i].Token,
+					"car", listings[i].Manufacturer+" "+listings[i].Model,
 					"consecutive_failures", consecutiveFailures,
 					"impact", fmt.Sprintf("%d remaining listings will not be enriched this cycle", len(candidates)-attempts),
 					"action_taken", "aborting enrichment, unenriched listings will be retried next cycle",
@@ -183,6 +187,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			enriched++
 			e.logger.DebugContext(ctx, "successfully enriched listing with mileage and location data",
 				"token", listings[i].Token,
+				"car", listings[i].Manufacturer+" "+listings[i].Model,
 				"km", details.Km,
 				"city", details.City,
 				"has_image", details.ImageURL != "",

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -37,6 +37,9 @@ func NewInstantDelivery(n notifier.Notifier, lang locale.Lang, opts ...func(*Ins
 	for _, o := range opts {
 		o(d)
 	}
+	if d.searchName != "" {
+		d.logger = d.logger.With("search_name", d.searchName)
+	}
 	return d
 }
 

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -66,7 +66,7 @@ type ProcessResult struct {
 //  5. Enrich with base price (if pricelist service is available)
 //  6. Build ListingRecords
 func (p *ListingPipeline) Process(ctx context.Context, raw []model.RawListing, params ProcessParams) ProcessResult {
-	log := p.logger.With("op", "pipeline", "search_id", params.SearchID, "chat_id", params.ChatID)
+	log := p.logger.With("op", "pipeline", "search_id", params.SearchID, "chat_id", params.ChatID, "search_name", params.SearchName)
 
 	if !params.SkipPrefill {
 		p.prefillFromDB(ctx, raw, log)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -888,7 +888,7 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				}
 				if err := s.enrichPublisher.PublishEnrich(ctx, req); err != nil {
 					s.logger.WarnContext(ctx, "failed to publish enrichment request to stream",
-						"token", l.Token, "error", err)
+						"token", l.Token, "car", l.Manufacturer+" "+l.Model, "error", err)
 				} else {
 					published++
 				}
@@ -996,6 +996,8 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				if len(filtered) < len(rawForPipeline) {
 					s.logger.InfoContext(searchCtx,
 						"filtered listings exceeding km limit after enrichment",
+						"search_name", acc.search.Name,
+						"chat_id", acc.search.ChatID,
 						"before", len(rawForPipeline),
 						"after", len(filtered),
 						"max_km", acc.search.MaxKm,
@@ -1016,9 +1018,10 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		}
 
 		// Persist listings.
+		searchLog := s.logger.With("chat_id", acc.search.ChatID, "search_name", acc.search.Name)
 		persistOK := true
 		if s.stores.Listings != nil && len(acc.result.listingRecords) > 0 {
-			if err := s.persistListings(searchCtx, acc.result.listingRecords, s.logger); err != nil {
+			if err := s.persistListings(searchCtx, acc.result.listingRecords, searchLog); err != nil {
 				persistOK = false
 			} else {
 				s.invalidateMarketCache()
@@ -1027,20 +1030,19 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 		if !persistOK {
 			acc.result.newListings = nil
 			acc.result.listingRecords = nil
-			s.revertPriceRecords(searchCtx, acc.result.recordedTokens, s.logger)
+			s.revertPriceRecords(searchCtx, acc.result.recordedTokens, searchLog)
 		}
 
 		stats.newListings += len(acc.result.newListings)
 
 		// Deliver notifications.
 		if len(acc.result.newListings) > 0 || len(acc.result.priceDropMessages) > 0 {
-			s.logger.InfoContext(searchCtx, "search matched listings, preparing delivery",
-				"search_name", acc.search.Name,
+			searchLog.InfoContext(searchCtx, "search matched listings, preparing delivery",
 				"new", len(acc.result.newListings),
 				"price_drops", len(acc.result.priceDropMessages),
 			)
 		}
-		delivered := s.deliverResults(searchCtx, acc.search, acc.lang, acc.result, s.logger)
+		delivered := s.deliverResults(searchCtx, acc.search, acc.lang, acc.result, searchLog)
 		if delivered {
 			stats.notificationsSent++
 		}


### PR DESCRIPTION
## Summary

Full log audit across 290 log calls found ~60 missing human-readable context. Instead of fixing each one individually, identified 6 systemic injection points that cascade through most of them.

**Before:** `"failed to persist price-drop listing" token=abc123`
**After:** `"failed to persist price-drop listing" token=abc123 search_name=mazda-3 chat_id=6025534247 car="Mazda 3"`

### Changes

| Component | Fix | Logs Affected |
|-----------|-----|---------------|
| Pipeline logger | Add `search_name` | ~10 pipeline logs |
| Delivery logger | Carry `search_name` on struct logger | 6 delivery logs |
| Processing callers | Pass per-search logger with `chat_id` + `search_name` | 12+ processing logs |
| Enricher | Add `"car"` field (manufacturer + model) | 5 enrichment logs |
| Broker consumer | Add `chat_id` + `search_name` to dead-letter logs | 3 dead-letter logs |
| Scheduler | Add car/search context to enrichment publish + km filter | 3 scheduler logs |

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)