### PR TITLE
feat(web): keyboard navigation on the listings grid (j/k/o/s/e)

### DIFF
--- a/web/src/hooks/useGridKeyboardNav.test.ts
+++ b/web/src/hooks/useGridKeyboardNav.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useGridKeyboardNav } from "./useGridKeyboardNav";
+
+function press(key: string) {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useGridKeyboardNav", () => {
+  it("moves the highlight with j / k", () => {
+    const { result } = renderHook(() =>
+      useGridKeyboardNav({ count: 3, onOpen: vi.fn() }),
+    );
+    expect(result.current.activeIndex).toBe(-1);
+    press("j");
+    expect(result.current.activeIndex).toBe(0);
+    press("j");
+    expect(result.current.activeIndex).toBe(1);
+    press("k");
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it("clamps at the ends", () => {
+    const { result } = renderHook(() =>
+      useGridKeyboardNav({ count: 2, onOpen: vi.fn() }),
+    );
+    press("k"); // from -1 -> 0
+    press("k"); // stays 0
+    expect(result.current.activeIndex).toBe(0);
+    press("j");
+    press("j");
+    press("j"); // clamp at 1
+    expect(result.current.activeIndex).toBe(1);
+  });
+
+  it("fires onOpen / onSave / onSeen for the active index", () => {
+    const onOpen = vi.fn();
+    const onSave = vi.fn();
+    const onSeen = vi.fn();
+    renderHook(() =>
+      useGridKeyboardNav({ count: 3, onOpen, onSave, onSeen }),
+    );
+    press("j"); // active = 0
+    press("o");
+    press("s");
+    press("e");
+    expect(onOpen).toHaveBeenCalledWith(0);
+    expect(onSave).toHaveBeenCalledWith(0);
+    expect(onSeen).toHaveBeenCalledWith(0);
+  });
+
+  it("does nothing when typing in an input", () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useGridKeyboardNav({ count: 3, onOpen }),
+    );
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    });
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it("ignores keys while a dialog is open", () => {
+    const { result } = renderHook(() =>
+      useGridKeyboardNav({ count: 3, onOpen: vi.fn() }),
+    );
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+    press("j");
+    expect(result.current.activeIndex).toBe(-1);
+  });
+});

