### PR TITLE
feat: auto-drop stale listings during scheduler cycles

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -636,7 +636,7 @@ func (s *Scheduler) writeCycleLog(ctx context.Context, entry storage.CycleLogEnt
 // search's full filter set (manufacturer, model, year, price, km, etc.).
 // This ensures Yad2 pre-filters results so every page contains relevant
 // listings, giving much better coverage than the unfiltered global feed.
-func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storage.Search, raw []model.RawListing, f fetcher.Fetcher) []model.RawListing {
+func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storage.Search, raw []model.RawListing, f fetcher.Fetcher) ([]model.RawListing, map[string][]string) {
 	// Build the dedup set from existing tokens.
 	seen := make(map[string]struct{}, len(raw))
 	for _, l := range raw {
@@ -646,6 +646,9 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 	// Track which param combinations we've already fetched so searches
 	// with identical filters don't produce redundant API calls.
 	fetchedKeys := make(map[string]struct{})
+	// feedTokensByKey tracks all tokens returned by each successful fetch,
+	// keyed by the param cache key. Used to detect stale listings.
+	feedTokensByKey := make(map[string][]string)
 
 	var fetched, added int
 	for _, sr := range searches {
@@ -655,7 +658,7 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 
 		select {
 		case <-ctx.Done():
-			return raw
+			return raw, feedTokensByKey
 		default:
 		}
 
@@ -672,7 +675,7 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				return raw
+				return raw, feedTokensByKey
 			}
 			delay := 3 * time.Second
 			if errors.Is(err, fetcher.ErrRateLimited) {
@@ -684,14 +687,16 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 				"error", err, "cooldown", delay.String())
 			select {
 			case <-ctx.Done():
-				return raw
+				return raw, feedTokensByKey
 			case <-time.After(delay):
 			}
 			continue
 		}
 		fetched++
 
+		tokens := make([]string, 0, len(targeted))
 		for _, l := range targeted {
+			tokens = append(tokens, l.Token)
 			if _, dup := seen[l.Token]; dup {
 				continue
 			}
@@ -699,11 +704,12 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 			raw = append(raw, l)
 			added++
 		}
+		feedTokensByKey[key] = tokens
 
 		// Pause between targeted fetches to avoid Yad2 rate limiting.
 		select {
 		case <-ctx.Done():
-			return raw
+			return raw, feedTokensByKey
 		case <-time.After(3 * time.Second):
 		}
 	}
@@ -715,7 +721,7 @@ func (s *Scheduler) fetchTargetedListings(ctx context.Context, searches []storag
 			"new_listings_added", added,
 		)
 	}
-	return raw
+	return raw, feedTokensByKey
 }
 
 // fetchAndMatch fetches listings for each active search via targeted
@@ -726,7 +732,7 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 	var stats cycleStats
 
 	fetchStart := time.Now()
-	raw := s.fetchTargetedListings(ctx, searches, nil, s.targetedFetcher)
+	raw, feedTokensByKey := s.fetchTargetedListings(ctx, searches, nil, s.targetedFetcher)
 	fetchDuration := time.Since(fetchStart)
 	stats.listingsFetched = len(raw)
 	s.observer.RecordFetch("yad2", fetchDuration, nil)
@@ -1091,6 +1097,31 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 	// are settled.
 	s.flushPendingPrices(ctx, pendingPrices, persistedTokens, persistFailedTokens)
 
