### PR TITLE
feat(web): SEO — sitemap, JSON-LD, canonical/OG, per-route titles

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="canonical" href="https://carwatch.duckdns.org/" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0B0D14" />
     <script>
@@ -21,13 +22,50 @@
     <meta property="og:title" content="CarWatch — מעקב חכם אחרי רכבים" />
     <meta property="og:description" content="מעקב אוטומטי אחרי מודעות רכב. התראות מיידיות, ניתוח מחירים וציון התאמה חכם." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/logo-512.png" />
+    <meta property="og:url" content="https://carwatch.duckdns.org/" />
+    <meta property="og:site_name" content="CarWatch" />
+    <meta property="og:image" content="https://carwatch.duckdns.org/logo-512.png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
+    <meta property="og:image:alt" content="CarWatch" />
     <meta property="og:locale" content="he_IL" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="CarWatch" />
+    <meta name="twitter:title" content="CarWatch — מעקב חכם אחרי רכבים" />
     <meta name="twitter:description" content="מעקב חכם אחרי מודעות רכב מיד2 ו-WinWin." />
+    <meta name="twitter:image" content="https://carwatch.duckdns.org/logo-512.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Organization",
+            "@id": "https://carwatch.duckdns.org/#organization",
+            "name": "CarWatch",
+            "url": "https://carwatch.duckdns.org/",
+            "logo": "https://carwatch.duckdns.org/logo-512.png"
+          },
+          {
+            "@type": "WebSite",
+            "@id": "https://carwatch.duckdns.org/#website",
+            "url": "https://carwatch.duckdns.org/",
+            "name": "CarWatch",
+            "description": "מעקב חכם אחרי מודעות רכב מיד2 ו-WinWin — התראות מיידיות, ניתוח מחירים וציון התאמה אוטומטי.",
+            "inLanguage": "he-IL",
+            "publisher": { "@id": "https://carwatch.duckdns.org/#organization" }
+          },
+          {
+            "@type": "SoftwareApplication",
+            "name": "CarWatch",
+            "applicationCategory": "BusinessApplication",
+            "operatingSystem": "Web",
+            "url": "https://carwatch.duckdns.org/",
+            "inLanguage": "he-IL",
+            "description": "מעקב אוטומטי אחרי מודעות רכב יד שנייה — התראות מיידיות, ניתוח מחירים וציון התאמה חכם.",
+            "offers": { "@type": "Offer", "price": "0", "priceCurrency": "ILS" }
+          }
+        ]
+      }
+    </script>
   </head>
   <body>
     <noscript>

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -12,3 +12,5 @@ Disallow: /history
 Disallow: /notifications
 Disallow: /settings
 Disallow: /api/
+
+Sitemap: https://carwatch.duckdns.org/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://carwatch.duckdns.org/</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://carwatch.duckdns.org/try</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://carwatch.duckdns.org/login</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://carwatch.duckdns.org/signup</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/web/src/hooks/useDocumentTitle.test.ts
+++ b/web/src/hooks/useDocumentTitle.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDocumentTitle, DEFAULT_DOCUMENT_TITLE } from "./useDocumentTitle";
+
+describe("useDocumentTitle", () => {
+  const original = document.title;
+  afterEach(() => {
+    document.title = original;
+  });
+
+  it("suffixes the brand onto a page title", () => {
+    renderHook(() => useDocumentTitle("התחברות"));
+    expect(document.title).toBe("התחברות · CarWatch");
+  });
+
+  it("applies the default brand title when given no argument", () => {
+    renderHook(() => useDocumentTitle());
+    expect(document.title).toBe(DEFAULT_DOCUMENT_TITLE);
+  });
+});

--- a/web/src/hooks/useDocumentTitle.ts
+++ b/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+export const DEFAULT_DOCUMENT_TITLE = "CarWatch — מעקב חכם אחרי רכבים";
+
+/**
+ * Sets `document.title` for SPA routes. Every route shares the single static
+ * `<title>` from index.html, so public pages set their own for clearer browser
+ * tabs, history entries, and shared-link previews. Pass no argument to apply the
+ * default brand title (used by the landing/home route).
+ */
+export function useDocumentTitle(title?: string): void {
+  useEffect(() => {
+    document.title = title ? `${title} · CarWatch` : DEFAULT_DOCUMENT_TITLE;
+  }, [title]);
+}

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { useAppVersion } from "@/hooks/useAppVersion";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { LandingNav, HeroSection } from "@/components/landing";
 
 const ProblemSolution = lazy(() =>
@@ -26,6 +27,7 @@ const LandingFooter = lazy(() =>
 
 export function LandingPage() {
   const version = useAppVersion();
+  useDocumentTitle();
 
   return (
     <div

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,5 +1,7 @@
 import { AuthPage } from "./AuthPage";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export function LoginPage() {
+  useDocumentTitle("התחברות");
   return <AuthPage defaultTab="login" />;
 }

--- a/web/src/pages/SignupPage.tsx
+++ b/web/src/pages/SignupPage.tsx
@@ -1,5 +1,7 @@
 import { AuthPage } from "./AuthPage";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export function SignupPage() {
+  useDocumentTitle("הרשמה");
   return <AuthPage defaultTab="signup" />;
 }

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -10,6 +10,7 @@ import {
   type Model,
 } from "@/lib/api";
 import { formatPrice, safeHref } from "@/lib/utils";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { Toggle } from "@/components/ui/toggle";
 
 const GEARBOX_OPTIONS = [
@@ -94,6 +95,7 @@ const STORAGE_KEY = "carwatch_try_search_form";
 /* ------------------------------------------------------------------ */
 
 export default function TrySearchPage() {
+  useDocumentTitle("נסה חיפוש");
   const [form, setForm] = useState<GuestFormData>(() => {
     try {
       const saved = sessionStorage.getItem(STORAGE_KEY);


### PR DESCRIPTION
## SEO / discoverability

Makes the public surface (home, /try, /login, /signup) discoverable in Google and
rich in social previews. The app is a client-rendered SPA, so this targets the
indexable public pages; deeper SSR/prerender of landing copy is a larger follow-up.

### Changes
- **`public/sitemap.xml`** listing the four public routes, referenced via a
  `Sitemap:` line in **`robots.txt`**.
- **`index.html`**: `rel=canonical`, `og:url`, `og:site_name`, **absolute**
  `og:image` + `twitter:image` (relative URLs often fail link scrapers),
  `og:image:alt`, and a **JSON-LD `@graph`** — `Organization` + `WebSite` +
  `SoftwareApplication` (he-IL, free offer).
- **`useDocumentTitle`** hook: a distinct `<title>` per public route
  (Landing / Login / Signup / Try) instead of the single shared static title.

Domain: `https://carwatch.duckdns.org`

### Testing
- `vitest run` — **49 files, 298 passing** (added `useDocumentTitle.test.ts`).
- `vite build` — green; confirmed `dist/sitemap.xml`, `dist/robots.txt`, and the
  JSON-LD/canonical land in the built `index.html`.
- `eslint` — no new errors.

### Recommended follow-ups (not here)
- **Prerender the landing** (e.g. `vite-react-ssg`) so the marketing copy is in the
  initial HTML — the biggest remaining SEO lever for a CSR SPA.
- A dedicated **1200×630 OG card** image (current `og:image` is the 512² logo, so
  `twitter:card` stays `summary`).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>