### PR TITLE
refactor: FormField shadcn Label + SearchFormFields shadcn Card

### DIFF
--- a/web/src/components/SearchFormFields.tsx
+++ b/web/src/components/SearchFormFields.tsx
@@ -2,6 +2,7 @@ import { formatPrice } from "@/lib/utils";
 import { useManufacturers, useModels } from "@/hooks/useCatalog";
 import { Toggle } from "@/components/ui/toggle";
 import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RangeSlider } from "@/components/ui/RangeSlider";
 import { Select } from "@/components/ui/NativeSelect";
 import { FormField } from "@/components/ui/FormField";
@@ -129,12 +130,14 @@ function formatKmLabel(value: number): string {
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="bg-card border border-border rounded-2xl overflow-hidden">
-      <div className="px-5 py-3 border-b border-border bg-secondary/30">
-        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{title}</h2>
-      </div>
-      <div className="p-5 space-y-4">{children}</div>
-    </div>
+    <Card>
+      <CardHeader className="pb-0">
+        <CardTitle className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-4">{children}</CardContent>
+    </Card>
   );
 }
 

--- a/web/src/components/ui/FormField.tsx
+++ b/web/src/components/ui/FormField.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
 export type FormFieldProps = {
@@ -23,21 +24,16 @@ export function FormField({
   const describedBy = [error && errorId, hint && hintId].filter(Boolean).join(" ") || undefined;
 
   return (
-    <div className={cn("dir-rtl", className)} data-describedby={describedBy}>
-      <label
-        htmlFor={htmlFor}
-        className="mb-1.5 block text-sm font-medium text-foreground"
-      >
-        {label}
-      </label>
+    <div className={cn("space-y-1.5 dir-rtl", className)} data-describedby={describedBy}>
+      <Label htmlFor={htmlFor}>{label}</Label>
       {children}
       {error ? (
-        <p id={errorId} className="mt-1.5 text-xs text-destructive" role="alert">
+        <p id={errorId} className="text-xs text-destructive" role="alert">
           {error}
         </p>
       ) : null}
       {hint && !error ? (
-        <p id={hintId} className="mt-1.5 text-xs text-muted-foreground">{hint}</p>
+        <p id={hintId} className="text-xs text-muted-foreground">{hint}</p>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

Final polish PR for the UI refactor (#1381):

- **FormField** — uses shadcn `Label` component for consistent typography across all forms
- **SearchFormFields** — `SectionCard` wrapper uses shadcn `Card`/`CardHeader`/`CardContent`

### Net impact

- Minimal line change (-1 net)
- All 295 tests pass, 0 TS errors, 0 lint errors

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run test` — 295/295 pass
- [ ] New search form renders correctly with card sections
- [ ] Edit search form renders correctly
- [ ] Try search form renders correctly
- [ ] Form labels styled consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)