### PR TITLE
fix: track scheduler goroutines and preserve cleanup context

### DIFF
--- a/internal/scheduler/background_test.go
+++ b/internal/scheduler/background_test.go
@@ -1,0 +1,95 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// blockingMarketStore blocks inside RefreshMarketMedians until released, so a
+// test can observe the background refresh goroutine still running at shutdown.
+type blockingMarketStore struct {
+	entered  chan struct{}
+	release  chan struct{}
+	once     sync.Once
+	released bool
+}
+
+func (m *blockingMarketStore) RefreshMarketMedians(_ context.Context) error {
+	m.once.Do(func() { close(m.entered) })
+	<-m.release
+	return nil
+}
+
+func (m *blockingMarketStore) LoadMarketMedians(_ context.Context) ([]storage.MarketMedianRow, error) {
+	return nil, nil
+}
+
+// TestScheduler_WaitsForBackgroundGoroutine verifies that the market-refresh
+// goroutine is tracked by bgWG, so a returning Run (which defers bgWG.Wait)
+// cannot complete — and let the caller close the store — while a refresh is
+// still in flight. (F2)
+func TestScheduler_WaitsForBackgroundGoroutine(t *testing.T) {
+	market := &blockingMarketStore{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	s := &Scheduler{
+		logger:         testLogger(),
+		marketCacheTTL: time.Hour,
+		stores:         Stores{Market: market},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.startBackgroundTasks(ctx)
+
+	// Wait until the goroutine is running and blocked inside the refresh.
+	select {
+	case <-market.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background refresh goroutine never started")
+	}
+
+	// Signal shutdown. The goroutine is still blocked inside RefreshMarketMedians,
+	// so bgWG.Wait must not return yet.
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		s.bgWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("bgWG.Wait returned while background refresh was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Let the refresh finish; Wait must now return promptly.
+	close(market.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("bgWG.Wait did not return after background goroutine exited")
+	}
+}
+
+// TestScheduler_StartBackgroundTasks_NoMarketStore verifies the no-op path:
+// with no market store, no goroutine is started and Wait returns immediately.
+func TestScheduler_StartBackgroundTasks_NoMarketStore(t *testing.T) {
+	s := &Scheduler{logger: testLogger(), marketCacheTTL: time.Hour}
+	s.startBackgroundTasks(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.bgWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("bgWG.Wait blocked even though no background task was started")
+	}
+}

--- a/internal/scheduler/background_test.go
+++ b/internal/scheduler/background_test.go
@@ -12,10 +12,9 @@ import (
 // blockingMarketStore blocks inside RefreshMarketMedians until released, so a
 // test can observe the background refresh goroutine still running at shutdown.
 type blockingMarketStore struct {
-	entered  chan struct{}
-	release  chan struct{}
-	once     sync.Once
-	released bool
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
 }
 
 func (m *blockingMarketStore) RefreshMarketMedians(_ context.Context) error {

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -76,7 +76,10 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 				"impact", "user will not see these listings until next successful delivery",
 				"action_taken", "releasing dedup claims so listings are retried next cycle")
 		}
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Survive the cancellation that may have caused the failure, but keep
+		// the request's trace/log context (WithoutCancel) instead of a bare
+		// Background.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cleanupCancel()
 		for _, l := range sr.newListings {
 			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, l.Token, search.ChatID, search.ID); relErr != nil {
@@ -103,7 +106,8 @@ func (s *Scheduler) persistListings(ctx context.Context, records []storage.Listi
 			"error", err.Error(),
 			"impact", "listings will not appear in user history until next successful cycle",
 			"action_taken", "releasing dedup claims so listings are retried next cycle")
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Survive cancellation but preserve trace/log context (WithoutCancel).
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cleanupCancel()
 		for _, rec := range records {
 			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, rec.Token, rec.ChatID, rec.SearchID); relErr != nil {
@@ -139,7 +143,8 @@ func (s *Scheduler) revertPriceRecords(ctx context.Context, tokens []string, log
 	if s.stores.Prices == nil || len(tokens) == 0 {
 		return
 	}
-	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Survive cancellation but preserve trace/log context (WithoutCancel).
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	for _, token := range tokens {
 		if err := s.stores.Prices.RevertPrice(cleanupCtx, token); err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -76,6 +76,12 @@ type Scheduler struct {
 	digestFailures sync.Map // chatID (int64) -> time.Time of last flush failure
 	cycleCount     uint64
 
+	// bgWG tracks long-lived background goroutines (e.g. the market-cache
+	// refresh loop) so Run can wait for them to exit before returning. Without
+	// this, a returning Run lets the caller close the store while a refresh is
+	// still mid-query.
+	bgWG sync.WaitGroup
+
 	marketCacheMu      sync.RWMutex
 	marketCache        *scoring.MarketCache
 	marketCacheBuiltAt time.Time
@@ -242,21 +248,10 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	signal.Notify(sighup, syscall.SIGHUP)
 	defer signal.Stop(sighup)
 
-	if s.stores.Market != nil {
-		go func() {
-			s.refreshMarketView(ctx)
-			ticker := time.NewTicker(s.marketCacheTTL)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					s.refreshMarketView(ctx)
-				}
-			}
-		}()
-	}
+	// Wait for background goroutines (market-cache refresh) to exit before
+	// returning, so the caller does not close the store out from under them.
+	defer s.bgWG.Wait()
+	s.startBackgroundTasks(ctx)
 
 	cycle := s.runMultiTenantCycle
 
@@ -320,6 +315,36 @@ func (s *Scheduler) Run(ctx context.Context) error {
 				return err
 			}
 			s.logger.Error("scheduler cycle failed, will retry on next interval", "error", err)
+		}
+	}
+}
+
+// startBackgroundTasks launches long-lived background goroutines tracked by
+// bgWG. Currently this is the periodic market-cache refresh. It is a no-op when
+// no market store is configured.
+func (s *Scheduler) startBackgroundTasks(ctx context.Context) {
+	if s.stores.Market == nil {
+		return
+	}
+	s.bgWG.Add(1)
+	go func() {
+		defer s.bgWG.Done()
+		s.marketRefreshLoop(ctx)
+	}()
+}
+
+// marketRefreshLoop refreshes the market view immediately and then on every
+// marketCacheTTL tick until the context is cancelled.
+func (s *Scheduler) marketRefreshLoop(ctx context.Context) {
+	s.refreshMarketView(ctx)
+	ticker := time.NewTicker(s.marketCacheTTL)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.refreshMarketView(ctx)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1293 (Epic #1283 — Goroutine lifecycle & shutdown). Two findings:

**F2 (P2) — untracked background goroutine.** The market-cache refresh loop (`scheduler.go`) was launched with a bare `go func()`. On shutdown `Run` returned as soon as the polling loop saw `ctx.Done()`, while the refresh goroutine could still be mid-query — and `cmd/scraper/main.go` then runs the deferred `store.Close()`, racing the pgx pool closed underneath it. This happens on every deploy (deploys are automatic on merge).

Fix: track the goroutine with a `WaitGroup` (`bgWG`) and `defer s.bgWG.Wait()` in `Run`, covering all three return paths. The loop is extracted into `startBackgroundTasks` / `marketRefreshLoop` for testability.

**F3 (P3) — cleanup context.** The three cleanup paths in `processing.go` used `context.WithTimeout(context.Background(), 5s)`, which correctly survives the cancellation that may have caused the failure but also discards trace/log context. Switched to `context.WithoutCancel(ctx)` (Go 1.21+) — survives cancellation *and* keeps request correlation.

## Tests

`background_test.go`:
- `TestScheduler_WaitsForBackgroundGoroutine`: a blocking market store proves `bgWG.Wait` does not return while a refresh is still in flight, and returns promptly once it finishes
- no-op path with no market store

## Review

✅ Verified locally: `go build`, `go vet`, `gofmt` (LF) clean; new tests pass. `-race` runs in CI.

Refs: docs/audit/02-findings.md#f2

Assisted-By: Claude Fable 5 <noreply@anthropic.com>