### PR TITLE
ci: stop Dependabot auto-merge failures and tame the update flood

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,38 +5,55 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: ci
     groups:
       actions:
         update-types: [minor, patch]
+    # Major action bumps are often breaking; upgrade them deliberately by hand.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Go modules.
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: chore
     groups:
       go-deps:
         update-types: [minor, patch]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Frontend npm dependencies.
   - package-ecosystem: npm
     directory: "/web"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: chore
     groups:
       npm-deps:
         update-types: [minor, patch]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
-  # Dockerfile base image.
+  # Dockerfile base images.
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: chore
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - run: gh pr merge --auto --squash "$PR_URL"
+      - name: Enable auto-merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          # Workflows triggered by Dependabot run with a restricted token and
+          # cannot read regular Actions secrets, so PAT_TOKEN is empty for them.
+          # Degrade gracefully instead of failing the check. To enable
+          # auto-merge for Dependabot PRs, add PAT_TOKEN as a *Dependabot* secret
+          # (Settings -> Secrets and variables -> Dependabot).
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::notice::PAT_TOKEN unavailable to this run (expected for Dependabot); skipping auto-merge enablement."
+            exit 0
+          fi
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What's going on

Enabling Dependabot (#1346) opened a first wave of 14 PRs on long-stale deps. The red X's are mostly **not** real build failures:

- **`auto-merge` job failed on every Dependabot PR.** Workflows triggered by Dependabot run with a restricted token and **cannot read regular Actions secrets**, so `secrets.PAT_TOKEN` was empty and `gh pr merge` exited 4 (`set the GH_TOKEN environment variable`). Pre-existing limitation in `auto-merge.yml`, exposed now.
- Only **2 are genuine failures** — TypeScript 5→6 (#1357) and ESLint 9→10 (#1359) break `Web Build` (breaking majors). The rest pass Build/Lint/Test/Web.

## Fix

1. **auto-merge.yml** — the enable-auto-merge step now **degrades gracefully** (exits 0 with a `::notice::`) when `PAT_TOKEN` is empty, so Dependabot PRs no longer show a red `auto-merge`. Human PRs (which *can* read the secret) still auto-merge as before.
2. **dependabot.yml** — **ignore semver-major** updates (upgrade those deliberately by hand) and **`open-pull-requests-limit: 5`** per ecosystem. Grouped minor/patch updates are unaffected.

## Follow-up for the maintainer
To make Dependabot PRs **actually auto-merge** (not just stop failing), add the PAT as a *Dependabot* secret:
```
gh secret set PAT_TOKEN --app dependabot --repo Danielsio/carwatch
```
I'll close the breaking/major Dependabot PRs separately; the grouped minor/patch ones (go-deps #1355, npm-deps #1356) have green CI and can be merged.

Part of #1345

Assisted-By: Claude opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>