### PR TITLE
fix: bound orphaned azuretls fetch goroutines

### DIFF
--- a/internal/fetcher/yad2/client.go
+++ b/internal/fetcher/yad2/client.go
@@ -2,6 +2,7 @@ package yad2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
@@ -15,6 +16,75 @@ import (
 
 // outstandingGoroutines tracks orphaned azuretls goroutines that outlived their context.
 var outstandingGoroutines atomic.Int64
+
+// maxInFlightStealthFetches bounds the number of concurrent upstream fetches the
+// stealth client will have in flight at once. azuretls has no native context
+// cancellation, so a goroutine started for a request keeps running (holding a
+// connection) until the request actually completes, even after the caller's
+// context is cancelled. Capping in-flight requests means stranded goroutines
+// can accumulate to at most this many before new fetches are refused, turning an
+// unbounded leak into bounded backpressure. The cap is set well above the
+// scheduler's normal fetch concurrency (max_concurrent_fetches defaults to 4) so
+// healthy operation never hits it.
+const maxInFlightStealthFetches = 16
+
+// errTooManyInFlight is returned when the in-flight fetch limit is reached. It is
+// a fail-fast signal: the upstream is hanging and we shed load rather than strand
+// another goroutine.
+var errTooManyInFlight = errors.New("yad2: too many in-flight fetches, refusing to spawn another")
+
+// inFlightLimiter bounds concurrent upstream fetches whose goroutines may outlive
+// a cancelled context. A slot is held until the real request returns, so an
+// orphaned (post-cancellation) request still counts against the limit.
+type inFlightLimiter struct {
+	sem chan struct{}
+}
+
+func newInFlightLimiter(max int) *inFlightLimiter {
+	if max < 1 {
+		max = 1
+	}
+	return &inFlightLimiter{sem: make(chan struct{}, max)}
+}
+
+// run executes fetch in a goroutine and returns its result, or the context error
+// if ctx is cancelled first. The goroutine — and the slot it holds — live until
+// fetch returns, so the number of orphaned in-flight requests can never exceed
+// the limiter's capacity. When no slot is free it returns errTooManyInFlight
+// immediately instead of spawning another goroutine.
+func (l *inFlightLimiter) run(ctx context.Context, fetch func() (*HTTPResult, error)) (*HTTPResult, error) {
+	select {
+	case l.sem <- struct{}{}:
+	default:
+		return nil, errTooManyInFlight
+	}
+
+	type fetchResult struct {
+		resp *HTTPResult
+		err  error
+	}
+	ch := make(chan fetchResult, 1)
+	go func() {
+		r, e := fetch()
+		ch <- fetchResult{r, e}
+		<-l.sem // release only once the real request has finished
+	}()
+
+	select {
+	case <-ctx.Done():
+		n := outstandingGoroutines.Add(1)
+		if n >= int64(cap(l.sem)) {
+			slog.Warn("azuretls orphaned goroutines at capacity", "outstanding", n, "cap", cap(l.sem))
+		}
+		go func() {
+			<-ch
+			outstandingGoroutines.Add(-1)
+		}()
+		return nil, ctx.Err()
+	case result := <-ch:
+		return result.resp, result.err
+	}
+}
 
 // HTTPResult holds the outcome of an HTTP GET request.
 type HTTPResult struct {
@@ -35,6 +105,7 @@ type HTTPDoer interface {
 type stealthClient struct {
 	session    *azuretls.Session
 	userAgents []string
+	limiter    *inFlightLimiter
 }
 
 func newStealthClient(userAgents []string, proxy string) (*stealthClient, error) {
@@ -48,7 +119,11 @@ func newStealthClient(userAgents []string, proxy string) (*stealthClient, error)
 		}
 	}
 
-	return &stealthClient{session: session, userAgents: userAgents}, nil
+	return &stealthClient{
+		session:    session,
+		userAgents: userAgents,
+		limiter:    newInFlightLimiter(maxInFlightStealthFetches),
+	}, nil
 }
 
 func (c *stealthClient) Get(ctx context.Context, reqURL string) (*HTTPResult, error) {
@@ -58,14 +133,11 @@ func (c *stealthClient) Get(ctx context.Context, reqURL string) (*HTTPResult, er
 
 	ua := c.userAgents[rand.IntN(len(c.userAgents))]
 
-	type fetchResult struct {
-		resp *azuretls.Response
-		err  error
-	}
-	ch := make(chan fetchResult, 1)
-	// NOTE: azuretls does not support context cancellation natively; the goroutine may outlive the context.
-	go func() {
-		r, e := c.session.Get(reqURL, azuretls.OrderedHeaders{
+	// azuretls does not support context cancellation natively; the request
+	// goroutine may outlive the context. The limiter bounds how many such
+	// goroutines can be in flight at once (see inFlightLimiter).
+	return c.limiter.run(ctx, func() (*HTTPResult, error) {
+		resp, err := c.session.Get(reqURL, azuretls.OrderedHeaders{
 			{"User-Agent", ua},
 			{"Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"},
 			{"Accept-Language", "he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7"},
@@ -78,43 +150,26 @@ func (c *stealthClient) Get(ctx context.Context, reqURL string) (*HTTPResult, er
 			{"Sec-Fetch-User", "?1"},
 			{"Cache-Control", "max-age=0"},
 		})
-		ch <- fetchResult{r, e}
-	}()
-
-	var resp *azuretls.Response
-	select {
-	case <-ctx.Done():
-		n := outstandingGoroutines.Add(1)
-		if n >= 5 {
-			slog.Warn("azuretls orphaned goroutines accumulating", "outstanding", n)
+		if err != nil {
+			return nil, err
 		}
-		go func() {
-			<-ch
-			outstandingGoroutines.Add(-1)
-		}()
-		return nil, ctx.Err()
-	case result := <-ch:
-		if result.err != nil {
-			return nil, result.err
+
+		header := make(http.Header, len(resp.Header))
+		for k, v := range resp.Header {
+			header[k] = v
 		}
-		resp = result.resp
-	}
 
-	header := make(http.Header, len(resp.Header))
-	for k, v := range resp.Header {
-		header[k] = v
-	}
+		body := resp.Body
+		if len(body) > maxResponseSize {
+			body = body[:maxResponseSize]
+		}
 
-	body := resp.Body
-	if len(body) > maxResponseSize {
-		body = body[:maxResponseSize]
-	}
-
-	return &HTTPResult{
-		Body:       body,
-		StatusCode: resp.StatusCode,
-		Header:     header,
-	}, nil
+		return &HTTPResult{
+			Body:       body,
+			StatusCode: resp.StatusCode,
+			Header:     header,
+		}, nil
+	})
 }
 
 func (c *stealthClient) Close() {

--- a/internal/fetcher/yad2/client_limiter_test.go
+++ b/internal/fetcher/yad2/client_limiter_test.go
@@ -1,0 +1,95 @@
+package yad2
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestInFlightLimiter_RefusesAboveCap verifies that once the limiter is
+// saturated with slow (still-running) fetches, further calls fail fast with
+// errTooManyInFlight rather than spawning unbounded goroutines.
+func TestInFlightLimiter_RefusesAboveCap(t *testing.T) {
+	const cap = 4
+	l := newInFlightLimiter(cap)
+
+	release := make(chan struct{})
+	slow := func() (*HTTPResult, error) {
+		<-release // block until the test lets it finish
+		return &HTTPResult{StatusCode: 200}, nil
+	}
+
+	// Saturate every slot with a goroutine whose context is already cancelled,
+	// so each call returns immediately but leaves its fetch goroutine running
+	// (and thus holding its slot) until we close(release).
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	var wg sync.WaitGroup
+	for i := 0; i < cap; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := l.run(cancelled, slow); !errors.Is(err, context.Canceled) {
+				t.Errorf("saturating call: expected context.Canceled, got %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All slots are now held by the still-blocked slow fetches. A fresh call
+	// must be refused immediately even with a healthy context.
+	if _, err := l.run(context.Background(), slow); !errors.Is(err, errTooManyInFlight) {
+		t.Fatalf("expected errTooManyInFlight when saturated, got %v", err)
+	}
+
+	// Let the blocked fetches finish, freeing their slots.
+	close(release)
+
+	// The limiter must recover: a new call now succeeds.
+	if !waitForFreeSlot(t, l) {
+		t.Fatal("limiter did not recover capacity after in-flight fetches completed")
+	}
+}
+
+// TestInFlightLimiter_PassesThroughResult verifies the happy path returns the
+// fetch result unchanged and holds no slot afterward.
+func TestInFlightLimiter_PassesThroughResult(t *testing.T) {
+	l := newInFlightLimiter(2)
+	want := &HTTPResult{StatusCode: 204, Body: []byte("ok")}
+	got, err := l.run(context.Background(), func() (*HTTPResult, error) {
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("result not passed through: got %v", got)
+	}
+	// Both slots should be free.
+	for i := 0; i < cap(l.sem); i++ {
+		select {
+		case l.sem <- struct{}{}:
+		default:
+			t.Fatalf("slot %d not released after successful run", i)
+		}
+	}
+}
+
+// waitForFreeSlot retries a trivial run until a slot frees up (the orphaned
+// fetch goroutines release asynchronously) or a deadline passes.
+func waitForFreeSlot(t *testing.T, l *inFlightLimiter) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := l.run(context.Background(), func() (*HTTPResult, error) {
+			return &HTTPResult{StatusCode: 200}, nil
+		})
+		if err == nil {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Closes #1292 (Epic #1283 — Goroutine lifecycle & shutdown). The only **P1** in the audit.

`internal/fetcher/yad2/client.go` starts a goroutine for each stealth fetch. azuretls has no native context cancellation, so that goroutine keeps running — holding a connection — until the request actually completes, even after the caller's context is cancelled. The previous code only incremented a counter and warned at ≥5 outstanding orphans; it never refused new work. Under sustained Yad2 challenge/timeout conditions, stranded goroutines accumulated without bound, precisely when Yad2 was already throttling us.

## Fix

A new `inFlightLimiter` holds a semaphore slot until the **real** request returns, so an orphaned (post-cancellation) request still counts against the limit. New fetches are refused with `errTooManyInFlight` once capacity is reached. Capacity is 16 — well above the scheduler's normal fetch concurrency (`max_concurrent_fetches` defaults to 4), so healthy operation never hits it; only runaway orphan accumulation does, and it's now capped instead of unbounded.

**Anti-bot envelope unchanged:** request headers, ordered-header sequence, TLS fingerprint, and UA rotation are byte-identical. Only the goroutine lifecycle is bounded.

## Tests

`client_limiter_test.go`:
- saturate every slot with still-running fetches, then assert a fresh call fails fast with `errTooManyInFlight`, and that the limiter recovers capacity once the in-flight fetches complete
- happy-path result pass-through + slot release

## Review

✅ Verified locally: `go build`, `go vet`, `gofmt` (LF-normalized) clean; limiter tests pass. `-race` runs in CI (no local C compiler on Windows).

Refs: docs/audit/02-findings.md#f1

Assisted-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added concurrency limits for upstream requests to prevent resource exhaustion and improve reliability when handling high request volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->