### PR TITLE
feat: per-search stats, admin reset button, hot badge from post date

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -191,6 +191,21 @@ func (s *Server) adminPurgeTable(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"table": body.Table, "deleted": deleted})
 }
 
+func (s *Server) adminResetAll(w http.ResponseWriter, r *http.Request) {
+	counts, err := s.admin.ResetAllData(r.Context())
+	if err != nil {
+		s.logger.Error("admin: reset all data", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to reset data")
+		return
+	}
+	var total int64
+	for _, n := range counts {
+		total += n
+	}
+	s.logger.Info("admin: reset all data", "tables", len(counts), "total_rows", total)
+	writeJSON(w, http.StatusOK, map[string]any{"tables": counts, "total": total})
+}
+
 func (s *Server) adminListListings(w http.ResponseWriter, r *http.Request) {
 	limit, ok := parseIntParam(w, r, "limit", 50)
 	if !ok {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -263,6 +263,7 @@ func (s *Server) Routes() http.Handler {
 		authMux.HandleFunc("PATCH /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminSetUserActive))
 		authMux.HandleFunc("DELETE /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminDeleteUser))
 		authMux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
+		authMux.HandleFunc("POST /api/v1/admin/reset-all", s.requireAdmin(s.adminResetAll))
 		authMux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))
 		authMux.HandleFunc("POST /api/v1/admin/sync-user-status", s.requireAdmin(s.adminSyncUserStatus))
 		authMux.HandleFunc("GET /api/v1/admin/activity", s.requireAdmin(s.adminActivity))

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -744,6 +744,9 @@ func (f *failingAdminStore) AdminActivityStats(_ context.Context, _ int) ([]stor
 func (f *failingAdminStore) DBPoolStats() *storage.DBPoolStats {
 	return &storage.DBPoolStats{}
 }
+func (f *failingAdminStore) ResetAllData(_ context.Context) (map[string]int64, error) {
+	return nil, nil
+}
 
 func TestAdminStats_DBFileSizeError(t *testing.T) {
 	srv, _ := setupTestServer(t)

--- a/internal/api/bookmarks.go
+++ b/internal/api/bookmarks.go
@@ -263,6 +263,9 @@ func toListingResponses(records []storage.ListingRecord, saved, seen map[string]
 			Seen:         seenFlag,
 			IsCommercial: l.IsCommercial,
 		}
+		if l.PostedAt != nil {
+			resp.PostedAt = l.PostedAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
 		if l.RemovedAt != nil {
 			s := l.RemovedAt.UTC().Format("2006-01-02T15:04:05Z")
 			resp.RemovedAt = &s

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -36,6 +36,7 @@ type listingResponse struct {
 	DealScore    *int     `json:"deal_score,omitempty"`
 	BasePrice    *int     `json:"base_price,omitempty"`
 	FirstSeenAt  string   `json:"first_seen_at"`
+	PostedAt     string   `json:"posted_at,omitempty"`
 	Saved        bool     `json:"saved,omitempty"`
 	// Seen: user dismissed this listing from the new-items feed (notifications).
 	Seen bool `json:"seen,omitempty"`
@@ -281,6 +282,9 @@ func (s *Server) getListing(w http.ResponseWriter, r *http.Request) {
 		Saved:        savedFlag,
 		Seen:         seenFlag,
 		IsCommercial: l.IsCommercial,
+	}
+	if l.PostedAt != nil {
+		resp.PostedAt = l.PostedAt.UTC().Format("2006-01-02T15:04:05Z")
 	}
 	if l.RemovedAt != nil {
 		s := l.RemovedAt.UTC().Format("2006-01-02T15:04:05Z")

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -349,6 +349,10 @@ func (p *ListingPipeline) buildRecord(listing model.Listing, params ProcessParam
 		BasePrice:    listing.BasePrice,
 		FirstSeenAt:  time.Now(),
 	}
+	if !listing.CreatedAt.IsZero() {
+		t := listing.CreatedAt
+		rec.PostedAt = &t
+	}
 	if listing.DealScore != nil {
 		rec.MedianPrice = &listing.DealScore.MedianPrice
 		rec.CohortSize = &listing.DealScore.CohortSize

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -928,6 +928,10 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 				IsCommercial: l.Commercial,
 				FitnessScore: &listing.FitnessScore, FirstSeenAt: time.Now(),
 			}
+			if !l.CreatedAt.IsZero() {
+				t := l.CreatedAt
+				rec.PostedAt = &t
+			}
 			if marketCache != nil {
 				if median, medKm, cohort, ok := marketCache.Lookup(l.Manufacturer, l.Model, l.Year); ok {
 					ds := scoring.ScoreWithKm(l.Price, l.Km, median, medKm)
@@ -1107,7 +1111,7 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 				ChatID:      search.ChatID,
 				SearchName:  search.Name,
 				CycleAt:     now,
-				FeedSize:    len(raw),
+				FeedSize:    matched + rej[percolator.RejectWrongModel] + rej[percolator.RejectYearOut] + rej[percolator.RejectPriceOut] + rej[percolator.RejectKmOver] + rej[percolator.RejectHandOver] + rej[percolator.RejectOtherFilter],
 				Matched:     matched,
 				NewListings: newListingCount,
 				KmFiltered:  kmFiltered,

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -152,6 +152,7 @@ type ListingRecord struct {
 	DealScore    *int
 	BasePrice    *int
 	FirstSeenAt  time.Time
+	PostedAt     *time.Time
 	// RemovedAt: non-nil when the listing disappeared from the source but was
 	// preserved because it is bookmarked ("likely sold").
 	RemovedAt *time.Time
@@ -383,6 +384,7 @@ type AdminStore interface {
 	VacuumDB(ctx context.Context) error
 	SyncUserActiveStatus(ctx context.Context) (activated, deactivated int64, err error)
 	AdminActivityStats(ctx context.Context, days int) ([]AdminDayActivity, error)
+	ResetAllData(ctx context.Context) (map[string]int64, error)
 	DBPoolStats() *DBPoolStats
 }
 

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -173,17 +173,20 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		var r storage.ListingRecord
 		var fs sql.NullFloat64
 		var ic, mp, cs, ds, bp sql.NullInt64
-		var removedAt sql.NullTime
+		var postedAt, removedAt sql.NullTime
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
 			&r.Manufacturer, &r.Model, &r.SubModel, &r.SubModelID, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
-			&ic, &fs, &mp, &cs, &ds, &bp, &r.FirstSeenAt, &removedAt,
+			&ic, &fs, &mp, &cs, &ds, &bp, &r.FirstSeenAt, &postedAt, &removedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
 		r.IsCommercial = storage.ListingCommercialFromSQL(ic)
+		if postedAt.Valid {
+			r.PostedAt = &postedAt.Time
+		}
 		if fs.Valid {
 			r.FitnessScore = &fs.Float64
 		}

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -90,6 +90,45 @@ func (s *Store) PurgeTable(ctx context.Context, table string) (int64, error) {
 	return result.RowsAffected()
 }
 
+var resetTables = []string{
+	"search_cycle_stats",
+	"listing_user_seen",
+	"saved_listings",
+	"hidden_listings",
+	"seen_listings",
+	"pending_digest",
+	"listing_history",
+	"price_history",
+	"price_list_cache",
+	"cycle_log",
+	"link_tokens",
+}
+
+func (s *Store) ResetAllData(ctx context.Context) (map[string]int64, error) {
+	counts := make(map[string]int64, len(resetTables))
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reset begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, table := range resetTables {
+		var count int64
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteIdent(table))).Scan(&count); err != nil {
+			return nil, fmt.Errorf("count %s: %w", table, err)
+		}
+		counts[table] = count
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("TRUNCATE %s CASCADE", quoteIdent(table))); err != nil {
+			return nil, fmt.Errorf("truncate %s: %w", table, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("reset commit: %w", err)
+	}
+	return counts, nil
+}
+
 func (s *Store) AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]storage.ListingRecord, int64, error) {
 	var total int64
 	if searchID > 0 {
@@ -109,7 +148,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
 			FROM listing_history
 			WHERE search_id = $1
 			ORDER BY first_seen_at DESC
@@ -119,7 +158,7 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 				km, hand, city, page_link, image_url,
 				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
 			FROM listing_history
 			ORDER BY first_seen_at DESC
 			LIMIT $1 OFFSET $2`, limit, offset)

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -683,7 +683,7 @@ func (s *Store) ListSaved(ctx context.Context, chatID int64, limit, offset int) 
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.posted_at, lh.removed_at
 		FROM saved_listings sl
 		JOIN listing_history lh ON sl.token = lh.token AND sl.chat_id = lh.chat_id
 		WHERE sl.chat_id = $1

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -38,8 +38,8 @@ GROUP BY lh.search_id`
 
 const upsertListingSQL = `
 	INSERT INTO listing_history
-	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
+	(token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price, km, hand, city, page_link, image_url, engine_volume, horse_power, engine_type, gear_box, description, is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
 	ON CONFLICT (token, chat_id) DO UPDATE SET
 		search_id = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_id ELSE listing_history.search_id END,
 		search_name = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_name ELSE listing_history.search_name END,
@@ -65,6 +65,7 @@ const upsertListingSQL = `
 		cohort_size = COALESCE(EXCLUDED.cohort_size, listing_history.cohort_size),
 		deal_score = COALESCE(EXCLUDED.deal_score, listing_history.deal_score),
 		base_price = COALESCE(EXCLUDED.base_price, listing_history.base_price),
+		posted_at = COALESCE(EXCLUDED.posted_at, listing_history.posted_at),
 		removed_at = NULL`
 
 const unenrichedBacklogWhereSQL = `
@@ -84,11 +85,11 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 	var l storage.ListingRecord
 	var fs sql.NullFloat64
 	var ic, mp, cs, ds, bp sql.NullInt64
-	var removedAt sql.NullTime
+	var removedAt, postedAt sql.NullTime
 	if err := sc.Scan(&l.Token, &l.SearchName, &l.Manufacturer, &l.Model, &l.SubModel, &l.SubModelID,
 		&l.Year, &l.Price, &l.Km, &l.Hand, &l.City, &l.PageLink, &l.ImageURL,
 		&l.EngineVolume, &l.HorsePower, &l.EngineType, &l.GearBox, &l.Description,
-		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt, &removedAt); err != nil {
+		&ic, &fs, &mp, &cs, &ds, &bp, &l.FirstSeenAt, &postedAt, &removedAt); err != nil {
 		return l, err
 	}
 	l.IsCommercial = storage.ListingCommercialFromSQL(ic)
@@ -111,6 +112,9 @@ func scanListingRow(sc listingScanner) (storage.ListingRecord, error) {
 		v := int(bp.Int64)
 		l.BasePrice = &v
 	}
+	if postedAt.Valid {
+		l.PostedAt = &postedAt.Time
+	}
 	if removedAt.Valid {
 		l.RemovedAt = &removedAt.Time
 	}
@@ -123,7 +127,7 @@ func upsertListingArgs(r storage.ListingRecord) []any {
 		r.Km, r.Hand, r.City, r.PageLink, r.ImageURL,
 		r.EngineVolume, r.HorsePower, r.EngineType, r.GearBox, r.Description,
 		storage.ListingCommercialToSQL(r.IsCommercial),
-		r.FitnessScore, r.MedianPrice, r.CohortSize, r.DealScore, r.BasePrice, r.FirstSeenAt.UTC(),
+		r.FitnessScore, r.MedianPrice, r.CohortSize, r.DealScore, r.BasePrice, r.FirstSeenAt.UTC(), r.PostedAt,
 	}
 }
 
@@ -266,7 +270,7 @@ func (s *Store) GetListing(ctx context.Context, chatID int64, token string) (*st
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
 		FROM listing_history
 		WHERE chat_id = $1 AND token = $2
 		ORDER BY first_seen_at DESC
@@ -286,7 +290,7 @@ func (s *Store) ListUserListings(ctx context.Context, chatID int64, limit, offse
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
 		FROM listing_history
 		WHERE chat_id = $1 AND removed_at IS NULL
 		ORDER BY first_seen_at DESC, token DESC
@@ -405,7 +409,7 @@ func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID i
 		SELECT token, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
 			km, hand, city, page_link, image_url,
 			engine_volume, horse_power, engine_type, gear_box, description,
-			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, removed_at
+			is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
 		FROM listing_history
 		WHERE chat_id = $1 AND search_id = $2%s
 		ORDER BY %s

--- a/internal/storage/postgres/notifications_center.go
+++ b/internal/storage/postgres/notifications_center.go
@@ -27,7 +27,7 @@ func (s *Store) NewListingsSince(ctx context.Context, chatID int64, since time.T
 		SELECT lh.token, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
 			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
 			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
-			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.removed_at
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.posted_at, lh.removed_at
 		FROM listing_history lh
 		JOIN searches s ON s.id = lh.search_id AND s.chat_id = lh.chat_id
 		WHERE lh.chat_id = $1 AND lh.first_seen_at > $2

--- a/migrations/000021_listing_posted_at.down.sql
+++ b/migrations/000021_listing_posted_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE listing_history DROP COLUMN IF EXISTS posted_at;

--- a/migrations/000021_listing_posted_at.up.sql
+++ b/migrations/000021_listing_posted_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE listing_history ADD COLUMN IF NOT EXISTS posted_at TIMESTAMPTZ;

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -50,9 +50,10 @@ function dealInfo(listing: Listing): {
 
 type Freshness = "hot" | "today" | "week" | "older";
 
-function listingFreshness(firstSeenAt: string): Freshness {
-  if (!firstSeenAt) return "older";
-  const posted = new Date(firstSeenAt).getTime();
+function listingFreshness(postedAt: string | undefined, firstSeenAt: string): Freshness {
+  const ts = postedAt || firstSeenAt;
+  if (!ts) return "older";
+  const posted = new Date(ts).getTime();
   const hoursAgo = Math.max(0, Date.now() - posted) / (1000 * 60 * 60);
   if (hoursAgo < 1) return "hot";
   if (hoursAgo < 24) return "today";
@@ -84,7 +85,7 @@ export function ListingCardBody({
   const source = listingSource(listing.page_link);
   const deal = dealInfo(listing);
   const isNew = listing.seen === false;
-  const freshness = listingFreshness(listing.first_seen_at);
+  const freshness = listingFreshness(listing.posted_at, listing.first_seen_at);
 
   return (
     <>

--- a/web/src/components/admin/OverviewTab.tsx
+++ b/web/src/components/admin/OverviewTab.tsx
@@ -21,29 +21,27 @@ const TABLE_LABELS: Record<string, string> = {
   searches: "חיפושים",
   listing_history: "היסטוריית מודעות",
   price_history: "היסטוריית מחירים",
-  dedup_seen: "סינון כפילויות",
   seen_listings: "מודעות שנצפו",
   listing_user_seen: "מודעות סומנו כנצפו",
-  notifications: "התראות",
-  pending_notifications: "התראות ממתינות",
-  catalog: "קטלוג",
   saved_listings: "מודעות שמורות",
   hidden_listings: "מודעות מוסתרות",
   pending_digest: "תקצירים ממתינים",
+  cycle_log: "לוג סריקות",
+  search_cycle_stats: "סטטיסטיקות חיפוש",
+  price_list_cache: "מחירון מטמון",
   link_tokens: "טוקנים לקישור",
 };
 
 const PURGEABLE = new Set([
   "listing_history",
   "price_history",
-  "dedup_seen",
   "seen_listings",
   "listing_user_seen",
-  "notifications",
-  "pending_notifications",
   "saved_listings",
   "hidden_listings",
   "pending_digest",
+  "cycle_log",
+  "search_cycle_stats",
 ]);
 
 function StorageIndicator({ sizeBytes }: { sizeBytes: number }) {
@@ -116,6 +114,20 @@ export function OverviewTab({
     },
   });
 
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const resetMutation = useMutation({
+    mutationFn: () => adminApi.resetAll(),
+    meta: { suppressToast: true },
+    onSuccess: (result) => {
+      toast(`איפוס הושלם — ${result.total.toLocaleString("he-IL")} שורות נמחקו`, "success");
+      void queryClient.invalidateQueries({ queryKey: ["admin"] });
+      onRefresh();
+    },
+    onError: () => {
+      toast("שגיאה באיפוס המערכת", "error");
+    },
+  });
+
   const mb = data.db.file_size_bytes / (1024 * 1024);
 
   return (
@@ -136,19 +148,34 @@ export function OverviewTab({
               </div>
               <h2 className="text-base font-semibold">אחסון</h2>
             </div>
-            <button
-              type="button"
-              onClick={() => void vacuumMutation.mutate()}
-              disabled={vacuumMutation.isPending}
-              className="inline-flex items-center gap-1.5 rounded-xl border border-border bg-secondary px-3 py-2 text-xs font-medium transition-colors hover:bg-muted disabled:opacity-50"
-            >
-              {vacuumMutation.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <HardDrive className="h-3.5 w-3.5" />
-              )}
-              דחיסת DB
-            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowResetConfirm(true)}
+                disabled={resetMutation.isPending}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
+              >
+                {resetMutation.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
+                )}
+                איפוס מערכת
+              </button>
+              <button
+                type="button"
+                onClick={() => void vacuumMutation.mutate()}
+                disabled={vacuumMutation.isPending}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-border bg-secondary px-3 py-2 text-xs font-medium transition-colors hover:bg-muted disabled:opacity-50"
+              >
+                {vacuumMutation.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <HardDrive className="h-3.5 w-3.5" />
+                )}
+                דחיסת DB
+              </button>
+            </div>
           </div>
           <div className="flex items-baseline gap-2.5 mb-3">
             <span className="text-4xl font-bold tabular-nums">
@@ -333,6 +360,37 @@ export function OverviewTab({
             })}
         </div>
       </div>
+      {showResetConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-xl">
+            <h3 className="text-lg font-bold text-destructive mb-2">איפוס מערכת</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              כל הנתונים יימחקו — היסטוריית מודעות, מחירים, סטטיסטיקות, ומועדפים.
+              <br />
+              <strong>משתמשים וחיפושים יישמרו.</strong>
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                type="button"
+                onClick={() => setShowResetConfirm(false)}
+                className="rounded-xl border border-border px-4 py-2 text-sm font-medium hover:bg-muted"
+              >
+                ביטול
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowResetConfirm(false);
+                  void resetMutation.mutate();
+                }}
+                className="rounded-xl bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
+              >
+                איפוס הכל
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -137,6 +137,7 @@ export interface Listing {
   cohort_size?: number;
   deal_score?: number;
   first_seen_at: string;
+  posted_at?: string;
   /** Present when API includes bookmark state */
   saved?: boolean;
   /** User dismissed this listing from the new / notifications feed */
@@ -469,6 +470,8 @@ export const adminApi = {
     }),
   vacuum: () =>
     fetchAPI<VacuumResult>("/admin/vacuum", { method: "POST" }),
+  resetAll: () =>
+    fetchAPI<{ tables: Record<string, number>; total: number }>("/admin/reset-all", { method: "POST" }),
   activity: (days?: number) =>
     fetchAPI<AdminActivityResponse>(`/admin/activity${days ? `?days=${days}` : ""}`),
   cycles: (limit?: number) =>


### PR DESCRIPTION
## Summary

Three fixes:

1. **Per-search feed_size**: Was showing total feed (163) for ALL searches. Now each search shows its own count (e.g., Honda ~82, Mazda ~82). Computed as `matched + sum(rejections)` per search.

2. **Admin Reset All button**: Single red "איפוס מערכת" button in the admin Overview tab. TRUNCATEs all transient data (listing_history, price_history, seen_listings, etc.) while preserving users and searches. Has confirmation modal.

3. **Hot badge from Yad2 post date**: Freshness badge was using `first_seen_at` (when CarWatch first fetched it). Now uses the listing's original Yad2 `createdAt` via a new `posted_at` column (migration 000021). Falls back to `first_seen_at` for old listings.

Also:
- Cleaned up stale PURGEABLE entries in admin frontend (removed dedup_seen, notifications, pending_notifications)
- Added cycle_log and search_cycle_stats to purgeable list

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` clean
- [x] `npm run build` passes
- [x] Non-Docker scheduler tests pass
- [ ] Verify per-search feed_size shows correct per-search counts after deploy
- [ ] Verify Reset All button clears data and system recovers on next cycle
- [ ] Verify hot badge uses Yad2 post date for new listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)