+	// Drop stale listings that no longer appear in the source feed.
+	droppedBySearch := make(map[int64]int64)
+	if s.stores.Listings != nil && len(feedTokensByKey) > 0 {
+		for _, search := range searches {
+			params := model.SourceParamsFromSearch(&search)
+			key := fetcher.CacheKeyFor(params)
+			feedTokens, ok := feedTokensByKey[key]
+			if !ok {
+				continue
+			}
+			dropped, err := s.stores.Listings.DeleteStaleListings(ctx, search.ChatID, search.ID, feedTokens)
+			if err != nil {
+				s.logger.WarnContext(ctx, "failed to drop stale listings",
+					"search_id", search.ID, "chat_id", search.ChatID, "error", err)
+				continue
+			}
+			if dropped > 0 {
+				droppedBySearch[search.ID] = dropped
+				s.logger.InfoContext(ctx, "dropped stale listings",
+					"search_id", search.ID, "search_name", search.Name,
+					"chat_id", search.ChatID, "dropped", dropped)
+			}
+		}
+	}
+
 	// Write per-search cycle stats for dashboard observability.
 	if s.stores.SearchCycleStats != nil && len(searches) > 0 {
 		rejections := s.percolator.CountRejections(raw)
@@ -1165,6 +1196,7 @@ func (s *Scheduler) fetchAndMatch(ctx context.Context, searches []storage.Search
 				EngineCC:    rej[percolator.RejectEngineCC],
 				Seller:      rej[percolator.RejectSeller],
 				OtherFilter: rej[percolator.RejectOtherFilter],
+				Dropped:     int(droppedBySearch[search.ID]),
 				ScoreMin:    scoreMin,
 				ScoreMax:    scoreMax,
 				ScoreAvg:    scoreAvg,

--- a/internal/scheduler/targeted_fetch_test.go
+++ b/internal/scheduler/targeted_fetch_test.go
@@ -59,7 +59,7 @@ func TestFetchTargetedListings_NoPairsNoFetch(t *testing.T) {
 		{ID: 2, Manufacturer: 27, Model: 0},
 	}
 	global := []model.RawListing{{Token: "g1"}}
-	result := s.fetchTargetedListings(context.Background(), searches, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), searches, global, f)
 
 	if len(result) != 1 {
 		t.Errorf("expected 1 listing (unchanged), got %d", len(result))
@@ -91,7 +91,7 @@ func TestFetchTargetedListings_FetchesWithFullParams(t *testing.T) {
 	s := newTestSchedulerWithFetcher(f)
 
 	global := []model.RawListing{{Token: "g1", ManufacturerID: 99, ModelID: 999}}
-	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
 
 	if len(result) != 3 {
 		t.Errorf("expected 3 listings (1 global + 2 targeted), got %d", len(result))
@@ -139,7 +139,7 @@ func TestFetchTargetedListings_AlwaysFetchesRegardlessOfCoverage(t *testing.T) {
 		}
 	}
 
-	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -165,7 +165,7 @@ func TestFetchTargetedListings_DeduplicatesTokens(t *testing.T) {
 	s := newTestSchedulerWithFetcher(f)
 
 	global := []model.RawListing{{Token: "shared", ManufacturerID: 17, ModelID: 10182}}
-	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), []storage.Search{sr}, global, f)
 
 	if len(result) != 2 {
 		t.Errorf("expected 2 listings (1 shared deduped + 1 new), got %d", len(result))
@@ -198,7 +198,7 @@ func TestFetchTargetedListings_FetchErrorContinues(t *testing.T) {
 	s := newTestSchedulerWithFetcher(f)
 
 	global := []model.RawListing{{Token: "g1"}}
-	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
 
 	hasOk1 := false
 	for _, l := range result {
@@ -225,7 +225,7 @@ func TestFetchTargetedListings_IdenticalParamsFetchedOnce(t *testing.T) {
 	s := newTestSchedulerWithFetcher(f)
 
 	global := []model.RawListing{{Token: "g1"}}
-	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -253,7 +253,7 @@ func TestFetchTargetedListings_DifferentFiltersFetchSeparately(t *testing.T) {
 	s := newTestSchedulerWithFetcher(f)
 
 	global := []model.RawListing{{Token: "g1"}}
-	result := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
+	result, _ := s.fetchTargetedListings(context.Background(), []storage.Search{sr1, sr2}, global, f)
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -283,7 +283,7 @@ func TestFetchTargetedListings_ContextCanceled(t *testing.T) {
 	cancel()
 
 	global := []model.RawListing{{Token: "g1"}}
-	result := s.fetchTargetedListings(ctx, []storage.Search{sr1, sr2}, global, f)
+	result, _ := s.fetchTargetedListings(ctx, []storage.Search{sr1, sr2}, global, f)
 
 	if len(result) != len(global) {
 		t.Errorf("expected %d listings (global only), got %d", len(global), len(result))

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -367,6 +367,7 @@ type SearchCycleStats struct {
 	EngineCC    int
 	Seller      int
 	OtherFilter int
+	Dropped     int
 	ScoreMin    *float64
 	ScoreMax    *float64
 	ScoreAvg    *float64

--- a/internal/storage/postgres/search_cycle_stats.go
+++ b/internal/storage/postgres/search_cycle_stats.go
@@ -13,12 +13,12 @@ func (s *Store) UpsertSearchCycleStats(ctx context.Context, stats []storage.Sear
 		return nil
 	}
 
-	const cols = 23
+	const cols = 24
 	var b strings.Builder
 	b.WriteString(`INSERT INTO search_cycle_stats
 		(search_id, chat_id, search_name, cycle_at,
 		 feed_size, matched, new_listings, km_filtered, delivered, price_drops,
-		 wrong_model, year_out, price_out, km_over, hand_over, engine_cc, seller, other_filter,
+		 wrong_model, year_out, price_out, km_over, hand_over, engine_cc, seller, other_filter, dropped,
 		 score_min, score_max, score_avg, price_min, price_max,
 		 updated_at)
 	VALUES `)
@@ -39,7 +39,7 @@ func (s *Store) UpsertSearchCycleStats(ctx context.Context, stats []storage.Sear
 		b.WriteString(",NOW())")
 		args = append(args, st.SearchID, st.ChatID, st.SearchName, st.CycleAt,
 			st.FeedSize, st.Matched, st.NewListings, st.KmFiltered, st.Delivered, st.PriceDrops,
-			st.WrongModel, st.YearOut, st.PriceOut, st.KmOver, st.HandOver, st.EngineCC, st.Seller, st.OtherFilter,
+			st.WrongModel, st.YearOut, st.PriceOut, st.KmOver, st.HandOver, st.EngineCC, st.Seller, st.OtherFilter, st.Dropped,
 			st.ScoreMin, st.ScoreMax, st.ScoreAvg, st.PriceMin, st.PriceMax)
 	}
 
@@ -61,6 +61,7 @@ func (s *Store) UpsertSearchCycleStats(ctx context.Context, stats []storage.Sear
 		engine_cc = EXCLUDED.engine_cc,
 		seller = EXCLUDED.seller,
 		other_filter = EXCLUDED.other_filter,
+		dropped = EXCLUDED.dropped,
 		score_min = EXCLUDED.score_min,
 		score_max = EXCLUDED.score_max,
 		score_avg = EXCLUDED.score_avg,
@@ -79,7 +80,7 @@ func (s *Store) ListSearchCycleStats(ctx context.Context, chatID int64) ([]stora
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT search_id, chat_id, search_name, cycle_at,
 		       feed_size, matched, new_listings, km_filtered, delivered, price_drops,
-		       wrong_model, year_out, price_out, km_over, hand_over, engine_cc, seller, other_filter,
+		       wrong_model, year_out, price_out, km_over, hand_over, engine_cc, seller, other_filter, dropped,
 		       score_min, score_max, score_avg, price_min, price_max
 		FROM search_cycle_stats
 		WHERE chat_id = $1
@@ -94,7 +95,7 @@ func (s *Store) ListSearchCycleStats(ctx context.Context, chatID int64) ([]stora
 		var st storage.SearchCycleStats
 		if err := rows.Scan(&st.SearchID, &st.ChatID, &st.SearchName, &st.CycleAt,
 			&st.FeedSize, &st.Matched, &st.NewListings, &st.KmFiltered, &st.Delivered, &st.PriceDrops,
-			&st.WrongModel, &st.YearOut, &st.PriceOut, &st.KmOver, &st.HandOver, &st.EngineCC, &st.Seller, &st.OtherFilter,
+			&st.WrongModel, &st.YearOut, &st.PriceOut, &st.KmOver, &st.HandOver, &st.EngineCC, &st.Seller, &st.OtherFilter, &st.Dropped,
 			&st.ScoreMin, &st.ScoreMax, &st.ScoreAvg, &st.PriceMin, &st.PriceMax); err != nil {
 			return nil, fmt.Errorf("scan search cycle stats: %w", err)
 		}

--- a/migrations/000023_cycle_stats_dropped.down.sql
+++ b/migrations/000023_cycle_stats_dropped.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE search_cycle_stats DROP COLUMN dropped;

--- a/migrations/000023_cycle_stats_dropped.up.sql
+++ b/migrations/000023_cycle_stats_dropped.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE search_cycle_stats ADD COLUMN dropped INT NOT NULL DEFAULT 0;

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -278,6 +278,9 @@ export function SearchCard({
                 {cycleStats.price_drops > 0 && (
                   <span className="text-score-good">{cycleStats.price_drops} ירידות מחיר</span>
                 )}
+                {cycleStats.dropped > 0 && (
+                  <span className="text-muted-foreground/60">{cycleStats.dropped} הוסרו</span>
+                )}
               </div>
 
               {/* Filter rejection breakdown */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -531,6 +531,7 @@ export interface SearchCycleStatsItem {
   engine_cc: number;
   seller: number;
   other_filter: number;
+  dropped: number;
   score_min: number | null;
   score_max: number | null;
   score_avg: number | null;


### PR DESCRIPTION
## Summary

- Scheduler now calls `DeleteStaleListings` after each fetch cycle, removing listings no longer in the source feed
- Only runs for searches whose fetch succeeded — skips on fetch error to avoid false deletion
- Bookmarked listings are soft-deleted (`removed_at`) not hard-deleted
- New `dropped` column in `search_cycle_stats` tracks how many were removed per cycle
- Frontend SearchCard shows "X הוסרו" in cycle stats breakdown when > 0
- Migration 000023 adds the `dropped` column

closes #1339

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go vet ./internal/scheduler/... ./internal/storage/...` passes
- [x] Targeted fetch tests pass
- [x] Frontend `npm run build` succeeds
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)