### PR TITLE
feat(web): signature UI — aurora backdrop, spotlight cards, ⌘K command palette

### DIFF
--- a/web/src/components/AppCommandPalette.tsx
+++ b/web/src/components/AppCommandPalette.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import {
+  LayoutDashboard,
+  Plus,
+  Bookmark,
+  History,
+  Bell,
+  Settings,
+  Wrench,
+  Car,
+  Sun,
+  Moon,
+  LogOut,
+} from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useTheme } from "@/contexts/ThemeContext";
+import { useMe } from "@/hooks/useMe";
+import { useSearches } from "@/hooks/useSearches";
+import { CommandPalette, type CommandItem } from "@/components/CommandPalette";
+
+/**
+ * App-level wiring for the command palette: builds the command list from the
+ * router, theme, auth and saved searches, and owns open state + the global
+ * ⌘K / Ctrl+K / "/" hotkey. Mounted once inside the authenticated Shell.
+ */
+export function AppCommandPalette() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const { theme, toggle } = useTheme();
+  const { user, signOut } = useAuth();
+  const { data: me } = useMe(!!user);
+  const { data: searches } = useSearches(!!user);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((o) => !o);
+        return;
+      }
+      if (e.key === "/" && !open) {
+        const target = e.target as HTMLElement | null;
+        const tag = target?.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        if (target?.isContentEditable) return;
+        e.preventDefault();
+        setOpen(true);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const NAV = "ניווט";
+    const go = (
+      path: string,
+      label: string,
+      icon: CommandItem["icon"],
+      hint?: string,
+    ): CommandItem => ({
+      id: `nav:${path}`,
+      group: NAV,
+      label,
+      icon,
+      hint,
+      keywords: path,
+      perform: () => navigate(path),
+    });
+
+    const list: CommandItem[] = [
+      go("/dashboard", "לוח בקרה", LayoutDashboard, "D"),
+      go("/searches/new", "חיפוש חדש", Plus),
+      go("/saved", "מועדפים", Bookmark),
+      go("/history", "היסטוריה", History, "H"),
+      go("/notifications", "התראות", Bell, "N"),
+      go("/settings", "הגדרות", Settings, "S"),
+    ];
+
+    if (me?.is_admin) list.push(go("/admin", "ניהול", Wrench));
+
+    list.push({
+      id: "action:theme",
+      group: "פעולות",
+      label: theme === "dark" ? "מצב בהיר" : "מצב כהה",
+      icon: theme === "dark" ? Sun : Moon,
+      keywords: "theme dark light מצב כהה בהיר ערכת נושא",
+      perform: toggle,
+    });
+
+    if (user) {
+      list.push({
+        id: "action:signout",
+        group: "פעולות",
+        label: "התנתק",
+        icon: LogOut,
+        keywords: "logout sign out יציאה",
+        perform: () => {
+          void signOut();
+        },
+      });
+    }
+
+    (searches ?? []).forEach((s) => {
+      list.push({
+        id: `search:${s.id}`,
+        group: "החיפושים שלי",
+        label: s.name,
+        icon: Car,
+        keywords: `${s.manufacturer_name} ${s.model_name} listings search`,
+        perform: () => navigate(`/searches/${s.id}/listings`),
+      });
+    });
+
+    return list;
+  }, [navigate, me, theme, toggle, user, signOut, searches]);
+
+  return <CommandPalette open={open} onClose={close} commands={commands} />;
+}

