### PR TITLE
fix: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.sh text eol=lf
+*.sql text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+Makefile text eol=lf
+Dockerfile text eol=lf


### PR DESCRIPTION
## Summary

Adds `.gitattributes` to enforce LF line endings for shell scripts, SQL migrations, YAML, Makefile, and Dockerfile. Prevents CRLF from being committed by Windows editors — these files run on the Linux deploy host.

closes #1362

## Test plan

- [x] No files needed renormalization (already LF)
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)