### PR TITLE
feat(web): listings density toggle — comfortable cards / compact rows

### DIFF
--- a/web/src/components/CompactListingCard.test.tsx
+++ b/web/src/components/CompactListingCard.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { CompactListingCard } from "./CompactListingCard";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { Listing } from "@/lib/api";
+
+const { toggleSaved, toggleSeen } = vi.hoisted(() => ({
+  toggleSaved: vi.fn(),
+  toggleSeen: vi.fn(),
+}));
+
+vi.mock("@/hooks/useListingActions", () => ({
+  useListingActions: () => ({
+    saved: false,
+    seen: false,
+    toggleSaved,
+    toggleSeen,
+    isSaving: false,
+    isTogglingSeen: false,
+  }),
+}));
+
+const listing: Listing = {
+  token: "tok-1",
+  manufacturer: "Toyota",
+  model: "Corolla",
+  year: 2021,
+  price: 120000,
+  km: 50000,
+  hand: 2,
+  city: "חיפה",
+  page_link: "https://www.yad2.co.il/item/tok-1",
+  fitness_score: 8.4,
+  first_seen_at: "2026-06-10T00:00:00Z",
+};
+
+function renderRow() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <CompactListingCard listing={listing} />
+      </ToastProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("CompactListingCard", () => {
+  it("links to the listing detail with an accessible label", () => {
+    renderRow();
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/listings/tok-1");
+    expect(link).toHaveAccessibleName(/Toyota Corolla 2021/);
+  });
+
+  it("shows price and compact meta", () => {
+    renderRow();
+    expect(screen.getByText(/120,000/)).toBeInTheDocument();
+    expect(screen.getByText(/חיפה/)).toBeInTheDocument();
+    expect(screen.getByText("8.4")).toBeInTheDocument();
+  });
+
+  it("toggles saved without navigating", () => {
+    renderRow();
+    fireEvent.click(screen.getByRole("button", { name: "שמור מודעה" }));
+    expect(toggleSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles seen", () => {
+    renderRow();
+    fireEvent.click(screen.getByRole("button", { name: "סמן כנצפה" }));
+    expect(toggleSeen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/CompactListingCard.tsx
+++ b/web/src/components/CompactListingCard.tsx
@@ -1,0 +1,148 @@
+import { memo } from "react";
+import { Link } from "react-router";
+import { Eye, EyeOff, Bookmark } from "lucide-react";
+import {
+  formatPrice,
+  formatKm,
+  marketComparison,
+  cn,
+} from "@/lib/utils";
+import type { Listing } from "@/lib/api";
+import { scoreHsl } from "@/lib/scoringAlgorithm";
+import { useListingActions } from "@/hooks/useListingActions";
+import { useSpotlight } from "@/hooks/useSpotlight";
+import { useToast } from "@/components/ui/Toast";
+
+/** Dense, scannable single-row variant of a listing — used in compact mode. */
+export const CompactListingCard = memo(function CompactListingCard({
+  listing,
+}: {
+  listing: Listing;
+}) {
+  const { saved, seen, toggleSaved, toggleSeen } = useListingActions(listing);
+  const { toast } = useToast();
+  const spotlight = useSpotlight();
+  const mc = marketComparison(
+    listing.price,
+    listing.median_price,
+    listing.base_price,
+  );
+
+  const meta = [
+    String(listing.year),
+    listing.km > 0 ? formatKm(listing.km) : null,
+    listing.hand > 0 ? `יד ${listing.hand}` : null,
+    listing.city || null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Link
+      to={`/listings/${listing.token}`}
+      state={{ listing }}
+      {...spotlight}
+      aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
+      className={cn(
+        "spotlight group flex items-center gap-3 rounded-xl border border-border/40 bg-card p-2.5 transition-all duration-200 hover:border-primary/30 hover:shadow-[0_8px_28px_-12px_var(--color-glow-primary)] dir-rtl",
+        listing.removed_at && "opacity-60",
+      )}
+    >
+      <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg bg-secondary">
+        {listing.image_url ? (
+          <img
+            src={listing.image_url}
+            alt=""
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-lg opacity-20">
+            🚗
+          </div>
+        )}
+        {listing.seen === false ? (
+          <span
+            className="absolute end-1 top-1 h-2 w-2 rounded-full bg-primary ring-2 ring-card"
+            aria-hidden
+          />
+        ) : null}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {listing.manufacturer} {listing.model}
+          </p>
+          {listing.fitness_score != null ? (
+            <span
+              className="shrink-0 text-[11px] font-bold tabular-nums"
+              style={{ color: scoreHsl(listing.fitness_score) }}
+            >
+              {listing.fitness_score.toFixed(1)}
+            </span>
+          ) : null}
+        </div>
+        <p className="truncate text-xs text-muted-foreground">{meta}</p>
+      </div>
+
+      <div className="flex shrink-0 flex-col items-end">
+        <span className="text-sm font-bold tabular-nums text-foreground">
+          {formatPrice(listing.price)}
+        </span>
+        {mc ? (
+          <span className={cn("text-[11px] font-medium", mc.color)}>
+            {mc.diffPercent > 5
+              ? `${mc.diffPercent}%−`
+              : mc.diffPercent >= -5
+                ? "שוק"
+                : `${-mc.diffPercent}%+`}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-0.5">
+        <button
+          type="button"
+          aria-label={seen ? "החזר לרשימת החדשות" : "סמן כנצפה"}
+          aria-pressed={seen}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleSeen();
+          }}
+          className={cn(
+            "flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+            seen
+              ? "bg-primary/10 text-primary"
+              : "text-muted-foreground hover:bg-primary/5 hover:text-primary",
+          )}
+        >
+          {seen ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        </button>
+        <button
+          type="button"
+          aria-label={saved ? "הסר משמורים" : "שמור מודעה"}
+          aria-pressed={saved}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleSaved({
+              onSuccess: (next) =>
+                toast(next ? "נשמר בהצלחה" : "הוסר מהשמורים", next ? "success" : "info"),
+            });
+          }}
+          className={cn(
+            "flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+            saved
+              ? "bg-primary/10 text-primary"
+              : "text-muted-foreground hover:bg-primary/5 hover:text-primary",
+          )}
+        >
+          <Bookmark className={cn("h-4 w-4", saved && "fill-current")} />
+        </button>
+      </div>
+    </Link>
+  );
+});

--- a/web/src/hooks/useListingDensity.test.ts
+++ b/web/src/hooks/useListingDensity.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useListingDensity } from "./useListingDensity";
+
+describe("useListingDensity", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults to comfortable", () => {
+    const { result } = renderHook(() => useListingDensity());
+    expect(result.current[0]).toBe("comfortable");
+  });
+
+  it("reads a persisted compact value", () => {
+    localStorage.setItem("listings-density", "compact");
+    const { result } = renderHook(() => useListingDensity());
+    expect(result.current[0]).toBe("compact");
+  });
+
+  it("updates and persists the density", () => {
+    const { result } = renderHook(() => useListingDensity());
+    act(() => result.current[1]("compact"));
+    expect(result.current[0]).toBe("compact");
+    expect(localStorage.getItem("listings-density")).toBe("compact");
+  });
+});

--- a/web/src/hooks/useListingDensity.ts
+++ b/web/src/hooks/useListingDensity.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+export type Density = "comfortable" | "compact";
+
+const STORAGE_KEY = "listings-density";
+
+/** Listing-grid density, persisted to localStorage. */
+export function useListingDensity(): readonly [Density, (d: Density) => void] {
+  const [density, setDensityState] = useState<Density>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "compact"
+        ? "compact"
+        : "comfortable";
+    } catch {
+      return "comfortable";
+    }
+  });
+
+  const setDensity = useCallback((d: Density) => {
+    setDensityState(d);
+    try {
+      localStorage.setItem(STORAGE_KEY, d);
+    } catch {
+      // ignore storage failures (private mode, quota)
+    }
+  }, []);
+
+  return [density, setDensity] as const;
+}

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -10,6 +10,8 @@ import {
   ArrowUp,
   Loader2,
   FilterX,
+  LayoutGrid,
+  Rows3,
 } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useInfiniteListings } from "@/hooks/useInfiniteListings";
