### PR TITLE
fix: batch 4 low-severity audit fixes — a11y, responsive

### DIFF
--- a/web/src/components/admin/DetailModal.tsx
+++ b/web/src/components/admin/DetailModal.tsx
@@ -89,6 +89,7 @@ export function DetailModal({
             ref={closeRef}
             type="button"
             onClick={onClose}
+            aria-label="סגור"
             className="flex h-8 w-8 items-center justify-center rounded-lg bg-secondary text-muted-foreground hover:text-foreground transition-colors"
           >
             <X className="h-4 w-4" />

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -15,6 +15,7 @@ function FloatingCard({
     <div
       className={`glass-card absolute rounded-2xl p-3.5 shadow-xl animate-slide-up motion-reduce:animate-none ${className ?? ""}`}
       style={delay > 0 ? { animationDelay: `${delay}s`, animationFillMode: "backwards" } : undefined}
+      aria-hidden="true"
     >
       {children}
     </div>
@@ -24,13 +25,13 @@ function FloatingCard({
 export function HeroSection() {
   return (
     <section className="relative flex min-h-screen items-center justify-center pt-16">
-      <div className="pointer-events-none absolute inset-0 overflow-hidden will-change-transform" style={{ transform: "translateZ(0)" }}>
+      <div className="pointer-events-none absolute inset-0 overflow-hidden will-change-transform" aria-hidden="true" style={{ transform: "translateZ(0)" }}>
         <div className="absolute top-1/4 end-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[100px]" />
         <div className="absolute bottom-1/3 start-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[80px]" />
         <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[120px]" />
       </div>
 
-      <div className="landing-grid-bg pointer-events-none absolute inset-0 opacity-[0.03]" />
+      <div className="landing-grid-bg pointer-events-none absolute inset-0 opacity-[0.03]" aria-hidden="true" />
 
       <div className="relative z-10 mx-auto max-w-5xl px-4 text-center sm:px-6">
         <div
@@ -229,6 +230,7 @@ export function HeroSection() {
       <div
         className="absolute bottom-8 left-1/2 flex -translate-x-1/2 flex-col items-center gap-1.5 animate-fade-in motion-reduce:animate-none"
         style={{ animationDelay: "1.5s", animationFillMode: "backwards" }}
+        aria-hidden="true"
       >
         <span className="text-xs text-muted-foreground/50">גלול למטה</span>
         <div className="flex h-8 w-5 items-start justify-center rounded-full border-2 border-border/50 p-1">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -48,7 +48,7 @@ export function SettingsPage() {
   });
 
   return (
-    <div className="space-y-6 pb-24 md:pb-8">
+    <div className="max-w-xl space-y-6 pb-24 md:pb-8">
       <PageHeader title="הגדרות" subtitle="ניהול חשבון וחיבורים" />
 
       {/* Account */}


### PR DESCRIPTION
## Summary

Final low-severity fixes from the [UI/UX audit](https://github.com/Danielsio/carwatch/issues/1221). 3 fixes applied, 8 verified as already handled.

### Fixed
- **Hero decorative elements** — `aria-hidden="true"` on blobs, grid, floating cards, scroll indicator (#46)
- **Detail modal close button** — `aria-label="סגור"` on X button (#47)
- **Settings page width** — `max-w-xl` to prevent stretching on wide screens (#57)

### Verified Already Handled
- #45 (theme toggle aria-label), #51 (back button), #58 (auth max-width), #62 (dark focus rings), #65 (pagination no chevrons), #67 (no hero images), #70 (English intentional), #71 (errors already translated)

### Remaining Low Items (not fixable as CSS/ARIA)
19 items remain in the epic — all are feature requests (onboarding tour, keyboard shortcuts, bulk actions, notification preferences, etc.) or require build config changes (WebP, chart theming).

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 238 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility**
  * Enhanced close button with proper accessibility labels
  * Refined decorative elements to improve screen reader experience

* **Style**
  * Applied width optimization to Settings page layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->