### PR TITLE
refactor: landing page + PriceHistoryChart → shadcn Card/Button

### DIFF
--- a/web/src/components/PriceHistoryChart.tsx
+++ b/web/src/components/PriceHistoryChart.tsx
@@ -11,6 +11,7 @@ import { TrendingDown, TrendingUp, Minus } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { formatPrice } from "@/lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface PriceHistoryChartProps {
@@ -51,42 +52,48 @@ export function PriceHistoryChart({
 
   if (loading) {
     return (
-      <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-3">
-        <Skeleton className="h-5 w-32" />
-        <Skeleton className="h-40 w-full rounded-xl" />
-      </div>
+      <Card>
+        <CardContent className="p-5 space-y-3">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-40 w-full rounded-xl" />
+        </CardContent>
+      </Card>
     );
   }
 
   if (error || records.length === 0) {
     return (
-      <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-2">
-        <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
-          <Minus className="h-4 w-4 text-muted-foreground" />
-          היסטוריית מחירים
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          אין היסטוריית מחירים
-        </p>
-      </div>
+      <Card>
+        <CardContent className="p-5 space-y-2">
+          <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
+            <Minus className="h-4 w-4 text-muted-foreground" />
+            היסטוריית מחירים
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            אין היסטוריית מחירים
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
   // Single data point: show static message
   if (records.length === 1) {
     return (
-      <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-2">
-        <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
-          <Minus className="h-4 w-4 text-muted-foreground" />
-          היסטוריית מחירים
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          המחיר לא השתנה מאז שהמודעה הופיעה
-        </p>
-        <p className="text-xs text-muted-foreground">
-          נצפה לראשונה: {formatFullDateHe(records[0].observed_at)}
-        </p>
-      </div>
+      <Card>
+        <CardContent className="p-5 space-y-2">
+          <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
+            <Minus className="h-4 w-4 text-muted-foreground" />
+            היסטוריית מחירים
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            המחיר לא השתנה מאז שהמודעה הופיעה
+          </p>
+          <p className="text-xs text-muted-foreground">
+            נצפה לראשונה: {formatFullDateHe(records[0].observed_at)}
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
@@ -134,7 +141,8 @@ export function PriceHistoryChart({
   const padding = Math.max(Math.round((maxPrice - minPrice) * 0.15), 1000);
 
   return (
-    <div className="rounded-2xl border border-border/50 bg-card p-5 space-y-3">
+    <Card>
+      <CardContent className="p-5 space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
           <TrendIcon className={`h-4 w-4 ${trendColor}`} />
@@ -205,6 +213,7 @@ export function PriceHistoryChart({
           {formatPrice(lastPrice)}
         </span>
       </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/components/landing/FeaturesSection.tsx
+++ b/web/src/components/landing/FeaturesSection.tsx
@@ -8,6 +8,7 @@ import {
   Layers,
   CalendarSync,
 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
 import { FadeUp } from "./FadeUp";
 
 const features = [
@@ -102,24 +103,26 @@ export function FeaturesSection() {
             const Icon = f.icon;
             return (
               <FadeUp key={f.title} delay={i * 0.05}>
-                <div
-                  className={`card-hover group relative flex h-full flex-col overflow-hidden rounded-2xl border ${f.border} bg-card p-6 ${f.highlight ? "border-primary/40 ring-1 ring-primary/10" : ""}`}
+                <Card
+                  className={`card-hover group relative flex h-full flex-col overflow-hidden ${f.highlight ? "border-primary/40 ring-1 ring-primary/10" : ""}`}
                 >
-                  {f.highlight ? (
+                  {f.highlight && (
                     <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-purple-500/[0.04]" />
-                  ) : null}
-                  <div
-                    className={`relative mb-4 flex h-12 w-12 items-center justify-center rounded-2xl ${f.bg} transition-transform duration-300 group-hover:scale-110`}
-                  >
-                    <Icon size={22} className={f.color} aria-hidden />
-                  </div>
-                  <h3 className="relative mb-2 text-base font-bold text-foreground md:text-lg">
-                    {f.title}
-                  </h3>
-                  <p className="relative text-sm leading-relaxed text-muted-foreground">
-                    {f.desc}
-                  </p>
-                </div>
+                  )}
+                  <CardContent className="relative flex h-full flex-col p-6">
+                    <div
+                      className={`mb-4 flex h-12 w-12 items-center justify-center rounded-2xl ${f.bg} transition-transform duration-300 group-hover:scale-110`}
+                    >
+                      <Icon size={22} className={f.color} aria-hidden />
+                    </div>
+                    <h3 className="mb-2 text-base font-bold text-foreground md:text-lg">
+                      {f.title}
+                    </h3>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      {f.desc}
+                    </p>
+                  </CardContent>
+                </Card>
               </FadeUp>
             );
           })}

--- a/web/src/components/landing/LandingNav.tsx
+++ b/web/src/components/landing/LandingNav.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Link } from "react-router";
 import { Car, Sun, Moon, Menu, X } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export function LandingNav() {
@@ -104,12 +105,9 @@ export function LandingNav() {
           >
             {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
           </button>
-          <Link
-            to="/signup"
-            className="hidden items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-primary/25 ring-1 ring-primary/20 transition-all hover:bg-primary/92 hover:shadow-primary/35 hover:active:translate-y-0 sm:flex sm:hover:-translate-y-px"
-          >
-            התחל עכשיו
-          </Link>
+          <Button asChild className="hidden sm:flex shadow-lg shadow-primary/25">
+            <Link to="/signup">התחל עכשיו</Link>
+          </Button>
           <button
             ref={menuToggleRef}
             type="button"

--- a/web/src/components/landing/StatsSection.tsx
+++ b/web/src/components/landing/StatsSection.tsx
@@ -1,3 +1,4 @@
+import { Card, CardContent } from "@/components/ui/card";
 import { FadeUp } from "./FadeUp";
 
 const stats = [
@@ -45,14 +46,16 @@ export function StatsSection() {
         <div className="relative grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
           {stats.map((s, i) => (
             <FadeUp key={s.label} delay={i * 0.1}>
-              <div className="group card-hover relative overflow-hidden rounded-2xl border border-border/80 bg-card p-6 text-center">
-                <p className="relative mb-2 text-3xl font-extrabold tabular-nums text-primary md:text-4xl">
-                  {s.value}
-                </p>
-                <p className="relative text-sm leading-relaxed text-muted-foreground">
-                  {s.label}
-                </p>
-              </div>
+              <Card className="card-hover group text-center">
+                <CardContent className="p-6">
+                  <p className="mb-2 text-3xl font-extrabold tabular-nums text-primary md:text-4xl">
+                    {s.value}
+                  </p>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {s.label}
+                  </p>
+                </CardContent>
+              </Card>
             </FadeUp>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Continues the visual redesign:

- **FeaturesSection** — 8 feature cards → shadcn Card/CardContent
- **StatsSection** — 4 stat cards → shadcn Card/CardContent  
- **LandingNav** — signup CTA → shadcn Button
- **PriceHistoryChart** — all 4 states (loading, empty, single-point, chart) → shadcn Card/CardContent

## Test plan

- [ ] `npm run test` — 295/295 pass
- [ ] `npm run build` succeeds
- [ ] Landing page features/stats cards render correctly
- [ ] Price history chart on listing detail page renders in Card
- [ ] Nav signup button styled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)