### PR TITLE
ci: add govulncheck and race detector on hotspot packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           version: v2.4
           args: --timeout=5m
+      - name: Vulnerability scan (govulncheck)
+        if: needs.changes.outputs.go == 'true'
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          govulncheck ./...
       - name: Validate production compose env contract
         run: |
           CARWATCH_IMAGE_TAG=1.2.3 \
@@ -222,6 +227,10 @@ jobs:
         run: mkdir -p web/dist && echo '<!doctype html>' > web/dist/index.html
       - name: Run tests
         run: make test
+        env:
+          TEST_POSTGRES_DSN: postgres://carwatch:carwatch@localhost:5432/carwatch_test?sslmode=disable
+      - name: Race detector on concurrency hotspots
+        run: go test -race -count=1 ./internal/scheduler/... ./internal/fetcher/... ./internal/broker/...
         env:
           TEST_POSTGRES_DSN: postgres://carwatch:carwatch@localhost:5432/carwatch_test?sslmode=disable
       - name: Run e2e tests


### PR DESCRIPTION
## Summary

Closes #1308 (Epic #1288 — Observability & operations).

The audit found a production-reachable `x/net` advisory only by running `govulncheck` manually, and the goroutine-lifecycle fixes (#1315, #1316) could only be race-tested in CI (no local C compiler on the dev machine). This wires both into CI so they are enforced, not ad-hoc.

- **Lint job**: `govulncheck` (pinned `v1.1.4`) on Go changes — a reachable vulnerability now fails the PR.
- **Test job**: `go test -race` over the concurrency hotspots (`scheduler`, `fetcher`, `broker`) against the Postgres service container. `make test` only uses `-covermode=atomic`, which is not the race detector.

## Review

✅ YAML structure mirrors existing steps; `govulncheck` step gated to Go changes, race step reuses the existing `TEST_POSTGRES_DSN`. On this infra-only PR the govulncheck step is skipped (go unchanged) and the race step runs.

Refs: docs/audit/04-testing-strategy.md

Assisted-By: Claude Fable 5 <noreply@anthropic.com>