### PR TITLE
fix(web): theme-aware score colours for contrast on light surfaces

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -140,6 +140,10 @@
   --score-good: #B45309;
   --score-low: #DC2626;
 
+  /* Dynamic score colour (hue from JS) — darker + more saturated on light bg */
+  --score-saturation: 78%;
+  --score-lightness: 42%;
+
   --deal-good: #059669;
   --deal-bad: #DC2626;
   --fresh-hot: #EA580C;
@@ -186,6 +190,10 @@
   --score-great: #34D399;
   --score-good: #FBBF24;
   --score-low: #F87171;
+
+  /* Dynamic score colour (hue from JS) — lighter on the dark surfaces */
+  --score-saturation: 75%;
+  --score-lightness: 62%;
 
   --deal-good: #10B981;
   --deal-bad: #F87171;

--- a/web/src/lib/scoringAlgorithm.test.ts
+++ b/web/src/lib/scoringAlgorithm.test.ts
@@ -145,6 +145,12 @@ describe("scoreHsl", () => {
   it("clamps scores over 10", () => {
     expect(scoreHsl(15)).toContain("hsl(160");
   });
+
+  it("drives saturation/lightness from theme-aware CSS vars", () => {
+    const c = scoreHsl(5);
+    expect(c).toContain("var(--score-saturation");
+    expect(c).toContain("var(--score-lightness");
+  });
 });
 
 describe("scoreHslAlpha", () => {

--- a/web/src/lib/scoringAlgorithm.ts
+++ b/web/src/lib/scoringAlgorithm.ts
@@ -179,15 +179,20 @@ function scoreHue(score: number): number {
   return Math.round(t * 160);
 }
 
+// Saturation/lightness come from theme-aware CSS vars (see index.css) so score
+// colours stay readable on the bright light-mode cards and the dark surfaces
+// alike; only the hue is computed here. Fallbacks match the original values.
+const SCORE_SL = "var(--score-saturation, 72%) var(--score-lightness, 55%)";
+
 export function scoreHsl(score: number): string {
   const hue = scoreHue(score);
-  return `hsl(${hue} 72% 55%)`;
+  return `hsl(${hue} ${SCORE_SL})`;
 }
 
 export function scoreHslAlpha(score: number, alpha: number): string {
   const hue = scoreHue(score);
   const a = Math.max(0, Math.min(1, alpha));
-  return `hsl(${hue} 72% 55% / ${a})`;
+  return `hsl(${hue} ${SCORE_SL} / ${a})`;
 }
 
 export function scoreLabel(score: number): string {


### PR DESCRIPTION
Part of #1369 (a11y finding). The dynamic match-score colour was a fixed `hsl(h 72% 55%)` — mid-score yellow-green at 55% lightness has weak contrast on the bright light-mode cards. Now saturation/lightness come from theme-aware CSS vars (`--score-saturation`/`--score-lightness`: darker+more saturated in light, lighter in dark), resolved at paint time so only the hue stays JS-driven. Tests green, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added theme-aware CSS variables for score color saturation and lightness with dedicated values for light and dark themes. Score hue values continue to be dynamically calculated from score values through JavaScript integration, enabling color customization per theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->