### PR TITLE
fix: hold back unenriched listings from km-filtered searches

### DIFF
--- a/internal/scheduler/enrichment_test.go
+++ b/internal/scheduler/enrichment_test.go
@@ -312,6 +312,51 @@ func TestEmptyFeed_NoEnrichment(t *testing.T) {
 	}
 }
 
+func TestUnenrichedListingHeldBack_WhenMaxKmSet(t *testing.T) {
+	// Listing arrives with Km=0 (not yet enriched). Search has MaxKm=130000.
+	// The listing should be held back (0 notifications) and the dedup claim
+	// released so it can be re-evaluated once the enricher fills in km.
+	f := &mockFetcher{listings: []model.RawListing{
+		{Token: "pending-km", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+			Price: 90000, Year: 2020, EngineVolume: 2000, Km: 0, City: "", ImageURL: ""},
+	}}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "mazda3-km-cap", Source: "yad2",
+				Manufacturer: 27, Model: 10332, MaxKm: 130000, Active: true},
+		},
+	}
+
+	s, err := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore: ss,
+	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 notifications (km unknown, MaxKm set), got %d", len(n.messages))
+	}
+
+	// Verify the dedup claim was released so the listing re-matches after enrichment.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	key := dedupKey{token: "pending-km", chatID: 100}
+	if d.seen[key] {
+		t.Error("dedup claim should be released for unenriched listing when MaxKm is set")
+	}
+}
+
 func TestPartialEnrichment(t *testing.T) {
 	// 3 listings match a search. Two have km data (simulating partial
 	// enrichment), the third has Km=0. All 3 should be delivered since the

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -978,25 +978,34 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 			}
 
 			// Post-enrichment MaxKm filter: drop listings whose km
-			// (now known after enrichment) exceeds this search's cap.
-			// Release dedup claims for dropped listings so they can be
-			// re-evaluated in future cycles.
+			// exceeds this search's cap OR whose km is still unknown
+			// (pending enrichment). Release dedup claims so they can
+			// be re-evaluated in future cycles once enriched.
 			if acc.search.MaxKm > 0 {
 				filtered := make([]model.RawListing, 0, len(rawForPipeline))
 				for _, r := range rawForPipeline {
-					if r.Km > 0 && r.Km > acc.search.MaxKm {
+					if r.Km <= 0 || r.Km > acc.search.MaxKm {
+						reason := "km_exceeded"
+						if r.Km <= 0 {
+							reason = "km_pending_enrichment"
+						}
 						if relErr := s.stores.Dedup.ReleaseClaim(ctx, r.Token, acc.search.ChatID, acc.search.ID); relErr != nil {
 							s.logger.ErrorContext(searchCtx,
 								"failed to release dedup claim for km-filtered listing",
-								"token", r.Token, "error", relErr.Error())
+								"token", r.Token, "reason", reason, "error", relErr.Error())
 						}
+						s.logger.InfoContext(searchCtx,
+							"holding back listing from notification pending km data",
+							"token", r.Token, "reason", reason,
+							"listing_km", r.Km, "max_km", acc.search.MaxKm,
+						)
 						continue
 					}
 					filtered = append(filtered, r)
 				}
 				if len(filtered) < len(rawForPipeline) {
 					s.logger.InfoContext(searchCtx,
-						"filtered listings exceeding km limit after enrichment",
+						"filtered listings by km limit after enrichment",
 						"search_name", acc.search.Name,
 						"chat_id", acc.search.ChatID,
 						"before", len(rawForPipeline),


### PR DESCRIPTION
## Summary

- Listings from Yad2 search results arrive with `Km=0` (mileage isn't in the search feed). The enricher fetches real km asynchronously, but notifications were sent **before** enrichment completed — bypassing the `MaxKm` filter entirely. Users with a 130K km cap were receiving 200K+ km cars.
- Changed the post-enrichment km filter from `Km > 0 && Km > MaxKm` to `Km <= 0 || Km > MaxKm` so listings with unknown km are held back when the search has a `MaxKm` cap. Dedup claims are released so listings re-match next cycle once the enricher writes real km to the DB.
- Searches without a `MaxKm` filter are unaffected.

## Test plan

- [x] New test `TestUnenrichedListingHeldBack_WhenMaxKmSet` — listing with `Km=0` + search with `MaxKm=130000` → 0 notifications, dedup released
- [x] All existing enrichment tests pass (km exceeded, within limit, no filter, multi-search divergence, partial enrichment, dedup release, empty feed)
- [x] `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)