### PR TITLE
feat: per-search targeted fetches with full filter set

### DIFF
--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -118,17 +118,7 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			continue
 		}
-		params := model.SourceParams{
-			Manufacturer: sr.Manufacturer,
-			Model:        sr.Model,
-			YearMin:      sr.YearMin,
-			YearMax:      sr.YearMax,
-			PriceMin:     sr.PriceMin,
-			PriceMax:     sr.PriceMax,
-			MaxKm:        sr.MaxKm,
-			MaxHand:      sr.MaxHand,
-			EngineMinCC:  sr.EngineMinCC,
-		}
+		params := model.SourceParamsFromSearch(sr)
 
 		var raw []model.RawListing
 		var fetchErr error

--- a/internal/fetcher/cache.go
+++ b/internal/fetcher/cache.go
@@ -113,6 +113,14 @@ func (c *CachingFetcher) touch(key string) {
 }
 
 func cacheKey(p model.SourceParams) string {
-	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d",
-		p.Manufacturer, p.Model, p.YearMin, p.YearMax, p.PriceMin, p.PriceMax, p.Page)
+	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d:%d:%d:%d",
+		p.Manufacturer, p.Model, p.YearMin, p.YearMax,
+		p.PriceMin, p.PriceMax, p.Page,
+		p.MaxKm, p.MaxHand, p.EngineMinCC)
+}
+
+// CacheKeyFor returns the cache key for the given params, allowing callers
+// to deduplicate fetches before hitting the cache layer.
+func CacheKeyFor(p model.SourceParams) string {
+	return cacheKey(p)
 }

--- a/internal/fetcher/cache_test.go
+++ b/internal/fetcher/cache_test.go
@@ -69,6 +69,37 @@ func TestCachingFetcher_FallsBackOnError(t *testing.T) {
 	}
 }
 
