### PR TITLE
feat: add health-alert dead-man switch and monitoring docs

### DIFF
--- a/docs/ops/monitoring-and-alerting.md
+++ b/docs/ops/monitoring-and-alerting.md
@@ -1,0 +1,55 @@
+# Monitoring & alerting
+
+CarWatch runs on a single VM at personal scale, so the alerting baseline is a
+lightweight **dead-man's switch** rather than a full Prometheus/Alertmanager
+stack. It pages the Telegram admin when something is actually wrong and stays
+silent otherwise.
+
+## What is monitored
+
+`scripts/health-alert.sh` runs every 15 minutes (systemd timer) and inspects
+each app service's `/healthz`:
+
+| Condition | Source | Why it matters |
+|---|---|---|
+| Service unreachable | no `/healthz` response | container down / crash loop |
+| `status: "degraded"` | `internal/health` (set when the scraper has had no successful cycle within its degraded threshold) | scraping has stalled — the product's core function |
+| `persist_failures` increased | F10 counter (`internal/scheduler/processing.go`) | listings delayed (retried next cycle) |
+| `claim_release_failures` increased | F10 counter | **permanent** listing loss for a user — investigate |
+
+The failure counters are compared against the previous run (state in
+`/var/lib/carwatch/health-alert.state`) so a single incident pages once rather
+than every 15 minutes.
+
+## Install (on the VM)
+
+```bash
+sudo cp /home/ubuntu/carwatch/scripts/carwatch-health-alert.service /etc/systemd/system/
+sudo cp /home/ubuntu/carwatch/scripts/carwatch-health-alert.timer   /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now carwatch-health-alert.timer
+
+# verify
+systemctl list-timers carwatch-health-alert.timer
+sudo systemctl start carwatch-health-alert.service && journalctl -u carwatch-health-alert -n 20
+```
+
+The script reads `TELEGRAM_BOT_TOKEN` from `.env` and the admin chat id from
+`config.yaml` (`telegram.admin_chat_id`) or `CARWATCH_ADMIN_CHAT_ID` in `.env`.
+It exits 0 even when it alerts, so a noisy run never trips other automation.
+
+## Metrics endpoint (optional)
+
+Each service also exposes Prometheus/OTel metrics at `/metrics` (auth-gated on
+non-local binds via `telemetry.auth_token`), including
+`carwatch.listings.persist_failures` and
+`carwatch.dedup.claim_release_failures`. Point a scraper at it if/when a
+Grafana stack is added; the dead-man's switch above is the zero-infrastructure
+baseline until then.
+
+## Related
+
+- [yad2-blocked-runbook.md](yad2-blocked-runbook.md) — when scraping is being
+  blocked rather than broken.
+- [backup-and-recovery.md](backup-and-recovery.md) — the analogous backup
+  timer.

