### PR TITLE
fix: record listing prices only after successful persist

### DIFF
--- a/internal/scheduler/price_staging_test.go
+++ b/internal/scheduler/price_staging_test.go
@@ -1,0 +1,95 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestFlushPendingPrices covers the staged-price flush rules (F4): a price is
+// durably recorded only when its listing's outcome settled — persisted in at
+// least one search, or never part of a persist at all (price-drop-only
+// tokens, whose history rows already exist).
+func TestFlushPendingPrices(t *testing.T) {
+	tests := []struct {
+		name          string
+		pending       map[string]int
+		persisted     map[string]bool
+		persistFailed map[string]bool
+		wantRecorded  map[string]int
+	}{
+		{
+			name:         "persisted token is flushed",
+			pending:      map[string]int{"tok-ok": 90000},
+			persisted:    map[string]bool{"tok-ok": true},
+			wantRecorded: map[string]int{"tok-ok": 90000},
+		},
+		{
+			name:          "failed-only token is skipped",
+			pending:       map[string]int{"tok-fail": 90000},
+			persistFailed: map[string]bool{"tok-fail": true},
+			wantRecorded:  map[string]int{},
+		},
+		{
+			name:          "token persisted by one search and failed by another is flushed",
+			pending:       map[string]int{"tok-mixed": 80000},
+			persisted:     map[string]bool{"tok-mixed": true},
+			persistFailed: map[string]bool{"tok-mixed": true},
+			wantRecorded:  map[string]int{"tok-mixed": 80000},
+		},
+		{
+			name:         "drop-only token (no persist involvement) is flushed",
+			pending:      map[string]int{"tok-drop": 70000},
+			wantRecorded: map[string]int{"tok-drop": 70000},
+		},
+		{
+			name:         "empty pending is a no-op",
+			pending:      map[string]int{},
+			wantRecorded: map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt := newMockPriceTracker()
+			s := &Scheduler{
+				logger: testLogger(),
+				stores: Stores{Prices: pt},
+			}
+			s.flushPendingPrices(context.Background(), tt.pending, tt.persisted, tt.persistFailed)
+
+			pt.mu.Lock()
+			defer pt.mu.Unlock()
+			if len(pt.prices) != len(tt.wantRecorded) {
+				t.Fatalf("recorded %d prices, want %d: %v", len(pt.prices), len(tt.wantRecorded), pt.prices)
+			}
+			for token, price := range tt.wantRecorded {
+				if got := pt.prices[token]; got != price {
+					t.Errorf("price[%s] = %d, want %d", token, got, price)
+				}
+			}
+		})
+	}
+}
+
+// TestFlushPendingPrices_RecordErrorContinues verifies that a failing record
+// neither panics nor stops the flush (a missed write self-corrects next cycle
+// because PeekPrice still sees the old value).
+func TestFlushPendingPrices_RecordErrorContinues(t *testing.T) {
+	pt := newErrPriceTracker()
+	pt.err = errors.New("db down")
+	s := &Scheduler{logger: testLogger(), stores: Stores{Prices: pt}}
+
+	s.flushPendingPrices(context.Background(),
+		map[string]int{"a": 1, "b": 2}, nil, nil)
+	// Nothing recorded, no panic.
+	if len(pt.prices) != 0 {
+		t.Fatalf("expected no recorded prices on error, got %v", pt.prices)
+	}
+}
+
+// TestFlushPendingPrices_NilStore verifies the nil-prices no-op path.
+func TestFlushPendingPrices_NilStore(t *testing.T) {
+	s := &Scheduler{logger: testLogger()}
+	s.flushPendingPrices(context.Background(), map[string]int{"a": 1}, nil, nil)
+}

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -158,24 +158,41 @@ func (s *Scheduler) deduplicateListings(ctx context.Context, token string, chatI
 	return isNew, true
 }
 
