### PR TITLE
build: pin Go toolchain to 1.25.11 for stdlib security patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/dsionov/carwatch
 
 go 1.25.0
 
+toolchain go1.25.11
+
 require (
 	firebase.google.com/go/v4 v4.19.0
 	github.com/Noooste/azuretls-client v1.13.2


### PR DESCRIPTION
## Summary

The `govulncheck` gate added in #1322 surfaced several **Go standard-library** advisories present in `go1.25.0` (the pinned toolchain) and fixed in later 1.25.x patches:

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-5039 | net/textproto | go1.25.11 |
| GO-2026-5037 | crypto/x509 | go1.25.11 |
| GO-2026-4982 | html/template | go1.25.10 |
| GO-2026-4980 | html/template | go1.25.10 |
| GO-2026-4971 | net | go1.25.10 |
| GO-2026-4947 | crypto/x509 | go1.25.9 |

These were latent before #1322; the new CI gate makes them visible (working as intended). Without this bump, every Go PR is now blocked.

## Fix

Add `toolchain go1.25.11` to `go.mod` so `setup-go` builds and scans against the patched standard library. `1.25.11` is the highest fixed-in version, covering all six. `govulncheck ./...` is clean on 1.25.11.

## Review

✅ `go mod verify` and `go build ./...` clean. No code changes — toolchain directive only.

Assisted-By: Claude Fable 5 <noreply@anthropic.com>