### PR TITLE
feat: show last cycle stats in countdown timer

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -765,6 +765,10 @@ type schedulerStatusResponse struct {
 	LastCycleStatus     string  `json:"last_cycle_status"`
 	NextCycleAt         *string `json:"next_cycle_at"`
 	PollingIntervalSec  int     `json:"polling_interval_seconds"`
+	Searches            int     `json:"searches"`
+	ListingsFetched     int     `json:"listings_fetched"`
+	ListingsMatched     int     `json:"listings_matched"`
+	Notifications       int     `json:"notifications"`
 }
 
 func (s *Server) schedulerStatus(w http.ResponseWriter, r *http.Request) {
@@ -787,6 +791,10 @@ func (s *Server) schedulerStatus(w http.ResponseWriter, r *http.Request) {
 		resp.LastCycleAt = &ts
 		resp.LastCycleDurationMs = last.DurationMs
 		resp.LastCycleStatus = last.Status
+		resp.Searches = last.Searches
+		resp.ListingsFetched = last.ListingsFetched
+		resp.ListingsMatched = last.ListingsMatched
+		resp.Notifications = last.Notifications
 
 		next := last.StartedAt.Add(time.Duration(last.DurationMs)*time.Millisecond + s.pollingInterval)
 		nextStr := next.UTC().Format(time.RFC3339)

--- a/web/src/components/NextScanCountdown.tsx
+++ b/web/src/components/NextScanCountdown.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Timer, Loader2, CheckCircle2 } from "lucide-react";
+import { Timer, Loader2, CheckCircle2, Eye, Filter, Bell } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSchedulerStatus } from "@/hooks/useSchedulerStatus";
 
