### PR TITLE
fix(caddy): use the working production CSP so the Caddyfile is deployable

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -6,7 +6,7 @@
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
 		Permissions-Policy "camera=(), microphone=(), geolocation=()"
-		Content-Security-Policy "default-src 'self'; script-src 'self' https://*.googleapis.com https://*.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; frame-src https://*.firebaseapp.com"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com https://www.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://*.googleapis.com https://accounts.google.com https://securetoken.googleapis.com https://identitytoolkit.googleapis.com https://www.googleapis.com https://www.gstatic.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com https://fonts.gstatic.com https://fonts.googleapis.com https://img.yad2.co.il https://apis.google.com; frame-src https://accounts.google.com https://*.firebaseapp.com; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
 	}
 	reverse_proxy api:8080
 }


### PR DESCRIPTION
## Make the repo Caddyfile the correct source of truth (+ enable asset compression in prod)

Found while inspecting the live site: production serves static assets
**uncompressed** — `vendor-*.js` returns **610KB with no `Content-Encoding`**
(~3× the gzipped size). That's a major first-paint cost, especially on mobile.

### What this PR changes
The repo `Caddyfile` already has `encode zstd gzip`, but its **CSP was stale and
would break the app if deployed** — it lacked `'unsafe-inline'` (the inline theme
script), Google sign-in origins, `worker-src` (service worker), and the yad2
image host. Swapped in the policy production actually serves, plus tighter
`frame-ancestors`/`base-uri`/`form-action`/`object-src`. Now the file is a
complete, deployable config.

### ⚠️ This does NOT auto-fix production
`release.yml` does not manage Caddy, and production is running a **drifted,
hand-edited** Caddyfile (its live CSP differs from the repo, and it's missing
`encode`, HSTS, and Permissions-Policy). To actually enable compression, the
file must be applied on the server and Caddy reloaded:

```bash
# copy this Caddyfile to the server, then:
docker compose -f docker-compose.prod.yaml restart caddy
# verify:
curl -sI -H 'Accept-Encoding: gzip' https://carwatch.duckdns.org/assets/vendor-*.js | grep -i content-encoding
```

### Deltas vs the current live config (applied when this is deployed)
- **Adds `encode zstd gzip`** → assets compressed (~610KB → ~199KB). *(the point)*
- Re-adds **HSTS** + **Permissions-Policy** (live config currently omits them).
- Changes `Referrer-Policy` `no-referrer` → `strict-origin-when-cross-origin`.
- Keeps the working CSP (drops a redundant hardcoded firebase host already
  covered by `*.firebaseapp.com`).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>