### PR TITLE
fix: add backpressure check to enrichment backfill

### DIFF
--- a/internal/broker/enrich.go
+++ b/internal/broker/enrich.go
@@ -17,7 +17,11 @@ const EnrichGroupName = "enricher-workers"
 // EnrichDeadLetterStream holds messages that exceeded retry limits.
 const EnrichDeadLetterStream = "carwatch:enrich:dead"
 
-const enrichStreamMaxLen = 50000
+// EnrichStreamMaxLen caps the enrichment stream via approximate XAdd trimming.
+// When the stream exceeds this, the OLDEST entries are silently evicted —
+// producers must therefore check EnrichQueueLen before bulk publishing (see the
+// scheduler backfill watermark).
+const EnrichStreamMaxLen = 50000
 
 // EnrichRequest represents a request to enrich a listing with km/city data.
 type EnrichRequest struct {
@@ -49,7 +53,7 @@ func (p *EnrichPublisher) PublishEnrich(ctx context.Context, req EnrichRequest) 
 	}
 	return p.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: EnrichStreamName,
-		MaxLen: enrichStreamMaxLen,
+		MaxLen: EnrichStreamMaxLen,
 		Approx: true,
 		Values: map[string]any{"data": string(data)},
 	}).Err()

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -41,8 +41,29 @@ func (s *Scheduler) pruneOldData(ctx context.Context) {
 	s.lastPruneTime = time.Now()
 }
 
+// enrichBackfillWatermark is the enrich-stream depth above which backfill
+// publishing is skipped. The stream is XAdd-trimmed at broker.EnrichStreamMaxLen,
+// so publishing into a near-full stream silently evicts the oldest in-flight
+// work; backing off at 80% lets the consumer drain instead.
+const enrichBackfillWatermark = broker.EnrichStreamMaxLen * 8 / 10
+
 func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
 	if s.enrichPublisher == nil || s.stores.Listings == nil {
+		return
+	}
+
+	depth, err := s.enrichPublisher.EnrichQueueLen(ctx)
+	if err != nil {
+		s.logger.Warn("could not check enrich stream depth, skipping backfill this cycle",
+			"error", err)
+		return
+	}
+	if depth >= enrichBackfillWatermark {
+		s.logger.Warn("enrich stream above backfill watermark, skipping backfill so the consumer can drain",
+			"depth", depth,
+			"watermark", enrichBackfillWatermark,
+			"impact", "unenriched listings stay queued for a later cycle instead of evicting in-flight work",
+		)
 		return
 	}
 

--- a/internal/scheduler/maintenance_backfill_test.go
+++ b/internal/scheduler/maintenance_backfill_test.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/dsionov/carwatch/internal/broker"
+)
+
+func backfillTestScheduler(t *testing.T, tokens []string) (*Scheduler, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	s := &Scheduler{
+		logger:          testLogger(),
+		enrichPublisher: broker.NewEnrichPublisher(client),
+		stores:          Stores{Listings: &mockListingStore{unenrichedTokens: tokens}},
+	}
+	return s, mr
+}
+
+// TestBackfill_PublishesBelowWatermark verifies the normal path: with a shallow
+// stream, every unenriched token is published.
+func TestBackfill_PublishesBelowWatermark(t *testing.T) {
+	s, mr := backfillTestScheduler(t, []string{"tok1", "tok2", "tok3"})
+
+	s.backfillUnenrichedListings(context.Background())
+
+	if got := streamLen(t, mr); got != 3 {
+		t.Fatalf("expected 3 published backfill requests, stream len = %d", got)
+	}
+}
+
+func streamLen(t *testing.T, mr *miniredis.Miniredis) int {
+	t.Helper()
+	entries, err := mr.Stream(broker.EnrichStreamName)
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	return len(entries)
+}
+
+// TestBackfill_SkipsAboveWatermark verifies the backpressure path: when the
+// enrich stream is at/above the watermark, backfill publishes nothing — the
+// stream is XAdd-trimmed at MaxLen, so publishing into a near-full stream
+// would silently evict in-flight work (F5).
+func TestBackfill_SkipsAboveWatermark(t *testing.T) {
+	s, mr := backfillTestScheduler(t, []string{"tok1", "tok2"})
+
+	// Seed the stream directly to the watermark via miniredis (in-process, fast).
+	for i := 0; i < enrichBackfillWatermark; i++ {
+		if _, err := mr.XAdd(broker.EnrichStreamName, "*", []string{"data", "x"}); err != nil {
+			t.Fatalf("seed stream: %v", err)
+		}
+	}
+
+	s.backfillUnenrichedListings(context.Background())
+
+	if got := streamLen(t, mr); got != enrichBackfillWatermark {
+		t.Fatalf("expected no publishes above watermark, stream len = %d (watermark %d)",
+			got, enrichBackfillWatermark)
+	}
+}
+
+// TestBackfill_SkipsOnDepthCheckError verifies that an unreachable Redis means
+// no backfill attempt (publishing would fail anyway; skip quietly).
+func TestBackfill_SkipsOnDepthCheckError(t *testing.T) {
+	s, mr := backfillTestScheduler(t, []string{"tok1"})
+	mr.Close() // make XLen fail
+
+	// Must not panic and must not publish.
+	s.backfillUnenrichedListings(context.Background())
+}


### PR DESCRIPTION
## Summary

Closes #1295 (Epic #1285 — Enrichment pipeline robustness). **P2.**

The enrich stream is XAdd-trimmed at `MaxLen: 50000` with approximate trimming (`internal/broker/enrich.go`). When the enricher consumer lags, the scheduler''s backfill pass (`internal/scheduler/maintenance.go`) kept publishing 30 requests per cycle unconditionally — each publish into a near-full stream **silently evicts the oldest in-flight work**. The backlog appears to drain while enrichment is actually lost, and listings stay without km/city/image with nothing reporting why.

## Fix

- Before publishing, check stream depth via the existing `EnrichQueueLen` helper (it was already implemented and unused by this path — finding F5 in the audit register).
- Skip the backfill with a structured warning (`depth`, `watermark`, `impact`) when depth ≥ 80% of the trim limit, letting the consumer drain.
- `broker.EnrichStreamMaxLen` is now exported so the watermark stays mechanically tied to the trim limit.
- If the depth check itself fails (Redis unreachable), skip quietly — publishing would fail anyway.

## Tests

`maintenance_backfill_test.go` (miniredis + the real `EnrichPublisher`):
- below watermark → all tokens published
- at watermark → zero publishes, stream untouched
- Redis down → no panic, no publish

## Review

✅ Verified locally: `go build`, `go vet` clean, no real lint findings; all three backfill tests pass plus the full broker package suite.

Refs: docs/audit/02-findings.md#f5

Assisted-By: Claude Fable 5 <noreply@anthropic.com>