### PR TITLE
fix: classify retriable vs permanent enrich errors

### DIFF
--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -19,8 +19,16 @@ const (
 	enrichOrphanIdleDefault = 5 * time.Minute
 )
 
+// ErrPermanent marks an enrichment failure that retrying cannot fix (e.g. the
+// listing was removed at the source). An EnrichFunc that returns an error
+// wrapping ErrPermanent is dead-lettered immediately instead of being retried
+// up to enrichMaxRetries, saving rate-limit budget and keeping the DLQ
+// meaningful.
+var ErrPermanent = errors.New("permanent enrich failure")
+
 // EnrichFunc processes a single enrichment request. It should return nil
-// on success (or skip), and an error to leave the message pending for retry.
+// on success (or skip), an error wrapping ErrPermanent for a non-retriable
+// failure, or any other error to leave the message pending for retry.
 type EnrichFunc func(ctx context.Context, req EnrichRequest) error
 
 // EnrichConsumer reads enrichment requests from the carwatch:enrich
@@ -144,6 +152,12 @@ func (c *EnrichConsumer) processBatch(ctx context.Context, msgs []redis.XMessage
 			return
 		}
 		if err := c.enrich(ctx, item.req); err != nil {
+			if errors.Is(err, ErrPermanent) {
+				c.logger.Warn("enrich request failed permanently, dead-lettering immediately",
+					"token", item.req.Token, "priority", item.req.Priority, "error", err)
+				c.deadLetter(ctx, item.msg.ID)
+				continue
+			}
 			c.logger.Warn("enrich request failed, will retry",
 				"token", item.req.Token, "priority", item.req.Priority, "error", err)
 			continue

--- a/internal/broker/enrich_permanent_test.go
+++ b/internal/broker/enrich_permanent_test.go
@@ -1,0 +1,106 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestEnrichConsumer_PermanentErrorDeadLettersImmediately verifies that an
+// EnrichFunc error wrapping ErrPermanent is moved to the dead-letter stream and
+// acked on the first attempt, rather than left pending for retry (F6).
+func TestEnrichConsumer_PermanentErrorDeadLettersImmediately(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+	if err := pub.PublishEnrich(ctx, EnrichRequest{Token: "gone-token", Priority: 1, Source: "test"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	calls := 0
+	fn := func(_ context.Context, _ EnrichRequest) error {
+		calls++
+		return fmt.Errorf("listing removed: %w", ErrPermanent)
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = cons.Run(runCtx)
+
+	if calls != 1 {
+		t.Fatalf("permanent error should be attempted exactly once, got %d", calls)
+	}
+
+	// The original message must be acked (not pending).
+	pending, err := client.XPending(ctx, EnrichStreamName, EnrichGroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Errorf("expected 0 pending after permanent dead-letter, got %d", pending.Count)
+	}
+
+	// And it must have landed in the dead-letter stream.
+	dlqLen, err := client.XLen(ctx, EnrichDeadLetterStream).Result()
+	if err != nil {
+		t.Fatalf("xlen dlq: %v", err)
+	}
+	if dlqLen != 1 {
+		t.Errorf("expected 1 message in dead-letter stream, got %d", dlqLen)
+	}
+}
+
+// TestEnrichConsumer_TransientErrorStaysPending verifies that a plain (non-
+// permanent) error leaves the message pending for retry instead of
+// dead-lettering.
+func TestEnrichConsumer_TransientErrorStaysPending(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+	if err := pub.PublishEnrich(ctx, EnrichRequest{Token: "flaky-token", Priority: 1, Source: "test"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	fn := func(_ context.Context, _ EnrichRequest) error {
+		return fmt.Errorf("temporary network blip")
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = cons.Run(runCtx)
+
+	// Transient failure: message stays pending, nothing dead-lettered.
+	pending, err := client.XPending(ctx, EnrichStreamName, EnrichGroupName).Result()
+	if err != nil {
+		t.Fatalf("xpending: %v", err)
+	}
+	if pending.Count != 1 {
+		t.Errorf("expected 1 pending after transient error, got %d", pending.Count)
+	}
+	dlqLen, _ := client.XLen(ctx, EnrichDeadLetterStream).Result()
+	if dlqLen != 0 {
+		t.Errorf("expected 0 dead-lettered for transient error, got %d", dlqLen)
+	}
+}

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -3,6 +3,7 @@ package enricher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/dsionov/carwatch/internal/broker"
@@ -86,6 +87,14 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 			w.logger.WarnContext(ctx, "bot challenge during enrichment, backing off",
 				append(carAttrs, "cooldown", w.limiter.InCooldown(), "current_delay", w.limiter.CurrentDelay())...)
 			return fetchErr
+		}
+
+		if errors.Is(fetchErr, fetcher.ErrItemGone) {
+			// The listing was removed at the source; mark permanent so the
+			// consumer dead-letters immediately instead of retrying.
+			w.logger.InfoContext(ctx, "listing no longer exists at source, will not retry",
+				append(carAttrs, "error", fetchErr.Error())...)
+			return fmt.Errorf("%w: %w", broker.ErrPermanent, fetchErr)
 		}
 
 		w.logger.WarnContext(ctx, "failed to fetch listing detail page",

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -11,6 +11,10 @@ import (
 var (
 	ErrChallenge   = errors.New("anti-bot challenge detected")
 	ErrRateLimited = errors.New("rate limited")
+	// ErrItemGone indicates the requested item no longer exists at the source
+	// (e.g. HTTP 404/410 — the listing was removed). It is permanent: retrying
+	// the same token will not succeed.
+	ErrItemGone = errors.New("item no longer exists at source")
 )
 
 type Fetcher interface {

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -3,6 +3,7 @@ package yad2
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
 )
 
@@ -322,6 +324,27 @@ func TestYad2Fetcher_FetchItem_BotProtection(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "anti-bot challenge") {
 		t.Errorf("error should mention anti-bot challenge: %v", err)
+	}
+}
+
+func TestYad2Fetcher_FetchItem_GoneIsPermanent(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusGone} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`<html>not found</html>`))
+			}))
+			defer server.Close()
+
+			f := newTestFetcher(t, server.URL)
+			_, err := f.FetchItem(context.Background(), "tok-removed")
+			if err == nil {
+				t.Fatalf("expected error for status %d", status)
+			}
+			if !errors.Is(err, fetcher.ErrItemGone) {
+				t.Errorf("status %d should map to ErrItemGone, got: %v", status, err)
+			}
+		})
 	}
 }
 

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -148,6 +148,10 @@ func (f *Yad2Fetcher) FetchItem(ctx context.Context, token string) (ItemDetails,
 			}
 			return ItemDetails{}, fmt.Errorf("fetch item %s: %w", token, fetcher.ErrChallenge)
 		}
