### PR TITLE
fix: drop listings whose source page is gone (404/410)

### DIFF
--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -90,10 +90,22 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		}
 
 		if errors.Is(fetchErr, fetcher.ErrItemGone) {
-			// The listing was removed at the source; mark permanent so the
-			// consumer dead-letters immediately instead of retrying.
-			w.logger.InfoContext(ctx, "listing no longer exists at source, will not retry",
-				append(carAttrs, "error", fetchErr.Error())...)
+			// The listing was removed at the source (404/410). Drop it from the
+			// active set so it stops surfacing in feeds/notifications, then mark
+			// the request permanent so the consumer dead-letters immediately
+			// instead of retrying. A drop failure is best-effort: log it and
+			// still dead-letter (the scrape cycle's stale-sweep is a backstop).
+			removed, dropErr := w.listings.DropListingByToken(ctx, req.Token)
+			if dropErr != nil {
+				w.logger.ErrorContext(ctx, "failed to drop listing gone at source",
+					append(carAttrs, "error", dropErr.Error())...)
+			} else {
+				if telemetry.EnrichItemsGone != nil {
+					telemetry.EnrichItemsGone.Add(ctx, 1)
+				}
+				w.logger.InfoContext(ctx, "dropped listing no longer at source, will not retry",
+					append(carAttrs, "deleted_rows", removed, "error", fetchErr.Error())...)
+			}
 			return fmt.Errorf("%w: %w", broker.ErrPermanent, fetchErr)
 		}
 

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -32,9 +32,11 @@ type mockListingStore struct {
 	enrichmentData map[string]storage.EnrichmentRecord
 	backfilled     []storage.ListingRecord
 	enrichAttempts map[string]int
+	droppedTokens  []string
 	backfillErr    error
 	lookupErr      error
 	incrementErr   error
+	dropErr        error
 }
 
 func newMockListingStore() *mockListingStore {
@@ -113,6 +115,15 @@ func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (in
 }
 func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
+}
+func (m *mockListingStore) DropListingByToken(_ context.Context, token string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dropErr != nil {
+		return 0, m.dropErr
+	}
+	m.droppedTokens = append(m.droppedTokens, token)
+	return 1, nil
 }
 func (m *mockListingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
 	return &storage.ListingIdentity{}, nil
@@ -253,6 +264,55 @@ func TestWorker_ChallengeTriggersBackoff(t *testing.T) {
 	defer ls.mu.Unlock()
 	if ls.enrichAttempts["tok-1"] != 1 {
 		t.Errorf("enrich attempts = %d, want 1 (even on failure)", ls.enrichAttempts["tok-1"])
+	}
+}
+
+func TestWorker_ItemGoneDropsListing(t *testing.T) {
+	f := &mockItemFetcher{err: fetcher.ErrItemGone}
+	ls := newMockListingStore()
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "gone-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+
+	// Permanent so the consumer dead-letters; still wraps the gone sentinel.
+	if !errors.Is(err, broker.ErrPermanent) {
+		t.Errorf("expected ErrPermanent, got %v", err)
+	}
+	if !errors.Is(err, fetcher.ErrItemGone) {
+		t.Errorf("expected ErrItemGone wrapped, got %v", err)
+	}
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if len(ls.droppedTokens) != 1 || ls.droppedTokens[0] != "gone-1" {
+		t.Errorf("expected listing dropped by token, got %v", ls.droppedTokens)
+	}
+	if ls.enrichAttempts["gone-1"] != 1 {
+		t.Errorf("enrich attempts = %d, want 1", ls.enrichAttempts["gone-1"])
+	}
+	if len(ls.backfilled) != 0 {
+		t.Error("should not backfill a listing that is gone")
+	}
+}
+
+func TestWorker_ItemGoneDeadLettersEvenIfDropFails(t *testing.T) {
+	f := &mockItemFetcher{err: fetcher.ErrItemGone}
+	ls := newMockListingStore()
+	ls.dropErr = errors.New("db delete failed")
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "gone-1", Priority: 1, Source: "match"}
+	err := w.HandleRequest(context.Background(), req)
+
+	// A best-effort drop failure must not mask the permanent dead-letter.
+	if !errors.Is(err, broker.ErrPermanent) {
+		t.Errorf("expected ErrPermanent despite drop failure, got %v", err)
+	}
+	if !errors.Is(err, fetcher.ErrItemGone) {
+		t.Errorf("expected ErrItemGone wrapped, got %v", err)
 	}
 }
 

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -56,6 +56,9 @@ func (s *prefillTrackingStore) PruneListings(_ context.Context, _ time.Duration)
 func (s *prefillTrackingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
 }