@@ -23,6 +25,8 @@ import {
   type ListingFilters,
 } from "@/hooks/useListingFilters";
 import { ListingsFilterBar } from "@/components/ListingsFilterBar";
+import { useListingDensity } from "@/hooks/useListingDensity";
+import { CompactListingCard } from "@/components/CompactListingCard";
 import { safeHref, cn, formatPrice } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { Listing, RefreshResponse } from "@/lib/api";
@@ -187,6 +191,7 @@ export function ListingsPage() {
   const facets = useMemo(() => deriveFacets(allListings), [allListings]);
   const visible = useListingFilters(allListings, filters);
   const hasFilters = activeFilterCount(filters) > 0;
+  const [density, setDensity] = useListingDensity();
 
   const unenrichedCount = useMemo(
     () =>
@@ -250,6 +255,36 @@ export function ListingsPage() {
                 {opt.label}
               </Button>
             ))}
+          </div>
+          <div className="flex shrink-0 items-center rounded-xl border border-border/50 bg-secondary/60 p-0.5" role="group" aria-label="צפיפות תצוגה">
+            <button
+              type="button"
+              onClick={() => setDensity("comfortable")}
+              aria-label="תצוגה מרווחת"
+              aria-pressed={density === "comfortable"}
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+                density === "comfortable"
+                  ? "bg-card text-primary shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <LayoutGrid className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setDensity("compact")}
+              aria-label="תצוגה צפופה"
+              aria-pressed={density === "compact"}
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
+                density === "compact"
+                  ? "bg-card text-primary shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Rows3 className="h-4 w-4" />
+            </button>
           </div>
           <RefreshButton searchId={searchId} />
         </div>
@@ -336,7 +371,13 @@ export function ListingsPage() {
         />
       ) : (
         <>
-          <div className="grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <div
+            className={cn(
+              density === "compact"
+                ? "space-y-2"
+                : "grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3",
+            )}
+          >
             {visible.map((listing, i) => (
               <div
                 key={listing.token}
@@ -346,7 +387,11 @@ export function ListingsPage() {
                   animationFillMode: "backwards",
                 }}
               >
-                <ListingCard listing={listing} />
+                {density === "compact" ? (
+                  <CompactListingCard listing={listing} />
+                ) : (
+                  <ListingCard listing={listing} />
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Listings density toggle

Part of the frontend transformation (#1369). Adds the audit's **density toggle** so the core browse screen flexes from rich cards to a Linear-style scannable list.

### What
- A persisted **comfortable ⇄ compact** segmented toggle in the sort bar (`useListingDensity`, localStorage).
- **Compact** swaps the card grid for dense single rows (`CompactListingCard`): thumbnail, title + score, key specs (year · km · hand · city), price + deal delta, unseen dot, and seen/save actions — reusing the spotlight + `content-visibility` treatment.
- **Comfortable** keeps the existing card grid.

### Tests
New: `useListingDensity` (3) + `CompactListingCard` (4). **299/299 web tests pass**, eslint clean, build green.

Web-only PR — Go `Lint`/`Test` checks skip by design, so merge needs admin.

Part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)