@@ -31,6 +31,8 @@ export function NextScanCountdown() {
 
   const mins = Math.max(0, Math.floor(remaining / 60_000));
   const secs = Math.max(0, Math.floor((remaining % 60_000) / 1000));
+
+  const hasStats = status.last_cycle_at && status.listings_fetched > 0;
 
   return (
     <div
@@ -76,6 +78,26 @@ export function NextScanCountdown() {
             {isOverdue ? "סורק עכשיו..." : "סריקה הבאה"}
           </p>
         </div>
+
+        {/* Last cycle stats */}
+        {hasStats && !isOverdue && (
+          <div className="hidden sm:flex items-center gap-3 text-[11px] text-muted-foreground">
+            <span className="flex items-center gap-1" title="מודעות שנסרקו">
+              <Eye className="h-3 w-3" />
+              <span className="tabular-nums">{status.listings_fetched.toLocaleString()}</span>
+            </span>
+            <span className="flex items-center gap-1" title="התאמות">
+              <Filter className="h-3 w-3" />
+              <span className="tabular-nums">{status.listings_matched}</span>
+            </span>
+            {status.notifications > 0 && (
+              <span className="flex items-center gap-1 text-primary" title="התראות שנשלחו">
+                <Bell className="h-3 w-3" />
+                <span className="tabular-nums">{status.notifications}</span>
+              </span>
+            )}
+          </div>
+        )}
 
         {!isOverdue && (
           <p className="text-sm font-semibold tabular-nums text-foreground tracking-tight">

--- a/web/src/components/NextScanCountdown.tsx
+++ b/web/src/components/NextScanCountdown.tsx
@@ -26,13 +26,16 @@ export function NextScanCountdown() {
 
   const isOverdue = remaining <= 0;
   const totalMs = (status.polling_interval_seconds || DEFAULT_INTERVAL_SEC) * 1000;
-  const elapsed = totalMs - remaining;
-  const progress = isOverdue ? 100 : Math.min(100, Math.max(0, (elapsed / totalMs) * 100));
+  const elapsed = isOverdue ? totalMs : totalMs - remaining;
+  const progress = Math.min(100, Math.max(0, (elapsed / totalMs) * 100));
 
   const mins = Math.max(0, Math.floor(remaining / 60_000));
   const secs = Math.max(0, Math.floor((remaining % 60_000) / 1000));
 
-  const hasStats = status.last_cycle_at && status.listings_fetched > 0;
+  const fetched = status.listings_fetched ?? 0;
+  const matched = status.listings_matched ?? 0;
+  const notifs = status.notifications ?? 0;
+  const hasStats = !!status.last_cycle_at && fetched > 0;
 
   return (
     <div
@@ -45,7 +48,7 @@ export function NextScanCountdown() {
       )}
     >
       {/* Progress bar */}
-      <div className="absolute inset-x-0 bottom-0 h-[2px] bg-border/20">
+      <div className="absolute inset-x-0 bottom-0 h-1 bg-border/20">
         <div
           className={cn(
             "h-full transition-all duration-1000 ease-linear rounded-full",
@@ -65,11 +68,11 @@ export function NextScanCountdown() {
           )}
         >
           {isOverdue ? (
-            <Loader2 className="h-4 w-4 text-primary animate-spin" />
+            <Loader2 className="h-4 w-4 text-primary animate-spin" aria-label="סורק" />
           ) : remaining < 60_000 ? (
-            <CheckCircle2 className="h-4 w-4 text-success" />
+            <CheckCircle2 className="h-4 w-4 text-success" aria-hidden="true" />
           ) : (
-            <Timer className="h-4 w-4 text-muted-foreground" />
+            <Timer className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           )}
         </div>
 
@@ -82,25 +85,25 @@ export function NextScanCountdown() {
         {/* Last cycle stats */}
         {hasStats && !isOverdue && (
           <div className="hidden sm:flex items-center gap-3 text-[11px] text-muted-foreground">
-            <span className="flex items-center gap-1" title="מודעות שנסרקו">
-              <Eye className="h-3 w-3" />
-              <span className="tabular-nums">{status.listings_fetched.toLocaleString()}</span>
+            <span className="flex items-center gap-1" aria-label={`${fetched.toLocaleString()} מודעות נסרקו`}>
+              <Eye className="h-3 w-3" aria-hidden="true" />
+              <span className="tabular-nums">{fetched.toLocaleString()}</span>
             </span>
-            <span className="flex items-center gap-1" title="התאמות">
-              <Filter className="h-3 w-3" />
-              <span className="tabular-nums">{status.listings_matched}</span>
+            <span className="flex items-center gap-1" aria-label={`${matched.toLocaleString()} התאמות`}>
+              <Filter className="h-3 w-3" aria-hidden="true" />
+              <span className="tabular-nums">{matched.toLocaleString()}</span>
             </span>
-            {status.notifications > 0 && (
-              <span className="flex items-center gap-1 text-primary" title="התראות שנשלחו">
-                <Bell className="h-3 w-3" />
-                <span className="tabular-nums">{status.notifications}</span>
+            {notifs > 0 && (
+              <span className="flex items-center gap-1 text-primary font-medium" aria-label={`${notifs.toLocaleString()} התראות נשלחו`}>
+                <Bell className="h-3 w-3" aria-hidden="true" />
+                <span className="tabular-nums">{notifs.toLocaleString()}</span>
               </span>
             )}
           </div>
         )}
 
         {!isOverdue && (
-          <p className="text-sm font-semibold tabular-nums text-foreground tracking-tight">
+          <p className="text-base font-bold tabular-nums text-foreground tracking-tight" role="timer" aria-live="off">
             {mins}:{String(secs).padStart(2, "0")}
           </p>
         )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -545,6 +545,10 @@ export interface SchedulerStatus {
   last_cycle_status: string;
   next_cycle_at: string | null;
   polling_interval_seconds: number;
+  searches: number;
+  listings_fetched: number;
+  listings_matched: number;
+  notifications: number;
 }
 
 export const schedulerApi = {


### PR DESCRIPTION
## Summary

- Extend the scheduler status API to include `listings_fetched`, `listings_matched`, `notifications`, and `searches` from the last cycle log entry
- Display these stats as compact icon+number pairs in the countdown timer bar:
  - **Eye icon** — total listings scanned (e.g., 847)
  - **Filter icon** — new matches found (e.g., 3)
  - **Bell icon** — notifications sent (highlighted in primary color when > 0)
- Stats are hidden on mobile to keep the timer slim, shown on `sm:` breakpoint and up

## Test plan

- [x] Backend compiles and lint passes
- [x] Frontend type-checks with `tsc --noEmit`
- [ ] Visual verification: stats appear next to countdown on desktop, hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler status now provides detailed cycle metrics including searches executed, listings fetched, matches found, and notifications sent
  * Interface displays last cycle statistics, offering visibility into scan results and performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->