### PR TITLE
feat: pass all search filters to Yad2 URL (server-side filtering)

### DIFF
--- a/internal/fetcher/cache.go
+++ b/internal/fetcher/cache.go
@@ -113,10 +113,11 @@ func (c *CachingFetcher) touch(key string) {
 }
 
 func cacheKey(p model.SourceParams) string {
-	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d:%d:%d:%d",
+	return fmt.Sprintf("%d:%d:%d-%d:%d-%d:%d:%d:%d:%d:%s:%v",
 		p.Manufacturer, p.Model, p.YearMin, p.YearMax,
 		p.PriceMin, p.PriceMax, p.Page,
-		p.MaxKm, p.MaxHand, p.EngineMinCC)
+		p.MaxKm, p.MaxHand, p.EngineMinCC,
+		p.SellerFilter, p.PhotoOnly)
 }
 
 // CacheKeyFor returns the cache key for the given params, allowing callers

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -290,6 +290,24 @@ func buildURL(base string, params model.SourceParams) string {
 		}
 		v.Set("price", strconv.Itoa(priceMin)+"-"+strconv.Itoa(priceMax))
 	}
+	if params.MaxKm > 0 {
+		v.Set("km", "-1-"+strconv.Itoa(params.MaxKm))
+	}
+	if params.EngineMinCC > 0 {
+		v.Set("engineval", strconv.Itoa(params.EngineMinCC)+"--1")
+	}
+	if params.MaxHand > 0 {
+		v.Set("hand", "0-"+strconv.Itoa(params.MaxHand))
+	}
+	switch strings.ToLower(strings.TrimSpace(params.SellerFilter)) {
+	case "private":
+		v.Set("ownerID", "1")
+	case "commercial", "dealer", "dealership":
+		v.Set("ownerID", "2")
+	}
+	if params.PhotoOnly {
+		v.Set("imgOnly", "1")
+	}
 	v.Set("Order", "1")
 	if params.Page > 0 {
 		v.Set("page", strconv.Itoa(params.Page))

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -58,6 +58,8 @@ func SourceParamsFromSearch(s *storage.Search) SourceParams {
 		MaxKm:        s.MaxKm,
 		MaxHand:      s.MaxHand,
 		EngineMinCC:  s.EngineMinCC,
+		SellerFilter: s.SellerFilter,
+		PhotoOnly:    s.PhotoOnly,
 	}
 }
 
@@ -73,6 +75,8 @@ type SourceParams struct {
 	MaxKm        int
 	MaxHand      int
 	EngineMinCC  int
+	SellerFilter string
+	PhotoOnly    bool
 }
 
 // FilterCriteria defines the criteria used to filter raw listings


### PR DESCRIPTION
## Summary

Pass all search filters to Yad2 as URL query parameters so the server pre-filters results instead of us fetching 86 listings and throwing away 80.

**Before:** `?manufacturer=27&model=10332&year=2016-2021&price=0-85000` → 86 results, 5 match
**After:** `?manufacturer=27&model=10332&year=2016-2021&price=0-85000&km=-1-110000&engineval=1900--1&hand=0-2&ownerID=1` → ~5-10 results, all match

### URL params added
| Param | Example | Filter |
|-------|---------|--------|
| `km` | `-1-110000` | Max km |
| `engineval` | `1900--1` | Min engine CC |
| `hand` | `0-2` | Max hand/ownership |
| `ownerID` | `1` (private) / `2` (dealer) | Seller type |
| `imgOnly` | `1` | Photo only |

### Impact
- Fewer listings fetched = less rate-limit pressure
- Older listings (like Mazda fjeqfe1w posted 8 days ago) appear on page 1 instead of page 3+
- Percolator has less work (most rejections now handled server-side)
- `feed_size` in stats will be much closer to `matched`

## Test plan

- [x] `go build ./...` passes
- [x] All 13 URL builder tests pass
- [x] `golangci-lint` clean
- [ ] Deploy and verify URL params appear in scraper logs
- [ ] Verify fewer listings fetched per search (~5-10 vs ~86)

🤖 Generated with [Claude Code](https://claude.com/claude-code)