### PR TITLE
ci: enable test shuffle to catch ordering dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run: build
 test:
 	@mkdir -p $(COVER_DIR)
 	go build ./...
-	go test -count=1 -coverprofile=$(COVER_PROFILE) -covermode=atomic $(TEST_PKGS)
+	go test -count=1 -shuffle=on -coverprofile=$(COVER_PROFILE) -covermode=atomic $(TEST_PKGS)
 	@echo ""
 	@echo "=== Coverage Summary ==="
 	@go tool cover -func=$(COVER_PROFILE) | tail -1


### PR DESCRIPTION
## Summary

Adds `-shuffle=on` to `go test` in the Makefile so tests run in random order, surfacing hidden inter-test dependencies.

Ref #1345 (item 8)

## Test plan

- [ ] CI tests pass with shuffle enabled (if an ordering dependency exists, it will surface here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)