### PR TITLE
ci: bump actions to Node 24, add Dependabot, fix web build gate, add timeouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # GitHub Actions — keeps pinned action SHAs current (incl. Node runtime bumps).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        update-types: [minor, patch]
+
+  # Go modules.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    groups:
+      go-deps:
+        update-types: [minor, patch]
+
+  # Frontend npm dependencies.
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+    groups:
+      npm-deps:
+        update-types: [minor, patch]
+
+  # Dockerfile base image.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.user.login == 'Danielsio' || github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,13 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       go: ${{ steps.filter.outputs.go }}
       web: ${{ steps.filter.outputs.web }}
       infra: ${{ steps.filter.outputs.infra }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: filter
         with:
@@ -52,8 +53,9 @@ jobs:
   secrets:
     name: Secret Scanning
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
@@ -63,11 +65,12 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -201,6 +204,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true'
     services:
@@ -218,8 +222,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -255,11 +259,12 @@ jobs:
   web:
     name: Web Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.infra == 'true'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: npm
@@ -283,16 +288,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [changes, lint, test, web]
     if: |
       always() &&
-      (needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true') &&
+      (needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true' || needs.changes.outputs.web == 'true') &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped') &&
       (needs.web.result == 'success' || needs.web.result == 'skipped')
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,11 @@ jobs:
   release:
     name: Version, Build & Push
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -144,11 +145,12 @@ jobs:
   deploy:
     name: Deploy to VM
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: release
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           sparse-checkout: |
             docker-compose.prod.yaml


### PR DESCRIPTION
Implements the high-value, low-risk portion of #1345.

## Changes

**P0 — Node 24 action bumps** (GitHub forces Node 20 actions to Node 24 on **2026-06-16**)
- `actions/checkout` v4 → **v5** (Node 24) — all 3 workflows
- `actions/setup-go` v5 → **v6** (Node 24) — ci.yml
- `actions/setup-node` v4 → **v5** (Node 24) — ci.yml web job

Verified each target declares `using: node24` and that the inputs we use are still supported.
`dorny/paths-filter` (v3) and `golangci-lint-action` (v8) have **no Node 24 release yet**, so
they're intentionally left as-is — Dependabot will bump them when one ships. (golangci-lint-action
v8 is still Node 20 *and* adds a config-schema `verify` step that risks breaking the lint job, so
bumping it now would be all downside.)

**P0 — Dependabot** (`.github/dependabot.yml`)
- Ecosystems: `github-actions`, `gomod`, `npm` (`/web`), `docker`; weekly; minor/patch grouped to
  limit PR noise; conventional-commit prefixes so the release version-bump parser treats them as
  patches. `auto-merge.yml` already whitelists `dependabot[bot]`, so these flow through automatically.

**P1 — web-only PRs now run the Docker `build` job** (`ci.yml`)
- Added `needs.changes.outputs.web == 'true'` to the build condition. Previously a `web/**`-only PR
  skipped the image build (which embeds `web/dist`), so a Dockerfile-breaking web change only
  surfaced post-merge in `release.yml`.

**P2 — per-job `timeout-minutes`** across `ci.yml` (5-20) and `release.yml` (30) so a hung job
can't burn up to 6h of runner minutes.

## Not included (left in #1345)
- #4 CodeRabbit enforcement (needs repo-admin branch protection)
- #6 gitleaks diff-scoping, #7 extract compose checks to a script
- #8 `go test -shuffle=on` (deferred: could surface a test-ordering failure best handled on its own)

## Verification
- All four YAML files parse; no stale action SHAs remain.
- CI on this PR exercises the bumped actions; the deprecation warnings for checkout/setup-go/setup-node should be gone.

Part of #1345

Assisted-By: Claude opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>