### PR TITLE
fix: batch 2 UI/UX audit fixes — responsive, nav, UX improvements

### DIFF
--- a/web/src/components/NextScanCountdown.tsx
+++ b/web/src/components/NextScanCountdown.tsx
@@ -84,7 +84,7 @@ export function NextScanCountdown() {
 
         {/* Last cycle stats */}
         {hasStats && !isOverdue && (
-          <div className="hidden sm:flex items-center gap-3 text-[11px] text-muted-foreground">
+          <div className="flex items-center gap-2 sm:gap-3 text-[11px] text-muted-foreground">
             <span className="flex items-center gap-1" aria-label={`${fetched.toLocaleString()} מודעות נסרקו`}>
               <Eye className="h-3 w-3" aria-hidden="true" />
               <span className="tabular-nums">{fetched.toLocaleString()}</span>

--- a/web/src/components/PriceHistoryChart.tsx
+++ b/web/src/components/PriceHistoryChart.tsx
@@ -59,7 +59,17 @@ export function PriceHistoryChart({
   }
 
   if (error || records.length === 0) {
-    return null;
+    return (
+      <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-2">
+        <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
+          <Minus className="h-4 w-4 text-muted-foreground" />
+          היסטוריית מחירים
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          אין היסטוריית מחירים
+        </p>
+      </div>
+    );
   }
 
   // Single data point: show static message

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -237,7 +237,10 @@ export function SearchCard({
       </Link>
 
       {isConfirmingDelete ? (
-        <div className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3" role="alertdialog" aria-label="אישור מחיקת חיפוש">
+        <div className="border-border/60 mt-3 flex flex-wrap items-center justify-end gap-2 border-t pt-3" role="alertdialog" aria-label="אישור מחיקה" aria-describedby={`delete-desc-${search.id}`}>
+          <p id={`delete-desc-${search.id}`} className="sr-only">
+            האם אתה בטוח שברצונך למחוק את החיפוש &quot;{search.name}&quot;? פעולה זו לא ניתנת לביטול.
+          </p>
           <Button
             ref={confirmRef}
             type="button"

--- a/web/src/components/landing/FinalCTA.tsx
+++ b/web/src/components/landing/FinalCTA.tsx
@@ -25,7 +25,7 @@ export function FinalCTA() {
               <span className="gradient-text">הרכב שלך?</span>
             </h2>
             <p className="mx-auto mb-10 max-w-md text-base leading-relaxed text-muted-foreground">
-              הצטרף לאלפי קונים שחוסכים זמן וכסף עם CarWatch. הגדרה תוך 2 דקות,
+              חסוך זמן וכסף עם CarWatch — מעקב חכם אחרי רכבים. הגדרה תוך 2 דקות,
               בלי כרטיס אשראי.
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -64,6 +64,7 @@ const mobileNav: MobileNavItem[] = [
   { path: "/dashboard", label: "ראשי", icon: LayoutDashboard, authOnly: true },
   { path: "/saved", label: "מועדפים", icon: Bookmark, authOnly: true },
   { path: "/searches/new", label: "חדש", icon: Plus, fab: true, authOnly: true },
+  { path: "/history", label: "היסטוריה", icon: History, authOnly: true },
   { path: "/notifications", label: "התראות", icon: Bell, badge: true, authOnly: true },
   { path: "/settings", label: "הגדרות", icon: Settings, authOnly: true },
 ];
@@ -275,7 +276,9 @@ export function Shell() {
           {user ? (
             <button
               type="button"
-              onClick={() => void signOut()}
+              onClick={() => {
+                if (window.confirm("האם לצאת מהחשבון?")) void signOut();
+              }}
               className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
             >
               <LogOut className="h-3.5 w-3.5" aria-hidden />
@@ -311,6 +314,7 @@ export function Shell() {
       </main>
 
       {/* ── Mobile Bottom Nav ── */}
+      {user && (
       <nav
         aria-label="ניווט"
         className="fixed inset-x-0 bottom-0 z-50 border-t border-border/50 bg-card/90 shadow-[0_-2px_16px_-6px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_24px_-8px_rgba(0,0,0,0.4)] backdrop-blur-xl backdrop-saturate-150 pb-[env(safe-area-inset-bottom,0px)] md:hidden"
@@ -374,6 +378,7 @@ export function Shell() {
           })}
         </div>
       </nav>
+      )}
     </div>
   );
 }

--- a/web/src/components/ui/MatchScoreBox.tsx
+++ b/web/src/components/ui/MatchScoreBox.tsx
@@ -32,6 +32,7 @@ export function MatchScoreBox({ score, size = "md", className }: MatchScoreBoxPr
         boxShadow: `0 0 16px -4px ${scoreHslAlpha(normalized, 0.3)}, inset 0 0 0 1.5px ${scoreHslAlpha(normalized, 0.25)}`,
       }}
       aria-label={`ציון ${formatted} מתוך 10`}
+      title="ציון התאמה - ככל שהציון גבוה יותר, הרכב מתאים יותר לחיפוש שלך"
     >
       <span className="tabular-nums">{formatted}</span>
       <span className="denom font-bold opacity-50">/10</span>

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -33,7 +33,7 @@ export function HistoryPage() {
     return (
       <PageShell>
         <PageHeader title="היסטוריה" />
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {[1, 2, 3, 4].map((i) => (
             <Skeleton key={i} className="h-72 rounded-2xl" />
           ))}
@@ -81,7 +81,7 @@ export function HistoryPage() {
         />
       ) : (
         <>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {data.items.map((listing) => (
               <HistoryCard key={listing.token} listing={listing} />
             ))}

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -260,7 +260,7 @@ export function ListingsPage() {
 
       {/* Grid */}
       {showSkeletons ? (
-        <div className="grid gap-5 sm:gap-4 sm:grid-cols-2">
+        <div className="grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <motion.div
               key={`skel-${i}`}
@@ -285,7 +285,7 @@ export function ListingsPage() {
         />
       ) : (
         <>
-          <div className="grid gap-5 sm:gap-4 sm:grid-cols-2">
+          <div className="grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
             <AnimatePresence mode="popLayout">
               {allListings.map((listing, i) => (
                 <motion.div

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -135,7 +135,7 @@ export function SearchesPage() {
           {
             icon: Car,
             label: "מודעות שנמצאו",
-            value: recentListings?.total ?? 0,
+            value: searches?.reduce((sum, s) => sum + (s.listings_count ?? 0), 0) ?? 0,
             color: "text-primary",
             bg: "bg-primary/12",
             glow: "shadow-[0_4px_20px_-4px_var(--color-glow-primary)]",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -285,7 +285,9 @@ export function SettingsPage() {
       <section className="rounded-2xl border border-border/50 bg-card p-5">
         <Button
           variant="ghost"
-          onClick={() => void signOut()}
+          onClick={() => {
+            if (window.confirm("האם לצאת מהחשבון?")) void signOut();
+          }}
           className="w-full text-destructive hover:bg-destructive/5 hover:text-destructive"
         >
           <LogOut className="h-4 w-4" />

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -181,6 +181,12 @@ export default function TrySearchPage() {
         >
           <ShieldAlert className="mx-auto mb-1 h-5 w-5" aria-hidden />
           הגעת למגבלת חיפושים. הירשם לחיפושים ללא הגבלה
+          <Link
+            to="/signup"
+            className="mt-2 inline-block rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-white shadow-lg"
+          >
+            הירשם כדי להמשיך
+          </Link>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Second batch from the [UI/UX audit](https://github.com/Danielsio/carwatch/issues/1221) — 11 issues resolved across 11 files.

### Responsive (2)
- **Listing/history grids** — `xl:grid-cols-3` for large desktop screens (#1247)
- **Countdown stats** — visible on mobile, not just desktop (#1249)

### Navigation (2)
- **History in mobile nav** — added History icon to bottom nav (#1236)
- **Guest bottom nav** — hidden for unauthenticated users (#1237)

### Accessibility (2)
- **Delete dialog ARIA** — `aria-describedby` + sr-only description (#1232)
- **Score tooltip** — title explaining what the match score means (#1241)

### UX (5)
- **Sign out confirmation** — `window.confirm` before logout (#1239)
- **Dashboard stat fix** — shows actual listings count, not notification count (#1242)
- **Price history empty state** — shows message instead of silent hide (#1243)
- **TrySearch signup link** — signup CTA in rate limit banner (#1251)
- **FinalCTA copy** — replaced unsubstantiated "thousands" claim (#1252)

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 238 tests pass (`vitest run`)
- [ ] Visual verification in browser

closes #1232
closes #1236
closes #1237
closes #1239
closes #1241
closes #1242
closes #1243
closes #1247
closes #1249
closes #1251
closes #1252

🤖 Generated with [Claude Code](https://claude.com/claude-code)