--- a/web/src/components/CommandPalette.test.tsx
+++ b/web/src/components/CommandPalette.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LayoutDashboard, Bookmark, Car } from "lucide-react";
+import { CommandPalette, type CommandItem } from "./CommandPalette";
+
+function makeCommands(): { commands: CommandItem[]; spies: ReturnType<typeof vi.fn>[] } {
+  const spies = [vi.fn(), vi.fn(), vi.fn()];
+  const commands: CommandItem[] = [
+    { id: "a", label: "לוח בקרה", group: "ניווט", icon: LayoutDashboard, perform: spies[0] },
+    { id: "b", label: "מועדפים", group: "ניווט", icon: Bookmark, perform: spies[1] },
+    { id: "c", label: "מאזדה 3", group: "החיפושים שלי", icon: Car, keywords: "mazda", perform: spies[2] },
+  ];
+  return { commands, spies };
+}
+
+describe("CommandPalette", () => {
+  it("renders nothing when closed", () => {
+    const { commands } = makeCommands();
+    render(<CommandPalette open={false} onClose={() => {}} commands={commands} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders a modal dialog with all commands when open", () => {
+    const { commands } = makeCommands();
+    render(<CommandPalette open onClose={() => {}} commands={commands} />);
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("filters commands by query (label and keywords)", () => {
+    const { commands } = makeCommands();
+    render(<CommandPalette open onClose={() => {}} commands={commands} />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "mazda" } });
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("מאזדה 3");
+  });
+
+  it("shows an empty message when nothing matches", () => {
+    const { commands } = makeCommands();
+    render(<CommandPalette open onClose={() => {}} commands={commands} />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "zzzzz" } });
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    expect(screen.getByText("לא נמצאו תוצאות")).toBeInTheDocument();
+  });
+
+  it("moves the highlight with ArrowDown", () => {
+    const { commands } = makeCommands();
+    render(<CommandPalette open onClose={() => {}} commands={commands} />);
+    const input = screen.getByRole("combobox");
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getAllByRole("option")[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("runs the active command and closes on Enter", () => {
+    const { commands, spies } = makeCommands();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} commands={commands} />);
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(spies[1]).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs a command on click", () => {
+    const { commands, spies } = makeCommands();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} commands={commands} />);
+    fireEvent.click(screen.getByText("מאזדה 3"));
+    expect(spies[2]).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const { commands } = makeCommands();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} commands={commands} />);
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when the backdrop is clicked", () => {
+    const { commands } = makeCommands();
+    const onClose = vi.fn();
+    const { container } = render(
+      <CommandPalette open onClose={onClose} commands={commands} />,
+    );
+    const backdrop = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,262 @@
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Search } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type CommandItem = {
+  /** Stable unique id. */
+  id: string;
+  /** Visible label. */
+  label: string;
+  /** Group heading the item is filed under. */
+  group: string;
+  icon: LucideIcon;
+  /** Optional trailing hint (e.g. a single-key shortcut). */
+  hint?: string;
+  /** Extra text matched against the query but not displayed. */
+  keywords?: string;
+  /** Invoked when the item is chosen. */
+  perform: () => void;
+};
+
+export type CommandPaletteProps = {
+  open: boolean;
+  onClose: () => void;
+  commands: CommandItem[];
+};
+
+/**
+ * Presentational, fully-controlled command palette. Knows nothing about the
+ * router or app contexts — every item carries its own `perform` callback — so
+ * it can be unit-tested in isolation. The container (`AppCommandPalette`)
+ * supplies commands and owns open/close + the global hotkey.
+ */
+export function CommandPalette({ open, onClose, commands }: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return commands;
+    return commands.filter((c) =>
+      `${c.label} ${c.keywords ?? ""} ${c.group}`.toLowerCase().includes(q),
+    );
+  }, [query, commands]);
+
+  // Reset query + highlight on open; restore focus to the trigger on close.
+  useEffect(() => {
+    if (open) {
+      restoreFocusRef.current = document.activeElement as HTMLElement | null;
+      setQuery("");
+      setActive(0);
+      const raf = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(raf);
+    }
+    restoreFocusRef.current?.focus?.();
+  }, [open]);
+
+  // Keep the highlight in range as the query narrows results.
+  useEffect(() => {
+    setActive(0);
+  }, [query]);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Keep the active option scrolled into view.
+  useEffect(() => {
+    if (!open) return;
+    const el = listRef.current?.querySelector(`[data-idx="${active}"]`);
+    el?.scrollIntoView?.({ block: "nearest" });
+  }, [active, open]);
+
+  const run = useCallback(
+    (cmd?: CommandItem) => {
+      if (!cmd) return;
+      onClose();
+      cmd.perform();
+    },
+    [onClose],
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((a) => (filtered.length ? (a + 1) % filtered.length : 0));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((a) =>
+        filtered.length ? (a - 1 + filtered.length) % filtered.length : 0,
+      );
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      run(filtered[active]);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === "Tab") {
+      // Trap focus on the input — the list is keyboard-driven.
+      e.preventDefault();
+    }
+  };
+
+  if (!open) return null;
+
+  // Group while preserving the commands' original order.
+  const groups: { name: string; items: { cmd: CommandItem; index: number }[] }[] =
+    [];
+  filtered.forEach((cmd, index) => {
+    let g = groups.find((x) => x.name === cmd.group);
+    if (!g) {
+      g = { name: cmd.group, items: [] };
+      groups.push(g);
+    }
+    g.items.push({ cmd, index });
+  });
+
+  return (
+    <div className="fixed inset-0 z-[200]" role="presentation">
+      <div
+        className="absolute inset-0 animate-fade-in bg-background/70 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="לוח פקודות"
+        dir="rtl"
+        className="glass-card glow-border absolute inset-x-0 top-[10vh] mx-auto w-[92vw] max-w-xl animate-scale-in overflow-hidden rounded-2xl shadow-2xl"
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-3 border-b border-border/50 px-4">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            role="combobox"
+            aria-expanded
+            aria-controls="cmdk-list"
+            aria-activedescendant={
+              filtered[active] ? `cmdk-opt-${active}` : undefined
+            }
+            aria-label="חיפוש פקודה"
+            placeholder="חפש פקודה, חיפוש שמור, או נווט…"
+            className="flex-1 bg-transparent py-4 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          />
+          <kbd className="hidden rounded border border-border/60 bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline">
+            ESC
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <ul
+          id="cmdk-list"
+          ref={listRef}
+          role="listbox"
+          aria-label="פקודות זמינות"
+          className="max-h-[55vh] overflow-y-auto p-2"
+        >
+          {filtered.length === 0 ? (
+            <li
+              role="presentation"
+              className="px-3 py-10 text-center text-sm text-muted-foreground"
+            >
+              לא נמצאו תוצאות
+            </li>
+          ) : (
+            groups.map((group) => (
+              <Fragment key={group.name}>
+                <li
+                  role="presentation"
+                  className="px-3 pt-3 pb-1 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase"
+                >
+                  {group.name}
+                </li>
+                {group.items.map(({ cmd, index }) => {
+                  const Icon = cmd.icon;
+                  const selected = index === active;
+                  return (
+                    <li
+                      key={cmd.id}
+                      id={`cmdk-opt-${index}`}
+                      data-idx={index}
+                      role="option"
+                      aria-selected={selected}
+                      onMouseMove={() => setActive(index)}
+                      onClick={() => run(cmd)}
+                      className={cn(
+                        "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors",
+                        selected
+                          ? "bg-primary/12 text-foreground"
+                          : "text-muted-foreground",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors",
+                          selected
+                            ? "bg-primary/15 text-primary"
+                            : "bg-secondary text-muted-foreground",
+                        )}
+                      >
+                        <Icon className="h-4 w-4" aria-hidden />
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-foreground">
+                        {cmd.label}
+                      </span>
+                      {cmd.hint ? (
+                        <kbd className="shrink-0 rounded border border-border/60 bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          {cmd.hint}
+                        </kbd>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </Fragment>
+            ))
+          )}
+        </ul>
+
+        {/* Footer hints */}
+        <div className="flex items-center gap-4 border-t border-border/50 px-4 py-2 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <Kbd>↑</Kbd>
+            <Kbd>↓</Kbd>
+            ניווט
+          </span>
+          <span className="flex items-center gap-1">
+            <Kbd>↵</Kbd>
+            בחירה
+          </span>
+          <span className="ms-auto flex items-center gap-1">
+            <Kbd>⌘</Kbd>
+            <Kbd>K</Kbd>
+            פתיחה
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex min-w-4 items-center justify-center rounded border border-border/60 bg-secondary px-1 py-0.5 text-[10px] font-medium text-muted-foreground">
+      {children}
+    </kbd>
+  );
+}

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -19,16 +19,16 @@ function dealInfo(listing: Listing): {
     return {
       label: `${mc.diffPercent}%−`,
       icon: TrendingDown,
-      badgeClass: "bg-emerald-500 text-white",
-      priceClass: "text-emerald-500",
+      badgeClass: "bg-deal-good text-white",
+      priceClass: "text-deal-good",
     };
   }
   if (mc.diffPercent > 5) {
     return {
       label: `${mc.diffPercent}%−`,
       icon: TrendingDown,
-      badgeClass: "bg-emerald-500/80 text-white",
-      priceClass: "text-emerald-500",
+      badgeClass: "bg-deal-good/80 text-white",
+      priceClass: "text-deal-good",
     };
   }
   if (mc.diffPercent >= -5) {
@@ -43,8 +43,8 @@ function dealInfo(listing: Listing): {
   return {
     label: `+${-mc.diffPercent}%`,
     icon: TrendingUp,
-    badgeClass: "bg-red-500/90 text-white",
-    priceClass: "text-red-400",
+    badgeClass: "bg-deal-bad/90 text-white",
+    priceClass: "text-deal-bad",
   };
 }
 
@@ -123,7 +123,7 @@ export function ListingCardBody({
               </span>
             ) : null}
             {listing.suspicious_reasons && listing.suspicious_reasons.length > 0 ? (
-              <span className="flex items-center gap-1 rounded-full bg-amber-500/90 px-2 py-0.5 text-[11px] font-bold text-white shadow-sm">
+              <span className="flex items-center gap-1 rounded-full bg-warning/90 px-2 py-0.5 text-[11px] font-bold text-white shadow-sm">
                 <AlertTriangle className="h-3 w-3" />
                 חשוד
               </span>
@@ -157,12 +157,12 @@ export function ListingCardBody({
                   {listing.manufacturer} {listing.model}
                 </h3>
                 {freshness === "hot" ? (
-                  <span className="shrink-0 flex items-center gap-0.5 rounded-full bg-gradient-to-r from-orange-500 to-red-500 px-2 py-0.5 text-[9px] font-bold text-white shadow-sm animate-pulse">
+                  <span className="shrink-0 flex items-center gap-0.5 rounded-full bg-gradient-to-r from-fresh-hot to-deal-bad px-2 py-0.5 text-[9px] font-bold text-white shadow-sm animate-pulse">
                     <Flame className="h-2.5 w-2.5" />
                     חם!
                   </span>
                 ) : freshness === "today" ? (
-                  <span className="shrink-0 flex items-center gap-0.5 rounded-full bg-emerald-500 px-2 py-0.5 text-[9px] font-bold text-white shadow-sm">
+                  <span className="shrink-0 flex items-center gap-0.5 rounded-full bg-fresh-today px-2 py-0.5 text-[9px] font-bold text-white shadow-sm">
                     <Clock className="h-2.5 w-2.5" />
                     חדש היום
                   </span>
@@ -187,9 +187,9 @@ export function ListingCardBody({
 
         {/* Freshness glow ring */}
         {freshness === "hot" ? (
-          <div className="pointer-events-none absolute inset-0 rounded-t-[inherit] ring-2 ring-inset ring-orange-500/60 shadow-[inset_0_0_24px_rgba(249,115,22,0.25)] animate-pulse" aria-hidden />
+          <div className="pointer-events-none absolute inset-0 rounded-t-[inherit] ring-2 ring-inset ring-fresh-hot/60 shadow-[inset_0_0_24px_rgba(249,115,22,0.25)] animate-pulse" aria-hidden />
         ) : freshness === "today" ? (
-          <div className="pointer-events-none absolute inset-0 rounded-t-[inherit] ring-2 ring-inset ring-emerald-500/50 shadow-[inset_0_0_20px_rgba(16,185,129,0.15)]" aria-hidden />
+          <div className="pointer-events-none absolute inset-0 rounded-t-[inherit] ring-2 ring-inset ring-fresh-today/50 shadow-[inset_0_0_20px_rgba(16,185,129,0.15)]" aria-hidden />
         ) : isNew ? (
           <div className="pointer-events-none absolute inset-0 rounded-t-[inherit] ring-2 ring-inset ring-primary/50 shadow-[inset_0_0_20px_rgba(59,130,246,0.15)]" aria-hidden />
         ) : null}
@@ -212,8 +212,8 @@ export function ListingCardBody({
           ) : null}
           <span className={cn(
             "ms-auto flex items-center gap-1 text-xs font-medium tabular-nums",
-            freshness === "hot" ? "text-orange-500" :
-            freshness === "today" ? "text-emerald-500" :
+            freshness === "hot" ? "text-fresh-hot" :
+            freshness === "today" ? "text-fresh-today" :
             "text-muted-foreground",
           )}>
             {freshness === "hot" ? <Flame className="h-3 w-3" /> :

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -23,6 +23,8 @@ import { useHealthCheck } from "@/hooks/useHealthCheck";
 import { useMe } from "@/hooks/useMe";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { ConnectionBanner } from "@/components/ui/ConnectionBanner";
+import { AuroraBackground } from "@/components/ui/AuroraBackground";
+import { AppCommandPalette } from "@/components/AppCommandPalette";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -186,7 +188,9 @@ export function Shell() {
     user?.email?.trim().charAt(0)?.toLocaleUpperCase("he-IL") || "?";
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen">
+      <AuroraBackground />
+      <AppCommandPalette />
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:right-4 focus:z-[60] focus:rounded-xl focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg"
@@ -198,7 +202,7 @@ export function Shell() {
       {/* ── Desktop Sidebar ── */}
       <aside
         aria-label="ניווט ראשי"
-        className="fixed inset-y-0 right-0 z-40 hidden h-full w-60 flex-col border-l border-sidebar-border bg-sidebar md:flex"
+        className="fixed inset-y-0 right-0 z-40 hidden h-full w-60 flex-col border-l border-sidebar-border bg-sidebar/85 backdrop-blur-xl backdrop-saturate-150 md:flex"
       >
         {/* Brand */}
         <div className="flex items-center gap-3 border-b border-sidebar-border px-4 py-5">

--- a/web/src/components/ui/AuroraBackground.test.tsx
+++ b/web/src/components/ui/AuroraBackground.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { AuroraBackground } from "./AuroraBackground";
+
+describe("AuroraBackground", () => {
+  it("is hidden from assistive tech and non-interactive", () => {
+    const { container } = render(<AuroraBackground />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute("aria-hidden");
+    expect(root.className).toContain("pointer-events-none");
+    expect(root.className).toContain("-z-10");
+  });
+
+  it("defaults to the app variant", () => {
+    const { container } = render(<AuroraBackground />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute("data-variant", "app");
+  });
+
+  it("renders the bolder hero variant when requested", () => {
+    const { container } = render(<AuroraBackground variant="hero" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute("data-variant", "hero");
+  });
+
+  it("renders three animated aurora blobs", () => {
+    const { container } = render(<AuroraBackground />);
+    expect(container.querySelectorAll(".aurora-blob")).toHaveLength(3);
+  });
+
+  it("merges a custom className", () => {
+    const { container } = render(<AuroraBackground className="opacity-0" />);
+    expect(container.firstChild).toHaveClass("opacity-0");
+  });
+});

--- a/web/src/components/ui/AuroraBackground.tsx
+++ b/web/src/components/ui/AuroraBackground.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils";
+
+export type AuroraBackgroundProps = {
+  /** "app" = subtle ambient wash, "hero" = bolder landing/auth treatment. */
+  variant?: "app" | "hero";
+  className?: string;
+};
+
+/**
+ * Fixed, GPU-friendly animated gradient mesh that sits behind all content.
+ * Colors are driven by the `--aurora-*` CSS vars, so it adapts to light/dark
+ * automatically. Motion is frozen via the reduced-motion media query in
+ * index.css. Purely decorative — hidden from assistive tech.
+ */
+export function AuroraBackground({
+  variant = "app",
+  className,
+}: AuroraBackgroundProps) {
+  const hero = variant === "hero";
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none fixed inset-0 -z-10 overflow-hidden",
+        className,
+      )}
+      data-variant={variant}
+    >
+      <div
+        className={cn(
+          "aurora-blob animate-aurora-a",
+          hero ? "opacity-90" : "opacity-60",
+        )}
+        style={{
+          insetInlineStart: "-8%",
+          top: "-12%",
+          width: "56vw",
+          height: "56vw",
+          background:
+            "radial-gradient(circle at center, var(--aurora-1), transparent 70%)",
+        }}
+      />
+      <div
+        className={cn(
+          "aurora-blob animate-aurora-b",
+          hero ? "opacity-90" : "opacity-55",
+        )}
+        style={{
+          insetInlineEnd: "-10%",
+          top: "8%",
+          width: "48vw",
+          height: "48vw",
+          background:
+            "radial-gradient(circle at center, var(--aurora-2), transparent 70%)",
+        }}
+      />
+      <div
+        className={cn(
+          "aurora-blob animate-aurora-c",
+          hero ? "opacity-80" : "opacity-50",
+        )}
+        style={{
+          insetInlineStart: "20%",
+          bottom: "-18%",
+          width: "52vw",
+          height: "52vw",
+          background:
+            "radial-gradient(circle at center, var(--aurora-3), transparent 72%)",
+        }}
+      />
+      {/* Focus vignette — keeps edges calm and content legible */}
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_40%,transparent,var(--color-background)_92%)]" />
+    </div>
+  );
+}

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  it("renders a button with its label", () => {
+    render(<Button>שמור</Button>);
+    expect(screen.getByRole("button", { name: "שמור" })).toBeInTheDocument();
+  });
+
+  it("defaults to type=button", () => {
+    render(<Button>שמור</Button>);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+  });
+
+  describe("loading", () => {
+    it("disables the button and marks it busy", () => {
+      render(<Button loading>שמור</Button>);
+      const btn = screen.getByRole("button");
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute("aria-busy", "true");
+    });
+
+    it("renders a spinner while loading", () => {
+      const { container } = render(<Button loading>שמור</Button>);
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+
+    it("does not fire onClick while loading", () => {
+      const onClick = vi.fn();
+      render(
+        <Button loading onClick={onClick}>
+          שמור
+        </Button>,
+      );
+      fireEvent.click(screen.getByRole("button"));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("is not busy when not loading", () => {
+      render(<Button>שמור</Button>);
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-busy");
+    });
+  });
+
+  it("respects an explicit disabled prop", () => {
+    render(<Button disabled>שמור</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("supports asChild composition", () => {
+    render(
+      <Button asChild>
+        <a href="/x">קישור</a>
+      </Button>,
+    );
+    const link = screen.getByRole("link", { name: "קישור" });
+    expect(link).toHaveAttribute("href", "/x");
+  });
+});

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components -- buttonVariants exported for composition */
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
@@ -31,6 +32,8 @@ const buttonVariants = cva(
 
 type ButtonOwnProps = VariantProps<typeof buttonVariants> & {
   asChild?: boolean;
+  /** Shows a leading spinner, sets aria-busy, and disables the button. */
+  loading?: boolean;
 };
 
 export type ButtonProps<T extends React.ElementType = "button"> =
@@ -53,10 +56,16 @@ function ButtonRender(
     size,
     type,
     children,
+    loading = false,
+    disabled,
     ...rest
-  } = props as ButtonProps<"button"> & { as?: React.ElementType };
+  } = props as ButtonProps<"button"> & {
+    as?: React.ElementType;
+    loading?: boolean;
+  };
 
   const classes = cn(buttonVariants({ variant, size }), className);
+  const isDisabled = disabled || loading;
 
   if (asChild) {
     if (!React.isValidElement(children)) {
@@ -67,6 +76,8 @@ function ButtonRender(
       children as React.ReactElement<Record<string, unknown>>,
       {
         ...rest,
+        ...(disabled != null ? { disabled } : {}),
+        "aria-busy": loading || undefined,
         className: cn(classes, childProps.className),
         ref,
       },
@@ -79,8 +90,13 @@ function ButtonRender(
       ref={ref}
       className={classes}
       type={Comp === "button" ? (type ?? "button") : undefined}
+      disabled={Comp === "button" ? isDisabled : undefined}
+      aria-busy={loading || undefined}
       {...rest}
     >
+      {loading ? (
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+      ) : null}
       {children}
     </Comp>
   );

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -6,6 +6,10 @@ export {
   buttonVariants,
   type ButtonProps,
 } from "./Button";
+export {
+  AuroraBackground,
+  type AuroraBackgroundProps,
+} from "./AuroraBackground";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";
 export { ErrorState, type ErrorStateProps } from "./ErrorState";
 export { FormField, type FormFieldProps } from "./FormField";

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -18,13 +18,10 @@ export function useKeyboardShortcuts() {
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
       if (e.ctrlKey || e.metaKey || e.altKey) return;
 
-      if (e.key === "/" || e.key === "k") {
-        e.preventDefault();
-        navigate("/searches/new");
-        return;
-      }
-
+      // "/" and "⌘K" are owned by the command palette — don't compete.
       if (e.key === "Escape") {
+        // Let an open overlay (command palette, dialog) handle its own Escape.
+        if (document.querySelector('[role="dialog"]')) return;
         const main = document.querySelector("main");
         if (main) main.scrollTo({ top: 0, behavior: "smooth" });
         return;

--- a/web/src/hooks/useSpotlight.test.ts
+++ b/web/src/hooks/useSpotlight.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useSpotlight } from "./useSpotlight";
+
+describe("useSpotlight", () => {
+  it("writes element-relative coordinates to CSS vars on pointer move", () => {
+    const { result } = renderHook(() => useSpotlight());
+
+    const el = document.createElement("div");
+    el.getBoundingClientRect = () =>
+      ({ left: 100, top: 50, width: 200, height: 120 }) as DOMRect;
+
+    result.current.onPointerMove({
+      currentTarget: el,
+      clientX: 150,
+      clientY: 90,
+    } as unknown as React.PointerEvent<HTMLElement>);
+
+    expect(el.style.getPropertyValue("--spot-x")).toBe("50px");
+    expect(el.style.getPropertyValue("--spot-y")).toBe("40px");
+  });
+
+  it("returns a stable handler across renders", () => {
+    const { result, rerender } = renderHook(() => useSpotlight());
+    const first = result.current.onPointerMove;
+    rerender();
+    expect(result.current.onPointerMove).toBe(first);
+  });
+});

--- a/web/src/hooks/useSpotlight.ts
+++ b/web/src/hooks/useSpotlight.ts
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+
+export type SpotlightHandlers = {
+  onPointerMove: (e: React.PointerEvent<HTMLElement>) => void;
+};
+
+/**
+ * Cursor-following spotlight. Pair with the `spotlight` utility class.
+ * Writes `--spot-x` / `--spot-y` straight to the element style on pointer
+ * move, so it never triggers a React re-render. Position is element-relative.
+ */
+export function useSpotlight(): SpotlightHandlers {
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    const el = e.currentTarget;
+    const rect = el.getBoundingClientRect();
+    el.style.setProperty("--spot-x", `${e.clientX - rect.left}px`);
+    el.style.setProperty("--spot-y", `${e.clientY - rect.top}px`);
+  }, []);
+
+  return { onPointerMove };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -74,6 +74,14 @@
   --color-glow-chart-purple: rgba(167, 139, 250, 0.20);
   --color-glow-violet: rgba(139, 92, 246, 0.15);
 
+  /* ─── Deal / Freshness (semantic, theme-aware — no raw palette in components) ─── */
+  --color-deal-good: var(--deal-good);
+  --color-deal-bad: var(--deal-bad);
+  --color-deal-neutral: var(--muted-fg);
+  --color-fresh-hot: var(--fresh-hot);
+  --color-fresh-today: var(--fresh-today);
+  --color-aurora-cyan: #06B6D4;
+
   /* ─── Radius ─── */
   --radius-lg: 0.75rem;
   --radius-md: 0.5rem;
@@ -85,6 +93,11 @@
   --animate-slide-up: slide-up 0.4s cubic-bezier(0, 0, 0.2, 1);
   --animate-pulse-soft: pulse-soft 2.5s ease-in-out infinite;
   --animate-pulse-glow: pulse-glow 2.5s ease-in-out infinite;
+  --animate-aurora-a: aurora-drift 20s ease-in-out infinite;
+  --animate-aurora-b: aurora-drift 28s ease-in-out infinite reverse;
+  --animate-aurora-c: aurora-drift 34s ease-in-out infinite;
+  --animate-text-shimmer: text-shimmer 6s linear infinite;
+  --animate-scale-in: scale-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* ═══ Layout ═══ */
@@ -126,6 +139,17 @@
   --score-great: #047857;
   --score-good: #B45309;
   --score-low: #DC2626;
+
+  --deal-good: #059669;
+  --deal-bad: #DC2626;
+  --fresh-hot: #EA580C;
+  --fresh-today: #059669;
+
+  /* Signature effects */
+  --spot-color: rgba(29, 78, 216, 0.22);
+  --aurora-1: rgba(29, 78, 216, 0.18);
+  --aurora-2: rgba(6, 182, 212, 0.14);
+  --aurora-3: rgba(139, 92, 246, 0.12);
 }
 
 /* ═══ Dark Mode — Deep, immersive, cinematic ═══ */
@@ -162,6 +186,17 @@
   --score-great: #34D399;
   --score-good: #FBBF24;
   --score-low: #F87171;
+
+  --deal-good: #10B981;
+  --deal-bad: #F87171;
+  --fresh-hot: #FB923C;
+  --fresh-today: #34D399;
+
+  /* Signature effects */
+  --spot-color: rgba(99, 165, 255, 0.30);
+  --aurora-1: rgba(59, 130, 246, 0.28);
+  --aurora-2: rgba(6, 182, 212, 0.20);
+  --aurora-3: rgba(139, 92, 246, 0.22);
 }
 
 /* ═══ Keyframes ═══ */
@@ -204,6 +239,37 @@
 @keyframes scroll-dot {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(10px); }
+}
+
+@keyframes aurora-drift {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  33% { transform: translate3d(4%, -5%, 0) scale(1.12); }
+  66% { transform: translate3d(-4%, 3%, 0) scale(1.06); }
+}
+
+@keyframes text-shimmer {
+  to { background-position: 200% center; }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.96) translateY(6px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes shine-sweep {
+  0% { transform: translateX(-130%) skewX(-18deg); }
+  100% { transform: translateX(130%) skewX(-18deg); }
+}
+
+/* Registered angle so the conic glow border can animate smoothly */
+@property --glow-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes glow-rotate {
+  to { --glow-angle: 360deg; }
 }
 
 /* ═══ Utilities ═══ */
@@ -256,6 +322,141 @@
     linear-gradient(color-mix(in oklab, var(--fg) 3%, transparent) 1px, transparent 1px),
     linear-gradient(90deg, color-mix(in oklab, var(--fg) 3%, transparent) 1px, transparent 1px);
   background-size: 36px 36px;
+}
+
+/* ─── Signature: cursor-following spotlight sheen ───
+   Set --spot-x / --spot-y (in px, relative to the element) on pointer move. */
+@utility spotlight {
+  position: relative;
+  isolation: isolate;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(
+      230px circle at var(--spot-x, 50%) var(--spot-y, 0%),
+      var(--spot-color),
+      transparent 65%
+    );
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+    z-index: 3;
+  }
+
+  &:hover::after,
+  &:focus-within::after {
+    opacity: 1;
+  }
+}
+
+/* ─── Signature: animated conic glow border ───
+   A 1px ring of rotating brand-spectrum light. Put on a rounded element. */
+@utility glow-border {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: conic-gradient(
+      from var(--glow-angle),
+      transparent 0deg,
+      var(--color-primary) 70deg,
+      var(--color-aurora-cyan) 140deg,
+      var(--color-violet) 210deg,
+      transparent 320deg
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    animation: glow-rotate 6s linear infinite;
+    pointer-events: none;
+  }
+}
+
+/* ─── Signature: diagonal shine sweep on hover ─── */
+@utility shine {
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 45%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in oklab, #fff 22%, transparent),
+      transparent
+    );
+    transform: translateX(-130%) skewX(-18deg);
+    pointer-events: none;
+    z-index: 4;
+  }
+
+  &:hover::before {
+    animation: shine-sweep 1s ease;
+  }
+}
+
+/* ─── Signature: subtle film grain for depth ─── */
+@utility grain {
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.035;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+  }
+}
+
+/* ─── Signature: animated brand-spectrum gradient text ─── */
+@utility text-aurora {
+  background-image: linear-gradient(
+    115deg,
+    var(--color-primary),
+    var(--color-aurora-cyan),
+    var(--color-violet),
+    var(--color-primary)
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: text-shimmer 6s linear infinite;
+}
+
+/* ─── Signature: aurora mesh blob (used by AuroraBackground) ─── */
+@utility aurora-blob {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(70px);
+  will-change: transform;
+}
+
+/* Respect reduced-motion: freeze ambient signature motion. */
+@media (prefers-reduced-motion: reduce) {
+  .glow-border::before,
+  .text-aurora,
+  .aurora-blob {
+    animation: none !important;
+  }
+  .shine::before {
+    display: none;
+  }
 }
 
 /* ═══ Base ═══ */

--- a/web/src/pages/AuthPage.tsx
+++ b/web/src/pages/AuthPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "firebase/auth";
 import { auth, firebaseAuthErrorCode, googleProvider } from "@/lib/firebase";
 import { useAuth } from "@/contexts/AuthContext";
+import { AuroraBackground } from "@/components/ui/AuroraBackground";
 import { cn } from "@/lib/utils";
 
 function mapLoginError(code: string) {
@@ -165,20 +166,21 @@ export function AuthPage({ defaultTab }: { defaultTab?: "login" | "signup" }) {
   }
 
   return (
-    <div dir="rtl" className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+    <div dir="rtl" className="relative flex min-h-screen items-center justify-center px-4 py-12">
+      <AuroraBackground variant="hero" />
       <div className="w-full max-w-[420px] animate-fade-in">
         {/* Brand */}
         <div className="mb-8 flex flex-col items-center gap-3 text-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-primary/80 text-white shadow-md">
+          <div className="shine flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-primary/80 text-white shadow-[0_8px_28px_-6px_var(--color-glow-primary)]">
             <Car className="h-7 w-7" />
           </div>
-          <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          <h1 className="text-aurora text-2xl font-extrabold tracking-tight">
             CarWatch
           </h1>
         </div>
 
         {/* Card */}
-        <div className="rounded-2xl border border-border/60 bg-card p-6 shadow-sm sm:p-8">
+        <div className="glass-card glow-border relative rounded-2xl p-6 shadow-2xl sm:p-8">
           {/* Tab toggle */}
           <div className="mb-6 flex rounded-lg bg-secondary p-1">
             <button

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -14,6 +14,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useInfiniteListings } from "@/hooks/useInfiniteListings";
 import { useListingActions } from "@/hooks/useListingActions";
+import { useSpotlight } from "@/hooks/useSpotlight";
 import { safeHref, cn, formatPrice } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing, RefreshResponse } from "@/lib/api";
@@ -343,13 +344,15 @@ export function ListingsPage() {
 const ListingCard = memo(function ListingCard({ listing }: { listing: Listing }) {
   const { saved, seen, toggleSaved, toggleSeen } = useListingActions(listing);
   const { toast } = useToast();
+  const spotlight = useSpotlight();
 
   return (
     <Link
       to={`/listings/${listing.token}`}
       state={{ listing }}
       aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
-      className="group block rounded-2xl border border-border/40 bg-card overflow-hidden shadow-sm transition-all duration-300 ease-out hover:border-primary/20 hover:shadow-[0_16px_48px_-12px_var(--color-glow-primary)] hover:-translate-y-1 dir-rtl"
+      {...spotlight}
+      className="spotlight group block rounded-2xl border border-border/40 bg-card overflow-hidden shadow-sm transition-all duration-300 ease-out hover:border-primary/20 hover:shadow-[0_16px_48px_-12px_var(--color-glow-primary)] hover:-translate-y-1 dir-rtl"
     >
       <ListingCardBody
         listing={listing}

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -14,6 +14,7 @@ import {
   useNotifications,
 } from "@/hooks/useNotifications";
 import { useSearchCycleStats } from "@/hooks/useSearchCycleStats";
+import { useSpotlight } from "@/hooks/useSpotlight";
 import { formatPrice, relativeTime, cn } from "@/lib/utils";
 import type { Listing } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
@@ -355,10 +356,12 @@ function StatCard({
   bg: string;
   glow?: string;
 }) {
+  const spotlight = useSpotlight();
   return (
     <div
+      {...spotlight}
       className={cn(
-        "group relative overflow-hidden rounded-2xl border border-border/40 bg-gradient-to-b from-card to-card/80 p-4 sm:p-5 backdrop-blur-sm transition-all duration-300",
+        "spotlight group relative overflow-hidden rounded-2xl border border-border/40 bg-gradient-to-b from-card to-card/80 p-4 sm:p-5 backdrop-blur-sm transition-all duration-300",
         "hover:border-primary/30 hover:shadow-[0_8px_32px_-8px_var(--color-glow-primary)] hover:-translate-y-1 active:scale-[0.98]",
         "dark:from-[#0d1017] dark:to-[#0a0d14] dark:border-white/[0.06]",
         "dark:hover:border-white/[0.12] dark:hover:shadow-[0_8px_40px_-8px_rgba(59,130,246,0.2)]",


### PR DESCRIPTION
## Signature UI transformation

First implementation slice of the frontend transformation audit (#1369). Focus: a **distinctive visual signature** layered onto the existing cinematic brand, plus the highest-leverage premium interaction (a ⌘K command palette) and two engineering wins.

### ✨ Signature styling
- **Aurora backdrop** — a fixed, GPU-friendly animated gradient mesh (`AuroraBackground`) behind the whole app and on the auth screen. Colours are driven by `--aurora-*` CSS vars, so it adapts to light/dark automatically; a focus-vignette keeps content legible.
- **Cursor spotlight** — listing cards and dashboard stat cards now have a sheen that follows the pointer (`useSpotlight` writes `--spot-x/--spot-y` straight to the element — zero React re-renders).
- **Glass + glow chrome** — the desktop sidebar becomes a glass panel over the aurora; the auth card gains an animated **conic glow-border** and the wordmark an animated **aurora-text** gradient.
- **Effect toolkit** in `index.css` — `spotlight`, `glow-border`, `shine`, `grain`, `text-aurora`, `aurora-blob` utilities + keyframes. All ambient motion is frozen under `prefers-reduced-motion`.

### ⌘ Command palette
- Global **⌘K / Ctrl+K / "/"** palette: navigation, theme toggle, sign-out, and jump-to-saved-search.
- Full keyboard model (↑/↓ to move, ↵ to run, Esc to close), `role="dialog"` + `combobox`/`listbox` + `aria-activedescendant`, focus trap, scroll-lock, and focus restore.
- Split into a **pure, fully-tested `CommandPalette` view** + a thin `AppCommandPalette` container that wires router/auth/searches — so the logic is unit-tested without mocking Firebase.
- `useKeyboardShortcuts` cedes `/` and `k` to the palette and no longer hijacks Escape while an overlay is open.

### 🛠 Engineering wins (from the audit)
- **Semantic tokens** — added `--color-deal-good/-bad` and `--color-fresh-hot/-today`; migrated the listing card's raw `emerald/red/amber/orange` classes onto them (fixes the token-leakage finding).
- **`<Button loading>`** — first-class loading state (spinner + `aria-busy` + auto-disable), backward compatible.

### Tests
- New suites: `CommandPalette` (9), `Button` (8), `AuroraBackground` (5), `useSpotlight` (2).
- **264/264 tests pass**, eslint clean (0 errors), `tsc -b` + `vite build` green. Firebase/recharts/motion remain code-split chunks.

### Scope notes
- Pure styling + additive UI. No business logic or API changes.
- Larger audit items (in-page filtering, list virtualization, bulk actions, tabbed Inbox) are intentionally **not** in this PR — tracked in #1369 for follow-ups.

## Review
⏳ `ce:review` agent pass not yet run — should be run before merge per repo policy. CodeRabbit threads will be addressed on this branch.

Part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Command palette with keyboard shortcuts (⌘/Ctrl+K and /)
  * Aurora background and pointer-following spotlight animations
  * Loading state for buttons

* **UI & Styling**
  * Updated deal and freshness color indicators
  * New visual effects: shine, grain, and glow animations
  * Enhanced auth page with glass-card design

* **Tests**
  * Added comprehensive test coverage for new components and features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->