### PR TITLE
fix: a11y improvements for countdown timer and admin pagination

### DIFF
--- a/web/src/components/NextScanCountdown.tsx
+++ b/web/src/components/NextScanCountdown.tsx
@@ -103,7 +103,7 @@ export function NextScanCountdown() {
         )}
 
         {!isOverdue && (
-          <p className="text-base font-bold tabular-nums text-foreground tracking-tight" role="timer" aria-live="off">
+          <p className="text-base font-bold tabular-nums text-foreground tracking-tight" role="timer" aria-live="polite">
             {mins}:{String(secs).padStart(2, "0")}
           </p>
         )}

--- a/web/src/components/admin/ListingsTab.tsx
+++ b/web/src/components/admin/ListingsTab.tsx
@@ -256,6 +256,7 @@ export function ListingsTab({
               type="button"
               onClick={() => setPage((p) => Math.max(0, p - 1))}
               disabled={page === 0}
+              aria-label="עמוד הקודם"
               className="flex h-9 w-9 items-center justify-center rounded-lg border border-border transition-colors hover:bg-muted disabled:opacity-30"
             >
               <ChevronRight className="h-4 w-4" />
@@ -269,6 +270,7 @@ export function ListingsTab({
                 setPage((p) => Math.min(totalPages - 1, p + 1))
               }
               disabled={page >= totalPages - 1}
+              aria-label="עמוד הבא"
               className="flex h-9 w-9 items-center justify-center rounded-lg border border-border transition-colors hover:bg-muted disabled:opacity-30"
             >
               <ChevronLeft className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- Set `aria-live="polite"` on NextScanCountdown timer (was `"off"`) so screen readers announce time updates
- Add `aria-label` attributes to admin ListingsTab pagination buttons (prev/next)
- Updated #1221 epic body: checked off 55 of 71 items as verified fixed

Remaining 16 unchecked items are feature requests (onboarding, keyboard shortcuts, bulk actions, etc.) — not CSS/markup fixable.

Ref #1221 items 41, 65

## Test plan

- [x] Code compiles (no TS errors)
- [ ] CI lint + build checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)