### PR TITLE
fix: address 6 CodeRabbit review comments from PRs #1215-#1272

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -768,8 +768,6 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	type searchCycleCounter struct {
 		matched    int // percolator hits before dedup
 		kmFiltered int // held back by km filter
-		priceMin   int // cheapest matched listing
-		priceMax   int // most expensive matched listing
 	}
 	searchCounters := make(map[int64]*searchCycleCounter)
 
@@ -823,14 +821,6 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 				searchCounters[m.SearchID] = ctr
 			}
 			ctr.matched++
-			if p := raw[i].Price; p > 0 {
-				if ctr.priceMin == 0 || p < ctr.priceMin {
-					ctr.priceMin = p
-				}
-				if p > ctr.priceMax {
-					ctr.priceMax = p
-				}
-			}
 
 			// Per-user hidden listing check (cached per chatID per cycle).
 			hidden, cached := hiddenCache[m.ChatID]
@@ -1076,29 +1066,31 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 	}
 
 	// Write per-search cycle stats for dashboard observability.
-	if s.stores.SearchCycleStats != nil && len(accums) > 0 {
+	if s.stores.SearchCycleStats != nil && len(searches) > 0 {
 		rejections := s.percolator.CountRejections(raw)
+		now := time.Now()
 
-		cycleStats := make([]storage.SearchCycleStats, 0, len(accums))
-		for _, acc := range accums {
-			ctr := searchCounters[acc.search.ID]
+		cycleStats := make([]storage.SearchCycleStats, 0, len(searches))
+		for _, search := range searches {
+			acc := accums[search.ID]
+			ctr := searchCounters[search.ID]
 			matched := 0
 			kmFiltered := 0
-			var priceMin, priceMax *int
 			if ctr != nil {
 				matched = ctr.matched
 				kmFiltered = ctr.kmFiltered
-				if ctr.priceMin > 0 {
-					priceMin = &ctr.priceMin
-					priceMax = &ctr.priceMax
-				}
 			}
 
-			rej := rejections[acc.search.ID]
+			rej := rejections[search.ID]
 
+			var newListingCount, priceDropCount int
 			var scoreMin, scoreMax, scoreAvg *float64
-			if len(acc.result.newListings) > 0 {
+			var priceMin, priceMax *int
+			if acc != nil && len(acc.result.newListings) > 0 {
+				newListingCount = len(acc.result.newListings)
+				priceDropCount = len(acc.result.priceDropMessages)
 				mn, mx, sum := acc.result.newListings[0].FitnessScore, acc.result.newListings[0].FitnessScore, 0.0
+				pMin, pMax := acc.result.newListings[0].Price, acc.result.newListings[0].Price
 				for _, l := range acc.result.newListings {
 					if l.FitnessScore < mn {
 						mn = l.FitnessScore
@@ -1107,24 +1099,38 @@ func (s *Scheduler) fetchGlobalAndMatch(ctx context.Context, searches []storage.
 						mx = l.FitnessScore
 					}
 					sum += l.FitnessScore
+					if l.Price > 0 {
+						if pMin == 0 || l.Price < pMin {
+							pMin = l.Price
+						}
+						if l.Price > pMax {
+							pMax = l.Price
+						}
+					}
 				}
 				avg := sum / float64(len(acc.result.newListings))
 				scoreMin = &mn
 				scoreMax = &mx
 				scoreAvg = &avg
+				if pMin > 0 {
+					priceMin = &pMin
+					priceMax = &pMax
+				}
+			} else if acc != nil {
+				priceDropCount = len(acc.result.priceDropMessages)
 			}
 
 			cycleStats = append(cycleStats, storage.SearchCycleStats{
-				SearchID:    acc.search.ID,
-				ChatID:      acc.search.ChatID,
-				SearchName:  acc.search.Name,
-				CycleAt:     time.Now(),
+				SearchID:    search.ID,
+				ChatID:      search.ChatID,
+				SearchName:  search.Name,
+				CycleAt:     now,
 				FeedSize:    len(raw),
 				Matched:     matched,
-				NewListings: len(acc.result.newListings),
+				NewListings: newListingCount,
 				KmFiltered:  kmFiltered,
-				Delivered:   len(acc.result.newListings),
-				PriceDrops:  len(acc.result.priceDropMessages),
+				Delivered:   newListingCount,
+				PriceDrops:  priceDropCount,
 				WrongModel:  rej[percolator.RejectWrongModel],
 				YearOut:     rej[percolator.RejectYearOut],
 				PriceOut:    rej[percolator.RejectPriceOut],

--- a/migrations/000020_cycle_stats_fk_cascade.down.sql
+++ b/migrations/000020_cycle_stats_fk_cascade.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE search_cycle_stats
+  DROP CONSTRAINT IF EXISTS fk_search_cycle_stats_search;

--- a/migrations/000020_cycle_stats_fk_cascade.up.sql
+++ b/migrations/000020_cycle_stats_fk_cascade.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE search_cycle_stats
+  ADD CONSTRAINT fk_search_cycle_stats_search
+  FOREIGN KEY (search_id) REFERENCES searches(id) ON DELETE CASCADE;

--- a/web/src/components/NextScanCountdown.tsx
+++ b/web/src/components/NextScanCountdown.tsx
@@ -35,7 +35,7 @@ export function NextScanCountdown() {
   const fetched = status.listings_fetched ?? 0;
   const matched = status.listings_matched ?? 0;
   const notifs = status.notifications ?? 0;
-  const hasStats = !!status.last_cycle_at && fetched > 0;
+  const hasStats = !!status.last_cycle_at;
 
   return (
     <div

--- a/web/src/components/ui/MatchScoreBox.tsx
+++ b/web/src/components/ui/MatchScoreBox.tsx
@@ -31,7 +31,6 @@ export function MatchScoreBox({ score, size = "md", className }: MatchScoreBoxPr
         backgroundColor: scoreHslAlpha(normalized, 0.10),
         boxShadow: `0 0 16px -4px ${scoreHslAlpha(normalized, 0.3)}, inset 0 0 0 1.5px ${scoreHslAlpha(normalized, 0.25)}`,
       }}
-      aria-label={`ציון ${formatted} מתוך 10`}
       title="ציון התאמה - ככל שהציון גבוה יותר, הרכב מתאים יותר לחיפוש שלך"
     >
       <span className="tabular-nums" aria-hidden="true">{formatted}</span>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -307,15 +307,15 @@ textarea:focus-visible {
 }
 
 .dark {
-  scrollbar-color: #2a3040 transparent;
+  scrollbar-color: var(--color-border) transparent;
 }
 
 .dark ::-webkit-scrollbar-thumb {
-  background-color: #2a3040;
+  background-color: var(--color-border);
 }
 
 .dark ::-webkit-scrollbar-thumb:hover {
-  background-color: #3a4558;
+  background-color: var(--color-muted-foreground);
 }
 
 /* ═══ Range Slider ═══ */


### PR DESCRIPTION
## Summary

Retroactive audit of CodeRabbit comments across the last 20 PRs. 13 comments total: 4 already addressed, 3 skipped (nitpick/low-value), **6 fixed here**.

| # | PR | Issue | Fix |
|---|-----|-------|-----|
| 1 | #1272 | Price/score stats computed from different populations | Both now from pipeline output |
| 2 | #1266 | Zero-match searches excluded from cycle stats | Stats recorded for ALL active searches |
| 3 | #1266 | Missing FK CASCADE on search_cycle_stats | Added migration #20 with ON DELETE CASCADE |
| 4 | #1265 | Redundant aria-label + sr-only in MatchScoreBox | Removed aria-label, kept sr-only |
| 5 | #1265 | Hardcoded scrollbar hex colors | Replaced with CSS variables |
| 6 | #1220 | hasStats gated on listings_fetched > 0 | Gate on cycle existence only |

### Skipped (with reason)
- #1272 nitpick: RejectOtherFilter test coverage — already covered by existing Match tests
- #1266 nitpick: Delivered count semantics — single bool return, rename not worth it
- #1266 minor: Division by zero — matched > 0 guard already prevents feed_size === 0

## Test plan

- [ ] Verify zero-match searches show last scan section with 0 matches
- [ ] Delete a search, verify its cycle stats row is cascade-deleted
- [ ] Verify scrollbar colors match dark theme
- [ ] Screen reader: MatchScoreBox announces once, not twice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of dashboard statistics calculation by deriving metrics directly from actual listing results.

* **Improvements**
  * Last cycle stats now display when cycle data is available.
  * Enhanced accessibility for match score display.
  * Dark mode scrollbar styling now uses consistent theme colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->