### PR TITLE
feat: alert on listing persistence failures

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -41,11 +41,13 @@ type SourceMetrics struct {
 type Status struct {
 	startTime         time.Time
 	version           string
-	cycleCount        atomic.Int64
-	errorCount        atomic.Int64
-	lastSuccessUnixNs atomic.Int64
-	listingsFound     atomic.Int64
-	notificationsSent atomic.Int64
+	cycleCount           atomic.Int64
+	errorCount           atomic.Int64
+	lastSuccessUnixNs    atomic.Int64
+	listingsFound        atomic.Int64
+	notificationsSent    atomic.Int64
+	persistFailures      atomic.Int64
+	claimReleaseFailures atomic.Int64
 	schedulerExpected atomic.Bool
 	schedulerStarted  atomic.Bool
 	botPollingAlive   atomic.Bool
@@ -127,6 +129,20 @@ func (s *Status) RecordNotificationSent() {
 	s.notificationsSent.Add(1)
 }
 
+// RecordPersistFailure counts a failed listing-batch persist. Listings are
+// retried next cycle, but a non-zero counter means the DB write path is
+// failing and deserves attention.
+func (s *Status) RecordPersistFailure() {
+	s.persistFailures.Add(1)
+}
+
+// RecordClaimReleaseFailure counts a failed dedup-claim release after a
+// persist/delivery failure. This is the only path where a listing can be
+// permanently lost for a user, so any non-zero value warrants investigation.
+func (s *Status) RecordClaimReleaseFailure() {
+	s.claimReleaseFailures.Add(1)
+}
+
 func (s *Status) RecordFetch(source string, duration time.Duration, err error) {
 	m := s.getSource(source)
 	m.FetchCount.Add(1)
@@ -199,14 +215,16 @@ func (s *Status) coreMetrics() map[string]any {
 	}
 
 	return map[string]any{
-		"status":             status,
-		"uptime":             time.Since(s.startTime).String(),
-		"cycles":             cycles,
-		"errors":             s.errorCount.Load(),
-		"last_success":       lastSuccess,
-		"listings_found":     s.listingsFound.Load(),
-		"notifications_sent": s.notificationsSent.Load(),
-		"bot_polling":        s.botPollingAlive.Load(),
+		"status":                 status,
+		"uptime":                 time.Since(s.startTime).String(),
+		"cycles":                 cycles,
+		"errors":                 s.errorCount.Load(),
+		"last_success":           lastSuccess,
+		"listings_found":         s.listingsFound.Load(),
+		"notifications_sent":     s.notificationsSent.Load(),
+		"persist_failures":       s.persistFailures.Load(),
+		"claim_release_failures": s.claimReleaseFailures.Load(),
+		"bot_polling":            s.botPollingAlive.Load(),
 	}
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -39,8 +39,8 @@ type SourceMetrics struct {
 }
 
 type Status struct {
-	startTime         time.Time
-	version           string
+	startTime            time.Time
+	version              string
 	cycleCount           atomic.Int64
 	errorCount           atomic.Int64
 	lastSuccessUnixNs    atomic.Int64
@@ -48,9 +48,9 @@ type Status struct {
 	notificationsSent    atomic.Int64
 	persistFailures      atomic.Int64
 	claimReleaseFailures atomic.Int64
-	schedulerExpected atomic.Bool
-	schedulerStarted  atomic.Bool
-	botPollingAlive   atomic.Bool
+	schedulerExpected    atomic.Bool
+	schedulerStarted     atomic.Bool
+	botPollingAlive      atomic.Bool
 
 	sourceMu sync.RWMutex
 	sources  map[string]*SourceMetrics

--- a/internal/scheduler/observer.go
+++ b/internal/scheduler/observer.go
@@ -8,6 +8,13 @@ type CycleObserver interface {
 	RecordListingsFound(n int)
 	RecordNotificationSent()
 	RecordFetch(source string, duration time.Duration, err error)
+	// RecordPersistFailure counts a failed listing-batch persist (listings are
+	// retried next cycle via released dedup claims).
+	RecordPersistFailure()
+	// RecordClaimReleaseFailure counts a failed dedup-claim release after a
+	// persist/delivery failure — the one path where a listing can be
+	// permanently lost for a user.
+	RecordClaimReleaseFailure()
 }
 
 type nopObserver struct{}
@@ -17,3 +24,5 @@ func (nopObserver) RecordError()                             {}
 func (nopObserver) RecordListingsFound(int)                  {}
 func (nopObserver) RecordNotificationSent()                  {}
 func (nopObserver) RecordFetch(string, time.Duration, error) {}
+func (nopObserver) RecordPersistFailure()                    {}
+func (nopObserver) RecordClaimReleaseFailure()               {}

--- a/internal/scheduler/observer_test.go
+++ b/internal/scheduler/observer_test.go
@@ -13,14 +13,18 @@ func TestNopObserver_DoesNotPanic(t *testing.T) {
 	o.RecordListingsFound(10)
 	o.RecordNotificationSent()
 	o.RecordFetch("yad2", time.Second, nil)
+	o.RecordPersistFailure()
+	o.RecordClaimReleaseFailure()
 }
 
 type countingObserver struct {
-	successes     atomic.Int64
-	errors        atomic.Int64
-	listingsFound atomic.Int64
-	notifications atomic.Int64
-	fetches       atomic.Int64
+	successes            atomic.Int64
+	errors               atomic.Int64
+	listingsFound        atomic.Int64
+	notifications        atomic.Int64
+	fetches              atomic.Int64
+	persistFailures      atomic.Int64
+	claimReleaseFailures atomic.Int64
 }
 
 func (o *countingObserver) RecordSuccess()                                 { o.successes.Add(1) }
@@ -28,6 +32,8 @@ func (o *countingObserver) RecordError()                                   { o.e
 func (o *countingObserver) RecordListingsFound(n int)                      { o.listingsFound.Add(int64(n)) }
 func (o *countingObserver) RecordNotificationSent()                        { o.notifications.Add(1) }
 func (o *countingObserver) RecordFetch(_ string, _ time.Duration, _ error) { o.fetches.Add(1) }
+func (o *countingObserver) RecordPersistFailure()                          { o.persistFailures.Add(1) }
+func (o *countingObserver) RecordClaimReleaseFailure()                     { o.claimReleaseFailures.Add(1) }
 
 func TestCycleObserver_Interface(t *testing.T) {
 	var obs CycleObserver = &countingObserver{}

--- a/internal/scheduler/persist_failure_metrics_test.go
+++ b/internal/scheduler/persist_failure_metrics_test.go
@@ -1,0 +1,69 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// TestPersistListings_RecordsFailureMetrics verifies that a failed batch
+// persist increments the persist-failure counter, and that failed dedup-claim
+// releases (the permanent listing-loss path, F10) increment the claim-release
+// counter — once per record.
+func TestPersistListings_RecordsFailureMetrics(t *testing.T) {
+	obs := &countingObserver{}
+	dedup := newErrDedup()
+	dedup.releaseErr = errors.New("release failed")
+
+	s := &Scheduler{
+		logger:   testLogger(),
+		observer: obs,
+		stores: Stores{
+			Dedup:    dedup,
+			Listings: &errListingStore{saveErr: errors.New("db write failed")},
+		},
+	}
+
+	records := []storage.ListingRecord{
+		{Token: "tok-a", ChatID: 100, SearchID: 1},
+		{Token: "tok-b", ChatID: 100, SearchID: 1},
+	}
+	if err := s.persistListings(context.Background(), records, testLogger()); err == nil {
+		t.Fatal("expected persist error")
+	}
+
+	if got := obs.persistFailures.Load(); got != 1 {
+		t.Errorf("persistFailures = %d, want 1", got)
+	}
+	if got := obs.claimReleaseFailures.Load(); got != 2 {
+		t.Errorf("claimReleaseFailures = %d, want 2 (one per record)", got)
+	}
+}
+
+// TestPersistListings_NoFailureMetricsOnSuccess verifies the happy path keeps
+// both counters at zero.
+func TestPersistListings_NoFailureMetricsOnSuccess(t *testing.T) {
+	obs := &countingObserver{}
+	s := &Scheduler{
+		logger:   testLogger(),
+		observer: obs,
+		stores: Stores{
+			Dedup:    newMockDedup(),
+			Listings: &mockListingStore{},
+		},
+	}
+
+	records := []storage.ListingRecord{{Token: "tok-a", ChatID: 100, SearchID: 1}}
+	if err := s.persistListings(context.Background(), records, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := obs.persistFailures.Load(); got != 0 {
+		t.Errorf("persistFailures = %d, want 0", got)
+	}
+	if got := obs.claimReleaseFailures.Load(); got != 0 {
+		t.Errorf("claimReleaseFailures = %d, want 0", got)
+	}
+}

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/telemetry"
 )
 
 func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, lang locale.Lang, sr searchResult, log *slog.Logger) bool {
@@ -83,6 +84,7 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 		defer cleanupCancel()
 		for _, l := range sr.newListings {
 			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, l.Token, search.ChatID, search.ID); relErr != nil {
+				s.recordClaimReleaseFailure(ctx)
 				log.ErrorContext(ctx, "failed to release dedup claim after delivery failure",
 					"token", l.Token,
 					"error", relErr.Error(),
@@ -100,6 +102,7 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 func (s *Scheduler) persistListings(ctx context.Context, records []storage.ListingRecord, log *slog.Logger) error {
 	saveStart := time.Now()
 	if err := s.stores.Listings.SaveListings(ctx, records); err != nil {
+		s.recordPersistFailure(ctx)
 		log.ErrorContext(ctx, "failed to persist matched listings to database, releasing all dedup claims for retry",
 			"batch_size", len(records),
 			"duration_ms", time.Since(saveStart).Milliseconds(),
@@ -111,6 +114,7 @@ func (s *Scheduler) persistListings(ctx context.Context, records []storage.Listi
 		defer cleanupCancel()
 		for _, rec := range records {
 			if relErr := s.stores.Dedup.ReleaseClaim(cleanupCtx, rec.Token, rec.ChatID, rec.SearchID); relErr != nil {
+				s.recordClaimReleaseFailure(ctx)
 				log.ErrorContext(ctx, "failed to release dedup claim after batch save failure, listing may be permanently lost",
 					"token", rec.Token,
 					"error", relErr.Error(),
@@ -121,6 +125,24 @@ func (s *Scheduler) persistListings(ctx context.Context, records []storage.Listi
 		return err
 	}
 	return nil
+}
+
+// recordPersistFailure surfaces a failed listing-batch persist on both the
+// health observer (/healthz, admin dashboard) and the OTel /metrics counter.
+func (s *Scheduler) recordPersistFailure(ctx context.Context) {
+	s.observer.RecordPersistFailure()
+	if telemetry.PersistFailures != nil {
+		telemetry.PersistFailures.Add(ctx, 1)
+	}
+}
+
+// recordClaimReleaseFailure surfaces a failed dedup-claim release — the only
+// permanent listing-loss path — on the health observer and /metrics.
+func (s *Scheduler) recordClaimReleaseFailure(ctx context.Context) {
+	s.observer.RecordClaimReleaseFailure()
+	if telemetry.ClaimReleaseFailures != nil {
+		telemetry.ClaimReleaseFailures.Add(ctx, 1)
+	}
 }
 
 func (s *Scheduler) deduplicateListings(ctx context.Context, token string, chatID, searchID int64, log *slog.Logger) (isNew bool, ok bool) {

--- a/internal/telemetry/app_metrics.go
+++ b/internal/telemetry/app_metrics.go
@@ -32,6 +32,12 @@ var (
 	// EnrichSkipped counts enrichment requests skipped (already enriched).
 	EnrichSkipped metric.Int64Counter
 
+	// PersistFailures counts failed listing-batch persists (retried next cycle).
+	PersistFailures metric.Int64Counter
+	// ClaimReleaseFailures counts failed dedup-claim releases after a persist or
+	// delivery failure — the only permanent listing-loss path.
+	ClaimReleaseFailures metric.Int64Counter
+
 	// QueueDepth reports the current number of messages in the alerts stream.
 	QueueDepth metric.Int64Gauge
 	// QueuePending reports the number of messages claimed but not yet acked.
@@ -108,6 +114,18 @@ func InitMetrics() error {
 
 	EnrichSkipped, err = meter.Int64Counter("carwatch.enrich.skipped",
 		metric.WithDescription("Enrichment requests skipped (already enriched)"))
+	if err != nil {
+		return err
+	}
+
+	PersistFailures, err = meter.Int64Counter("carwatch.listings.persist_failures",
+		metric.WithDescription("Failed listing-batch persists (retried next cycle)"))
+	if err != nil {
+		return err
+	}
+
+	ClaimReleaseFailures, err = meter.Int64Counter("carwatch.dedup.claim_release_failures",
+		metric.WithDescription("Failed dedup-claim releases (permanent listing loss path)"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Closes #1296 (Epic #1284 — Pipeline data integrity). **P2 — observability gap.**

`persistListings` correctly releases dedup claims for retry when a batch save fails — but a **failed release is permanent listing loss for that user**, and both paths were observable only by reading logs after the fact (`internal/scheduler/processing.go`: "manual intervention may be needed to clear stuck claim").

## Fix

Both failure classes now surface on every operational channel:

| Channel | What |
|---|---|
| `CycleObserver` interface | new `RecordPersistFailure()` / `RecordClaimReleaseFailure()` |
| `/healthz` + admin dashboard | `persist_failures`, `claim_release_failures` in the health snapshot |
| `/metrics` (Prometheus/OTel) | `carwatch.listings.persist_failures`, `carwatch.dedup.claim_release_failures` |

Call sites: persist failure in `persistListings`, claim-release failures in both `persistListings` and the delivery-failure cleanup in `deliverResults`.

Deliberately sequenced **before** the price-record ordering change (#1297) so that higher-risk fix is observable from the moment it deploys.

## Tests

- `persist_failure_metrics_test.go`: failing store + failing dedup release ⇒ persist counter = 1, claim-release counter = one per record; happy path ⇒ both zero
- `observer_test.go` extended for the new interface methods; health/telemetry suites pass

## Review

✅ Verified locally: `go build`, `go vet` clean, no real lint findings; scheduler/health/telemetry suites pass.

Refs: docs/audit/02-findings.md#f10

Assisted-By: Claude Fable 5 <noreply@anthropic.com>