+		if result.StatusCode == http.StatusNotFound || result.StatusCode == http.StatusGone {
+			// The listing was removed from Yad2; retrying this token is futile.
+			return ItemDetails{}, fmt.Errorf("fetch item %s: status %d: %w", token, result.StatusCode, fetcher.ErrItemGone)
+		}
 		snippet := string(result.Body)
 		if len(snippet) > 200 {
 			snippet = snippet[:200]


### PR DESCRIPTION
## Summary

Closes #1300 (Epic #1285 — Enrichment pipeline robustness). **P3.**

The enrich consumer left every `EnrichFunc` error pending and retried it up to `enrichMaxRetries` before dead-lettering — even when the listing was permanently gone (HTTP 404/410). That wastes the enricher''s rate-limit budget on tokens that will never succeed and delays genuinely retriable work.

## Fix — error classification

- **`fetcher.ErrItemGone`** — new sentinel; `yad2.FetchItem` returns it for 404/410 (listing removed), kept distinct from the bot-challenge path.
- **`broker.ErrPermanent`** — an `EnrichFunc` error wrapping it is **dead-lettered immediately** (acked + moved to the DLQ) instead of retried.
- The enricher **worker** maps `ErrItemGone` → `broker.ErrPermanent`.

Other failures (network blips, DB errors, bot challenges) remain retriable, unchanged.

## Tests

- `broker`: permanent error ⇒ attempted once, 0 pending, 1 in DLQ; transient error ⇒ stays pending, 0 in DLQ
- `yad2`: `FetchItem` returns `ErrItemGone` for both 404 and 410

## Review

✅ Verified locally: `go build`, gofmt-clean, no real lint findings; broker + yad2 + enricher suites pass.

Refs: docs/audit/02-findings.md#f6

Assisted-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented intelligent error handling that distinguishes between permanent and transient enrichment failures.
  * Messages that fail due to permanent conditions (e.g., missing source items) are now immediately marked as dead-lettered instead of being retried.
  
* **Tests**
  * Added tests validating permanent and transient error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->