### PR TITLE
fix: translate error messages to Hebrew and improve empty results UX

### DIFF
--- a/web/src/lib/error-messages.ts
+++ b/web/src/lib/error-messages.ts
@@ -3,6 +3,26 @@ import { ApiError } from "./api";
 const knownMessages: Record<string, string> = {
   "search limit reached": "הגעת למגבלת החיפושים — מחק חיפוש קיים כדי ליצור חדש",
   "search name already exists": "שם החיפוש כבר קיים — בחר שם אחר",
+  "search not found": "החיפוש לא נמצא",
+  "listing not found": "המודעה לא נמצאה",
+  "invalid JSON": "בקשה לא תקינה",
+  "invalid JSON body": "בקשה לא תקינה",
+  "invalid request body": "בקשה לא תקינה",
+  "invalid search id": "מזהה חיפוש לא תקין",
+  "invalid source": "מקור לא תקין",
+  "invalid manufacturer id": "מזהה יצרן לא תקין",
+  "missing token": "מזהה מודעה חסר",
+  "token is required": "מזהה מודעה חסר",
+  "endpoint is required": "כתובת התראה חסרה",
+  "endpoint, keys.p256dh, and keys.auth are required": "פרטי מנוי התראות חסרים",
+  "chat_id is required in body": "מזהה משתמש חסר",
+  "valid chat_id is required": "מזהה משתמש לא תקין",
+  "valid search id is required": "מזהה חיפוש לא תקין",
+  "table is required": "שם טבלה חסר",
+  "manufacturer is required for instant search": "יש לבחור יצרן לחיפוש מהיר",
+  "saved listings limit reached": "הגעת למגבלת המודעות השמורות",
+  "hidden listings limit reached": "הגעת למגבלת המודעות המוסתרות",
+  "vacuum already in progress": "תחזוקת מסד הנתונים כבר רצה",
 };
 
 export function errorToHebrew(error: unknown): string {
@@ -23,7 +43,7 @@ export function errorToHebrew(error: unknown): string {
     if (error.status >= 500) {
       return "שגיאת שרת — נסה שוב מאוחר יותר";
     }
-    return error.message || "שגיאה בלתי צפויה";
+    return "שגיאה בלתי צפויה";
   }
 
   if (

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -276,11 +276,16 @@ export function ListingsPage() {
         <EmptyState
           icon={Car}
           title="אין תוצאות עדיין"
-          description="רכבים חדשים יופיעו כאן כשהם ימצאו"
+          description="רכבים חדשים יופיעו כאן כשהם ימצאו. נסה להרחיב את טווח המחיר או השנים, או להסיר מסננים כמו ק״מ מקסימלי."
           action={
-            <Button asChild variant="secondary" size="sm">
-              <Link to="/dashboard">חזרה ללוח הבקרה</Link>
-            </Button>
+            <div className="flex flex-wrap gap-2 justify-center">
+              <Button asChild variant="secondary" size="sm">
+                <Link to={`/searches/${searchId}/edit`}>ערוך מסננים</Link>
+              </Button>
+              <Button asChild variant="ghost" size="sm">
+                <Link to="/dashboard">חזרה ללוח הבקרה</Link>
+              </Button>
+            </div>
           }
         />
       ) : (


### PR DESCRIPTION
## Summary

- **#71**: Add Hebrew translations for 20+ server error messages (search not found, invalid JSON, listing not found, etc.) so users never see raw English errors. Fallback always returns Hebrew instead of raw `error.message`.
- **#53**: Improve empty search results with actionable suggestion to adjust filters + link to edit search page.
- Updated #1221 epic: **62 of 71 items checked off** (was 55).

Also verified as already fixed: #51 (breadcrumb), #52 (skeletons), #61 (mobile flex-wrap), #70 (English terms are proper nouns).

Ref #1221 items 51, 52, 53, 61, 70, 71

## Test plan

- [x] Code compiles (no TS errors)
- [ ] CI lint + build checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Edit Filters" button to the empty listings state, enabling users to quickly adjust search filters.
  * Expanded error message translations for improved user guidance.

* **Improvements**
  * Enhanced empty listings messaging to guide users on removing or adjusting filters for better search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->