--- a/scripts/carwatch-health-alert.service
+++ b/scripts/carwatch-health-alert.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=CarWatch health alerter (dead-man's switch)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=ubuntu
+ExecStart=/home/ubuntu/carwatch/scripts/health-alert.sh
+StandardOutput=journal
+StandardError=journal

--- a/scripts/carwatch-health-alert.timer
+++ b/scripts/carwatch-health-alert.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run CarWatch health alerter every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/health-alert.sh
+++ b/scripts/health-alert.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CarWatch health alerter / dead-man's switch.
+#
+# Run periodically (see carwatch-health-alert.timer). For each app service it
+# checks /healthz and alerts the Telegram admin when:
+#   - a service is unreachable (dead-man's switch), or
+#   - a service reports status "degraded" (the scraper sets this when no
+#     successful cycle has completed within its degraded threshold), or
+#   - the scraper's persist-failure / claim-release-failure counters have
+#     increased since the last run (the only permanent listing-loss path; see
+#     internal/scheduler/processing.go and the F10 metrics).
+#
+# Designed to be dependency-light: no jq required, only docker + wget + curl.
+# Exit 0 always (a monitoring run failing should not page on its own); problems
+# are reported via Telegram.
+
+COMPOSE_DIR="${1:-/home/ubuntu/carwatch}"
+STATE_DIR="${CARWATCH_STATE_DIR:-/var/lib/carwatch}"
+STATE_FILE="${STATE_DIR}/health-alert.state"
+
+SERVICES=(api bot-poller scraper notifier enricher)
+HEALTH_PORTS=(8080 8082 8081 8083 8084)
+
+TOKEN=$(grep -oP 'TELEGRAM_BOT_TOKEN=\K[^\s]+' "${COMPOSE_DIR}/.env" 2>/dev/null || echo "")
+ADMIN_CHAT=$(grep -oP 'admin_chat_id:\s*\K[0-9]+' "${COMPOSE_DIR}/config.yaml" 2>/dev/null || echo "")
+[ -z "$ADMIN_CHAT" ] && ADMIN_CHAT=$(grep -oP 'CARWATCH_ADMIN_CHAT_ID=\K[0-9]+' "${COMPOSE_DIR}/.env" 2>/dev/null || echo "")
+
+alerts=()
+
+notify() {
+  local msg="$1"
+  echo "ALERT: ${msg}"
+  if [ -n "$TOKEN" ] && [ -n "$ADMIN_CHAT" ]; then
+    curl -fsS --max-time 10 \
+      "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+      --data-urlencode "chat_id=${ADMIN_CHAT}" \
+      --data-urlencode "text=🚨 CarWatch: ${msg}" >/dev/null 2>&1 || \
+      echo "WARN: failed to send Telegram alert"
+  else
+    echo "WARN: TELEGRAM_BOT_TOKEN or admin chat id not found; cannot send alert"
+  fi
+}
+
+# Fetch a service's /healthz body via the container (matches smoke-test.sh).
+health_body() {
+  local svc="$1" port="$2"
+  docker exec "carwatch-${svc}" wget -qO- --timeout=5 "http://localhost:${port}/healthz" 2>/dev/null || true
+}
+
+# Extract an integer field like "field":123 from a JSON blob (no jq).
+json_int() {
+  local body="$1" field="$2"
+  echo "$body" | grep -oP "\"${field}\":\s*\K[0-9]+" | head -1
+}
+
+for i in "${!SERVICES[@]}"; do
+  svc="${SERVICES[$i]}"
+  port="${HEALTH_PORTS[$i]}"
+  body="$(health_body "$svc" "$port")"
+
+  if [ -z "$body" ]; then
+    alerts+=("service '${svc}' is UNREACHABLE on :${port}/healthz")
+    continue
+  fi
+  if echo "$body" | grep -q '"status":"degraded"'; then
+    alerts+=("service '${svc}' reports status=degraded")
+  fi
+done
+
+# Scraper failure counters: alert only on an increase since the last run.
+scraper_body="$(health_body scraper 8081)"
+if [ -n "$scraper_body" ]; then
+  pf="$(json_int "$scraper_body" persist_failures)"; pf="${pf:-0}"
+  cr="$(json_int "$scraper_body" claim_release_failures)"; cr="${cr:-0}"
+
+  prev_pf=0; prev_cr=0
+  if [ -f "$STATE_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE" 2>/dev/null || true
+    prev_pf="${PREV_PERSIST_FAILURES:-0}"
+    prev_cr="${PREV_CLAIM_RELEASE_FAILURES:-0}"
+  fi
+
+  if [ "$pf" -gt "$prev_pf" ]; then
+    alerts+=("scraper persist_failures rose ${prev_pf} → ${pf} (listings delayed; retried next cycle)")
+  fi
+  if [ "$cr" -gt "$prev_cr" ]; then
+    alerts+=("scraper claim_release_failures rose ${prev_cr} → ${cr} — PERMANENT listing loss; investigate")
+  fi
+
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  {
+    echo "PREV_PERSIST_FAILURES=${pf}"
+    echo "PREV_CLAIM_RELEASE_FAILURES=${cr}"
+  } > "$STATE_FILE" 2>/dev/null || true
+fi
+
+if [ "${#alerts[@]}" -eq 0 ]; then
+  echo "OK: all services healthy"
+  exit 0
+fi
+
+msg="$(printf '%s; ' "${alerts[@]}")"
+notify "${msg%; }"
+exit 0


### PR DESCRIPTION
## Summary

Closes #1305 (Epic #1288 — Observability & operations).

A zero-infrastructure alerting baseline suited to the single-VM deployment — a **dead-man''s switch** that pages the Telegram admin when something is actually wrong, rather than a full Prometheus/Alertmanager stack.

- **`scripts/health-alert.sh`** — every 15 min, checks each app service `/healthz` and alerts when: a service is unreachable, reports `status=degraded` (scraper stalled — no successful cycle within the threshold), or when the F10 `persist_failures` / `claim_release_failures` counters increase since the last run (the permanent listing-loss path). No `jq` dependency; reads `TELEGRAM_BOT_TOKEN`/admin chat from `.env`/`config.yaml`; exits 0 even when alerting so it never trips other automation. Counter alerts are edge-triggered via a state file.
- **`carwatch-health-alert.service` / `.timer`** — systemd units matching the existing backup-timer pattern.
- **`docs/ops/monitoring-and-alerting.md`** — what is monitored, install steps, and the `/metrics` path for a future Grafana stack.

## Review

✅ `bash -n` clean; LF line endings in the index (Linux VM); follows the conventions of `scripts/smoke-test.sh` and `scripts/backup-pg.sh`.

Refs: docs/audit/05-tech-debt-register.md (D-8)

Assisted-By: Claude Fable 5 <noreply@anthropic.com>