### PR TITLE
fix: update MatchScoreBox test to match sr-only text

### DIFF
--- a/web/src/components/ui/MatchScoreBox.test.tsx
+++ b/web/src/components/ui/MatchScoreBox.test.tsx
@@ -28,10 +28,10 @@ describe("MatchScoreBox", () => {
     expect(screen.getByText("/10")).toBeInTheDocument();
   });
 
-  it("has correct aria-label", () => {
+  it("has correct screen reader text", () => {
     render(<MatchScoreBox score={9.2} />);
     expect(
-      screen.getByLabelText("ציון 9.2 מתוך 10"),
+      screen.getByText("ציון התאמה: 9.2 מתוך 10"),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- Fix pre-existing failing test in `MatchScoreBox.test.tsx`
- Component uses `sr-only` span with "ציון התאמה:" prefix, test expected `aria-label` with "ציון"
- This was blocking CI Web Build across all PRs

## Test plan

- [x] `npx vitest run src/components/ui/MatchScoreBox.test.tsx` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)