+func (s *prefillTrackingStore) DropListingByToken(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
 func (s *prefillTrackingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
 	return nil, nil
 }

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -313,6 +313,9 @@ func (m *mockListingStore) SearchStats(_ context.Context, _ int64, _ int64, _ st
 func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int64, _ []string) (int64, error) {
 	return 0, nil
 }
+func (m *mockListingStore) DropListingByToken(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
 func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
 	return m.unenrichedTokens, nil
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -249,6 +249,11 @@ type ListingStore interface {
 	IncrementEnrichAttempt(ctx context.Context, token string) error
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
+	// DropListingByToken removes a listing that no longer exists at the source
+	// (e.g. its detail page returns 404/410), across all chats/searches.
+	// Bookmarked copies are kept but flagged removed_at ("likely sold"); all
+	// other copies are hard-deleted. Returns the number of rows hard-deleted.
+	DropListingByToken(ctx context.Context, token string) (int64, error)
 }
 
 type SavedListingStore interface {

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -495,6 +495,55 @@ func (s *Store) SearchStats(ctx context.Context, chatID int64, searchID int64, f
 	return &st, nil
 }
 
+// DropListingByToken removes a listing whose source page no longer exists
+// (HTTP 404/410). It mirrors DeleteStaleListings but is keyed by token alone,
+// so it removes the listing for every chat/search that holds it: bookmarked
+// copies are flagged removed_at ("likely sold") and kept, all other copies are
+// hard-deleted. Returns the number of rows hard-deleted.
+func (s *Store) DropListingByToken(ctx context.Context, token string) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("drop listing begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Preserve bookmarked copies as "likely sold".
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE listing_history
+		SET removed_at = NOW()
+		WHERE token = $1
+		  AND removed_at IS NULL
+		  AND EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, token); err != nil {
+		return 0, fmt.Errorf("drop listing mark removed_at: %w", err)
+	}
+
+	// Hard-delete every non-bookmarked copy.
+	result, err := tx.ExecContext(ctx, `
+		DELETE FROM listing_history
+		WHERE token = $1
+		  AND NOT EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, token)
+	if err != nil {
+		return 0, fmt.Errorf("drop listing delete: %w", err)
+	}
+	removed, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("drop listing commit: %w", err)
+	}
+	return removed, nil
+}
+
 func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/storage/postgres/listings_enrich_test.go
+++ b/internal/storage/postgres/listings_enrich_test.go
@@ -202,3 +202,65 @@ func TestPostgres_ListUserListingsPagination(t *testing.T) {
 		t.Errorf("offset past end = %d rows, want 0", len(page))
 	}
 }
+
+func TestPostgres_DropListingByToken(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	save := func(token string, chatID int64) {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: chatID, SearchName: "s",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000,
+			FirstSeenAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("save %s/%d: %v", token, chatID, err)
+		}
+	}
+
+	// "gone-1" is held by two different chats, none bookmarked.
+	save("gone-1", 100)
+	save("gone-1", 200)
+	// "gone-2" is bookmarked by chat 100.
+	save("gone-2", 100)
+	if err := store.SaveBookmark(ctx, 100, "gone-2"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
+
+	// Non-bookmarked copies are hard-deleted across every chat that held them.
+	deleted, err := store.DropListingByToken(ctx, "gone-1")
+	if err != nil {
+		t.Fatalf("DropListingByToken gone-1: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("deleted = %d, want 2 (both chats)", deleted)
+	}
+	if l, _ := store.GetListing(ctx, 100, "gone-1"); l != nil {
+		t.Error("gone-1 should be deleted for chat 100")
+	}
+	if l, _ := store.GetListing(ctx, 200, "gone-1"); l != nil {
+		t.Error("gone-1 should be deleted for chat 200")
+	}
+
+	// Bookmarked copies are preserved but flagged removed_at ("likely sold").
+	deleted, err = store.DropListingByToken(ctx, "gone-2")
+	if err != nil {
+		t.Fatalf("DropListingByToken gone-2: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 (bookmarked is preserved)", deleted)
+	}
+	l, _ := store.GetListing(ctx, 100, "gone-2")
+	if l == nil {
+		t.Fatal("bookmarked gone-2 should be preserved, not deleted")
+	}
+	if l.RemovedAt == nil {
+		t.Error("bookmarked gone-2 should be flagged removed_at")
+	}
+
+	// Unknown token is a no-op.
+	if deleted, err := store.DropListingByToken(ctx, "never-existed"); err != nil || deleted != 0 {
+		t.Errorf("drop unknown token = %d, %v; want 0, nil", deleted, err)
+	}
+}

--- a/internal/telemetry/app_metrics.go
+++ b/internal/telemetry/app_metrics.go
@@ -31,6 +31,9 @@ var (
 	EnrichChallenges metric.Int64Counter
 	// EnrichSkipped counts enrichment requests skipped (already enriched).
 	EnrichSkipped metric.Int64Counter
+	// EnrichItemsGone counts listings dropped because their source page is gone
+	// (HTTP 404/410) and they no longer exist at the source.
+	EnrichItemsGone metric.Int64Counter
 
 	// PersistFailures counts failed listing-batch persists (retried next cycle).
 	PersistFailures metric.Int64Counter
@@ -114,6 +117,12 @@ func InitMetrics() error {
 
 	EnrichSkipped, err = meter.Int64Counter("carwatch.enrich.skipped",
 		metric.WithDescription("Enrichment requests skipped (already enriched)"))
+	if err != nil {
+		return err
+	}
+
+	EnrichItemsGone, err = meter.Int64Counter("carwatch.enrich.items_gone",
+		metric.WithDescription("Listings dropped because their source page is gone (404/410)"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

Listings whose detail page now returns **404/410** were not being dropped — they kept showing up in feeds and notifications with dead URLs.

## Root cause

`yad2.FetchItem` correctly maps a 404/410 to `fetcher.ErrItemGone`, and the enrichment worker catches it ([worker.go](internal/enricher/worker.go)) — but it only **dead-lettered the enrichment job** (`ErrItemGone → ErrPermanent`). It never removed the row from `listing_history`, so the listing lingered. The scrape-cycle stale-sweep (`DeleteStaleListings`) only drops listings that fall *out of a search's feed*, which a 404'd-but-still-listed item may not, so nothing ever cleaned these up.

## Fix

- New store method **`DropListingByToken(token)`** — mirrors `DeleteStaleListings` semantics but keyed by token, so it removes the listing for **every** chat/search that holds it: bookmarked copies are flagged `removed_at` ("likely sold") and kept; all other copies are hard-deleted.
- The worker's `ErrItemGone` branch now calls it as a **best-effort** drop before dead-lettering (a drop failure is logged, not fatal — the scrape-cycle sweep remains a backstop).
- New `carwatch.enrich.items_gone` counter for observability.

## Tests

- `TestWorker_ItemGoneDropsListing` — `ErrItemGone` → listing dropped by token, enrich-attempt incremented, returns `ErrPermanent` wrapping `ErrItemGone`, no backfill.
- `TestWorker_ItemGoneDeadLettersEvenIfDropFails` — a drop error still dead-letters.
- `TestPostgres_DropListingByToken` (integration) — non-bookmarked copies hard-deleted across multiple chats; bookmarked copy preserved with `removed_at`; unknown token is a no-op.

Verified locally: `go vet ./...`, `go build ./...`, enricher tests pass; postgres test compiles and skips without `TEST_POSTGRES_DSN` (runs in CI).

## Review

✅ Self-reviewed. Interface change touches all 4 `ListingStore` implementers (real `*Store` + 3 test mocks), all updated and compiling. Per-token drop is correct because a 404 means the source listing is gone for every holder.

Assisted-By: Claude opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>