### PR TITLE
fix(web): cut mobile GPU cost & fix phantom bottom-bar gap

### DIFF
--- a/web/src/hooks/useSpotlight.test.ts
+++ b/web/src/hooks/useSpotlight.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useSpotlight } from "./useSpotlight";
 
 describe("useSpotlight", () => {
+  const realMatchMedia = window.matchMedia;
+  afterEach(() => {
+    window.matchMedia = realMatchMedia;
+  });
+
   it("writes element-relative coordinates to CSS vars on pointer move", () => {
     const { result } = renderHook(() => useSpotlight());
 
@@ -25,5 +30,36 @@ describe("useSpotlight", () => {
     const first = result.current.onPointerMove;
     rerender();
     expect(result.current.onPointerMove).toBe(first);
+  });
+
+  it("no-ops on coarse-pointer (touch) devices — no layout reads on scroll", () => {
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes("coarse"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useSpotlight());
+
+    let rectRead = false;
+    const el = document.createElement("div");
+    el.getBoundingClientRect = () => {
+      rectRead = true;
+      return { left: 0, top: 0, width: 10, height: 10 } as DOMRect;
+    };
+
+    result.current.onPointerMove({
+      currentTarget: el,
+      clientX: 5,
+      clientY: 5,
+    } as unknown as React.PointerEvent<HTMLElement>);
+
+    expect(rectRead).toBe(false);
+    expect(el.style.getPropertyValue("--spot-x")).toBe("");
   });
 });

--- a/web/src/hooks/useSpotlight.ts
+++ b/web/src/hooks/useSpotlight.ts
@@ -1,13 +1,30 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 export type SpotlightHandlers = {
   onPointerMove: (e: React.PointerEvent<HTMLElement>) => void;
 };
 
+const NOOP = () => {};
+
+/**
+ * True on touch-primary devices. There the cursor spotlight never shows (it
+ * only reveals on `:hover`/`:focus-within`), so the per-pointermove
+ * `getBoundingClientRect()` would be pure overhead — and worse, it fires during
+ * touch scrolling and forces a synchronous layout each frame (scroll jank).
+ */
+function isCoarsePointer(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(pointer: coarse)").matches
+  );
+}
+
 /**
  * Cursor-following spotlight. Pair with the `spotlight` utility class.
  * Writes `--spot-x` / `--spot-y` straight to the element style on pointer
  * move, so it never triggers a React re-render. Position is element-relative.
+ * On touch devices it returns a no-op handler (see {@link isCoarsePointer}).
  */
 export function useSpotlight(): SpotlightHandlers {
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
@@ -17,5 +34,8 @@ export function useSpotlight(): SpotlightHandlers {
     el.style.setProperty("--spot-y", `${e.clientY - rect.top}px`);
   }, []);
 
-  return { onPointerMove };
+  return useMemo(
+    () => (isCoarsePointer() ? { onPointerMove: NOOP } : { onPointerMove }),
+    [onPointerMove],
+  );
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -116,7 +116,11 @@
    ═══════════════════════════════════════════════════════════ */
 :root {
   --radius: 0.625rem;
-  --bottom-nav-h: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+  /* Offset used by fixed/sticky mobile action bars. There is currently no
+     bottom tab bar rendered, so this is just the iOS home-indicator inset —
+     the bars sit flush at the bottom edge instead of floating ~4.5rem above
+     it. If a bottom nav is added later, restore its height here. */
+  --bottom-nav-h: env(safe-area-inset-bottom, 0px);
 
   /* Core palette */
   --background: #F4F6FA;
@@ -518,6 +522,35 @@
   }
   .shine::before {
     display: none;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Touch / mobile performance
+   Coarse-pointer devices (phones, tablets) have weaker GPUs and run on
+   battery. The decorative effects below — large blur surfaces, stacked
+   backdrop-filters and never-ending compositor animations — are the main
+   source of scroll jank there, so we make them cheap (or freeze them).
+   The visuals remain; they just stop costing a frame every 16ms.
+   ═══════════════════════════════════════════════════════════ */
+@media (pointer: coarse) {
+  /* Half the blur radius (blur cost scales super-linearly with radius) and
+     stop the drift so the three full-bleed blobs no longer recomposite. */
+  .aurora-blob {
+    filter: blur(40px);
+    will-change: auto;
+    animation: none !important;
+  }
+  /* Lighter frosted glass — backdrop-filter is recomputed on every scroll
+     frame over the content beneath it. */
+  .glass-card {
+    backdrop-filter: blur(10px) saturate(1.1);
+    -webkit-backdrop-filter: blur(10px) saturate(1.1);
+  }
+  /* Purely ambient infinite loops — freeze them on battery devices. */
+  .glow-border::before,
+  .text-aurora {
+    animation: none !important;
   }
 }
 


### PR DESCRIPTION
## Mobile-focused performance & layout audit

Mobile felt sluggish. Root causes were continuous compositor work from decorative
effects + a layout bug. This PR makes the effects cheap on touch devices (the
visuals stay; they just stop costing a frame every 16ms) and fixes the bug.

### Changes
1. **Spotlight no longer thrashes layout on touch** — `useSpotlight` ran
   `getBoundingClientRect()` on every `pointermove`, which fires continuously
   during touch-scroll and forces a synchronous layout each frame. The spotlight
   only ever reveals on `:hover`/`:focus-within` (never on touch), so on
   coarse-pointer devices it now returns a no-op handler. Zero visual change on
   mobile; removes a per-frame reflow from every card while scrolling.
2. **Tamed GPU effects under `@media (pointer: coarse)`** — the aurora background
   is three full-bleed blobs at `blur(70px)` animated forever (the dominant mobile
   GPU cost), compounded by stacked `backdrop-filter` glass. On touch devices:
   blur 70→40px (blur cost is super-linear), freeze the drift + drop `will-change`,
   lighten glass `backdrop-filter` 20→10px, and freeze the ambient
   `glow-border`/`text-aurora` infinite loops.
3. **Fixed a phantom bottom gap** — `--bottom-nav-h` reserved `4.5rem`, but no
   bottom-nav component is rendered anywhere. Three fixed/sticky mobile bars (the
   listing-detail action bar, New-Search footer, scroll-to-top button) floated
   ~72px above the screen edge. Collapsed the reserve to just the safe-area inset
   so they sit flush. *(If a bottom tab bar is added later, restore its height.)*

### Testing
- `vitest run` — **48 files, 296 tests passing** (added a coarse-pointer case to
  `useSpotlight.test.ts`).
- `vite build` — green.
- `eslint` — clean on changed files.

### Follow-ups (intentionally out of scope here — one concern per PR)
- **Firebase lazy-init:** `firebase/auth` (~162KB) loads on every route incl. the
  public landing because `AuthProvider` wraps the app. Deferring it off the
  landing's critical path is worthwhile but is an auth-correctness-sensitive
  refactor — better as its own reviewed PR.
- **`vendor` chunk is ~610KB (gzip ~199KB):** grew with the in-progress shadcn /
  base-ui / sonner / cmdk / react-hook-form migration. Worth a tree-shaking pass
  once that lands.
- Consider an actual **bottom tab bar** for mobile nav (currently hamburger-only).

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent touch device detection to optimize mobile experience

* **Bug Fixes**
  * Improved performance on mobile devices by reducing visual effect complexity and animation overhead, eliminating unnecessary processing on touch-primary platforms

* **Tests**
  * Expanded test coverage for touch device behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->