### PR TITLE
feat(web): unified inbox tabs (Saved / History / Notifications)

### DIFF
--- a/web/src/components/InboxTabs.test.tsx
+++ b/web/src/components/InboxTabs.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { InboxTabs } from "./InboxTabs";
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotificationCount: () => ({ data: { count: 3 } }),
+}));
+
+function renderAt(path: string, action?: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <InboxTabs action={action} />
+    </MemoryRouter>,
+  );
+}
+
+describe("InboxTabs", () => {
+  it("renders the three inbox tabs", () => {
+    renderAt("/saved");
+    expect(screen.getByRole("link", { name: /התראות/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /מועדפים/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /היסטוריה/ })).toBeInTheDocument();
+  });
+
+  it("marks the current route's tab as the active page", () => {
+    renderAt("/history");
+    expect(screen.getByRole("link", { name: /היסטוריה/ })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: /מועדפים/ })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("shows the unread badge on the notifications tab", () => {
+    renderAt("/notifications");
+    expect(
+      screen.getByRole("link", { name: /התראות/ }),
+    ).toHaveTextContent("3");
+  });
+
+  it("renders an action slot", () => {
+    renderAt("/saved", <button>פעולה</button>);
+    expect(screen.getByRole("button", { name: "פעולה" })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/InboxTabs.tsx
+++ b/web/src/components/InboxTabs.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { Link, useLocation } from "react-router";
+import { Bell, Bookmark, History } from "lucide-react";
+import { useNotificationCount } from "@/hooks/useNotifications";
+import { cn } from "@/lib/utils";
+
+const TABS = [
+  { to: "/notifications", label: "התראות", icon: Bell, badge: true },
+  { to: "/saved", label: "מועדפים", icon: Bookmark, badge: false },
+  { to: "/history", label: "היסטוריה", icon: History, badge: false },
+] as const;
+
+/**
+ * Unified header for the inbox surfaces (Notifications / Saved / History).
+ * Renders the tab bar (with the live unread badge) plus an optional per-page
+ * action slot, replacing the standalone PageHeader on those pages.
+ */
+export function InboxTabs({ action }: { action?: ReactNode }) {
+  const { pathname } = useLocation();
+  const { data: count } = useNotificationCount();
+  const unread = count?.count ?? 0;
+
+  return (
+    <header className="flex flex-col gap-3 border-b border-border/50 pb-4 dir-rtl">
+      <div className="flex items-center justify-between gap-3">
+        <nav
+          className="flex gap-1 overflow-x-auto scrollbar-hide"
+          aria-label="תיבת דואר"
+        >
+          {TABS.map((t) => {
+            const active = pathname === t.to;
+            const Icon = t.icon;
+            return (
+              <Link
+                key={t.to}
+                to={t.to}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "relative flex shrink-0 items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-medium transition-all duration-150",
+                  active
+                    ? "bg-primary/10 text-primary ring-1 ring-primary/20"
+                    : "text-muted-foreground hover:bg-surface-hover hover:text-foreground",
+                )}
+              >
+                <Icon className="h-4 w-4" aria-hidden />
+                {t.label}
+                {t.badge && unread > 0 ? (
+                  <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white tabular-nums">
+                    {unread > 99 ? "99+" : unread}
+                  </span>
+                ) : null}
+              </Link>
+            );
+          })}
+        </nav>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+    </header>
+  );
+}

--- a/web/src/pages/HistoryPage.test.tsx
+++ b/web/src/pages/HistoryPage.test.tsx
@@ -34,6 +34,10 @@ vi.mock("@/hooks/useBookmarks", () => ({
   useHistory: () => historyReturn,
 }));
 
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotificationCount: () => ({ data: { count: 0 } }),
+}));
+
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -8,10 +8,10 @@ import {
   Button,
   EmptyState,
   ErrorState,
-  PageHeader,
   PageShell,
   Pagination,
 } from "@/components/ui";
+import { InboxTabs } from "@/components/InboxTabs";
 import { ListingCardSkeleton } from "@/components/ListingCardSkeleton";
 import { Select } from "@/components/ui/Select";
 import type { Listing } from "@/lib/api";
@@ -40,7 +40,7 @@ export function HistoryPage() {
   if (isLoading) {
     return (
       <PageShell>
-        <PageHeader title="היסטוריה" />
+        <InboxTabs />
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {[1, 2, 3, 4].map((i) => (
             <ListingCardSkeleton key={i} />
@@ -53,7 +53,7 @@ export function HistoryPage() {
   if (isError) {
     return (
       <PageShell>
-        <PageHeader title="היסטוריה" />
+        <InboxTabs />
         <ErrorState
           title="שגיאה בטעינת ההיסטוריה"
           description="נסה לרענן את הדף"
@@ -65,8 +65,7 @@ export function HistoryPage() {
 
   return (
     <PageShell>
-      <PageHeader
-        title="היסטוריה"
+      <InboxTabs
         action={
           data ? (
             <div className="flex items-center gap-3">

--- a/web/src/pages/NotificationsPage.test.tsx
+++ b/web/src/pages/NotificationsPage.test.tsx
@@ -40,6 +40,7 @@ vi.mock("@/hooks/useNotifications", () => ({
     mutate: mockMarkSeenMutate,
     isPending: false,
   }),
+  useNotificationCount: () => ({ data: { count: 1 } }),
 }));
 
 vi.mock("@/hooks/useListingSeen", () => ({
@@ -76,9 +77,9 @@ describe("NotificationsPage", () => {
     };
   });
 
-  it("renders page header", () => {
+  it("renders the inbox tab header", () => {
     renderPage();
-    expect(screen.getByText("התראות")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /התראות/ })).toBeInTheDocument();
   });
 
   it("renders empty state when no notifications", () => {

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -12,11 +12,11 @@ import {
   Button,
   EmptyState,
   ErrorState,
-  PageHeader,
   PageShell,
   Pagination,
   Skeleton,
 } from "@/components/ui";
+import { InboxTabs } from "@/components/InboxTabs";
 import type { Listing } from "@/lib/api";
 
 const PAGE_SIZE = 20;
@@ -37,7 +37,7 @@ export function NotificationsPage() {
   if (isLoading) {
     return (
       <PageShell>
-        <PageHeader title="התראות" />
+        <InboxTabs />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2, 3, 4].map((i) => (
             <Skeleton key={i} className="h-72 rounded-2xl" />
@@ -50,7 +50,7 @@ export function NotificationsPage() {
   if (isError) {
     return (
       <PageShell>
-        <PageHeader title="התראות" />
+        <InboxTabs />
         <ErrorState
           title="שגיאה בטעינת ההתראות"
           description="נסה לרענן את הדף"
@@ -62,8 +62,7 @@ export function NotificationsPage() {
 
   return (
     <PageShell>
-      <PageHeader
-        title="התראות"
+      <InboxTabs
         action={
           data && data.total > 0 ? (
             <div className="flex flex-wrap items-center gap-2 justify-end">

--- a/web/src/pages/SavedPage.test.tsx
+++ b/web/src/pages/SavedPage.test.tsx
@@ -40,6 +40,10 @@ vi.mock("@/hooks/useBookmarks", () => ({
   useSaveBookmark: () => ({ mutate: vi.fn() }),
 }));
 
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotificationCount: () => ({ data: { count: 0 } }),
+}));
+
 vi.mock("@/hooks/usePageTitle", () => ({
   usePageTitle: vi.fn(),
 }));
@@ -69,9 +73,9 @@ describe("SavedPage", () => {
     };
   });
 
-  it("renders page header", () => {
+  it("renders the inbox tab header", () => {
     renderPage();
-    expect(screen.getByText("שמורים")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /מועדפים/ })).toBeInTheDocument();
   });
 
   it("renders empty state when no saved listings", () => {

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -13,11 +13,11 @@ import {
   Button,
   EmptyState,
   ErrorState,
-  PageHeader,
   PageShell,
   Pagination,
   useToast,
 } from "@/components/ui";
+import { InboxTabs } from "@/components/InboxTabs";
 import { ListingCardSkeleton } from "@/components/ListingCardSkeleton";
 import type { Listing } from "@/lib/api";
 
@@ -42,7 +42,7 @@ export function SavedPage() {
   if (isLoading) {
     return (
       <PageShell>
-        <PageHeader title="שמורים" />
+        <InboxTabs />
         <div className="grid gap-4 sm:grid-cols-2">
           {[1, 2].map((i) => (
             <ListingCardSkeleton key={i} />
@@ -55,7 +55,7 @@ export function SavedPage() {
   if (isError) {
     return (
       <PageShell>
-        <PageHeader title="שמורים" />
+        <InboxTabs />
         <ErrorState
           title="שגיאה בטעינת המודעות"
           description="נסה לרענן את הדף"
@@ -67,8 +67,7 @@ export function SavedPage() {
 
   return (
     <PageShell>
-      <PageHeader
-        title="שמורים"
+      <InboxTabs
         action={
           data ? (
             <span className="text-sm text-muted-foreground tabular-nums">


### PR DESCRIPTION
Part of #1369. Unifies the three inbox surfaces with a shared `InboxTabs` header (Notifications / Saved / History) + live unread badge, so users switch in one tap instead of hunting through the sidebar. Per-page actions (sort, counts, **mark all as seen**) live in the tab bar's action slot. New `InboxTabs` test (4); page tests updated. 311 tests pass, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)