### PR TITLE
fix: validate push subscription endpoints against known push services

### DIFF
--- a/internal/api/push.go
+++ b/internal/api/push.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -37,8 +36,8 @@ func (s *Server) pushSubscribe(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "endpoint, keys.p256dh, and keys.auth are required")
 		return
 	}
-	if len(req.Endpoint) > 2048 || !strings.HasPrefix(req.Endpoint, "https://") {
-		writeError(w, http.StatusBadRequest, "endpoint must be an HTTPS URL (max 2048 chars)")
+	if err := validatePushEndpoint(req.Endpoint); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/api/push_test.go
+++ b/internal/api/push_test.go
@@ -52,6 +52,29 @@ func TestPushSubscribe_MissingFields(t *testing.T) {
 	}
 }
 
+func TestPushSubscribe_RejectsNonPushServiceEndpoint(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	// A well-formed HTTPS endpoint pointing anywhere other than a known push
+	// service must be rejected — the notifier POSTs to stored endpoints, so
+	// accepting arbitrary hosts is a stored SSRF.
+	w := doRequest(t, srv, "POST", "/api/v1/push/subscribe", subscribeRequest{
+		Endpoint: "https://attacker.example.com/collect",
+		Keys:     subscribeKeys{P256DH: "key", Auth: "auth"},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("non-push-service endpoint: expected 400, got %d", w.Code)
+	}
+
+	w = doRequest(t, srv, "POST", "/api/v1/push/subscribe", subscribeRequest{
+		Endpoint: "https://169.254.169.254/latest/meta-data/",
+		Keys:     subscribeKeys{P256DH: "key", Auth: "auth"},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("metadata IP endpoint: expected 400, got %d", w.Code)
+	}
+}
+
 func TestPushUnsubscribe(t *testing.T) {
 	srv, _ := setupTestServer(t)
 

--- a/internal/api/push_validation.go
+++ b/internal/api/push_validation.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// maxPushEndpointLen bounds the stored endpoint length.
+const maxPushEndpointLen = 2048
+
+// allowedPushHosts is the set of registrable domains operated by the browser
+// push services CarWatch supports. An endpoint host must equal one of these or
+// be a subdomain of one. This is the primary defense against stored SSRF: the
+// notifier POSTs to whatever endpoint we persist, so we only persist URLs that
+// point at a real push service.
+//
+//   - fcm.googleapis.com          — Chrome / Android (FCM)
+//   - push.services.mozilla.com   — Firefox (e.g. updates.push.services.mozilla.com)
+//   - notify.windows.com          — Edge / WNS (e.g. *.notify.windows.com)
+//   - push.apple.com              — Safari (e.g. web.push.apple.com)
+var allowedPushHosts = []string{
+	"fcm.googleapis.com",
+	"push.services.mozilla.com",
+	"notify.windows.com",
+	"push.apple.com",
+}
+
+// validatePushEndpoint checks that raw is a well-formed HTTPS URL pointing at a
+// known push service, rejecting anything that could be used to make the server
+// issue requests to internal or arbitrary hosts (stored SSRF).
+func validatePushEndpoint(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("endpoint is required")
+	}
+	if len(raw) > maxPushEndpointLen {
+		return fmt.Errorf("endpoint must be at most %d characters", maxPushEndpointLen)
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("endpoint must be a valid URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("endpoint must be an HTTPS URL")
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("endpoint must include a host")
+	}
+
+	// Reject IP-literal hosts outright: real push services are addressed by
+	// name, and an IP literal is the classic SSRF vector (loopback, link-local,
+	// cloud metadata, private ranges).
+	if ip := net.ParseIP(host); ip != nil {
+		return fmt.Errorf("endpoint host must be a domain name, not an IP address")
+	}
+
+	if !hostIsAllowedPushService(host) {
+		return fmt.Errorf("endpoint host %q is not a recognized push service", host)
+	}
+	return nil
+}
+
+func hostIsAllowedPushService(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, allowed := range allowedPushHosts {
+		if host == allowed || strings.HasSuffix(host, "."+allowed) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/push_validation_test.go
+++ b/internal/api/push_validation_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePushEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  bool
+	}{
+		// Real push services — must be accepted.
+		{"FCM (Chrome)", "https://fcm.googleapis.com/fcm/send/abc123:APA91b", false},
+		{"Mozilla autopush", "https://updates.push.services.mozilla.com/wpush/v2/gAAAA", false},
+		{"Mozilla bare domain", "https://push.services.mozilla.com/wpush/v2/x", false},
+		{"WNS (Edge)", "https://db5p.notify.windows.com/w/?token=AwYAAAB", false},
+		{"WNS regional subdomain", "https://par02p.notify.windows.com/w/?token=x", false},
+		{"Apple web push", "https://web.push.apple.com/QOXxkfmZSt", false},
+		{"trailing-dot FQDN", "https://fcm.googleapis.com./fcm/send/x", false},
+		{"uppercase host", "https://FCM.GOOGLEAPIS.COM/fcm/send/x", false},
+
+		// SSRF candidates — must be rejected.
+		{"loopback IP", "https://127.0.0.1/admin", true},
+		{"loopback name", "https://localhost/admin", true},
+		{"private IP", "https://10.0.0.5:5432/", true},
+		{"link-local metadata IP", "https://169.254.169.254/latest/meta-data/", true},
+		{"IPv6 loopback", "https://[::1]/", true},
+		{"arbitrary external host", "https://attacker.example.com/collect", true},
+		{"lookalike suffix", "https://fcm.googleapis.com.evil.example/", true},
+		{"lookalike prefix", "https://evilfcm.googleapis.com.attacker.io/", true},
+		{"userinfo trick", "https://fcm.googleapis.com@attacker.example.com/", true},
+		{"http scheme", "http://fcm.googleapis.com/fcm/send/x", true},
+		{"no scheme", "fcm.googleapis.com/fcm/send/x", true},
+		{"empty", "", true},
+		{"whitespace URL", "https:// fcm.googleapis.com/x", true},
+		{"too long", "https://fcm.googleapis.com/" + strings.Repeat("a", maxPushEndpointLen), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePushEndpoint(tt.endpoint)
+			if tt.wantErr && err == nil {
+				t.Errorf("validatePushEndpoint(%q) = nil, want error", tt.endpoint)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validatePushEndpoint(%q) = %v, want nil", tt.endpoint, err)
+			}
+		})
+	}
+}
+
+func TestHostIsAllowedPushService(t *testing.T) {
+	if hostIsAllowedPushService("googleapis.com") {
+		t.Error("bare registrable parent of an allowed host must not match")
+	}
+	if !hostIsAllowedPushService("sub.deep.notify.windows.com") {
+		t.Error("nested subdomain of an allowed host must match")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1294 (Epic #1286 — Security hardening). **P2 — stored SSRF.**

`POST /api/v1/push/subscribe` accepted any HTTPS URL ≤ 2048 chars (`internal/api/push.go:40`), and the webpush notifier later POSTs to whatever endpoint is stored with no host validation (`internal/notifier/webpush/webpush.go:121-135`). Any authenticated user could therefore make the server send VAPID-signed POSTs to internal services, HTTPS-fronted metadata endpoints, or arbitrary third parties.

## Fix

New `validatePushEndpoint` (`internal/api/push_validation.go`):
- HTTPS only, ≤ 2048 chars, well-formed URL
- host must equal or be a subdomain of a known push service: `fcm.googleapis.com`, `push.services.mozilla.com`, `notify.windows.com`, `push.apple.com`
- IP-literal hosts rejected outright (loopback / private / link-local metadata all impossible by construction)

Real-browser subscriptions are unaffected — those four cover Chrome/Android, Firefox, Edge, and Safari.

## Tests

- Table-driven unit tests: all four real services (incl. regional WNS subdomains, trailing-dot FQDN, uppercase), and rejections for lookalike domains (`fcm.googleapis.com.evil.example`), userinfo trick (`https://fcm.googleapis.com@attacker/`), loopback, private IP, cloud-metadata IP, IPv6 loopback, http scheme, oversized URL
- Handler-level tests asserting 400 for attacker-controlled and metadata endpoints
- Existing push tests already use `fcm.googleapis.com` endpoints — unchanged and passing

## Review

✅ Verified locally: `go build`, `go vet` clean; validation unit tests pass. Handler tests run against the Postgres container in CI.

Refs: docs/audit/02-findings.md#f7

Assisted-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced push subscription validation to ensure endpoints use approved push services. Requests with invalid, unsupported, or malformed endpoints now receive HTTP 400 Bad Request responses.

* **Tests**
  * Added comprehensive test coverage for push endpoint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->