--- a/web/src/hooks/useGridKeyboardNav.ts
+++ b/web/src/hooks/useGridKeyboardNav.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type GridKeyboardNav = {
+  /** Highlighted index, or -1 when nothing is selected yet. */
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+};
+
+/**
+ * Power-user keyboard navigation for a list/grid:
+ *   j / ↓  next        k / ↑  previous
+ *   o / ↵  open        s  save        e  toggle seen
+ *
+ * Ignores keystrokes while typing in a field or while an overlay (command
+ * palette / dialog) is open. The window listener binds once; current callbacks
+ * and count are read through a ref so it never needs to re-bind.
+ */
+export function useGridKeyboardNav(opts: {
+  count: number;
+  onOpen: (index: number) => void;
+  onSave?: (index: number) => void;
+  onSeen?: (index: number) => void;
+  enabled?: boolean;
+}): GridKeyboardNav {
+  const { count, onOpen, onSave, onSeen, enabled = true } = opts;
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const activeRef = useRef(activeIndex);
+  activeRef.current = activeIndex;
+  const cbRef = useRef({ count, onOpen, onSave, onSeen });
+  cbRef.current = { count, onOpen, onSave, onSeen };
+
+  // Keep the highlight in range as the list shrinks/grows.
+  useEffect(() => {
+    setActiveIndex((i) => (i >= count ? count - 1 : i));
+  }, [count]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    function handler(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (target?.isContentEditable) return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      if (document.querySelector('[role="dialog"]')) return;
+
+      const { count: c, onOpen, onSave, onSeen } = cbRef.current;
+      if (c <= 0) return;
+
+      switch (e.key) {
+        case "j":
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((i) => Math.min(c - 1, i + 1));
+          break;
+        case "k":
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((i) => (i <= 0 ? 0 : i - 1));
+          break;
+        case "o":
+        case "Enter":
+          if (activeRef.current >= 0) {
+            e.preventDefault();
+            onOpen(activeRef.current);
+          }
+          break;
+        case "s":
+          if (activeRef.current >= 0 && onSave) {
+            e.preventDefault();
+            onSave(activeRef.current);
+          }
+          break;
+        case "e":
+          if (activeRef.current >= 0 && onSeen) {
+            e.preventDefault();
+            onSeen(activeRef.current);
+          }
+          break;
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled]);
+
+  const set = useCallback((i: number) => setActiveIndex(i), []);
+  return { activeIndex, setActiveIndex: set };
+}

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, memo, useMemo } from "react";
-import { useParams, Link } from "react-router";
+import { useParams, Link, useNavigate } from "react-router";
 import {
   ExternalLink,
   Bookmark,
@@ -26,6 +26,9 @@ import {
 } from "@/hooks/useListingFilters";
 import { ListingsFilterBar } from "@/components/ListingsFilterBar";
 import { useListingDensity } from "@/hooks/useListingDensity";
+import { useGridKeyboardNav } from "@/hooks/useGridKeyboardNav";
+import { useSaveBookmark, useRemoveBookmark } from "@/hooks/useBookmarks";
+import { useMarkListingSeen, useUnmarkListingSeen } from "@/hooks/useListingSeen";
 import { CompactListingCard } from "@/components/CompactListingCard";
 import { safeHref, cn, formatPrice } from "@/lib/utils";
 import { api } from "@/lib/api";
@@ -192,6 +195,56 @@ export function ListingsPage() {
   const visible = useListingFilters(allListings, filters);
   const hasFilters = activeFilterCount(filters) > 0;
   const [density, setDensity] = useListingDensity();
+
+  // Keyboard navigation (j/k move, o open, s save, e toggle seen)
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const saveBookmark = useSaveBookmark();
+  const removeBookmark = useRemoveBookmark();
+  const markSeen = useMarkListingSeen();
+  const unmarkSeen = useUnmarkListingSeen();
+
+  const openListing = useCallback(
+    (i: number) => {
+      const l = visible[i];
+      if (l) navigate(`/listings/${l.token}`, { state: { listing: l } });
+    },
+    [visible, navigate],
+  );
+  const saveListing = useCallback(
+    (i: number) => {
+      const l = visible[i];
+      if (!l) return;
+      const wasSaved = l.saved ?? false;
+      (wasSaved ? removeBookmark : saveBookmark).mutate(l.token, {
+        onSuccess: () =>
+          toast(wasSaved ? "הוסר מהשמורים" : "נשמר בהצלחה", wasSaved ? "info" : "success"),
+      });
+    },
+    [visible, saveBookmark, removeBookmark, toast],
+  );
+  const seenListing = useCallback(
+    (i: number) => {
+      const l = visible[i];
+      if (!l) return;
+      ((l.seen ?? false) ? unmarkSeen : markSeen).mutate(l.token);
+    },
+    [visible, markSeen, unmarkSeen],
+  );
+
+  const { activeIndex } = useGridKeyboardNav({
+    count: visible.length,
+    onOpen: openListing,
+    onSave: saveListing,
+    onSeen: seenListing,
+  });
+
+  useEffect(() => {
+    if (activeIndex < 0) return;
+    document
+      .querySelector(`[data-kbd="${activeIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
 
   const unenrichedCount = useMemo(
     () =>
@@ -381,7 +434,12 @@ export function ListingsPage() {
             {visible.map((listing, i) => (
               <div
                 key={listing.token}
-                className="cv-auto animate-slide-up motion-reduce:animate-none"
+                data-kbd={i}
+                className={cn(
+                  "cv-auto animate-slide-up motion-reduce:animate-none rounded-2xl",
+                  activeIndex === i &&
+                    "ring-2 ring-primary ring-offset-2 ring-offset-background",
+                )}
                 style={{
                   animationDelay: `${Math.min(i, 8) * 40}ms`,
                   animationFillMode: "backwards",


### PR DESCRIPTION
Part of #1369 (power-user / Linear-grade interactions). `useGridKeyboardNav` adds **j/↓ k/↑** to move a highlighted ring through the visible results, **o/Enter** to open, **s** to save, **e** to toggle seen. Ignores input fields and open overlays (command palette / dialog); the active card scrolls into view. New hook test (5). 312 tests pass, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)