-// revertPriceRecords undoes RecordPrice calls for the given tokens.
-// Called when persistListings fails to avoid stale price records that
-// would cause spurious price-drop notifications on the next cycle.
-func (s *Scheduler) revertPriceRecords(ctx context.Context, tokens []string, log *slog.Logger) {
-	if s.stores.Prices == nil || len(tokens) == 0 {
+// flushPendingPrices durably records price observations staged during the
+// match pass. Prices are written only after listing outcomes are settled: a
+// token observed solely in searches whose persist failed is skipped, so the
+// next cycle re-detects the same change and the price-drop notification is
+// not swallowed (previously a best-effort revert could fail and leave a
+// stale row). A failed flush is only logged — PeekPrice still sees the old
+// value next cycle, so the write self-corrects.
+func (s *Scheduler) flushPendingPrices(ctx context.Context, pending map[string]int, persisted, persistFailed map[string]bool) {
+	if s.stores.Prices == nil || len(pending) == 0 {
 		return
 	}
 	// Survive cancellation but preserve trace/log context (WithoutCancel).
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
-	for _, token := range tokens {
-		if err := s.stores.Prices.RevertPrice(cleanupCtx, token); err != nil {
-			log.ErrorContext(ctx, "failed to revert price record after persist failure, may cause spurious price-drop notification",
+	flushed, skipped := 0, 0
+	for token, price := range pending {
+		if persistFailed[token] && !persisted[token] {
+			// The listing made it into history nowhere; leave no price row
+			// behind so the next cycle re-detects the change from scratch.
+			skipped++
+			continue
+		}
+		if _, _, err := s.stores.Prices.RecordPrice(flushCtx, token, price); err != nil {
+			s.logger.ErrorContext(ctx, "failed to flush staged price record",
 				"token", token,
 				"error", err.Error(),
-				"impact", "stale price record may trigger a false price-drop notification on next cycle",
-				"action_taken", "continuing with remaining reverts")
+				"impact", "price change will be re-detected and re-staged next cycle",
+				"action_taken", "continuing with remaining flushes")
+			continue
 		}
+		flushed++
+	}
+	if skipped > 0 {
+		s.logger.WarnContext(ctx, "skipped staged price records for unpersisted listings",
+			"skipped", skipped, "flushed", flushed)
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -116,11 +116,6 @@ type searchResult struct {
 	newListings       []model.Listing
 	priceDropMessages []string
 	listingRecords    []storage.ListingRecord
-	// recordedTokens tracks tokens whose prices were recorded via
-	// RecordPrice during this processing pass.  When persistListings
-	// fails the scheduler reverts these records so the next cycle does
-	// not see stale prices and fire spurious price-drop notifications.
-	recordedTokens []string
 }
 
 type Options struct {
@@ -780,7 +775,7 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 	}
 	searchCounters := make(map[int64]*searchCycleCounter)
 
-	// Deferred price drop candidates: we record prices during matching
+	// Deferred price drop candidates: we read prices during matching
 	// (to detect changes) but defer notification formatting until after
 	// enrichment so messages include enriched km/city data.
 	type priceDropCandidate struct {
@@ -789,6 +784,14 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 		oldPrice int
 	}
 	var priceDropCandidates []priceDropCandidate
+
+	// Price observations are staged here during matching and durably
+	// recorded only after the listing outcome is settled (see
+	// flushPendingPrices). persistedTokens / persistFailedTokens track
+	// per-token persist outcomes across all searches in this cycle.
+	pendingPrices := make(map[string]int)
+	persistedTokens := make(map[string]bool)
+	persistFailedTokens := make(map[string]bool)
 
 	// 5. Percolator match: for each listing, find matching searches.
 	hiddenCache := make(map[int64]map[string]bool)
@@ -848,21 +851,22 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 				continue
 			}
 
-			// Record price to detect changes. Cache per token so
-			// subsequent matches for the same listing see the
-			// original price, not the just-recorded one.
+			// Read the last recorded price to detect changes; the durable
+			// write is staged and flushed only after the listing outcome
+			// is settled (flushPendingPrices). Cache per token so
+			// subsequent matches for the same listing reuse the read.
 			if s.stores.Prices != nil && raw[i].Price > 0 {
 				pr, cached := priceCache[raw[i].Token]
 				if !cached {
-					oldPrice, changed, err := s.stores.Prices.RecordPrice(ctx, raw[i].Token, raw[i].Price)
+					prevPrice, found, err := s.stores.Prices.PeekPrice(ctx, raw[i].Token)
 					if err != nil {
-						matchLog.ErrorContext(ctx, "failed to record listing price in price tracker",
+						matchLog.ErrorContext(ctx, "failed to read last recorded listing price",
 							"token", raw[i].Token, "error", err.Error())
 						pr = priceResult{err: true}
 					} else {
-						pr = priceResult{oldPrice: oldPrice, changed: changed}
-						if changed || oldPrice == 0 {
-							acc.result.recordedTokens = append(acc.result.recordedTokens, raw[i].Token)
+						pr = priceResult{oldPrice: prevPrice, changed: found && raw[i].Price != prevPrice}
+						if !found || pr.changed {
+							pendingPrices[raw[i].Token] = raw[i].Price
 						}
 					}
 					priceCache[raw[i].Token] = pr
@@ -1045,20 +1049,27 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 			}
 		}
 
-		// Persist listings.
+		// Persist listings. Per-token outcomes feed flushPendingPrices: a
+		// staged price is only written durably once its listing made it
+		// into history somewhere.
 		searchLog := s.logger.With("chat_id", acc.search.ChatID, "search_name", acc.search.Name)
 		persistOK := true
 		if s.stores.Listings != nil && len(acc.result.listingRecords) > 0 {
 			if err := s.persistListings(searchCtx, acc.result.listingRecords, searchLog); err != nil {
 				persistOK = false
+				for _, rec := range acc.result.listingRecords {
+					persistFailedTokens[rec.Token] = true
+				}
 			} else {
 				s.invalidateMarketCache()
+				for _, rec := range acc.result.listingRecords {
+					persistedTokens[rec.Token] = true
+				}
 			}
 		}
 		if !persistOK {
 			acc.result.newListings = nil
 			acc.result.listingRecords = nil
-			s.revertPriceRecords(searchCtx, acc.result.recordedTokens, searchLog)
 		}
 
 		stats.newListings += len(acc.result.newListings)
@@ -1075,6 +1086,10 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 			stats.notificationsSent++
 		}
 	}
+
+	// Durably record staged price observations now that listing outcomes
+	// are settled.
+	s.flushPendingPrices(ctx, pendingPrices, persistedTokens, persistFailedTokens)
 
 	// Write per-search cycle stats for dashboard observability.
 	if s.stores.SearchCycleStats != nil && len(searches) > 0 {

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -81,6 +81,13 @@ func (m *errPriceTracker) RecordPrice(ctx context.Context, token string, price i
 	return m.mockPriceTracker.RecordPrice(ctx, token, price)
 }
 
+func (m *errPriceTracker) PeekPrice(ctx context.Context, token string) (int, bool, error) {
+	if m.err != nil {
+		return 0, false, m.err
+	}
+	return m.mockPriceTracker.PeekPrice(ctx, token)
+}
+
 type errSearchStore struct {
 	mockSearchStore
 	listErr error

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -138,11 +138,11 @@ func (m *mockPriceTracker) RecordPrice(_ context.Context, token string, price in
 	return 0, false, nil
 }
 
-func (m *mockPriceTracker) RevertPrice(_ context.Context, token string) error {
+func (m *mockPriceTracker) PeekPrice(_ context.Context, token string) (int, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	delete(m.prices, token)
-	return nil
+	p, ok := m.prices[token]
+	return p, ok, nil
 }
 
 func (m *mockPriceTracker) PrunePrices(_ context.Context, _ time.Duration) (int64, error) {

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -104,11 +104,13 @@ type DedupStore interface {
 
 type PriceTracker interface {
 	RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error)
-	// RevertPrice removes the most recent price_history row for the given
-	// token.  It is used to undo a RecordPrice call when downstream
-	// persistence (e.g. listing save) fails, preventing spurious price-drop
-	// notifications on the next scheduler cycle.
-	RevertPrice(ctx context.Context, token string) error
+	// PeekPrice returns the most recently recorded price for the token
+	// without writing anything. found is false when no price has been
+	// recorded yet. The scheduler uses it to detect price changes during
+	// matching and defers the durable RecordPrice until the listing
+	// outcome (persist) is settled, so a persist failure leaves no stale
+	// price row behind.
+	PeekPrice(ctx context.Context, token string) (price int, found bool, err error)
 	PrunePrices(ctx context.Context, olderThan time.Duration) (int64, error)
 	GetPriceHistory(ctx context.Context, token string) ([]PricePoint, error)
 }

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -899,6 +899,44 @@ func TestPostgres_PriceTracking(t *testing.T) {
 	}
 }
 
+func TestPostgres_PeekPrice(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Peek on an unknown token: not found, no error.
+	if _, found, err := store.PeekPrice(ctx, "peek-none"); err != nil || found {
+		t.Fatalf("peek unknown: found=%v err=%v, want found=false err=nil", found, err)
+	}
+
+	// Record then peek returns the latest price.
+	if _, _, err := store.RecordPrice(ctx, "peek-tok", 100000); err != nil {
+		t.Fatal(err)
+	}
+	if p, found, err := store.PeekPrice(ctx, "peek-tok"); err != nil || !found || p != 100000 {
+		t.Fatalf("peek after record: p=%d found=%v err=%v, want 100000/true/nil", p, found, err)
+	}
+
+	// After a price change, peek returns the newest row.
+	if _, _, err := store.RecordPrice(ctx, "peek-tok", 90000); err != nil {
+		t.Fatal(err)
+	}
+	if p, _, _ := store.PeekPrice(ctx, "peek-tok"); p != 90000 {
+		t.Fatalf("peek after change = %d, want 90000", p)
+	}
+
+	// Peek is read-only: history length is unchanged by repeated peeks.
+	for i := 0; i < 3; i++ {
+		_, _, _ = store.PeekPrice(ctx, "peek-tok")
+	}
+	points, err := store.GetPriceHistory(ctx, "peek-tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("history length = %d after peeks, want 2 (peek must not write)", len(points))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Market medians (materialized view)
 // ---------------------------------------------------------------------------

--- a/internal/storage/postgres/prices.go
+++ b/internal/storage/postgres/prices.go
@@ -58,14 +58,18 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	return prev, false, nil
 }
 
-func (s *Store) RevertPrice(ctx context.Context, token string) error {
-	_, err := s.db.ExecContext(ctx,
-		`DELETE FROM price_history WHERE id = (SELECT id FROM price_history WHERE token = $1 ORDER BY observed_at DESC, id DESC LIMIT 1)`,
+func (s *Store) PeekPrice(ctx context.Context, token string) (int, bool, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT price FROM price_history WHERE token = $1 ORDER BY observed_at DESC, id DESC LIMIT 1`,
 		token)
-	if err != nil {
-		return fmt.Errorf("revert price: %w", err)
+	var price int
+	switch err := row.Scan(&price); {
+	case err == sql.ErrNoRows:
+		return 0, false, nil
+	case err != nil:
+		return 0, false, fmt.Errorf("peek price: %w", err)
 	}
-	return nil
+	return price, true, nil
 }
 
 func (s *Store) GetPriceHistory(ctx context.Context, token string) ([]storage.PricePoint, error) {


### PR DESCRIPTION
## Summary

Closes #1297 (Epic #1284 — Pipeline data integrity). **P2 — last and highest-behavioral-risk quick win.**

`RecordPrice` wrote a `price_history` row during the match pass, *before* the listing was persisted (`internal/scheduler/scheduler.go`). On persist failure, a best-effort `revertPriceRecords` tried to undo it — but a failed revert only logged, leaving a stale row that made the next cycle see a **phantom price drop** and fire a spurious "price dropped" notification. That directly attacks the product''s core trust signal.

## Fix — stage-then-flush instead of write-then-maybe-revert

- `PriceTracker.RevertPrice` → **`PeekPrice`**: a read-only lookup of the last recorded price, used to detect changes during matching without writing anything.
- Observed prices are staged in-memory (`pendingPrices`) during the match pass and durably recorded (`flushPendingPrices`) only **after** listing outcomes settle.
- A token whose only persist attempts failed is **skipped**, so the next cycle re-detects the change from scratch rather than inheriting a stale row. A token persisted by at least one search (or never part of a persist, e.g. price-drop-only) is flushed.
- A failed flush merely logs — `PeekPrice` still returns the old value next cycle, so the write self-corrects. No more unrecoverable stale-row window.

## Tests

- `price_staging_test.go`: table-driven `flushPendingPrices` rules (persisted→flush, failed-only→skip, mixed→flush, drop-only→flush, empty→no-op) + record-error-continues + nil-store
- `postgres_test.go`: `TestPostgres_PeekPrice` — not-found, latest-after-change, and **read-only** (repeated peeks do not grow history)
- Existing `TestProcessGroup_PersistFails_RevertsPriceRecords` (full two-cycle scenario asserting no spurious drop) **passes unchanged** — behavior preserved end-to-end

## Review

✅ Verified locally: `go build`, `go vet` (incl. `-tags e2e`) clean, no real lint findings, all gofmt-clean; flush tests + the end-to-end persist-fail scenario pass. Postgres `PeekPrice` test runs against the container in CI.

Refs: docs/audit/02-findings.md#f4

Assisted-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for price record flushing behavior, covering success scenarios, failure cases, and edge conditions
  * Added integration test validating price retrieval does not modify stored data

* **Refactor**
  * Updated price persistence workflow to defer recording until after listing settlement completes
  * Updated price tracker interface to support read-only price lookup in place of revert capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->