### PR TITLE
chore: include enrich-bench in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,14 @@ RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/api-server ./cmd/api-se
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/bot-poller ./cmd/bot-poller && \
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/scraper ./cmd/scraper && \
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier && \
-    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/enricher ./cmd/enricher
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/enricher ./cmd/enricher && \
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/enrich-bench ./cmd/enrich-bench
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata \
     && adduser -D -u 1000 carwatch
 USER carwatch
-COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /bin/enricher /usr/local/bin/
+COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /bin/enricher /bin/enrich-bench /usr/local/bin/
 COPY --from=builder /app/migrations /migrations
 HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
   CMD wget -q --spider http://localhost:8080/healthz || exit 1


### PR DESCRIPTION
## Summary

- Include `enrich-bench` binary in the Docker image so it can run on the production VM with the real network and config
- Usage: `docker exec carwatch enrich-bench --config /config.yaml --ramp`

## Why

We already ran the bench via scp'd binary, but having it in the image means we can re-run anytime after config changes to validate the new delay is still safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include a benchmarking utility in the runtime image alongside existing server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->