### PR TITLE
feat: inline enrichment during refresh for accurate fitness scores

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -127,7 +127,7 @@ func run(configPath string, skipMigrate bool, logger *slog.Logger) error {
 	}
 	defer plCleanup()
 
-	apiServer, err := app.BuildAPI(cfg, store, dynCatalog, logger, fb.Factory, plSvc, logHub, logLevelVar)
+	apiServer, err := app.BuildAPI(cfg, store, dynCatalog, logger, fb.Factory, fb.Yad2, plSvc, logHub, logLevelVar)
 	if err != nil {
 		return err
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/cwlog"
 	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 	"github.com/dsionov/carwatch/internal/logstream"
 	"github.com/dsionov/carwatch/internal/pricelist"
 	"github.com/dsionov/carwatch/internal/scheduler"
@@ -118,6 +119,7 @@ type Config struct {
 	FirebaseAuth    TokenVerifier
 	BotUsername     string
 	Fetchers        *fetcher.Factory
+	Yad2Fetcher     *yad2.Yad2Fetcher // optional; enables inline enrichment during refresh
 	LogHub          *logstream.Hub
 	LogLevel        *slog.LevelVar
 	CycleLog        storage.CycleLogStore
@@ -137,6 +139,17 @@ func New(c Config) *Server {
 	fetchCap := c.API.MaxConcurrentFetches
 	if fetchCap <= 0 {
 		fetchCap = 10
+	}
+
+	pipeline := scheduler.NewListingPipeline(c.Listings, c.PriceListSvc, c.Logger)
+	if c.Yad2Fetcher != nil {
+		enricher := yad2.NewEnricher(c.Yad2Fetcher,
+			c.Logger.With("component", "inline-enricher"),
+			yad2.EnricherConfig{
+				Delay:       500 * time.Millisecond,
+				MaxPerCycle: 15,
+			})
+		pipeline.SetInlineEnricher(enricher.Enrich)
 	}
 
 	return &Server{
@@ -162,7 +175,7 @@ func New(c Config) *Server {
 		guestRL:         newIPRateLimiter(15, 3*time.Minute, c.API.TrustForwardedFor),
 		fetchers:        c.Fetchers,
 		priceListSvc:    c.PriceListSvc,
-		pipeline:        scheduler.NewListingPipeline(c.Listings, c.PriceListSvc, c.Logger),
+		pipeline:        pipeline,
 		logHub:          c.LogHub,
 		logLevel:        c.LogLevel,
 		cycleLog:        c.CycleLog,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -194,7 +194,7 @@ func BuildDynamicCatalog(ctx context.Context, yad2Fetcher *yad2.Yad2Fetcher, log
 }
 
 // BuildAPI creates the API server with all REST endpoints.
-func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, logger *slog.Logger, fetcherFactory *fetcher.Factory, plSvc *pricelist.Service, logHub *logstream.Hub, logLevel *slog.LevelVar) (*api.Server, error) {
+func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.DynamicCatalog, logger *slog.Logger, fetcherFactory *fetcher.Factory, yad2Fetcher *yad2.Yad2Fetcher, plSvc *pricelist.Service, logHub *logstream.Hub, logLevel *slog.LevelVar) (*api.Server, error) {
 	if api.IsNonLocalBind(cfg.HTTP.Bind) && cfg.Telemetry.AuthToken == "" {
 		return nil, fmt.Errorf("telemetry.auth_token must be configured for non-local bind address %q", cfg.HTTP.Bind)
 	}
@@ -235,6 +235,7 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		CycleLog:        store,
 		PollingInterval: cfg.Polling.Interval,
 		Fetchers:        fetcherFactory,
+		Yad2Fetcher:     yad2Fetcher,
 		PriceListSvc:    plSvc,
 		Bind:            cfg.HTTP.Bind,
 	})

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -235,7 +235,7 @@ func TestBuildAPIRejectsMissingFirebaseOnNonLocalBind(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatalf("expected error, got nil (server=%v)", apiServer)
 	}
@@ -271,7 +271,7 @@ func TestBuildAPIFirebaseRequirementByBind(t *testing.T) {
 					AuthToken: "telemetry-secret",
 				},
 			}
-			apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+			apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil, nil)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (server=%v)", apiServer)
@@ -297,7 +297,7 @@ func TestBuildAPIRejectsMissingTelemetryAuthOnNonLocalBind(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil)
+	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatalf("expected error, got nil (server=%v)", apiServer)
 	}

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -86,6 +86,10 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 	consecutiveFailures := 0
 	challengeRetries := 0
 
