### PR TITLE
fix: gate dev-auth on non-local bind behind explicit opt-in

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -133,9 +133,12 @@ type Config struct {
 
 func New(c Config) *Server {
 	if c.FirebaseAuth == nil && IsNonLocalBind(c.Bind) {
+		// Reaching here on a non-local bind requires the explicit
+		// api.allow_insecure_dev_auth opt-in (BuildAPI refuses otherwise).
 		if c.Logger != nil {
-			c.Logger.Warn("firebase auth not configured — using dev auth mode on non-localhost bind address",
-				"bind", c.Bind)
+			c.Logger.Warn("firebase auth not configured — using insecure dev auth mode on non-localhost bind address",
+				"bind", c.Bind,
+				"impact", "all API access is unauthenticated; for local development only")
 		}
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -208,7 +208,14 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		firebaseAuth = v
 	}
 	if firebaseAuth == nil && api.IsNonLocalBind(cfg.HTTP.Bind) {
-		return nil, fmt.Errorf("firebase auth must be configured for non-local bind address %q", cfg.HTTP.Bind)
+		if !cfg.API.AllowInsecureDevAuth {
+			return nil, fmt.Errorf("firebase auth must be configured for non-local bind address %q "+
+				"(set api.allow_insecure_dev_auth: true to override for local development only)", cfg.HTTP.Bind)
+		}
+		logger.Warn("SECURITY: starting API with unauthenticated dev-auth on a non-local bind address",
+			"bind", cfg.HTTP.Bind,
+			"reason", "api.allow_insecure_dev_auth is enabled",
+			"impact", "anyone who can reach this address has full API access — never enable in production")
 	}
 
 	cfg.API.AdminChatID = cfg.Telegram.AdminChatID

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -245,6 +245,32 @@ func TestBuildAPIRejectsMissingFirebaseOnNonLocalBind(t *testing.T) {
 	if !strings.Contains(err.Error(), "0.0.0.0:8080") {
 		t.Fatalf("error should include bind address, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "allow_insecure_dev_auth") {
+		t.Fatalf("error should mention the override flag, got: %v", err)
+	}
+}
+
+func TestBuildAPIAllowsInsecureDevAuthOptIn(t *testing.T) {
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			Bind: "0.0.0.0:8080",
+		},
+		Telemetry: config.TelemetryConfig{
+			AuthToken: "telemetry-secret",
+		},
+	}
+	cfg.API.AllowInsecureDevAuth = true
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// With the explicit opt-in, the non-local bind without Firebase is
+	// permitted (dangerous, for local dev only) instead of erroring.
+	apiServer, err := BuildAPI(cfg, nil, nil, logger, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected dev-auth opt-in to permit startup, got error: %v", err)
+	}
+	if apiServer == nil {
+		t.Fatal("expected a server when dev-auth opt-in is set")
+	}
 }
 
 func TestBuildAPIFirebaseRequirementByBind(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,12 @@ type APIConfig struct {
 	AdminEmail           string `yaml:"admin_email"`
 	MaxSearches          int    `yaml:"-"` // derived from telegram.max_searches at startup
 	MaxConcurrentFetches int    `yaml:"max_concurrent_fetches"`
+	// AllowInsecureDevAuth permits the API to start with the unauthenticated
+	// dev-auth fallback on a non-localhost bind address (no Firebase verifier).
+	// This is an explicit, dangerous opt-in for local container development;
+	// production must never set it. Without it, a non-local bind without a
+	// configured verifier is a hard startup error.
+	AllowInsecureDevAuth bool `yaml:"allow_insecure_dev_auth"`
 }
 
 type PollingConfig struct {


### PR DESCRIPTION
## Summary

Closes #1299 (Epic #1286 — Security hardening). **P2.**

`BuildAPI` already refused to start without a Firebase verifier on a non-local bind (`internal/app/app.go`), so production cannot silently downgrade to unauthenticated. But two gaps remained:
1. No escape hatch for legitimate local container development on a non-local bind.
2. `api.New` still logged "using dev auth mode on non-localhost bind" — misleading, since BuildAPI would already have errored.

## Fix

- New `api.allow_insecure_dev_auth` config flag (default `false`).
- Non-local bind + no verifier + flag off ⇒ hard startup error, and the error now names the override flag.
- Flag explicitly on ⇒ startup proceeds with a prominent `SECURITY:` warning. Production must never set it.
- `api.New`''s warning reworded to make the unauthenticated state explicit.

## Tests

- existing rejection test extended to assert the error mentions `allow_insecure_dev_auth`
- new `TestBuildAPIAllowsInsecureDevAuthOptIn`: with the opt-in, non-local + no-Firebase startup is permitted

## Review

✅ Verified locally: `go build`, gofmt-clean, no real lint findings; app BuildAPI tests pass.

Refs: docs/audit/02-findings.md#f8

Assisted-By: Claude Fable 5 <noreply@anthropic.com>