### PR TITLE
feat(web): in-page faceted filtering + render-virtualized listings grid

### DIFF
--- a/web/src/components/ListingsFilterBar.test.tsx
+++ b/web/src/components/ListingsFilterBar.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ListingsFilterBar } from "./ListingsFilterBar";
+import { EMPTY_FILTERS, type ListingFacets } from "@/hooks/useListingFilters";
+
+const facets: ListingFacets = {
+  fuels: ["בנזין", "היברידי"],
+  gearboxes: ["אוטומטית"],
+  priceMax: 200000,
+  yearMin: 2015,
+  yearMax: 2023,
+  kmMax: 150000,
+};
+
+function setup(overrides = {}) {
+  const onChange = vi.fn();
+  const onClear = vi.fn();
+  render(
+    <ListingsFilterBar
+      filters={EMPTY_FILTERS}
+      onChange={onChange}
+      onClear={onClear}
+      facets={facets}
+      resultCount={10}
+      totalCount={42}
+      {...overrides}
+    />,
+  );
+  return { onChange, onClear };
+}
+
+describe("ListingsFilterBar", () => {
+  it("renders quick toggles and derived facet chips", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /מציאות/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /חדשות/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "בנזין" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "היברידי" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "אוטומטית" })).toBeInTheDocument();
+  });
+
+  it("toggles a quick filter", () => {
+    const { onChange } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /מציאות/ }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ dealsOnly: true }),
+    );
+  });
+
+  it("adds a fuel facet to the array", () => {
+    const { onChange } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "היברידי" }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ fuels: ["היברידי"] }),
+    );
+  });
+
+  it("emits text changes", () => {
+    const { onChange } = setup();
+    fireEvent.change(screen.getByRole("searchbox"), {
+      target: { value: "mazda" },
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "mazda" }),
+    );
+  });
+
+  it("reveals range sliders when expanded", () => {
+    setup();
+    expect(screen.queryByLabelText("מחיר מקסימלי")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /טווחים/ }));
+    expect(screen.getByLabelText("מחיר מקסימלי")).toBeInTheDocument();
+    expect(screen.getByLabelText("שנה מינימלית")).toBeInTheDocument();
+    expect(screen.getByLabelText("קילומטראז׳ מקסימלי")).toBeInTheDocument();
+  });
+
+  it("shows count + clear only when filters are active", () => {
+    const { onClear } = setup({ filters: { ...EMPTY_FILTERS, dealsOnly: true } });
+    const clear = screen.getByRole("button", { name: /נקה/ });
+    expect(clear).toBeInTheDocument();
+    expect(screen.getByText(/מתוך/)).toBeInTheDocument();
+    fireEvent.click(clear);
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it("hides count + clear when no filters are active", () => {
+    setup();
+    expect(screen.queryByRole("button", { name: /נקה/ })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ListingsFilterBar.tsx
+++ b/web/src/components/ListingsFilterBar.tsx
@@ -1,0 +1,206 @@
+import { useId, useState } from "react";
+import { Search, SlidersHorizontal, X, Flame, EyeOff, Image as ImageIcon } from "lucide-react";
+import { ChipButton } from "@/components/ui/ChipButton";
+import { RangeSlider } from "@/components/ui/RangeSlider";
+import { formatKm, formatPrice, cn } from "@/lib/utils";
+import {
+  activeFilterCount,
+  type ListingFacets,
+  type ListingFilters,
+} from "@/hooks/useListingFilters";
+
+export type ListingsFilterBarProps = {
+  filters: ListingFilters;
+  onChange: (next: ListingFilters) => void;
+  onClear: () => void;
+  facets: ListingFacets;
+  resultCount: number;
+  totalCount: number;
+};
+
+function toggleInArray(arr: string[], value: string): string[] {
+  return arr.includes(value)
+    ? arr.filter((v) => v !== value)
+    : [...arr, value];
+}
+
+export function ListingsFilterBar({
+  filters,
+  onChange,
+  onClear,
+  facets,
+  resultCount,
+  totalCount,
+}: ListingsFilterBarProps) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const advancedId = useId();
+  const active = activeFilterCount(filters);
+
+  const set = (partial: Partial<ListingFilters>) =>
+    onChange({ ...filters, ...partial });
+
+  const hasPriceRange = facets.priceMax > 0;
+  const hasYearRange = facets.yearMax > facets.yearMin && facets.yearMin > 0;
+  const hasKmRange = facets.kmMax > 0;
+  const hasAdvanced = hasPriceRange || hasYearRange || hasKmRange;
+
+  return (
+    <div
+      role="group"
+      aria-label="סינון תוצאות"
+      className="space-y-3 rounded-2xl border border-border/50 bg-card/70 p-3 backdrop-blur-sm dir-rtl"
+    >
+      {/* Search + advanced toggle + count */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search
+            className="pointer-events-none absolute top-1/2 start-3 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={filters.text}
+            onChange={(e) => set({ text: e.target.value })}
+            placeholder="חפש לפי דגם, עיר, או תיאור…"
+            aria-label="חיפוש חופשי בתוצאות"
+            className="w-full rounded-xl border border-input bg-secondary/60 py-2.5 ps-9 pe-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground/60 focus:border-primary/50 focus:bg-secondary"
+          />
+        </div>
+
+        {hasAdvanced ? (
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((v) => !v)}
+            aria-expanded={advancedOpen}
+            aria-controls={advancedId}
+            className={cn(
+              "flex shrink-0 items-center gap-1.5 rounded-xl border px-3 py-2.5 text-sm font-medium transition-colors",
+              advancedOpen
+                ? "border-primary/40 bg-primary/10 text-primary"
+                : "border-border/50 bg-secondary/60 text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <SlidersHorizontal className="h-4 w-4" aria-hidden />
+            <span className="hidden sm:inline">טווחים</span>
+          </button>
+        ) : null}
+      </div>
+
+      {/* Quick chips */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <ChipButton
+          selected={filters.dealsOnly}
+          onClick={() => set({ dealsOnly: !filters.dealsOnly })}
+        >
+          <span className="flex items-center gap-1">
+            <Flame className="h-3.5 w-3.5" aria-hidden />
+            מציאות
+          </span>
+        </ChipButton>
+        <ChipButton
+          selected={filters.unseenOnly}
+          onClick={() => set({ unseenOnly: !filters.unseenOnly })}
+        >
+          <span className="flex items-center gap-1">
+            <EyeOff className="h-3.5 w-3.5" aria-hidden />
+            חדשות
+          </span>
+        </ChipButton>
+        <ChipButton
+          selected={filters.photoOnly}
+          onClick={() => set({ photoOnly: !filters.photoOnly })}
+        >
+          <span className="flex items-center gap-1">
+            <ImageIcon className="h-3.5 w-3.5" aria-hidden />
+            עם תמונה
+          </span>
+        </ChipButton>
+
+        {facets.fuels.map((fuel) => (
+          <ChipButton
+            key={fuel}
+            selected={filters.fuels.includes(fuel)}
+            onClick={() => set({ fuels: toggleInArray(filters.fuels, fuel) })}
+          >
+            {fuel}
+          </ChipButton>
+        ))}
+        {facets.gearboxes.map((gb) => (
+          <ChipButton
+            key={gb}
+            selected={filters.gearboxes.includes(gb)}
+            onClick={() =>
+              set({ gearboxes: toggleInArray(filters.gearboxes, gb) })
+            }
+          >
+            {gb}
+          </ChipButton>
+        ))}
+      </div>
+
+      {/* Advanced ranges */}
+      {advancedOpen && hasAdvanced ? (
+        <div
+          id={advancedId}
+          className="grid gap-4 rounded-xl bg-secondary/40 p-4 sm:grid-cols-3"
+        >
+          {hasPriceRange ? (
+            <RangeSlider
+              aria-label="מחיר מקסימלי"
+              min={0}
+              max={facets.priceMax}
+              step={1000}
+              value={filters.priceMax ?? facets.priceMax}
+              onChange={(v) =>
+                set({ priceMax: v >= facets.priceMax ? null : v })
+              }
+              formatLabel={(v) => `עד ${formatPrice(v)}`}
+            />
+          ) : null}
+          {hasYearRange ? (
+            <RangeSlider
+              aria-label="שנה מינימלית"
+              min={facets.yearMin}
+              max={facets.yearMax}
+              step={1}
+              value={filters.yearMin ?? facets.yearMin}
+              onChange={(v) =>
+                set({ yearMin: v <= facets.yearMin ? null : v })
+              }
+              formatLabel={(v) => `משנת ${v}`}
+            />
+          ) : null}
+          {hasKmRange ? (
+            <RangeSlider
+              aria-label="קילומטראז׳ מקסימלי"
+              min={0}
+              max={facets.kmMax}
+              step={5000}
+              value={filters.kmMax ?? facets.kmMax}
+              onChange={(v) => set({ kmMax: v >= facets.kmMax ? null : v })}
+              formatLabel={(v) => `עד ${formatKm(v)}`}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Result count + clear */}
+      {active > 0 ? (
+        <div className="flex items-center justify-between gap-2 border-t border-border/40 pt-2.5">
+          <p className="text-xs text-muted-foreground tabular-nums" aria-live="polite">
+            {resultCount.toLocaleString("he-IL")} מתוך{" "}
+            {totalCount.toLocaleString("he-IL")} מודעות
+          </p>
+          <button
+            type="button"
+            onClick={onClear}
+            className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden />
+            נקה ({active})
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/hooks/useListingFilters.test.ts
+++ b/web/src/hooks/useListingFilters.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_FILTERS,
+  filterListings,
+  deriveFacets,
+  activeFilterCount,
+  isDeal,
+  type ListingFilters,
+} from "./useListingFilters";
+import type { Listing } from "@/lib/api";
+
+function listing(over: Partial<Listing> = {}): Listing {
+  return {
+    token: Math.random().toString(36).slice(2),
+    manufacturer: "Toyota",
+    model: "Corolla",
+    year: 2018,
+    price: 80000,
+    km: 60000,
+    hand: 2,
+    city: "תל אביב",
+    page_link: "https://www.yad2.co.il/item/x",
+    first_seen_at: "2026-06-10T00:00:00Z",
+    ...over,
+  };
+}
+
+function f(over: Partial<ListingFilters> = {}): ListingFilters {
+  return { ...EMPTY_FILTERS, ...over };
+}
+
+describe("filterListings", () => {
+  it("returns everything with empty filters", () => {
+    const items = [listing(), listing(), listing()];
+    expect(filterListings(items, EMPTY_FILTERS)).toHaveLength(3);
+  });
+
+  it("matches free text across manufacturer/model/sub_model/city/description", () => {
+    const items = [
+      listing({ manufacturer: "Mazda", model: "3" }),
+      listing({ description: "רכב במצב מצוין" }),
+      listing({ city: "חיפה" }),
+    ];
+    expect(filterListings(items, f({ text: "mazda" }))).toHaveLength(1);
+    expect(filterListings(items, f({ text: "מצוין" }))).toHaveLength(1);
+    expect(filterListings(items, f({ text: "חיפה" }))).toHaveLength(1);
+    expect(filterListings(items, f({ text: "nomatch" }))).toHaveLength(0);
+  });
+
+  it("filters unseen only", () => {
+    const items = [
+      listing({ seen: false }),
+      listing({ seen: true }),
+      listing({ seen: undefined }),
+    ];
+    expect(filterListings(items, f({ unseenOnly: true }))).toHaveLength(1);
+  });
+
+  it("filters photo only", () => {
+    const items = [
+      listing({ image_url: "https://img/1.jpg" }),
+      listing({ image_url: undefined }),
+    ];
+    expect(filterListings(items, f({ photoOnly: true }))).toHaveLength(1);
+  });
+
+  it("filters deals only (>5% under reference)", () => {
+    const items = [
+      listing({ price: 90000, base_price: 100000 }), // 10% under → deal
+      listing({ price: 99000, base_price: 100000 }), // 1% under → not a deal
+      listing({ price: 80000 }), // no reference → not a deal
+    ];
+    expect(filterListings(items, f({ dealsOnly: true }))).toHaveLength(1);
+  });
+
+  it("filters by selected fuels", () => {
+    const items = [
+      listing({ engine_type: "בנזין" }),
+      listing({ engine_type: "היברידי" }),
+      listing({ engine_type: undefined }),
+    ];
+    expect(filterListings(items, f({ fuels: ["היברידי"] }))).toHaveLength(1);
+    expect(
+      filterListings(items, f({ fuels: ["בנזין", "היברידי"] })),
+    ).toHaveLength(2);
+  });
+
+  it("filters by price/year ceilings and floors", () => {
+    const items = [
+      listing({ price: 50000, year: 2015 }),
+      listing({ price: 120000, year: 2022 }),
+    ];
+    expect(filterListings(items, f({ priceMax: 100000 }))).toHaveLength(1);
+    expect(filterListings(items, f({ yearMin: 2020 }))).toHaveLength(1);
+  });
+
+  it("treats unknown km (<=0) as not excluded by kmMax", () => {
+    const items = [
+      listing({ km: 200000 }),
+      listing({ km: 0 }), // unknown — keep
+    ];
+    expect(filterListings(items, f({ kmMax: 100000 }))).toHaveLength(1);
+    expect(
+      filterListings(items, f({ kmMax: 100000 })).some((l) => l.km === 0),
+    ).toBe(true);
+  });
+
+  it("combines multiple filters (AND)", () => {
+    const items = [
+      listing({ price: 70000, seen: false, engine_type: "בנזין" }),
+      listing({ price: 70000, seen: true, engine_type: "בנזין" }),
+      listing({ price: 200000, seen: false, engine_type: "בנזין" }),
+    ];
+    const out = filterListings(
+      items,
+      f({ unseenOnly: true, priceMax: 100000, fuels: ["בנזין"] }),
+    );
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe("deriveFacets", () => {
+  it("collects distinct sorted fuels/gearboxes and numeric bounds", () => {
+    const items = [
+      listing({ engine_type: "בנזין", gear_box: "אוטומטית", price: 50000, km: 30000, year: 2016 }),
+      listing({ engine_type: "דיזל", gear_box: "ידנית", price: 150000, km: 90000, year: 2021 }),
+      listing({ engine_type: "בנזין", gear_box: "אוטומטית", price: 80000, km: 10000, year: 2019 }),
+    ];
+    const facets = deriveFacets(items);
+    expect(facets.fuels).toEqual(["בנזין", "דיזל"]);
+    expect(facets.gearboxes).toEqual(["אוטומטית", "ידנית"]);
+    expect(facets.priceMax).toBe(150000);
+    expect(facets.kmMax).toBe(90000);
+    expect(facets.yearMin).toBe(2016);
+    expect(facets.yearMax).toBe(2021);
+  });
+
+  it("is safe on an empty set", () => {
+    const facets = deriveFacets([]);
+    expect(facets.fuels).toEqual([]);
+    expect(facets.yearMin).toBe(0);
+  });
+});
+
+describe("activeFilterCount", () => {
+  it("counts active facets", () => {
+    expect(activeFilterCount(EMPTY_FILTERS)).toBe(0);
+    expect(
+      activeFilterCount(f({ text: "x", dealsOnly: true, priceMax: 100000 })),
+    ).toBe(3);
+    expect(activeFilterCount(f({ text: "   " }))).toBe(0);
+  });
+});
+
+describe("isDeal", () => {
+  it("is true only when meaningfully under reference", () => {
+    expect(isDeal(listing({ price: 90000, base_price: 100000 }))).toBe(true);
+    expect(isDeal(listing({ price: 99000, base_price: 100000 }))).toBe(false);
+    expect(isDeal(listing({ price: 80000 }))).toBe(false);
+  });
+});

--- a/web/src/hooks/useListingFilters.ts
+++ b/web/src/hooks/useListingFilters.ts
@@ -1,0 +1,136 @@
+import { useMemo } from "react";
+import type { Listing } from "@/lib/api";
+import { marketComparison } from "@/lib/utils";
+
+export type ListingFilters = {
+  /** Free-text match over manufacturer / model / sub-model / city / description. */
+  text: string;
+  /** Only listings priced meaningfully below market (>5% under reference). */
+  dealsOnly: boolean;
+  /** Only listings the user has not yet seen. */
+  unseenOnly: boolean;
+  /** Only listings that have a photo. */
+  photoOnly: boolean;
+  /** Selected fuel types (engine_type); empty = any. */
+  fuels: string[];
+  /** Selected gearboxes (gear_box); empty = any. */
+  gearboxes: string[];
+  /** Inclusive upper bound on price; null = no bound. */
+  priceMax: number | null;
+  /** Inclusive lower bound on year; null = no bound. */
+  yearMin: number | null;
+  /** Inclusive upper bound on km (ignores listings with unknown km); null = no bound. */
+  kmMax: number | null;
+};
+
+export const EMPTY_FILTERS: ListingFilters = {
+  text: "",
+  dealsOnly: false,
+  unseenOnly: false,
+  photoOnly: false,
+  fuels: [],
+  gearboxes: [],
+  priceMax: null,
+  yearMin: null,
+  kmMax: null,
+};
+
+export function isDeal(listing: Listing): boolean {
+  const mc = marketComparison(
+    listing.price,
+    listing.median_price,
+    listing.base_price,
+  );
+  return !!mc && mc.diffPercent > 5;
+}
+
+/** Number of active (non-default) filter facets — drives the "clear" affordance. */
+export function activeFilterCount(f: ListingFilters): number {
+  let n = 0;
+  if (f.text.trim()) n++;
+  if (f.dealsOnly) n++;
+  if (f.unseenOnly) n++;
+  if (f.photoOnly) n++;
+  if (f.fuels.length) n++;
+  if (f.gearboxes.length) n++;
+  if (f.priceMax != null) n++;
+  if (f.yearMin != null) n++;
+  if (f.kmMax != null) n++;
+  return n;
+}
+
+export type ListingFacets = {
+  fuels: string[];
+  gearboxes: string[];
+  /** Whole-shekel max price across the set (for slider bounds). */
+  priceMax: number;
+  yearMin: number;
+  yearMax: number;
+  kmMax: number;
+};
+
+/** Distinct facet values + numeric bounds derived from the loaded set. */
+export function deriveFacets(listings: Listing[]): ListingFacets {
+  const fuels = new Set<string>();
+  const gearboxes = new Set<string>();
+  let priceMax = 0;
+  let kmMax = 0;
+  let yearMin = Number.POSITIVE_INFINITY;
+  let yearMax = 0;
+
+  for (const l of listings) {
+    if (l.engine_type) fuels.add(l.engine_type);
+    if (l.gear_box) gearboxes.add(l.gear_box);
+    if (l.price > priceMax) priceMax = l.price;
+    if (l.km > kmMax) kmMax = l.km;
+    if (l.year > 0 && l.year < yearMin) yearMin = l.year;
+    if (l.year > yearMax) yearMax = l.year;
+  }
+
+  return {
+    fuels: [...fuels].sort(),
+    gearboxes: [...gearboxes].sort(),
+    priceMax,
+    kmMax,
+    yearMin: Number.isFinite(yearMin) ? yearMin : 0,
+    yearMax,
+  };
+}
+
+/** Pure predicate-based filter — exported for direct unit testing. */
+export function filterListings(
+  listings: Listing[],
+  f: ListingFilters,
+): Listing[] {
+  const q = f.text.trim().toLowerCase();
+  return listings.filter((l) => {
+    if (q) {
+      const haystack =
+        `${l.manufacturer} ${l.model} ${l.sub_model ?? ""} ${l.city ?? ""} ${l.description ?? ""}`.toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    if (f.unseenOnly && l.seen !== false) return false;
+    if (f.photoOnly && !l.image_url) return false;
+    if (f.dealsOnly && !isDeal(l)) return false;
+    if (f.fuels.length > 0 && (!l.engine_type || !f.fuels.includes(l.engine_type)))
+      return false;
+    if (
+      f.gearboxes.length > 0 &&
+      (!l.gear_box || !f.gearboxes.includes(l.gear_box))
+    )
+      return false;
+    if (f.priceMax != null && l.price > f.priceMax) return false;
+    if (f.yearMin != null && l.year < f.yearMin) return false;
+    // km <= 0 means "unknown" (still enriching) — don't exclude on an unknown.
+    if (f.kmMax != null && l.km > 0 && l.km > f.kmMax) return false;
+    return true;
+  });
+}
+
+/** Memoized filtering for use in components. */
+export function useListingFilters(
+  listings: Listing[],
+  filters: ListingFilters,
+): Listing[] {
+  return useMemo(() => filterListings(listings, filters), [listings, filters]);
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -447,6 +447,14 @@
   will-change: transform;
 }
 
+/* ─── Perf: skip rendering/layout/paint for off-screen cards ───
+   Browser-native render virtualization for long, variable-height grids.
+   The reserved intrinsic size keeps the scrollbar stable. */
+@utility cv-auto {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 480px;
+}
+
 /* Respect reduced-motion: freeze ambient signature motion. */
 @media (prefers-reduced-motion: reduce) {
   .glow-border::before,

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -9,12 +9,20 @@ import {
   RefreshCw,
   ArrowUp,
   Loader2,
+  FilterX,
 } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useInfiniteListings } from "@/hooks/useInfiniteListings";
 import { useListingActions } from "@/hooks/useListingActions";
 import { useSpotlight } from "@/hooks/useSpotlight";
+import {
+  useListingFilters,
+  deriveFacets,
+  activeFilterCount,
+  EMPTY_FILTERS,
+  type ListingFilters,
+} from "@/hooks/useListingFilters";
+import { ListingsFilterBar } from "@/components/ListingsFilterBar";
 import { safeHref, cn, formatPrice } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing, RefreshResponse } from "@/lib/api";
@@ -175,6 +183,19 @@ export function ListingsPage() {
   );
   const total = data?.pages[0]?.total ?? 0;
 
+  const [filters, setFilters] = useState<ListingFilters>(EMPTY_FILTERS);
+  const facets = useMemo(() => deriveFacets(allListings), [allListings]);
+  const visible = useListingFilters(allListings, filters);
+  const hasFilters = activeFilterCount(filters) > 0;
+
+  const unenrichedCount = useMemo(
+    () =>
+      allListings.filter(
+        (l) => l.km <= 0 || !l.horse_power || !l.gear_box || !l.engine_type,
+      ).length,
+    [allListings],
+  );
+
   if (!searchId || Number.isNaN(searchId)) {
     return (
       <PageShell gap="sm">
@@ -234,9 +255,21 @@ export function ListingsPage() {
         </div>
       </div>
 
+      {/* Filter bar */}
+      {!showSkeletons && allListings.length > 0 ? (
+        <ListingsFilterBar
+          filters={filters}
+          onChange={setFilters}
+          onClear={() => setFilters(EMPTY_FILTERS)}
+          facets={facets}
+          resultCount={visible.length}
+          totalCount={allListings.length}
+        />
+      ) : null}
+
       {/* Enrichment progress banner */}
       {!showSkeletons && allListings.length > 0 && (() => {
-        const unenriched = allListings.filter(l => l.km <= 0 || !l.horse_power || !l.gear_box || !l.engine_type).length;
+        const unenriched = unenrichedCount;
         if (unenriched === 0) return null;
         const pct = Math.round(((allListings.length - unenriched) / allListings.length) * 100);
         return (
@@ -265,14 +298,13 @@ export function ListingsPage() {
       {showSkeletons ? (
         <div className="grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
-            <motion.div
+            <div
               key={`skel-${i}`}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: i * 0.06, duration: 0.4, ease: "easeOut" }}
+              className="animate-slide-up motion-reduce:animate-none"
+              style={{ animationDelay: `${i * 60}ms`, animationFillMode: "backwards" }}
             >
               <ListingCardSkeleton />
-            </motion.div>
+            </div>
           ))}
         </div>
       ) : allListings.length === 0 ? (
@@ -291,31 +323,35 @@ export function ListingsPage() {
             </div>
           }
         />
+      ) : visible.length === 0 ? (
+        <EmptyState
+          icon={FilterX}
+          title="אין תוצאות לסינון"
+          description="אף מודעה לא תואמת את הסינון הנוכחי. נסה להרחיב או לאפס את המסננים."
+          action={
+            <Button variant="secondary" size="sm" onClick={() => setFilters(EMPTY_FILTERS)}>
+              נקה מסננים
+            </Button>
+          }
+        />
       ) : (
         <>
           <div className="grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            <AnimatePresence mode="popLayout">
-              {allListings.map((listing, i) => (
-                <motion.div
-                  key={listing.token}
-                  layout
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  transition={{
-                    delay: Math.min(i, 6) * 0.04,
-                    duration: 0.3,
-                    ease: "easeOut",
-                    layout: { duration: 0.25 },
-                  }}
-                >
-                  <ListingCard listing={listing} />
-                </motion.div>
-              ))}
-            </AnimatePresence>
+            {visible.map((listing, i) => (
+              <div
+                key={listing.token}
+                className="cv-auto animate-slide-up motion-reduce:animate-none"
+                style={{
+                  animationDelay: `${Math.min(i, 8) * 40}ms`,
+                  animationFillMode: "backwards",
+                }}
+              >
+                <ListingCard listing={listing} />
+              </div>
+            ))}
           </div>
 
-          {/* Infinite scroll trigger */}
+          {/* Infinite scroll trigger — keeps loading more raw results to filter */}
           <div ref={loadMoreRef} className="flex justify-center py-6">
             {isFetchingNextPage ? (
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -327,11 +363,13 @@ export function ListingsPage() {
               >
                 טען עוד
               </button>
-            ) : allListings.length > 0 ? (
+            ) : (
               <p className="text-xs text-muted-foreground">
-                הצגת כל {total.toLocaleString("he-IL")} המודעות
+                {hasFilters
+                  ? `${visible.length.toLocaleString("he-IL")} תוצאות מסוננות`
+                  : `הצגת כל ${total.toLocaleString("he-IL")} המודעות`}
               </p>
-            ) : null}
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Filterable, render-virtualized listings grid

Second slice of the frontend transformation (#1369). Tackles the audit's **#1 UX hole** — "you built a beautiful car-browsing app where you can't filter the cars" — plus the listing-grid **perf liability**.

### 🔎 In-page faceted filtering
The listings screen can now refine the loaded set without leaving to edit the saved search (which mutated the search + re-triggered scraping):
- **Free-text search** over manufacturer / model / sub-model / city / description.
- **Quick toggles**: deals-only (>5% under market), unseen-only, has-photo.
- **Facet chips** for fuel type and gearbox, derived from the actual loaded data.
- **Range sliders** for max price, min year, and max km (collapsible "טווחים" panel).
- Active-filter count, live result count ("X of Y"), and one-tap clear.
- Dedicated empty state when filters exclude everything.

Filtering logic is a **pure, fully-tested** `filterListings` / `deriveFacets` / `activeFilterCount` module (`useListingFilters`); the bar is a controlled `ListingsFilterBar` reusing `ChipButton` + `RangeSlider`.

### ⚡ Perf: render virtualization
- Replaced the per-card **Framer Motion `layout` + `AnimatePresence`** (which recomputed layout for every card and janked as the infinite-scroll list grew / filtered) with a lightweight CSS stagger.
- Added a `cv-auto` **`content-visibility: auto`** utility on each card so off-screen cards skip layout/paint — browser-native render virtualization with a stable scrollbar (`contain-intrinsic-size`), no new dependency, and no grid-windowing complexity for variable-height cards.

### Notes / scope
- Filtering operates on the **loaded** set (client-side); infinite scroll keeps pulling more rows to filter. Server-side filter push-down is a sensible later step.
- No API/business-logic changes. Sort remains server-driven.

### Tests
New: `useListingFilters` (17) + `ListingsFilterBar` (7). **284/284 web tests pass**, eslint clean (0 errors), `tsc -b` + `vite build` green.

## Review
⏳ `ce:review` agent pass not run here; CodeRabbit threads (if any) will be addressed on this branch. Web-only PR — Go `Lint`/`Test` checks skip by design (paths-filter), so merge needs admin like #1370 until branch-protection contexts are made conditional.

Part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
