### PR TITLE
refactor: unify dual Yad2 __NEXT_DATA__ parsers

### DIFF
--- a/internal/catalog/yad2.go
+++ b/internal/catalog/yad2.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"regexp"
-	"strings"
+
+	"github.com/dsionov/carwatch/internal/fetcher/yad2"
 )
 
 // CatalogResult holds manufacturers and models parsed from a Yad2 page.
@@ -24,8 +24,6 @@ type Yad2PageFetcher interface {
 
 const defaultCatalogURL = "https://www.yad2.co.il/vehicles/cars"
 
-var nextDataRe = regexp.MustCompile(`(?s)<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>`)
-
 // FetchCatalogFromYad2 fetches the Yad2 cars page and extracts
 // manufacturer/model entries from listings in __NEXT_DATA__.
 func FetchCatalogFromYad2(ctx context.Context, fetcher Yad2PageFetcher) (*CatalogResult, error) {
@@ -39,16 +37,11 @@ func FetchCatalogFromYad2(ctx context.Context, fetcher Yad2PageFetcher) (*Catalo
 // ParseCatalogFromHTML extracts manufacturer/model catalog entries from
 // Yad2 HTML containing a __NEXT_DATA__ script tag.
 func ParseCatalogFromHTML(html []byte) (*CatalogResult, error) {
-	if strings.Contains(string(html), "Are you for real") {
-		return nil, fmt.Errorf("yad2: anti-bot challenge detected")
+	data, err := yad2.ExtractNextDataJSON(bytes.NewReader(html))
+	if err != nil {
+		return nil, err
 	}
-
-	matches := nextDataRe.FindSubmatch(html)
-	if len(matches) < 2 || len(matches[1]) == 0 {
-		return nil, fmt.Errorf("__NEXT_DATA__ script tag not found")
-	}
-
-	return parseCatalogFromNextData(matches[1])
+	return parseCatalogFromNextData(data)
 }
 
 func parseCatalogFromNextData(data []byte) (*CatalogResult, error) {

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -4,13 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
-
-	"github.com/dsionov/carwatch/internal/fetcher"
 )
-
-var itemNextDataRe = regexp.MustCompile(`(?is)<script[^>]*\bid=["']__NEXT_DATA__["'][^>]*>(.*?)</script>`)
 
 // ItemDetails holds enrichment data parsed from an individual listing page.
 type ItemDetails struct {
@@ -22,22 +17,11 @@ type ItemDetails struct {
 
 // ParseItemPage extracts listing details (primarily km) from a Yad2 item page.
 func ParseItemPage(body io.Reader) (ItemDetails, error) {
-	raw, err := io.ReadAll(body)
+	data, err := ExtractNextDataJSON(body)
 	if err != nil {
-		return ItemDetails{}, fmt.Errorf("read item page body: %w", err)
+		return ItemDetails{}, err
 	}
-	html := string(raw)
-
-	if strings.Contains(html, challengeMarker) {
-		return ItemDetails{}, fetcher.ErrChallenge
-	}
-
-	matches := itemNextDataRe.FindStringSubmatch(html)
-	if len(matches) < 2 || matches[1] == "" {
-		return ItemDetails{}, fmt.Errorf("item page: __NEXT_DATA__ not found")
-	}
-
-	return parseItemNextData([]byte(matches[1]))
+	return parseItemNextData(data)
 }
 
 func parseItemNextData(data []byte) (ItemDetails, error) {

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -17,7 +17,7 @@ import (
 
 const challengeMarker = "Are you for real"
 
-var nextDataRe = regexp.MustCompile(`(?s)<script\s+id="__NEXT_DATA__"[^>]*>(.*?)</script>`)
+var nextDataRe = regexp.MustCompile(`(?is)<script[^>]*\bid=["']__NEXT_DATA__["'][^>]*>(.*?)</script>`)
 
 // subModelHPRe extracts horsepower from sub-model text like "(165 כ״ס)".
 var subModelHPRe = regexp.MustCompile(`\((\d+)\s*כ״ס\)`)
@@ -25,11 +25,9 @@ var subModelHPRe = regexp.MustCompile(`\((\d+)\s*כ״ס\)`)
 // subModelGearRe detects automatic transmission markers in sub-model text.
 var subModelGearRe = regexp.MustCompile(`אוט[׳']`)
 
-func ParseListingsPage(body io.Reader) ([]model.RawListing, error) {
-	return ParseListingsPageWithLogger(body, nil)
-}
-
-func ParseListingsPageWithLogger(body io.Reader, logger *slog.Logger) ([]model.RawListing, error) {
+// ExtractNextDataJSON reads an HTML page, checks for a bot challenge, and
+// returns the raw JSON content of the __NEXT_DATA__ script tag.
+func ExtractNextDataJSON(body io.Reader) ([]byte, error) {
 	raw, err := io.ReadAll(body)
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
@@ -45,7 +43,19 @@ func ParseListingsPageWithLogger(body io.Reader, logger *slog.Logger) ([]model.R
 		return nil, fmt.Errorf("__NEXT_DATA__ script tag not found")
 	}
 
-	return parseNextData([]byte(matches[1]), logger)
+	return []byte(matches[1]), nil
+}
+
+func ParseListingsPage(body io.Reader) ([]model.RawListing, error) {
+	return ParseListingsPageWithLogger(body, nil)
+}
+
+func ParseListingsPageWithLogger(body io.Reader, logger *slog.Logger) ([]model.RawListing, error) {
+	data, err := ExtractNextDataJSON(body)
+	if err != nil {
+		return nil, err
+	}
+	return parseNextData(data, logger)
 }
 
 func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error) {


### PR DESCRIPTION
## Summary

- Extracts `ExtractNextDataJSON()` as the single shared entry point for Yad2 `__NEXT_DATA__` extraction
- Eliminates duplicate regex + challenge check + extraction logic from `parser.go`, `item_parser.go`, and `catalog/yad2.go`
- Uses the more robust regex pattern (case-insensitive, handles single/double quotes on the id attribute)
- Net -13 lines: a markup change now only needs to be fixed in one place

Closes #1311

## Test plan

- [x] All 79 `internal/fetcher/yad2` tests pass
- [x] All 35 `internal/catalog` tests pass
- [x] `go build ./...` compiles clean
- [ ] CI lint + test checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated JSON extraction logic across multiple parsers to reduce code duplication and improve maintainability.
  * Enhanced extraction pattern to support more flexible script tag detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->