### PR TITLE
ci(release): sync Caddyfile to the VM and reload Caddy on deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,15 +154,16 @@ jobs:
         with:
           sparse-checkout: |
             docker-compose.prod.yaml
+            Caddyfile
             migrations
 
-      - name: Sync compose file and migrations to VM
+      - name: Sync compose file, Caddyfile and migrations to VM
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          source: "docker-compose.prod.yaml,migrations"
+          source: "docker-compose.prod.yaml,Caddyfile,migrations"
           target: ~/carwatch/
 
       - name: Prepare immutable deploy tag and rollback marker
@@ -341,6 +342,21 @@ jobs:
             rm -f .deploy_recreate_started
             rm -f next_image_tag
             echo "==> Persisted CARWATCH_IMAGE_TAG=${NEW_TAG} in .env"
+
+            # Apply the latest Caddyfile (synced above, bind-mounted into the
+            # long-lived caddy container) via a graceful, zero-downtime reload —
+            # without recreating the container. caddy keeps the current config if
+            # the new one fails to validate, so a bad reload never drops the site.
+            if docker ps --format '{{.Names}}' | grep -qx caddy; then
+              echo "==> Reloading Caddy with latest config..."
+              if docker exec caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile; then
+                echo "==> Caddy reloaded."
+              else
+                echo "WARN: caddy reload failed; previous config remains active"
+              fi
+            else
+              echo "==> caddy container not running; skipping reload"
+            fi
 
       - name: Rollback on failure
         if: failure()


### PR DESCRIPTION
## Make Caddy config actually deploy (root cause of the missing compression)

The deploy job only scp'd `docker-compose.prod.yaml` + `migrations`, so the
**`Caddyfile` was never shipped to the server**. Its server copy is hand-managed
and has drifted from the repo — notably it lacks `encode`, so production serves
static assets **uncompressed** (the ~610KB vendor bundle ships raw, ~3× the
gzipped size). Verified live: `vendor-*.js` → `Content-Length: 610806`, no
`Content-Encoding`.

### Change
- Add `Caddyfile` to the sparse-checkout + scp source list.
- After a successful deploy, **`caddy reload`** (graceful, zero-downtime; the
  long-lived caddy container is never recreated, and caddy keeps the current
  config if the new one fails to validate — so a bad reload never drops the site).

Combined with #1398 (which corrected the repo CSP), the repo Caddyfile is now the
source of truth and reaches production automatically.

### ⚠️ Effect on merge
`release.yml` runs on push to `main`, so **merging this triggers a deploy that
overwrites the server's hand-edited `Caddyfile` with the repo version and reloads
Caddy** — this is what finally turns compression on. The repo CSP was reconciled
to production's working policy in #1398, so auth/SW/images keep working; it also
re-adds HSTS + Permissions-Policy. If the server `Caddyfile` had any extra
directives not in the repo, capture them first.

### Verify after deploy
```bash
curl -sI -H 'Accept-Encoding: gzip' https://carwatch.duckdns.org/assets/vendor-*.js | grep -i content-encoding
# expect: content-encoding: gzip  (or zstd)
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to synchronize and apply Caddy configuration updates gracefully during deployments without recreating containers, improving deployment reliability and reducing potential service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->