+func TestCacheKeyFor_IncludesAllFilterFields(t *testing.T) {
+	base := model.SourceParams{Manufacturer: 27, Model: 10332, YearMin: 2020}
+
+	// Changing MaxKm should produce a different key.
+	withKm := base
+	withKm.MaxKm = 130000
+	if CacheKeyFor(base) == CacheKeyFor(withKm) {
+		t.Error("different MaxKm should produce different cache keys")
+	}
+
+	// Changing MaxHand should produce a different key.
+	withHand := base
+	withHand.MaxHand = 3
+	if CacheKeyFor(base) == CacheKeyFor(withHand) {
+		t.Error("different MaxHand should produce different cache keys")
+	}
+
+	// Changing EngineMinCC should produce a different key.
+	withCC := base
+	withCC.EngineMinCC = 1600
+	if CacheKeyFor(base) == CacheKeyFor(withCC) {
+		t.Error("different EngineMinCC should produce different cache keys")
+	}
+
+	// Identical params should produce the same key.
+	same := base
+	if CacheKeyFor(base) != CacheKeyFor(same) {
+		t.Error("identical params should produce the same cache key")
+	}
+}
+
 func TestCachingFetcher_EvictsOldest(t *testing.T) {
 	inner := &countingFetcher{
 		listings: []model.RawListing{{Token: "x"}},

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -44,6 +44,23 @@ func FilterCriteriaFromSearch(s *storage.Search) FilterCriteria {
 	return criteria
 }
 
+// SourceParamsFromSearch builds the SourceParams sent to listing sources
+// from a saved search definition. Used by both the scheduler's targeted
+// fetches and the API refresh handler.
+func SourceParamsFromSearch(s *storage.Search) SourceParams {
+	return SourceParams{
+		Manufacturer: s.Manufacturer,
+		Model:        s.Model,
+		YearMin:      s.YearMin,
+		YearMax:      s.YearMax,
+		PriceMin:     s.PriceMin,
+		PriceMax:     s.PriceMax,
+		MaxKm:        s.MaxKm,
+		MaxHand:      s.MaxHand,
+		EngineMinCC:  s.EngineMinCC,
+	}
+}
+
 // SourceParams defines the search parameters sent to listing sources.
 type SourceParams struct {
 	Manufacturer int

--- a/internal/model/params_test.go
+++ b/internal/model/params_test.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func TestSourceParamsFromSearch(t *testing.T) {
+	s := &storage.Search{
+		Manufacturer: 27,
+		Model:        10332,
+		YearMin:      2020,
+		YearMax:      2024,
+		PriceMin:     50000,
+		PriceMax:     150000,
+		MaxKm:        130000,
+		MaxHand:      3,
+		EngineMinCC:  1600,
+	}
+
+	p := SourceParamsFromSearch(s)
+
+	if p.Manufacturer != 27 {
+		t.Errorf("Manufacturer = %d, want 27", p.Manufacturer)
+	}
+	if p.Model != 10332 {
+		t.Errorf("Model = %d, want 10332", p.Model)
+	}
+	if p.YearMin != 2020 {
+		t.Errorf("YearMin = %d, want 2020", p.YearMin)
+	}
+	if p.YearMax != 2024 {
+		t.Errorf("YearMax = %d, want 2024", p.YearMax)
+	}
+	if p.PriceMin != 50000 {
+		t.Errorf("PriceMin = %d, want 50000", p.PriceMin)
+	}
+	if p.PriceMax != 150000 {
+		t.Errorf("PriceMax = %d, want 150000", p.PriceMax)
+	}
+	if p.MaxKm != 130000 {
+		t.Errorf("MaxKm = %d, want 130000", p.MaxKm)
+	}
+	if p.MaxHand != 3 {
+		t.Errorf("MaxHand = %d, want 3", p.MaxHand)
+	}
+	if p.EngineMinCC != 1600 {
+		t.Errorf("EngineMinCC = %d, want 1600", p.EngineMinCC)
+	}
+	if p.Page != 0 {
+		t.Errorf("Page = %d, want 0 (not set by SourceParamsFromSearch)", p.Page)
+	}
+}

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -159,9 +159,9 @@ func TestRunMultiTenantCycle_SharedScraping(t *testing.T) {
 	fetchCalls := f.calls
 	f.mu.Unlock()
 
-	// 1 global feed + 1 targeted fetch for the shared (27, 10332) pair.
-	if fetchCalls != 2 {
-		t.Errorf("fetcher called %d times, want 2 (global + targeted)", fetchCalls)
+	// 1 global feed + 2 targeted fetches (different year/price filters per search).
+	if fetchCalls != 3 {
+		t.Errorf("fetcher called %d times, want 3 (global + 2 targeted)", fetchCalls)
 	}
 
 	n.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -619,7 +619,7 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 
 	var fetched, added int
 	for _, sr := range searches {
-		if sr.Manufacturer == 0 {
+		if sr.Manufacturer == 0 || sr.Model == 0 {
 			continue
 		}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -602,54 +602,41 @@ func (s *Scheduler) writeCycleLog(ctx context.Context, entry storage.CycleLogEnt
 	}
 }
 
-// targetedFetchCoverageThreshold is the minimum number of listings for a
-// manufacturer/model pair in the global feed before targeted fetch is skipped.
-const targetedFetchCoverageThreshold = 5
-
-// fetchTargetedListings supplements the global feed with targeted fetches for
-// specific manufacturer/model pairs from active searches. Models that rarely
-// appear in the top-200 global feed would otherwise never match.
+// fetchTargetedListings fetches listings for each active search using the
+// search's full filter set (manufacturer, model, year, price, km, etc.).
+// This ensures Yad2 pre-filters results so every page contains relevant
+// listings, giving much better coverage than the unfiltered global feed.
 func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storage.Search, raw []model.RawListing, f fetcher.Fetcher) []model.RawListing {
-	type mfrModel struct{ Manufacturer, Model int }
-	pairs := make(map[mfrModel]struct{})
-	for _, sr := range searches {
-		if sr.Manufacturer > 0 {
-			pairs[mfrModel{sr.Manufacturer, sr.Model}] = struct{}{}
-		}
-	}
-	if len(pairs) == 0 {
-		return raw
-	}
-
-	// Count how many global-feed listings already cover each pair.
-	coverage := make(map[mfrModel]int, len(pairs))
-	for _, l := range raw {
-		key := mfrModel{l.ManufacturerID, l.ModelID}
-		if _, needed := pairs[key]; needed {
-			coverage[key]++
-		}
-	}
-
 	// Build the dedup set from existing tokens.
 	seen := make(map[string]struct{}, len(raw))
 	for _, l := range raw {
 		seen[l.Token] = struct{}{}
 	}
 
+	// Track which param combinations we've already fetched so searches
+	// with identical filters don't produce redundant API calls.
+	fetchedKeys := make(map[string]struct{})
+
 	var fetched, added int
-	for pair := range pairs {
+	for _, sr := range searches {
+		if sr.Manufacturer == 0 {
+			continue
+		}
+
 		select {
 		case <-ctx.Done():
 			return raw
 		default:
 		}
 
-		if coverage[pair] >= targetedFetchCoverageThreshold {
+		params := model.SourceParamsFromSearch(&sr)
+		key := fetcher.CacheKeyFor(params)
+		if _, done := fetchedKeys[key]; done {
 			continue
 		}
+		fetchedKeys[key] = struct{}{}
 
 		targetCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
-		params := model.SourceParams{Manufacturer: pair.Manufacturer, Model: pair.Model}
 		targeted, err := s.fetchWithRetryUsing(targetCtx, f, params, s.logger)
 		cancel()
 
@@ -661,9 +648,9 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 			if errors.Is(err, fetcher.ErrRateLimited) {
 				delay = 5 * time.Second
 			}
-			s.logger.WarnContext(ctx, "targeted fetch failed, skipping pair",
-				"manufacturer", pair.Manufacturer, "model", pair.Model,
-				"car", s.carName(pair.Manufacturer, pair.Model),
+			s.logger.WarnContext(ctx, "targeted fetch failed, skipping search",
+				"search_id", sr.ID, "search_name", sr.Name,
+				"car", s.carName(sr.Manufacturer, sr.Model),
 				"error", err, "cooldown", delay.String())
 			select {
 			case <-ctx.Done():
@@ -692,9 +679,9 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 	}
 
 	if fetched > 0 {
-		s.logger.InfoContext(ctx, "fetched targeted listings for search-specific models",
-			"pairs_fetched", fetched,
-			"pairs_skipped", len(pairs)-fetched,
+		s.logger.InfoContext(ctx, "fetched targeted listings for active searches",
+			"searches_fetched", fetched,
+			"unique_params", len(fetchedKeys),
 			"new_listings_added", added,
 		)
 	}

--- a/internal/scheduler/targeted_fetch_test.go
+++ b/internal/scheduler/targeted_fetch_test.go
@@ -53,8 +53,10 @@ func TestFetchTargetedListings_NoPairsNoFetch(t *testing.T) {
 	f := &paramAwareFetcher{}
 	s := newTestSchedulerWithFetcher(f)
 
+	// Wildcard searches (Manufacturer=0 or Model=0) should not trigger targeted fetches.
 	searches := []storage.Search{
 		{ID: 1, Manufacturer: 0, Model: 0},
+		{ID: 2, Manufacturer: 27, Model: 0},
 	}
 	global := []model.RawListing{{Token: "g1"}}
 	result := s.fetchTargetedListings(context.Background(), searches, global, f)
@@ -65,7 +67,7 @@ func TestFetchTargetedListings_NoPairsNoFetch(t *testing.T) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if len(f.calls) != 0 {
-		t.Errorf("expected 0 fetch calls for wildcard-only searches, got %d", len(f.calls))
+		t.Errorf("expected 0 fetch calls for wildcard searches, got %d", len(f.calls))
 	}
 }
 

--- a/internal/scheduler/targeted_fetch_test.go
+++ b/internal/scheduler/targeted_fetch_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -10,22 +11,26 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-// paramAwareFetcher returns different listings based on SourceParams.
+// paramAwareFetcher returns different listings based on the full SourceParams.
 type paramAwareFetcher struct {
 	mu       sync.Mutex
 	calls    []model.SourceParams
-	results  map[paramKey][]model.RawListing
-	errors   map[paramKey]error
+	results  map[string][]model.RawListing
+	errors   map[string]error
 	fallback []model.RawListing
 }
 
-type paramKey struct{ Manufacturer, Model int }
+func paramKeyStr(p model.SourceParams) string {
+	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d:%d:%d",
+		p.Manufacturer, p.Model, p.YearMin, p.YearMax,
+		p.PriceMin, p.PriceMax, p.MaxKm, p.MaxHand, p.EngineMinCC)
+}
 
 func (f *paramAwareFetcher) Fetch(_ context.Context, p model.SourceParams) ([]model.RawListing, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, p)
-	key := paramKey{p.Manufacturer, p.Model}
+	key := paramKeyStr(p)
 	if err, ok := f.errors[key]; ok {
 		return nil, err
 	}
@@ -64,11 +69,18 @@ func TestFetchTargetedListings_NoPairsNoFetch(t *testing.T) {
 	}
 }
 
-func TestFetchTargetedListings_FetchesUncoveredPair(t *testing.T) {
+func TestFetchTargetedListings_FetchesWithFullParams(t *testing.T) {
+	// Search has year/price/km filters — targeted fetch should pass them all.
+	sr := storage.Search{
+		ID: 1, Manufacturer: 27, Model: 10332,
+		YearMin: 2020, YearMax: 2024, PriceMax: 150000,
+		MaxKm: 130000, MaxHand: 3, EngineMinCC: 1600,
+	}
+	key := paramKeyStr(model.SourceParamsFromSearch(&sr))
+
 	f := &paramAwareFetcher{
-		results: map[paramKey][]model.RawListing{
-			{0, 0}: {{Token: "g1", ManufacturerID: 99, ModelID: 999}},
-			{27, 10332}: {
+		results: map[string][]model.RawListing{
+			key: {
 				{Token: "t1", ManufacturerID: 27, ModelID: 10332},
 				{Token: "t2", ManufacturerID: 27, ModelID: 10332},
 			},
@@ -76,11 +88,8 @@ func TestFetchTargetedListings_FetchesUncoveredPair(t *testing.T) {
 	}
 	s := newTestSchedulerWithFetcher(f)
 
-	searches := []storage.Search{
-		{ID: 1, Manufacturer: 27, Model: 10332},
-	}
 	global := []model.RawListing{{Token: "g1", ManufacturerID: 99, ModelID: 999}}
-	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
 
 	if len(result) != 3 {
 		t.Errorf("expected 3 listings (1 global + 2 targeted), got %d", len(result))
@@ -91,44 +100,61 @@ func TestFetchTargetedListings_FetchesUncoveredPair(t *testing.T) {
 	if len(f.calls) != 1 {
 		t.Fatalf("expected 1 targeted fetch call, got %d", len(f.calls))
 	}
-	if f.calls[0].Manufacturer != 27 || f.calls[0].Model != 10332 {
-		t.Errorf("targeted fetch used wrong params: %+v", f.calls[0])
+	c := f.calls[0]
+	if c.Manufacturer != 27 || c.Model != 10332 {
+		t.Errorf("wrong manufacturer/model: %+v", c)
+	}
+	if c.YearMin != 2020 || c.YearMax != 2024 {
+		t.Errorf("expected year range 2020-2024, got %d-%d", c.YearMin, c.YearMax)
+	}
+	if c.PriceMax != 150000 {
+		t.Errorf("expected PriceMax=150000, got %d", c.PriceMax)
+	}
+	if c.MaxKm != 130000 {
+		t.Errorf("expected MaxKm=130000, got %d", c.MaxKm)
 	}
 }
 
-func TestFetchTargetedListings_SkipsWellCoveredPair(t *testing.T) {
-	f := &paramAwareFetcher{}
+func TestFetchTargetedListings_AlwaysFetchesRegardlessOfCoverage(t *testing.T) {
+	// Even with many global-feed listings for a model, a targeted fetch
+	// should still run to ensure full filter coverage.
+	sr := storage.Search{ID: 1, Manufacturer: 27, Model: 10332, YearMin: 2020}
+	key := paramKeyStr(model.SourceParamsFromSearch(&sr))
+	f := &paramAwareFetcher{
+		results: map[string][]model.RawListing{
+			key: {{Token: "targeted1", ManufacturerID: 27, ModelID: 10332}},
+		},
+	}
 	s := newTestSchedulerWithFetcher(f)
 
-	searches := []storage.Search{
-		{ID: 1, Manufacturer: 27, Model: 10332},
-	}
-	// Global feed already has 5 listings for this pair.
-	global := make([]model.RawListing, 5)
+	// Global feed already has 10 listings for this model.
+	global := make([]model.RawListing, 10)
 	for i := range global {
 		global[i] = model.RawListing{
-			Token:          "g" + string(rune('0'+i)),
+			Token:          fmt.Sprintf("g%d", i),
 			ManufacturerID: 27,
 			ModelID:        10332,
 		}
 	}
 
-	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
 
-	if len(result) != 5 {
-		t.Errorf("expected 5 listings (no targeted fetch), got %d", len(result))
-	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if len(f.calls) != 0 {
-		t.Errorf("expected 0 fetch calls (pair well-covered), got %d", len(f.calls))
+	if len(f.calls) != 1 {
+		t.Errorf("expected 1 fetch call (no coverage threshold), got %d", len(f.calls))
+	}
+	if len(result) != 11 {
+		t.Errorf("expected 11 listings (10 global + 1 targeted), got %d", len(result))
 	}
 }
 
 func TestFetchTargetedListings_DeduplicatesTokens(t *testing.T) {
+	sr := storage.Search{ID: 1, Manufacturer: 17, Model: 10182}
+	key := paramKeyStr(model.SourceParamsFromSearch(&sr))
 	f := &paramAwareFetcher{
-		results: map[paramKey][]model.RawListing{
-			{17, 10182}: {
+		results: map[string][]model.RawListing{
+			key: {
 				{Token: "shared", ManufacturerID: 17, ModelID: 10182},
 				{Token: "new1", ManufacturerID: 17, ModelID: 10182},
 			},
@@ -136,12 +162,8 @@ func TestFetchTargetedListings_DeduplicatesTokens(t *testing.T) {
 	}
 	s := newTestSchedulerWithFetcher(f)
 
-	searches := []storage.Search{
-		{ID: 1, Manufacturer: 17, Model: 10182},
-	}
 	global := []model.RawListing{{Token: "shared", ManufacturerID: 17, ModelID: 10182}}
-
-	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
 
 	if len(result) != 2 {
 		t.Errorf("expected 2 listings (1 shared deduped + 1 new), got %d", len(result))
@@ -159,25 +181,23 @@ func TestFetchTargetedListings_DeduplicatesTokens(t *testing.T) {
 }
 
 func TestFetchTargetedListings_FetchErrorContinues(t *testing.T) {
+	sr1 := storage.Search{ID: 1, Manufacturer: 27, Model: 10332}
+	sr2 := storage.Search{ID: 2, Manufacturer: 19, Model: 10222}
+	key2 := paramKeyStr(model.SourceParamsFromSearch(&sr2))
+
 	f := &paramAwareFetcher{
-		results: map[paramKey][]model.RawListing{
-			{19, 10222}: {{Token: "ok1", ManufacturerID: 19, ModelID: 10222}},
+		results: map[string][]model.RawListing{
+			key2: {{Token: "ok1", ManufacturerID: 19, ModelID: 10222}},
 		},
-		errors: map[paramKey]error{
-			{27, 10332}: fetcher.ErrChallenge,
+		errors: map[string]error{
+			paramKeyStr(model.SourceParamsFromSearch(&sr1)): fetcher.ErrChallenge,
 		},
 	}
 	s := newTestSchedulerWithFetcher(f)
 
-	searches := []storage.Search{
-		{ID: 1, Manufacturer: 27, Model: 10332},
-		{ID: 2, Manufacturer: 19, Model: 10222},
-	}
 	global := []model.RawListing{{Token: "g1"}}
+	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
 
-	result := s.fetchTargetedListings(context.Background(), searches, global, f)
-
-	// Should have global + successful targeted fetch, despite first pair failing.
 	hasOk1 := false
 	for _, l := range result {
 		if l.Token == "ok1" {
@@ -185,66 +205,84 @@ func TestFetchTargetedListings_FetchErrorContinues(t *testing.T) {
 		}
 	}
 	if !hasOk1 {
-		t.Error("expected targeted listing 'ok1' from successful pair, not found")
+		t.Error("expected targeted listing 'ok1' from successful search, not found")
 	}
 }
 
-func TestFetchTargetedListings_SharedPairFetchedOnce(t *testing.T) {
+func TestFetchTargetedListings_IdenticalParamsFetchedOnce(t *testing.T) {
+	// Two searches with the same model AND same filters → one fetch.
+	sr1 := storage.Search{ID: 1, ChatID: 100, Manufacturer: 27, Model: 10332, YearMin: 2020}
+	sr2 := storage.Search{ID: 2, ChatID: 200, Manufacturer: 27, Model: 10332, YearMin: 2020}
+	key := paramKeyStr(model.SourceParamsFromSearch(&sr1))
+
 	f := &paramAwareFetcher{
-		results: map[paramKey][]model.RawListing{
-			{27, 10332}: {{Token: "t1", ManufacturerID: 27, ModelID: 10332}},
+		results: map[string][]model.RawListing{
+			key: {{Token: "t1", ManufacturerID: 27, ModelID: 10332}},
 		},
 	}
 	s := newTestSchedulerWithFetcher(f)
 
-	// Two searches for the same manufacturer/model pair.
-	searches := []storage.Search{
-		{ID: 1, ChatID: 100, Manufacturer: 27, Model: 10332},
-		{ID: 2, ChatID: 200, Manufacturer: 27, Model: 10332},
-	}
 	global := []model.RawListing{{Token: "g1"}}
-
-	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
-
-	targetedCalls := 0
-	for _, c := range f.calls {
-		if c.Manufacturer == 27 && c.Model == 10332 {
-			targetedCalls++
-		}
-	}
-	if targetedCalls != 1 {
-		t.Errorf("expected 1 targeted fetch for shared pair, got %d", targetedCalls)
+	if len(f.calls) != 1 {
+		t.Errorf("expected 1 targeted fetch for identical params, got %d", len(f.calls))
 	}
 	if len(result) != 2 {
 		t.Errorf("expected 2 listings (1 global + 1 targeted), got %d", len(result))
 	}
 }
 
-func TestFetchTargetedListings_ContextCanceled(t *testing.T) {
+func TestFetchTargetedListings_DifferentFiltersFetchSeparately(t *testing.T) {
+	// Two searches for same model with different year ranges → two fetches.
+	sr1 := storage.Search{ID: 1, Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2020}
+	sr2 := storage.Search{ID: 2, Manufacturer: 27, Model: 10332, YearMin: 2021, YearMax: 2024}
+	key1 := paramKeyStr(model.SourceParamsFromSearch(&sr1))
+	key2 := paramKeyStr(model.SourceParamsFromSearch(&sr2))
+
 	f := &paramAwareFetcher{
-		results: map[paramKey][]model.RawListing{
-			{27, 10332}: {{Token: "t1"}},
-			{19, 10222}: {{Token: "t2"}},
+		results: map[string][]model.RawListing{
+			key1: {{Token: "old1", ManufacturerID: 27, ModelID: 10332}},
+			key2: {{Token: "new1", ManufacturerID: 27, ModelID: 10332}},
 		},
 	}
 	s := newTestSchedulerWithFetcher(f)
 
-	searches := []storage.Search{
-		{ID: 1, Manufacturer: 27, Model: 10332},
-		{ID: 2, Manufacturer: 19, Model: 10222},
+	global := []model.RawListing{{Token: "g1"}}
+	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) != 2 {
+		t.Errorf("expected 2 targeted fetches for different filters, got %d", len(f.calls))
 	}
+	if len(result) != 3 {
+		t.Errorf("expected 3 listings (1 global + 2 targeted), got %d", len(result))
+	}
+}
+
+func TestFetchTargetedListings_ContextCanceled(t *testing.T) {
+	sr1 := storage.Search{ID: 1, Manufacturer: 27, Model: 10332}
+	sr2 := storage.Search{ID: 2, Manufacturer: 19, Model: 10222}
+	key1 := paramKeyStr(model.SourceParamsFromSearch(&sr1))
+	key2 := paramKeyStr(model.SourceParamsFromSearch(&sr2))
+
+	f := &paramAwareFetcher{
+		results: map[string][]model.RawListing{
+			key1: {{Token: "t1"}},
+			key2: {{Token: "t2"}},
+		},
+	}
+	s := newTestSchedulerWithFetcher(f)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately.
+	cancel()
 
 	global := []model.RawListing{{Token: "g1"}}
-	result := s.fetchTargetedListings(ctx, searches, global, f)
+	result := s.fetchTargetedListings(ctx, []storage.Search{sr1, sr2}, global, f)
 
-	// With context already cancelled, the method should return early.
-	// Only global listings should be present — no targeted tokens.
 	if len(result) != len(global) {
 		t.Errorf("expected %d listings (global only), got %d", len(global), len(result))
 	}
@@ -252,9 +290,6 @@ func TestFetchTargetedListings_ContextCanceled(t *testing.T) {
 		if l.Token == "t1" || l.Token == "t2" {
 			t.Errorf("targeted token %q should not appear after context cancellation", l.Token)
 		}
-	}
-	if result[0].Token != "g1" {
-		t.Error("global listing 'g1' missing from result after context cancellation")
 	}
 
 	f.mu.Lock()


### PR DESCRIPTION
## Summary

- **Root cause**: Targeted fetches only sent `{Manufacturer, Model}` to Yad2 — no year, price, km, or hand filters. Yad2 returned ALL listings for a model unfiltered, and the 5-page cap (~200 results) meant many matching listings were pushed past the pagination cutoff by irrelevant ones. A coverage threshold of 5 also skipped targeted fetches entirely when a few listings appeared in the global feed.
- **Fix**: Every active search now gets its own targeted fetch with the search's full filter set (year, price, km, hand, engine CC). Yad2 pre-filters so all 5 pages contain only relevant results — exactly what the manual refresh button already does.
- Searches with identical params deduplicate automatically via cache key, so no redundant API calls.

### Changes

| File | Change |
|------|--------|
| `internal/model/params.go` | New `SourceParamsFromSearch` helper (shared by scheduler + API) |
| `internal/api/listings.go` | Refactored to use `SourceParamsFromSearch` |
| `internal/fetcher/cache.go` | Cache key now includes MaxKm/MaxHand/EngineMinCC; exported `CacheKeyFor` |
| `internal/scheduler/scheduler.go` | Rewrote `fetchTargetedListings` — per-search iteration, full params, no coverage threshold |
| Tests | 8 targeted fetch tests, 1 cache key test, updated multitenant test |

## Test plan

- [x] All 8 targeted fetch tests pass (full params, dedup, errors, coverage, context cancel)
- [x] Cache key test verifies MaxKm/MaxHand/EngineMinCC produce distinct keys
- [x] Multitenant test updated — 2 searches with different filters now correctly produce 2 targeted fetches
- [x] `golangci-lint run ./...` clean
- [ ] Deploy and compare listing counts: scheduler cycle vs manual refresh for the same search

closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Search caching is now more precise, with deduplication based on all filter parameters (price, year, mileage, condition, engine size).
  * Targeted fetch operations now fully respect all search filters instead of partial matching.

* **Tests**
  * Enhanced test coverage for filter-aware deduplication and targeted listing retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->