### PR TITLE
feat: per-search activity sparkline (14-day new-listing trend)

### DIFF
--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// searchActivity returns the daily new-listing counts for a search (sparkline data).
+func (s *Server) searchActivity(w http.ResponseWriter, r *http.Request) {
+	chatID, ok := s.requireResolvedChatID(w, r)
+	if !ok {
+		return
+	}
+	searchID, ok := parsePathID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid search id")
+		return
+	}
+	days, ok := parseIntParam(w, r, "days", 14)
+	if !ok {
+		return
+	}
+
+	counts, err := s.activity.SearchDailyCounts(r.Context(), chatID, searchID, days)
+	if err != nil {
+		s.handlerLogger(r, "search_id", searchID).Error("search activity", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if counts == nil {
+		counts = []storage.DailyListingCount{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"days": counts})
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -80,6 +80,7 @@ type Server struct {
 	logLevel   *slog.LevelVar
 	cycleLog   storage.CycleLogStore
 	cycleStats storage.SearchCycleStatsStore
+	activity   storage.SearchActivityStore
 	vitals     *vitalsRing
 
 	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
@@ -130,6 +131,7 @@ type Config struct {
 	LogLevel         *slog.LevelVar
 	CycleLog         storage.CycleLogStore
 	SearchCycleStats storage.SearchCycleStatsStore
+	Activity         storage.SearchActivityStore
 	PriceListSvc     *pricelist.Service
 	PollingInterval  time.Duration
 	Bind             string
@@ -203,6 +205,7 @@ func New(c Config) *Server {
 		logLevel:        c.LogLevel,
 		cycleLog:        c.CycleLog,
 		cycleStats:      c.SearchCycleStats,
+		activity:        c.Activity,
 		pollingInterval: c.PollingInterval,
 		vitals:          newVitalsRing(),
 		fetchSem:        make(chan struct{}, fetchCap),
@@ -271,6 +274,10 @@ func (s *Server) Routes() http.Handler {
 
 	if s.cycleStats != nil {
 		authMux.HandleFunc("GET /api/v1/searches/cycle-stats", s.listSearchCycleStats)
+	}
+
+	if s.activity != nil {
+		authMux.HandleFunc("GET /api/v1/searches/{id}/activity", s.searchActivity)
 	}
 
 	if s.admin != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -241,6 +241,7 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		LogLevel:         logLevel,
 		CycleLog:         store,
 		SearchCycleStats: store,
+		Activity:         store,
 		PollingInterval:  cfg.Polling.Interval,
 		Fetchers:         fetcherFactory,
 		Yad2Fetcher:      yad2Fetcher,

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -256,6 +256,19 @@ type ListingStore interface {
 	DropListingByToken(ctx context.Context, token string) (int64, error)
 }
 
+// DailyListingCount is the number of distinct listings first seen on a day.
+type DailyListingCount struct {
+	Day   string `json:"day"` // YYYY-MM-DD day bucket
+	Count int    `json:"count"`
+}
+
+// SearchActivityStore exposes a per-search activity time series (for sparklines).
+type SearchActivityStore interface {
+	// SearchDailyCounts returns distinct listings first seen per day for the
+	// given search over the last `days` days. Sparse: only days with data.
+	SearchDailyCounts(ctx context.Context, chatID, searchID int64, days int) ([]DailyListingCount, error)
+}
+
 type SavedListingStore interface {
 	SaveBookmark(ctx context.Context, chatID int64, token string) error
 	RemoveBookmark(ctx context.Context, chatID int64, token string) error

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -265,7 +265,7 @@ type DailyListingCount struct {
 // SearchActivityStore exposes a per-search activity time series (for sparklines).
 type SearchActivityStore interface {
 	// SearchDailyCounts returns distinct listings first seen per day for the
-	// given search over the last `days` days. Sparse: only days with data.
+	// given search over the last `days` days. Dense: includes 0-count days.
 	SearchDailyCounts(ctx context.Context, chatID, searchID int64, days int) ([]DailyListingCount, error)
 }
 

--- a/internal/storage/postgres/search_activity.go
+++ b/internal/storage/postgres/search_activity.go
@@ -1,0 +1,49 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// SearchDailyCounts returns the number of distinct listings first seen per day
+// for a search over the last `days` days. Days with no new listings are omitted
+// (callers fill gaps). `days` is clamped to a sane 1..90 window.
+func (s *Store) SearchDailyCounts(ctx context.Context, chatID, searchID int64, days int) ([]storage.DailyListingCount, error) {
+	if days <= 0 || days > 90 {
+		days = 14
+	}
+
+	// Dense, 0-filled series over the last `days` days (server-local day
+	// buckets) so the client never has to reconcile timezones when plotting.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT to_char(d.day, 'YYYY-MM-DD') AS day, COALESCE(c.cnt, 0)::int AS cnt
+		FROM generate_series(
+		       date_trunc('day', NOW()) - make_interval(days => $3 - 1),
+		       date_trunc('day', NOW()),
+		       interval '1 day'
+		     ) AS d(day)
+		LEFT JOIN (
+		       SELECT date_trunc('day', first_seen_at) AS day, COUNT(DISTINCT token) AS cnt
+		       FROM listing_history
+		       WHERE chat_id = $1 AND search_id = $2
+		         AND first_seen_at >= date_trunc('day', NOW()) - make_interval(days => $3 - 1)
+		       GROUP BY 1
+		     ) c ON c.day = d.day
+		ORDER BY d.day`, chatID, searchID, days)
+	if err != nil {
+		return nil, fmt.Errorf("search daily counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []storage.DailyListingCount
+	for rows.Next() {
+		var d storage.DailyListingCount
+		if err := rows.Scan(&d.Day, &d.Count); err != nil {
+			return nil, fmt.Errorf("scan daily count: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/postgres/search_activity.go
+++ b/internal/storage/postgres/search_activity.go
@@ -11,8 +11,10 @@ import (
 // for a search over the last `days` days. Days with no new listings are omitted
 // (callers fill gaps). `days` is clamped to a sane 1..90 window.
 func (s *Store) SearchDailyCounts(ctx context.Context, chatID, searchID int64, days int) ([]storage.DailyListingCount, error) {
-	if days <= 0 || days > 90 {
+	if days <= 0 {
 		days = 14
+	} else if days > 90 {
+		days = 90
 	}
 
 	// Dense, 0-filled series over the last `days` days (server-local day

--- a/internal/storage/postgres/search_activity_test.go
+++ b/internal/storage/postgres/search_activity_test.go
@@ -1,0 +1,75 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+func TestPostgres_SearchDailyCounts(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	searchID, err := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "trend", Manufacturer: 1, Model: 1,
+	})
+	if err != nil {
+		t.Fatalf("create search: %v", err)
+	}
+
+	now := time.Now()
+	save := func(token string, daysAgo int) {
+		t.Helper()
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: 100, SearchID: searchID, SearchName: "trend",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000,
+			FirstSeenAt: now.AddDate(0, 0, -daysAgo),
+		}); err != nil {
+			t.Fatalf("save %s: %v", token, err)
+		}
+	}
+	save("d-a", 0)
+	save("d-b", 0)
+	save("d-c", 1)
+	save("d-old", 40) // outside the 14-day window
+
+	got, err := store.SearchDailyCounts(ctx, 100, searchID, 14)
+	if err != nil {
+		t.Fatalf("SearchDailyCounts: %v", err)
+	}
+	// Dense series: exactly 14 day buckets, all labelled.
+	if len(got) != 14 {
+		t.Fatalf("len(got) = %d, want 14 dense buckets", len(got))
+	}
+	total := 0
+	for _, d := range got {
+		total += d.Count
+		if d.Day == "" {
+			t.Errorf("empty day bucket in %+v", got)
+		}
+	}
+	if total != 3 {
+		t.Fatalf("total in 14d window = %d, want 3 (rows: %+v)", total, got)
+	}
+
+	// A different search has data on no day (dense zero series).
+	other, err := store.SearchDailyCounts(ctx, 100, searchID+9999, 14)
+	if err != nil {
+		t.Fatalf("other: %v", err)
+	}
+	otherTotal := 0
+	for _, d := range other {
+		otherTotal += d.Count
+	}
+	if otherTotal != 0 {
+		t.Fatalf("other search total = %d, want 0", otherTotal)
+	}
+
+	// days is clamped; an absurd value falls back to the default window.
+	if _, err := store.SearchDailyCounts(ctx, 100, searchID, 9999); err != nil {
+		t.Fatalf("clamped days: %v", err)
+	}
+}

--- a/internal/storage/postgres/search_activity_test.go
+++ b/internal/storage/postgres/search_activity_test.go
@@ -60,6 +60,9 @@ func TestPostgres_SearchDailyCounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("other: %v", err)
 	}
+	if len(other) != 14 {
+		t.Fatalf("len(other) = %d, want 14 dense buckets", len(other))
+	}
 	otherTotal := 0
 	for _, d := range other {
 		otherTotal += d.Count
@@ -68,8 +71,12 @@ func TestPostgres_SearchDailyCounts(t *testing.T) {
 		t.Fatalf("other search total = %d, want 0", otherTotal)
 	}
 
-	// days is clamped; an absurd value falls back to the default window.
-	if _, err := store.SearchDailyCounts(ctx, 100, searchID, 9999); err != nil {
+	// days is clamped to 90; an absurd value should not error.
+	clamped, err := store.SearchDailyCounts(ctx, 100, searchID, 9999)
+	if err != nil {
 		t.Fatalf("clamped days: %v", err)
+	}
+	if len(clamped) != 90 {
+		t.Fatalf("len(clamped) = %d, want 90 buckets", len(clamped))
 	}
 }

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -244,7 +244,7 @@ export function SearchCard({
         </div>
       </Link>
 
-      {activitySeries && activitySeries.some((v) => v > 0) ? (
+      {activitySeries && activitySeries.length >= 2 ? (
         <div className="mt-3 flex items-center gap-2 border-t border-border/30 pt-3">
           <span className="text-[11px] text-muted-foreground">פעילות (14 ימים)</span>
           <Sparkline

--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -12,6 +12,8 @@ import {
 import { cn, formatKm, formatPrice, relativeTime } from "@/lib/utils";
 import type { Search, SearchCycleStatsItem } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
+import { Sparkline } from "@/components/ui/Sparkline";
+import { useSearchActivity } from "@/hooks/useSearchActivity";
 import {
   manufacturerLogoSrc,
   manufacturerLogoSrcFromCatalogId,
@@ -44,6 +46,8 @@ export function SearchCard({
   const isActive = search.active;
   const listingsPath = `/searches/${search.id}/listings`;
   const stats = search.stats;
+  const { data: activity } = useSearchActivity(search.id);
+  const activitySeries = activity?.map((d) => d.count);
 
   useEffect(() => {
     if (isConfirmingDelete) confirmRef.current?.focus();
@@ -239,6 +243,17 @@ export function SearchCard({
           />
         </div>
       </Link>
+
+      {activitySeries && activitySeries.some((v) => v > 0) ? (
+        <div className="mt-3 flex items-center gap-2 border-t border-border/30 pt-3">
+          <span className="text-[11px] text-muted-foreground">פעילות (14 ימים)</span>
+          <Sparkline
+            data={activitySeries}
+            className="ms-auto"
+            ariaLabel="מגמת מודעות חדשות ב-14 הימים האחרונים"
+          />
+        </div>
+      ) : null}
 
       {cycleStats && (
         <div className="border-t border-border/30 pt-3 mt-3">

--- a/web/src/components/ui/Sparkline.test.tsx
+++ b/web/src/components/ui/Sparkline.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Sparkline } from "./Sparkline";
+
+describe("Sparkline", () => {
+  it("renders an svg with a polyline for the data", () => {
+    const { container } = render(<Sparkline data={[0, 2, 1, 5, 3]} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(container.querySelector("polyline")).toBeInTheDocument();
+    expect(container.querySelector("polygon")).toBeInTheDocument();
+  });
+
+  it("returns nothing for fewer than two points", () => {
+    const { container } = render(<Sparkline data={[3]} />);
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("exposes an accessible label when provided", () => {
+    const { getByRole } = render(
+      <Sparkline data={[1, 2, 3]} ariaLabel="trend" />,
+    );
+    expect(getByRole("img", { name: "trend" })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/Sparkline.tsx
+++ b/web/src/components/ui/Sparkline.tsx
@@ -1,0 +1,67 @@
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+
+export type SparklineProps = {
+  data: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+  ariaLabel?: string;
+};
+
+/**
+ * Tiny inline SVG trend chart (area + line + endpoint dot). Uses currentColor,
+ * so the parent's text color drives the hue. Decorative when no ariaLabel.
+ */
+export function Sparkline({
+  data,
+  width = 100,
+  height = 28,
+  className,
+  ariaLabel,
+}: SparklineProps) {
+  const gradId = useId();
+  if (!data || data.length < 2) return null;
+
+  const max = Math.max(1, ...data);
+  const last = data.length - 1;
+  const stepX = width / last;
+  const yOf = (v: number) => height - 2 - (v / max) * (height - 4);
+
+  const pts = data.map((v, i) => `${(i * stepX).toFixed(1)},${yOf(v).toFixed(1)}`);
+  const line = pts.join(" ");
+  const area = `0,${height} ${line} ${width},${height}`;
+  const lastX = (last * stepX).toFixed(1);
+  const lastY = yOf(data[last]).toFixed(1);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn("text-primary", className)}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.25" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <polygon points={area} fill={`url(#${gradId})`} />
+      <polyline
+        points={line}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle cx={lastX} cy={lastY} r="2" fill="currentColor" />
+    </svg>
+  );
+}

--- a/web/src/hooks/useSearchActivity.ts
+++ b/web/src/hooks/useSearchActivity.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+const DAYS = 14;
+
+/** Daily new-listing counts for a search over the last 14 days (dense series). */
+export function useSearchActivity(searchId: number, enabled = true) {
+  return useQuery({
+    queryKey: ["search-activity", searchId, DAYS],
+    queryFn: async () => (await api.searchActivity(searchId, DAYS)).days,
+    enabled: enabled && searchId > 0,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -262,7 +262,16 @@ export const api = {
     fetchAPI<RefreshResponse>(`/searches/${searchId}/refresh`, {
       method: "POST",
     }),
+  searchActivity: (searchId: number, days = 14) =>
+    fetchAPI<{ days: DailyListingCount[] }>(
+      `/searches/${searchId}/activity?days=${days}`,
+    ),
 };
+
+export interface DailyListingCount {
+  day: string; // YYYY-MM-DD
+  count: number;
+}
 
 export interface NotificationCount {
   count: number;


### PR DESCRIPTION
Part of #1369 (SearchCard trend). Adds a small new-listings trend sparkline to each dashboard search card.

**Backend (additive, read-only — no schema change):** new `GET /api/v1/searches/{id}/activity?days=N` returning a **dense, 0-filled** daily count of distinct listings first-seen over the last N days, derived from `listing_history` via `generate_series` (server-tz day buckets, so the client needs no tz reconciliation). Implemented as a **separate optional `storage.SearchActivityStore`** wired through the existing optional-store pattern (`if s.activity != nil`), so no existing store fakes change. Includes a pgtest.

**Frontend:** `api.searchActivity` + `useSearchActivity` + an inline SVG `Sparkline` (area+line+endpoint, currentColor) rendered on `SearchCard` when there's activity.

Go `build`/`vet` + `gofmt` clean; 321 web tests pass; web build green. The pgtest runs in CI. **This PR changes Go (auto-deploys on merge) — letting the full Go CI gate it; not admin-bypassing the Go checks.**

closes part of #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new “activity (14 days)” visualization to search cards, including a sparkline showing distinct daily listing counts for the selected search.
  * Introduced a new authenticated activity API endpoint to retrieve per-day activity series.

* **UI Enhancements**
  * Added a reusable Sparkline component with accessibility support.

* **Tests**
  * Added unit tests for the Sparkline component and a Postgres test for daily activity series output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->