### PR TITLE
perf(web): lazy-load Firebase Auth off the first-paint path

### DIFF
--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "./AuthContext";
@@ -52,19 +52,29 @@ function renderWithProviders() {
   return { ...result, queryClient };
 }
 
+// Firebase is imported lazily, so the auth-state subscription (and thus
+// authStateCallback) is registered a microtask after render. Wait for it before
+// driving auth-state changes.
+async function flushAuthInit() {
+  await waitFor(() => expect(authStateCallback).not.toBeNull());
+}
+
 describe("AuthContext", () => {
   beforeEach(() => {
     authStateCallback = null;
     mockSignOut.mockClear();
   });
 
-  it("exposes loading=true initially while rendering children", () => {
+  it("stays loading=true until the lazy auth subscription emits", async () => {
     renderWithProviders();
+    await flushAuthInit();
+    // Subscribed, but no auth event yet → still loading.
     expect(screen.getByTestId("loading")).toHaveTextContent("true");
   });
 
   it("sets user after auth resolves with a user", async () => {
     renderWithProviders();
+    await flushAuthInit();
 
     await act(async () => {
       authStateCallback?.({ uid: "u1", email: "test@example.com" });
@@ -76,6 +86,7 @@ describe("AuthContext", () => {
 
   it("sets user to null after auth resolves with null", async () => {
     renderWithProviders();
+    await flushAuthInit();
 
     await act(async () => {
       authStateCallback?.(null);
@@ -88,6 +99,7 @@ describe("AuthContext", () => {
   it("calls firebase signOut on logout", async () => {
     const user = userEvent.setup();
     renderWithProviders();
+    await flushAuthInit();
 
     await act(async () => {
       authStateCallback?.({ uid: "u1", email: "test@example.com" });
@@ -99,6 +111,7 @@ describe("AuthContext", () => {
 
   it("clears query cache when user UID changes (user switch)", async () => {
     const { queryClient } = renderWithProviders();
+    await flushAuthInit();
     const clearSpy = vi.spyOn(queryClient, "clear");
 
     // User A logs in — first auth event, prevUid is null so no clear
@@ -118,6 +131,7 @@ describe("AuthContext", () => {
 
   it("does not clear query cache on initial login", async () => {
     const { queryClient } = renderWithProviders();
+    await flushAuthInit();
     const clearSpy = vi.spyOn(queryClient, "clear");
 
     // First auth event — prevUid starts as null, no clear expected
@@ -129,6 +143,7 @@ describe("AuthContext", () => {
 
   it("clears query cache when switching from a user to signed-out", async () => {
     const { queryClient } = renderWithProviders();
+    await flushAuthInit();
     const clearSpy = vi.spyOn(queryClient, "clear");
 
     // User logs in

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -8,10 +8,8 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import type { User } from "firebase/auth";
-import { onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
+import type { Auth, User } from "firebase/auth";
 import { useQueryClient } from "@tanstack/react-query";
-import { auth } from "@/lib/firebase";
 import { setAuthTokenGetter } from "@/lib/auth-token";
 import { reportWebVitals } from "@/lib/webVitals";
 
@@ -29,11 +27,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const queryClient = useQueryClient();
   const prevUidRef = useRef<string | null>(null);
+  const authRef = useRef<Auth | null>(null);
   const vitalsStartedRef = useRef(false);
 
+  // Token getter reads the live Firebase instance once it has loaded. Registered
+  // synchronously so any API call made before Firebase finishes loading simply
+  // gets a null token (same as signed-out) rather than throwing.
   useEffect(() => {
     setAuthTokenGetter(async (forceRefresh?: boolean) => {
-      const u = auth.currentUser;
+      const u = authRef.current?.currentUser;
       if (!u) return null;
       return u.getIdToken(forceRefresh);
     });
@@ -46,22 +48,46 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  // Firebase Auth (~160KB) is imported lazily so it never blocks first paint on
+  // public routes (landing, /try, auth-less visits). The auth-state subscription
+  // is established as soon as the chunk resolves.
   useEffect(() => {
-    return onAuthStateChanged(auth, (u) => {
-      const newUid = u?.uid ?? null;
-      if (prevUidRef.current !== null && prevUidRef.current !== newUid) {
-        queryClient.clear();
-      }
-      prevUidRef.current = newUid;
-      setUser(u);
-      setLoading(false);
-    });
+    let cancelled = false;
+    let unsubscribe = () => {};
+
+    void (async () => {
+      const [{ auth }, { onAuthStateChanged }] = await Promise.all([
+        import("@/lib/firebase"),
+        import("firebase/auth"),
+      ]);
+      if (cancelled) return;
+      authRef.current = auth;
+      unsubscribe = onAuthStateChanged(auth, (u) => {
+        const newUid = u?.uid ?? null;
+        if (prevUidRef.current !== null && prevUidRef.current !== newUid) {
+          queryClient.clear();
+        }
+        prevUidRef.current = newUid;
+        setUser(u);
+        setLoading(false);
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, [queryClient]);
 
-  const signOut = useCallback(() => firebaseSignOut(auth), []);
+  const signOut = useCallback(async () => {
+    const auth = authRef.current;
+    if (!auth) return;
+    const { signOut: firebaseSignOut } = await import("firebase/auth");
+    await firebaseSignOut(auth);
+  }, []);
 
   const getIdToken = useCallback(async (forceRefresh?: boolean) => {
-    const u = auth.currentUser;
+    const u = authRef.current?.currentUser;
     if (!u) return null;
     return u.getIdToken(forceRefresh);
   }, []);
@@ -71,10 +97,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [user, loading, signOut, getIdToken],
   );
 
-  // Always render children â public pages (landing, /try, /login, /signup)
-  // should never be blocked by the auth loading spinner. The loading gate
-  // now lives in ProtectedRoute, which shows a spinner only for routes
-  // that actually require authentication.
+  // Always render children — public pages (landing, /try, /login, /signup)
+  // should never be blocked by the auth loading spinner. The loading gate lives
+  // in ProtectedRoute, which shows a spinner only for routes that require auth.
   return (
     <AuthContext.Provider value={value}>
       {children}


### PR DESCRIPTION
## Defer Firebase off the landing's critical path

`AuthProvider` statically imported `firebase/auth` (~233KB / 46KB gz), so Vite
modulepreloaded it and the browser parsed it on **every** route — including the
public landing, which needs no auth. That's wasted work before first paint.

### Change (isolated to AuthContext)
- Import `firebase/auth` + `@/lib/firebase` **dynamically** inside the effect and
  hold the `Auth` instance in a ref. The token getter, `signOut`, and the
  auth-state subscription all read from that ref.
- `firebase.ts` is unchanged; `/login` + `/signup` are already lazy routes.

### Behaviour (unchanged)
- `getAuthToken()` returns `null` until the chunk resolves — identical to a
  signed-out user, never throws.
- `ProtectedRoute` still gates on `loading`; public pages still render immediately.

### Result
- **No `firebase` modulepreload in the initial HTML** — it loads after first paint
  instead of blocking it.

### Testing
- `vitest run` — **48 files, 296 passing** (rewrote `AuthContext.test.tsx` to await
  the now-async subscription; auth-switch / cache-clear / sign-out coverage intact).
- `vite build` — green; verified the initial `index.html` no longer preloads firebase.
- `eslint` — clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>