### PR TITLE
fix(caddy): stop duplicating security headers the app already sets

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,12 +1,11 @@
 {$CARWATCH_DOMAIN:localhost} {
 	encode zstd gzip
+	# The app (api) already sets CSP, X-Frame-Options, X-Content-Type-Options and
+	# Referrer-Policy on every response. Only add headers it does NOT set, to
+	# avoid duplicate headers (and, for CSP, an intersection-enforced policy).
 	header {
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
-		X-Frame-Options "DENY"
-		X-Content-Type-Options "nosniff"
-		Referrer-Policy "strict-origin-when-cross-origin"
 		Permissions-Policy "camera=(), microphone=(), geolocation=()"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com https://www.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://*.googleapis.com https://accounts.google.com https://securetoken.googleapis.com https://identitytoolkit.googleapis.com https://www.googleapis.com https://www.gstatic.com https://*.firebaseapp.com https://*.firebaseio.com wss://*.firebaseio.com https://fonts.gstatic.com https://fonts.googleapis.com https://img.yad2.co.il https://apis.google.com; frame-src https://accounts.google.com https://*.firebaseapp.com; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
 	}
 	reverse_proxy api:8080
 }


### PR DESCRIPTION
Trim the Caddyfile to only add HSTS + Permissions-Policy (which the app does not set) plus encode; the app already sets CSP/X-Frame/X-CTO/Referrer, so Caddy was duplicating them (duplicate CSP = fragile intersection). Compression (encode zstd gzip) is retained.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security header configuration to eliminate duplicate headers and clarify header management between the application and web server layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->