### PR TITLE
fix(web): 44px touch targets on listing controls + full reduce-motion support

### DIFF
--- a/web/src/components/CompactListingCard.tsx
+++ b/web/src/components/CompactListingCard.tsx
@@ -113,7 +113,7 @@ export const CompactListingCard = memo(function CompactListingCard({
             toggleSeen();
           }}
           className={cn(
-            "flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+            "flex h-11 w-11 items-center justify-center rounded-lg transition-colors",
             seen
               ? "bg-primary/10 text-primary"
               : "text-muted-foreground hover:bg-primary/5 hover:text-primary",
@@ -134,7 +134,7 @@ export const CompactListingCard = memo(function CompactListingCard({
             });
           }}
           className={cn(
-            "flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+            "flex h-11 w-11 items-center justify-center rounded-lg transition-colors",
             saved
               ? "bg-primary/10 text-primary"
               : "text-muted-foreground hover:bg-primary/5 hover:text-primary",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -515,6 +515,18 @@
    Reduced Motion
    ═══════════════════════════════════════════════════════════ */
 @media (prefers-reduced-motion: reduce) {
+  /* Honour the OS "reduce motion" setting app-wide. The app has many ambient
+     infinite loops (pulse, shimmer, glow, freshness rings); collapse all
+     animations/transitions to near-instant (non-zero so transitionend /
+     animationend still fire), stop infinite repeats, and disable smooth scroll. */
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
   .glow-border::before,
   .text-aurora,
   .aurora-blob {

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -128,7 +128,7 @@ function NotificationCard({ listing }: { listing: Listing }) {
     <div className="relative overflow-hidden rounded-2xl border border-border/50 bg-card transition-all duration-300 hover:border-border hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)] hover:-translate-y-0.5">
       <button
         type="button"
-        className="absolute top-2 end-2 z-20 flex h-9 w-9 items-center justify-center rounded-full bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border/60 backdrop-blur-[2px] hover:bg-background hover:text-foreground"
+        className="absolute top-2 end-2 z-20 flex h-11 w-11 items-center justify-center rounded-full bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border/60 backdrop-blur-[2px] hover:bg-background hover:text-foreground"
         aria-label="סמן כנצפה והסר מהחדשות"
         disabled={markOne.isPending}
         onClick={() => markOne.mutate(listing.token)}


### PR DESCRIPTION
## UI/UX accessibility pass

Two concrete, low-risk a11y/UX fixes.

### 44px touch targets
`CompactListingCard`'s seen/save buttons and the `NotificationsPage` dismiss
button were 36px (`h-9 w-9`) — below the WCAG 2.5.5 / mobile 44px minimum, and
inconsistent with `SearchCard` and the comfortable listing card (already 44px).
Bumped to `h-11 w-11`.

### Complete prefers-reduced-motion support
The app has many ambient infinite animations (pulse, shimmer, glow, freshness
rings). The existing reduce-motion rule only froze the aurora/glow effects.
Extended it to collapse **all** animations + transitions to near-instant
(non-zero so `transitionend`/`animationend` still fire) and stop infinite loops,
so motion-sensitive users get a calm UI everywhere.

### Testing
- `vitest run` — **49 files, 298 passing**.
- `eslint` — clean on changed files.
- `vite build` — green.

### Noted, not changed (needs its own PR)
- Listing cards nest `<button>`/`<a>` inside the card `<Link>` (invalid nested
  interactive content). Works today via `stopPropagation`, but a proper fix
  (stretched-link overlay) is a broader refactor across several pages.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>