### PR TITLE
feat: sort pills ARIA, sidebar arrow keys, and keyboard shortcuts

### DIFF
--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -21,6 +21,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useHealthCheck } from "@/hooks/useHealthCheck";
 import { useMe } from "@/hooks/useMe";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { ConnectionBanner } from "@/components/ui/ConnectionBanner";
 import { cn } from "@/lib/utils";
 
@@ -179,6 +180,7 @@ export function Shell() {
   const appVersion = useAppVersion();
   const connectionStatus = useHealthCheck();
   const { data: me } = useMe(!!user);
+  useKeyboardShortcuts();
   const isAdmin = me?.is_admin ?? false;
   const emailInitial =
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
@@ -223,7 +225,19 @@ export function Shell() {
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4">
+        <nav
+          className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4"
+          onKeyDown={(e) => {
+            if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+            e.preventDefault();
+            const links = Array.from(
+              e.currentTarget.querySelectorAll<HTMLAnchorElement>("a[href]"),
+            );
+            const idx = links.indexOf(document.activeElement as HTMLAnchorElement);
+            const next = e.key === "ArrowDown" ? idx + 1 : idx - 1;
+            links[((next % links.length) + links.length) % links.length]?.focus();
+          }}
+        >
           <SidebarSection label="ראשי" items={mainNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} isAuthenticated={!!user} />
           <SidebarSection label="ספריה" items={libraryNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} isAuthenticated={!!user} />
           <SidebarSection label="מערכת" items={systemNav} pathname={location.pathname} unread={unread} isAdmin={isAdmin} isAuthenticated={!!user} />

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router";
+
+const SHORTCUT_ROUTES: Record<string, string> = {
+  d: "/dashboard",
+  h: "/history",
+  s: "/settings",
+  n: "/notifications",
+};
+
+export function useKeyboardShortcuts() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      if (e.key === "/" || e.key === "k") {
+        e.preventDefault();
+        navigate("/searches/new");
+        return;
+      }
+
+      if (e.key === "Escape") {
+        const main = document.querySelector("main");
+        if (main) main.scrollTo({ top: 0, behavior: "smooth" });
+        return;
+      }
+
+      const route = SHORTCUT_ROUTES[e.key];
+      if (route && location.pathname !== route) {
+        navigate(route);
+      }
+    }
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [navigate, location.pathname]);
+}

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -214,11 +214,13 @@ export function ListingsPage() {
       {/* Sort pills + refresh */}
       <div className="sticky top-0 z-30 -mx-4 bg-background/90 px-4 py-2 backdrop-blur-lg border-b border-border/30 will-change-transform md:static md:mx-0 md:px-0 md:bg-transparent md:backdrop-blur-none md:border-0 md:will-change-auto">
         <div className="flex items-center gap-2 dir-rtl">
-          <div className="flex flex-nowrap gap-1.5 flex-1 overflow-x-auto scrollbar-hide">
+          <div className="flex flex-nowrap gap-1.5 flex-1 overflow-x-auto scrollbar-hide" role="radiogroup" aria-label="מיון תוצאות">
             {SORT_OPTIONS.map((opt) => (
               <Button
                 key={opt.value}
                 type="button"
+                role="radio"
+                aria-checked={sort === opt.value}
                 size="sm"
                 variant={sort === opt.value ? "primary" : "secondary"}
                 onClick={() => setSort(opt.value)}


### PR DESCRIPTION
## Summary

- **#40**: Sort pills now use `role=radiogroup` + `role=radio` with `aria-checked` for proper screen reader support
- **#44**: Sidebar nav supports ArrowDown/ArrowUp to cycle focus through navigation links
- **#50**: Global keyboard shortcuts: `d` dashboard, `h` history, `s` settings, `n` notifications, `/` or `k` new search, `Esc` scroll to top

Ref #1221 items 40, 44, 50

## Remaining items requiring backend changes or design decisions

- #48: Profile editing (needs backend API for name/avatar)
- #49: Onboarding tour (needs design/product decision)
- #54: Bulk search actions (significant new feature)
- #55: Per-search notification prefs (needs backend schema)
- #56: Price change visual diff (needs previous_price in API)
- #68: WebP/AVIF (N/A — images come from external CDN)

## Test plan

- [x] \`npm run build\` succeeds
- [ ] CI lint + build checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)