### PR TITLE
feat(web): accessible ConfirmDialog primitive; replace window.confirm

### DIFF
--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Outlet, Link, useLocation } from "react-router";
 import {
   LayoutDashboard,
@@ -25,6 +26,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { ConnectionBanner } from "@/components/ui/ConnectionBanner";
 import { AuroraBackground } from "@/components/ui/AuroraBackground";
 import { AppCommandPalette } from "@/components/AppCommandPalette";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -176,6 +178,7 @@ function SidebarSection({
 export function Shell() {
   const location = useLocation();
   const { user, signOut } = useAuth();
+  const [signOutOpen, setSignOutOpen] = useState(false);
   const { data: notifCount } = useNotificationCount(!!user);
   const unread = notifCount?.count ?? 0;
   const { theme, toggle: toggleTheme } = useTheme();
@@ -191,6 +194,18 @@ export function Shell() {
     <div className="min-h-screen">
       <AuroraBackground />
       <AppCommandPalette />
+      <ConfirmDialog
+        open={signOutOpen}
+        title="האם לצאת מהחשבון?"
+        description="תוכל להתחבר מחדש בכל עת."
+        confirmLabel="התנתק"
+        variant="destructive"
+        onConfirm={() => {
+          setSignOutOpen(false);
+          void signOut();
+        }}
+        onCancel={() => setSignOutOpen(false)}
+      />
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:right-4 focus:z-[60] focus:rounded-xl focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg"
@@ -294,9 +309,7 @@ export function Shell() {
           {user ? (
             <button
               type="button"
-              onClick={() => {
-                if (window.confirm("האם לצאת מהחשבון?")) void signOut();
-              }}
+              onClick={() => setSignOutOpen(true)}
               className="flex w-full items-center justify-center gap-2 rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-2 text-sm font-medium text-sidebar-foreground transition-all duration-150 hover:bg-sidebar-accent-hover hover:text-foreground dark:hover:text-white active:scale-[0.99] motion-reduce:active:scale-100"
             >
               <LogOut className="h-3.5 w-3.5" aria-hidden />

--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+function setup(props = {}) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <ConfirmDialog
+      open
+      title="האם לצאת מהחשבון?"
+      description="תצטרך להתחבר מחדש."
+      confirmLabel="התנתק"
+      cancelLabel="ביטול"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...props}
+    />,
+  );
+  return { onConfirm, onCancel };
+}
+
+describe("ConfirmDialog", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <ConfirmDialog open={false} title="x" onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("renders an accessible alertdialog with title and description", () => {
+    setup();
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByText("האם לצאת מהחשבון?")).toBeInTheDocument();
+    expect(screen.getByText("תצטרך להתחבר מחדש.")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the confirm action is clicked", () => {
+    const { onConfirm } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "התנתק" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when the cancel action is clicked", () => {
+    const { onCancel } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "ביטול" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel on Escape", () => {
+    const { onCancel } = setup();
+    fireEvent.keyDown(screen.getByRole("alertdialog"), { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when the backdrop is clicked", () => {
+    const { onCancel } = setup();
+    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a destructive confirm button when requested", () => {
+    setup({ variant: "destructive" });
+    expect(
+      screen.getByRole("button", { name: "התנתק" }).className,
+    ).toContain("destructive");
+  });
+
+  it("disables actions while loading", () => {
+    setup({ loading: true });
+    expect(screen.getByRole("button", { name: "התנתק" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "ביטול" })).toBeDisabled();
+  });
+});

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useId, useRef, type ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+export type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+/**
+ * Accessible confirmation modal — a styled replacement for window.confirm.
+ * Traps focus between its two actions, closes on Escape / backdrop, restores
+ * focus to the trigger on close, and locks body scroll while open.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "אישור",
+  cancelLabel = "ביטול",
+  variant = "default",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      restoreFocusRef.current = document.activeElement as HTMLElement | null;
+      const raf = requestAnimationFrame(() => cancelRef.current?.focus());
+      return () => cancelAnimationFrame(raf);
+    }
+    restoreFocusRef.current?.focus?.();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const isDestructive = variant === "destructive";
+
+  // Two focusable actions — trap Tab between them.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+      return;
+    }
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const active = document.activeElement;
+      (active === confirmRef.current ? cancelRef : confirmRef).current?.focus();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[200]" role="presentation" onKeyDown={onKeyDown}>
+      <div
+        className="absolute inset-0 animate-fade-in bg-background/70 backdrop-blur-sm"
+        onClick={onCancel}
+        aria-hidden
+      />
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descId : undefined}
+        dir="rtl"
+        className="glass-card absolute inset-x-0 top-1/2 mx-auto w-[92vw] max-w-sm -translate-y-1/2 animate-scale-in rounded-2xl border border-border/60 p-6 shadow-2xl"
+      >
+        <div className="flex items-start gap-3.5">
+          <div
+            className={cn(
+              "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl",
+              isDestructive
+                ? "bg-destructive/10 text-destructive"
+                : "bg-primary/10 text-primary",
+            )}
+          >
+            <AlertTriangle className="h-5 w-5" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <h2 id={titleId} className="text-base font-semibold text-foreground">
+              {title}
+            </h2>
+            {description ? (
+              <p id={descId} className="text-sm leading-relaxed text-muted-foreground">
+                {description}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-6 flex items-center justify-start gap-2.5">
+          <Button
+            ref={confirmRef}
+            variant={isDestructive ? "destructive" : "primary"}
+            loading={loading}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </Button>
+          <Button ref={cancelRef} variant="secondary" onClick={onCancel} disabled={loading}>
+            {cancelLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -10,6 +10,7 @@ export {
   AuroraBackground,
   type AuroraBackgroundProps,
 } from "./AuroraBackground";
+export { ConfirmDialog, type ConfirmDialogProps } from "./ConfirmDialog";
 export { EmptyState, type EmptyStateProps } from "./EmptyState";
 export { ErrorState, type ErrorStateProps } from "./ErrorState";
 export { FormField, type FormFieldProps } from "./FormField";


### PR DESCRIPTION
## Accessible ConfirmDialog

Third slice of the frontend transformation (#1369). Replaces the jarring native `window.confirm` (audit a11y finding) with a reusable, accessible modal.

### What
- New `ConfirmDialog` primitive: `role="alertdialog"`, focus trap between its two actions, Escape + backdrop to cancel, focus restore to the trigger, body-scroll lock, a `destructive` variant, and `Button loading` support. Styled to match the command palette (glass + scale-in).
- Wired into the Shell sign-out, replacing `window.confirm("האם לצאת מהחשבון?")`.
- Exported from the `ui` barrel for reuse (e.g. future destructive confirms).

### Tests
New: `ConfirmDialog` (8). Full suite green (272), eslint clean, `tsc -b` + `vite build` green.

Web-only PR — Go `Lint`/`Test` checks skip by design, so merge needs admin until branch-protection contexts are made conditional.

Part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)