+	e.logger.InfoContext(ctx, "enrichment pass started",
+		"candidates", len(candidates), "delay", e.cfg.Delay, "max_per_cycle", e.cfg.MaxPerCycle)
+	passStart := time.Now()
+
 	for _, i := range candidates {
 		if e.cfg.MaxPerCycle > 0 && enriched >= e.cfg.MaxPerCycle {
 			e.logger.DebugContext(ctx, "reached per-cycle enrichment limit, deferring remaining listings",
@@ -112,8 +116,10 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 
 		attempts++
+		fetchStart := time.Now()
 		details, err := e.fetcher.FetchItem(ctx, listings[i].Token)
 		if err != nil {
+			fetchElapsed := time.Since(fetchStart)
 			if errors.Is(err, fetcher.ErrChallenge) {
 				challengeRetries++
 				if challengeRetries >= maxChallengeRetries {
@@ -121,6 +127,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 						"token", listings[i].Token,
 						"car", listings[i].Manufacturer+" "+listings[i].Model,
 						"challenges", challengeRetries,
+						"fetch_ms", fetchElapsed.Milliseconds(),
 						"impact", fmt.Sprintf("%d remaining listings will not be enriched this cycle", len(candidates)-attempts),
 						"action_taken", "aborting enrichment, will retry unenriched listings next cycle",
 						"enriched_so_far", enriched,
@@ -132,6 +139,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 					"token", listings[i].Token,
 					"car", listings[i].Manufacturer+" "+listings[i].Model,
 					"challenge_count", challengeRetries,
+					"fetch_ms", fetchElapsed.Milliseconds(),
 					"backoff", e.cfg.ChallengeBackoff,
 				)
 				select {
@@ -146,6 +154,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 				"token", listings[i].Token,
 				"car", listings[i].Manufacturer+" "+listings[i].Model,
 				"error", err.Error(),
+				"fetch_ms", fetchElapsed.Milliseconds(),
 				"impact", "listing will appear without km/city data until next cycle",
 				"action_taken", "continuing with remaining candidates",
 				"consecutive_failures", consecutiveFailures,
@@ -164,6 +173,7 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			continue
 		}
 
+		fetchElapsed := time.Since(fetchStart)
 		consecutiveFailures = 0
 		challengeRetries = 0
 		changed := false
@@ -185,14 +195,20 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 		}
 		if changed {
 			enriched++
-			e.logger.DebugContext(ctx, "successfully enriched listing with mileage and location data",
+			e.logger.InfoContext(ctx, "enriched listing",
 				"token", listings[i].Token,
 				"car", listings[i].Manufacturer+" "+listings[i].Model,
 				"km", details.Km,
 				"city", details.City,
 				"has_image", details.ImageURL != "",
+				"fetch_ms", fetchElapsed.Milliseconds(),
+				"progress", fmt.Sprintf("%d/%d", enriched, len(candidates)),
 			)
 		}
 	}
+
+	e.logger.InfoContext(ctx, "enrichment pass completed",
+		"enriched", enriched, "attempts", attempts, "candidates", len(candidates),
+		"elapsed", time.Since(passStart).Round(time.Millisecond))
 	return enriched
 }

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -11,15 +11,21 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
+// InlineEnricher enriches a batch of raw listings in place by fetching
+// individual listing pages for items missing km/city/image data.
+// Returns the number of successfully enriched listings.
+type InlineEnricher func(ctx context.Context, listings []model.RawListing) int
+
 // ListingPipeline encapsulates the shared processing steps for converting
 // raw listings into scored, enriched ListingRecords. Both the scheduler
 // and the API refresh handler use this pipeline so that users always get
 // fitness scores, deal scores, suspicious-listing detection, and base
 // price enrichment regardless of how the listing was fetched.
 type ListingPipeline struct {
-	listings     storage.ListingStore // for prefill (LookupEnrichmentData); may be nil
-	priceListSvc *pricelist.Service   // for base price enrichment; may be nil
-	logger       *slog.Logger
+	listings       storage.ListingStore // for prefill (LookupEnrichmentData); may be nil
+	priceListSvc   *pricelist.Service   // for base price enrichment; may be nil
+	inlineEnricher InlineEnricher       // optional; fetches missing data inline before scoring
+	logger         *slog.Logger
 }
 
 // NewListingPipeline creates a ListingPipeline. Both listings and priceListSvc
@@ -30,6 +36,14 @@ func NewListingPipeline(listings storage.ListingStore, priceListSvc *pricelist.S
 		priceListSvc: priceListSvc,
 		logger:       logger,
 	}
+}
+
+// SetInlineEnricher configures an optional inline enricher that fetches
+// missing km/city/image data from listing pages before scoring. This is
+// used by the API refresh handler so users see accurate fitness scores
+// without waiting for the background enricher.
+func (p *ListingPipeline) SetInlineEnricher(fn InlineEnricher) {
+	p.inlineEnricher = fn
 }
 
 // ProcessParams holds the per-call parameters for a pipeline invocation.
@@ -60,16 +74,21 @@ type ProcessResult struct {
 //
 // Steps performed:
 //  1. Prefill km/city/image from DB (if listings store is available)
-//  2. Compute fitness score
-//  3. Compute deal score (if market cache is available)
-//  4. Detect suspicious listings (if market cache is available)
-//  5. Enrich with base price (if pricelist service is available)
-//  6. Build ListingRecords
+//  2. Inline enrichment — fetch missing data from source (if inline enricher is set)
+//  3. Compute fitness score
+//  4. Compute deal score (if market cache is available)
+//  5. Detect suspicious listings (if market cache is available)
+//  6. Enrich with base price (if pricelist service is available)
+//  7. Build ListingRecords
 func (p *ListingPipeline) Process(ctx context.Context, raw []model.RawListing, params ProcessParams) ProcessResult {
 	log := p.logger.With("op", "pipeline", "search_id", params.SearchID, "chat_id", params.ChatID, "search_name", params.SearchName)
 
 	if !params.SkipPrefill {
 		p.prefillFromDB(ctx, raw, log)
+	}
+
+	if p.inlineEnricher != nil {
+		p.inlineEnrich(ctx, raw, log)
 	}
 
 	result := ProcessResult{
@@ -238,6 +257,67 @@ func (p *ListingPipeline) prefillFromDB(ctx context.Context, listings []model.Ra
 	if filled > 0 {
 		log.InfoContext(ctx, "prefilled listing data from database to supplement missing fields",
 			"filled", filled, "looked_up", len(tokens))
+	}
+}
+
+const inlineEnrichTimeout = 20 * time.Second
+
+// inlineEnrich fetches missing km/city/image from the source for listings
+// that are still unenriched after DB prefill. Results are persisted back to
+// the DB so the background enricher skips them.
+func (p *ListingPipeline) inlineEnrich(ctx context.Context, listings []model.RawListing, log *slog.Logger) {
+	needed := 0
+	for i := range listings {
+		if listings[i].Km <= 0 || listings[i].City == "" || listings[i].ImageURL == "" {
+			needed++
+		}
+	}
+	if needed == 0 {
+		return
+	}
+
+	type snapshot struct {
+		km    int
+		city  string
+		image string
+	}
+	before := make([]snapshot, len(listings))
+	for i := range listings {
+		before[i] = snapshot{listings[i].Km, listings[i].City, listings[i].ImageURL}
+	}
+
+	log.InfoContext(ctx, "starting inline enrichment",
+		"needed", needed, "total_listings", len(listings), "timeout", inlineEnrichTimeout)
+
+	enrichCtx, cancel := context.WithTimeout(ctx, inlineEnrichTimeout)
+	defer cancel()
+
+	start := time.Now()
+	enriched := p.inlineEnricher(enrichCtx, listings)
+	elapsed := time.Since(start)
+	log.InfoContext(ctx, "inline enrichment completed",
+		"needed", needed, "enriched", enriched, "elapsed", elapsed.Round(time.Millisecond))
+
+	if enriched == 0 || p.listings == nil {
+		return
+	}
+
+	var backfill []storage.ListingRecord
+	for i := range listings {
+		if listings[i].Km != before[i].km || listings[i].City != before[i].city || listings[i].ImageURL != before[i].image {
+			backfill = append(backfill, storage.ListingRecord{
+				Token:    listings[i].Token,
+				Km:       listings[i].Km,
+				City:     listings[i].City,
+				ImageURL: listings[i].ImageURL,
+			})
+		}
+	}
+	if len(backfill) > 0 {
+		if err := p.listings.BackfillListings(ctx, backfill); err != nil {
+			log.WarnContext(ctx, "failed to persist inline enrichment to DB",
+				"error", err.Error(), "records", len(backfill))
+		}
 	}
 }
 

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -112,6 +112,143 @@ func TestPipeline_WithPrefill(t *testing.T) {
 	}
 }
 
+type backfillTrackingStore struct {
+	prefillTrackingStore
+	backfillCalls   atomic.Int32
+	backfillRecords []storage.ListingRecord
+}
+
+func (s *backfillTrackingStore) BackfillListings(_ context.Context, records []storage.ListingRecord) error {
+	s.backfillCalls.Add(1)
+	s.backfillRecords = append(s.backfillRecords, records...)
+	return nil
+}
+
+func TestPipeline_InlineEnrichment_FillsMissingKm(t *testing.T) {
+	store := &backfillTrackingStore{}
+	p := NewListingPipeline(store, nil, pipelineTestLogger())
+	p.SetInlineEnricher(func(_ context.Context, listings []model.RawListing) int {
+		enriched := 0
+		for i := range listings {
+			if listings[i].Km <= 0 {
+				listings[i].Km = 36900
+				listings[i].City = "Tel Aviv"
+				listings[i].ImageURL = "https://img.example.com/car.jpg"
+				enriched++
+			}
+		}
+		return enriched
+	})
+
+	raw := []model.RawListing{
+		{Token: "t1", Price: 100000, Year: 2019, Manufacturer: "Honda", Model: "Civic", Km: 0},
+	}
+	params := ProcessParams{
+		ChatID: 1, SearchID: 1, SearchName: "test",
+		SkipPrefill: true, PriceMax: 150000,
+	}
+
+	result := p.Process(context.Background(), raw, params)
+
+	if len(result.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(result.Records))
+	}
+	if result.Records[0].Km != 36900 {
+		t.Errorf("expected km=36900 after inline enrichment, got %d", result.Records[0].Km)
+	}
+	if result.Records[0].City != "Tel Aviv" {
+		t.Errorf("expected city=Tel Aviv, got %q", result.Records[0].City)
+	}
+	if store.backfillCalls.Load() != 1 {
+		t.Errorf("expected 1 BackfillListings call, got %d", store.backfillCalls.Load())
+	}
+	if len(store.backfillRecords) != 1 || store.backfillRecords[0].Token != "t1" {
+		t.Errorf("expected backfill for token t1, got %v", store.backfillRecords)
+	}
+}
+
+func TestPipeline_InlineEnrichment_ScoresReflectEnrichedData(t *testing.T) {
+	p := NewListingPipeline(nil, nil, pipelineTestLogger())
+
+	raw := []model.RawListing{
+		{Token: "t1", Price: 100000, Year: 2019, Manufacturer: "Honda", Model: "Civic", Km: 0, Hand: 2},
+	}
+	params := ProcessParams{
+		ChatID: 1, SearchID: 1, SearchName: "test",
+		SkipPrefill: true, PriceMax: 150000,
+	}
+
+	resultNoEnrich := p.Process(context.Background(), raw, params)
+	scoreWithoutKm := *resultNoEnrich.Records[0].FitnessScore
+
+	raw[0].Km = 0
+	p.SetInlineEnricher(func(_ context.Context, listings []model.RawListing) int {
+		for i := range listings {
+			if listings[i].Km <= 0 {
+				listings[i].Km = 36900
+			}
+		}
+		return 1
+	})
+	resultEnriched := p.Process(context.Background(), raw, params)
+	scoreWithKm := *resultEnriched.Records[0].FitnessScore
+
+	if scoreWithKm <= scoreWithoutKm {
+		t.Errorf("score with low km (%v) should be higher than without km (%v)", scoreWithKm, scoreWithoutKm)
+	}
+}
+
+func TestPipeline_InlineEnrichment_NilEnricher_Skips(t *testing.T) {
+	store := &backfillTrackingStore{}
+	p := NewListingPipeline(store, nil, pipelineTestLogger())
+
+	raw := []model.RawListing{
+		{Token: "t1", Price: 100000, Year: 2019, Manufacturer: "Honda", Model: "Civic", Km: 0},
+	}
+	params := ProcessParams{
+		ChatID: 1, SearchID: 1, SearchName: "test",
+		SkipPrefill: true, PriceMax: 150000,
+	}
+
+	result := p.Process(context.Background(), raw, params)
+
+	if result.Records[0].Km != 0 {
+		t.Errorf("expected km=0 without enricher, got %d", result.Records[0].Km)
+	}
+	if store.backfillCalls.Load() != 0 {
+		t.Errorf("expected 0 BackfillListings calls without enricher, got %d", store.backfillCalls.Load())
+	}
+}
+
+func TestPipeline_InlineEnrichment_AllEnriched_NoBackfill(t *testing.T) {
+	store := &backfillTrackingStore{}
+	p := NewListingPipeline(store, nil, pipelineTestLogger())
+
+	enricherCalled := false
+	p.SetInlineEnricher(func(_ context.Context, _ []model.RawListing) int {
+		enricherCalled = true
+		return 0
+	})
+
+	raw := []model.RawListing{
+		{Token: "t1", Price: 100000, Year: 2019, Manufacturer: "Honda", Model: "Civic",
+			Km: 50000, City: "Haifa", ImageURL: "https://img.example.com/a.jpg"},
+	}
+	params := ProcessParams{
+		ChatID: 1, SearchID: 1, SearchName: "test",
+		SkipPrefill: true, PriceMax: 150000,
+	}
+
+	p.Process(context.Background(), raw, params)
+
+	if enricherCalled {
+		t.Error("enricher should not be called when all listings already have data")
+	}
+	if store.backfillCalls.Load() != 0 {
+		t.Errorf("expected 0 BackfillListings calls, got %d", store.backfillCalls.Load())
+	}
+}
+
 func TestPipeline_NilListingStore_NoPrefill(t *testing.T) {
 	p := NewListingPipeline(nil, nil, pipelineTestLogger())
 


### PR DESCRIPTION
## Summary

- Enrich listings inline during the refresh API call (fetch km/city/image from Yad2 item pages) **before** computing fitness scores
- Fixes misleading scores where unenriched listings (km=0) scored 1.6/10 instead of ~7.5 for low-mileage cars
- Uses existing `yad2.Enricher` with interactive-friendly settings: 500ms delay, max 15 per cycle, 20s timeout
- Persists enriched data via `BackfillListings` so the background enricher skips them
- Adds per-item timing logs (`fetch_ms`, `progress`, `elapsed`) to diagnose enrichment speed

## Test plan

- [ ] Deploy and click refresh on a search with unenriched listings
- [ ] Verify logs show inline enrichment timing (search for `inline enrichment` and `enrichment pass`)
- [ ] Confirm fitness scores reflect actual km data, not km=0 defaults
- [ ] Verify background enricher still works independently
- [ ] Confirm scheduler pipeline (no inline enricher) is unaffected