### PR TITLE
fix: config and code-quality hardening (F9 + F13)

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -71,8 +71,17 @@ type httpStats struct {
 }
 
 func (s *Server) isAdmin(chatID int64, email string) bool {
-	return (chatID > 0 && s.cfg.AdminChatID != 0 && chatID == s.cfg.AdminChatID) ||
-		(s.cfg.AdminEmail != "" && email != "" && strings.EqualFold(email, s.cfg.AdminEmail))
+	if chatID > 0 && s.cfg.AdminChatID != 0 && chatID == s.cfg.AdminChatID {
+		return true
+	}
+	// s.cfg.AdminEmail is normalized (trimmed + ASCII-lowercased) once in New.
+	// Comparing against an explicitly ASCII-lowercased input — rather than
+	// strings.EqualFold — avoids Unicode case folding treating distinct
+	// characters as equal (e.g. ı/I, ﬀ/ff) in an authorization check.
+	if s.cfg.AdminEmail == "" || email == "" {
+		return false
+	}
+	return strings.ToLower(strings.TrimSpace(email)) == s.cfg.AdminEmail
 }
 
 func (s *Server) getMe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/admin_isadmin_test.go
+++ b/internal/api/admin_isadmin_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/config"
+)
+
+func TestIsAdmin_EmailMatching(t *testing.T) {
+	// AdminEmail is stored pre-normalized (New lowercases/trims it once).
+	srv := &Server{cfg: config.APIConfig{AdminEmail: "admin@example.com", AdminChatID: 42}}
+
+	tests := []struct {
+		name   string
+		chatID int64
+		email  string
+		want   bool
+	}{
+		{"exact email", 0, "admin@example.com", true},
+		{"mixed-case input email", 0, "Admin@Example.com", true},
+		{"email with surrounding space", 0, "  admin@example.com  ", true},
+		{"different email", 0, "someone@example.com", false},
+		{"empty email", 0, "", false},
+		// Unicode case-fold characters must NOT be treated as ASCII equals.
+		{"dotless-i homoglyph rejected", 0, "admın@example.com", false},
+		{"admin chat id", 42, "", true},
+		{"non-admin chat id", 7, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := srv.isAdmin(tt.chatID, tt.email); got != tt.want {
+				t.Errorf("isAdmin(%d, %q) = %v, want %v", tt.chatID, tt.email, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAdmin_NoAdminConfigured(t *testing.T) {
+	srv := &Server{cfg: config.APIConfig{}}
+	if srv.isAdmin(0, "anyone@example.com") {
+		t.Error("no admin email configured: must not grant admin")
+	}
+	if srv.isAdmin(123, "") {
+		t.Error("no admin chat id configured: must not grant admin")
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -37,6 +37,10 @@ const (
 	requestIDKey contextKey = "requestID"
 )
 
+// maxConcurrentFetchesCeiling bounds api.max_concurrent_fetches so a
+// misconfigured value cannot spawn an unbounded number of fetch goroutines.
+const maxConcurrentFetchesCeiling = 64
+
 type PollTrigger interface {
 	TriggerPoll()
 }
@@ -142,9 +146,22 @@ func New(c Config) *Server {
 		}
 	}
 
+	// Normalize the admin email once so isAdmin can compare exactly (no
+	// per-request Unicode case folding).
+	c.API.AdminEmail = strings.ToLower(strings.TrimSpace(c.API.AdminEmail))
+
 	fetchCap := c.API.MaxConcurrentFetches
 	if fetchCap <= 0 {
 		fetchCap = 10
+	}
+	// Clamp to a sane ceiling so a misconfigured value cannot spawn an
+	// unbounded number of concurrent fetch goroutines.
+	if fetchCap > maxConcurrentFetchesCeiling {
+		if c.Logger != nil {
+			c.Logger.Warn("api.max_concurrent_fetches above ceiling, clamping",
+				"configured", fetchCap, "ceiling", maxConcurrentFetchesCeiling)
+		}
+		fetchCap = maxConcurrentFetchesCeiling
 	}
 
 	pipeline := scheduler.NewListingPipeline(c.Listings, c.PriceListSvc, c.Logger)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -526,8 +526,8 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	s.logger.InfoContext(ctx, "starting scheduler cycle, loading active searches", "scan", cycle)
 
-	s.langCache.Range(func(k, _ any) bool { s.langCache.Delete(k); return true })
-	s.digestCache.Range(func(k, _ any) bool { s.digestCache.Delete(k); return true })
+	s.langCache.Clear()
+	s.digestCache.Clear()
 	if s.priceListSvc != nil {
 		s.priceListSvc.ResetCycleCounter()
 	}

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -64,7 +64,11 @@ func (s *Store) TableSizes(ctx context.Context) (map[string]int64, error) {
 	return sizes, nil
 }
 
-// quoteIdent returns a safely quoted PostgreSQL identifier (table name from information_schema).
+// quoteIdent returns a safely quoted PostgreSQL identifier. It escapes quoting
+// but performs NO validation: callers MUST only pass identifiers from a trusted
+// source — information_schema query results, the `purgeable` allowlist, or the
+// `resetTables` constant — never raw user input. It exists because table names
+// cannot be passed as bind parameters.
 func quoteIdent(ident string) string {
 	return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
 }


### PR DESCRIPTION
## Summary

Closes #1301 (Epic #1286 — Security hardening). Grouped **P3** items from the audit register.

- **F9** — clamp `api.max_concurrent_fetches` to a ceiling (64) at construction; a misconfigured large value can no longer spawn unbounded fetch goroutines (warns + clamps).
- **Admin email** — normalize the configured admin email once in `New` (trim + ASCII-lowercase) and compare against an ASCII-lowercased input, replacing `strings.EqualFold` whose Unicode case folding can treat distinct characters as equal (e.g. `ı`/`I`, `ﬀ`/`ff`) in an authorization check.
- **quoteIdent** — documented that it escapes but does **not** validate; callers must only pass trusted/whitelisted identifiers (information_schema results, `purgeable`, `resetTables`).
- **sync.Map clears** — replaced `Range`+`Delete` with `sync.Map.Clear()` (atomic, simpler).

User-deactivation-on-block failure was evaluated and **intentionally left as-is**: it self-heals next cycle (the next delivery re-attempts deactivation), so a synchronous retry would only add delivery-path latency.

## Tests

`admin_isadmin_test.go`: exact/mixed-case/whitespace email matches, Unicode-homoglyph rejection, admin-chat-id path, and no-admin-configured negative cases.

## Review

✅ Verified locally: `go build`, gofmt-clean, no real lint findings (staticcheck SA6005 avoided by the normalize-once design); isAdmin tests pass.

Refs: docs/audit/02-findings.md#f13

Assisted-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin email validation to correctly handle whitespace and character case variations.

* **New Features**
  * Enforced maximum limit of 64 concurrent API fetches with configuration warning.

* **Tests**
  * Added comprehensive test coverage for admin authorization logic including edge cases.

* **Chores**
  * Optimized cache clearing mechanism for improved performance.
  * Updated internal documentation for database helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->