### PR TITLE
fix: update error-messages test to expect Hebrew fallback

### DIFF
--- a/web/src/lib/error-messages.test.ts
+++ b/web/src/lib/error-messages.test.ts
@@ -33,9 +33,9 @@ describe("errorToHebrew", () => {
     expect(msg).toContain("שרת");
   });
 
-  it("returns generic ApiError message for other status codes", () => {
+  it("returns Hebrew fallback for unknown ApiError status codes", () => {
     const msg = errorToHebrew(new ApiError(422, "custom error"));
-    expect(msg).toBe("custom error");
+    expect(msg).toContain("שגיאה");
   });
 
   it("returns network error for TypeError with 'failed to fetch'", () => {


### PR DESCRIPTION
## Summary

The `errorToHebrew` change in #1336 always returns Hebrew for unknown errors, but the existing test expected raw English passthrough. Updates the test assertion to match the new behavior.

## Test plan

- [x] Fixes the web build failure from #1336
- [ ] CI test + build

🤖 Generated with [Claude Code](https://claude.com/claude-code)