### PR TITLE
fix(notifier): respect channel preference & stop silently dropping alerts (#1402, #1403)

### DIFF
--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -250,6 +250,16 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 			c.ack(ctx, msg.ID)
 			return
 		}
+		if errors.Is(err, notifier.ErrNoDelivery) {
+			// The recipient has no reachable target right now (e.g. a web user
+			// with no push subscription). Retrying or re-claiming would loop
+			// forever, so ack and keep the dedup claim — but log it so the
+			// missed delivery is visible rather than a silent success.
+			c.logger.Warn("no delivery target for recipient; acking without retry",
+				"id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
+			c.ack(ctx, msg.ID)
+			return
+		}
 		c.logger.Error("deliver alert failed", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
 		return
 	}

--- a/internal/notifier/multi.go
+++ b/internal/notifier/multi.go
@@ -115,58 +115,49 @@ func (m *MultiNotifier) NotifyRaw(ctx context.Context, recipient string, message
 	return errors.Join(errs...)
 }
 
+// resolveAll returns the notifier(s) a recipient should be delivered through,
+// based strictly on the user's platform channel (telegram or web). Each user
+// record belongs to exactly one channel, so we never fan out to channels the
+// user did not opt into — previously web-push was added to every recipient,
+// which caused duplicate sends and, worse, let a no-op web-push "success"
+// (zero subscriptions) mask a failed Telegram delivery, silently dropping the
+// alert. A last-resort fallback is used only when the recipient/user/channel
+// cannot be resolved, so we never drop an alert without attempting delivery.
 func (m *MultiNotifier) resolveAll(ctx context.Context, recipient string) map[string]Notifier {
 	result := make(map[string]Notifier)
 
 	chatID, err := strconv.ParseInt(recipient, 10, 64)
 	if err != nil {
-		if n := m.notifiers[m.fallback]; n != nil {
-			result[m.fallback] = n
-		}
+		m.addFallback(result)
 		return result
 	}
 
 	user, uErr := m.userStore.GetUser(ctx, chatID)
 	if uErr != nil {
 		m.logger.Warn("resolve user failed, using fallback", "recipient", recipient, "error", uErr)
-		if n := m.notifiers[m.fallback]; n != nil {
-			result[m.fallback] = n
-		}
+		m.addFallback(result)
 		return result
 	}
 
-	if user != nil && user.Channel != "" {
-		resolvedChannel := normalizeChannel(user.Channel)
-		if n, ok := m.notifiers[resolvedChannel]; ok {
-			result[resolvedChannel] = n
-		}
+	channel := ""
+	if user != nil {
+		channel = normalizeChannel(user.Channel)
+	}
+	if n, ok := m.notifiers[channel]; ok {
+		result[channel] = n
+		return result
 	}
 
-	if _, ok := result["telegram"]; !ok {
-		if n, ok := m.notifiers["telegram"]; ok {
-			if user != nil && normalizeChannel(user.Channel) == "telegram" {
-				result["telegram"] = n
-			}
-		}
-	}
-
-	if n, ok := m.notifiers["webpush"]; ok {
-		if _, alreadyAdded := result["webpush"]; !alreadyAdded {
-			result["webpush"] = n
-		}
-	}
-
-	if len(result) == 0 {
-		channel := ""
-		if user != nil {
-			channel = user.Channel
-		}
-		m.logger.Warn("no notification channel resolved for user",
-			"recipient", recipient, "channel", channel)
-		if n := m.notifiers[m.fallback]; n != nil {
-			result[m.fallback] = n
-		}
-	}
-
+	m.logger.Warn("no notifier for user channel, using fallback",
+		"recipient", recipient, "channel", channel)
+	m.addFallback(result)
 	return result
+}
+
+// addFallback adds the first-registered (fallback) notifier to result, if one
+// exists. Used only when a recipient's own channel cannot be resolved.
+func (m *MultiNotifier) addFallback(result map[string]Notifier) {
+	if n := m.notifiers[m.fallback]; n != nil {
+		result[m.fallback] = n
+	}
 }

--- a/internal/notifier/multi_test.go
+++ b/internal/notifier/multi_test.go
@@ -97,7 +97,10 @@ func (f *fakeUserStore) GetLinkedTelegramUser(_ context.Context, webChatID int64
 	return u, nil
 }
 
-func TestMultiNotifier_FanOutToAllChannels(t *testing.T) {
+func TestMultiNotifier_TelegramUserGetsOnlyTelegram(t *testing.T) {
+	// A user whose channel is "telegram" must be delivered ONLY via Telegram —
+	// web-push must not be fanned out (it would duplicate, and a no-op push
+	// "success" could mask a Telegram failure).
 	tg := &fakeNotifier{name: "telegram"}
 	wp := &fakeNotifier{name: "webpush"}
 
@@ -117,12 +120,16 @@ func TestMultiNotifier_FanOutToAllChannels(t *testing.T) {
 	if len(tg.rawCalls) != 1 {
 		t.Errorf("telegram got %d calls, want 1", len(tg.rawCalls))
 	}
-	if len(wp.rawCalls) != 1 {
-		t.Errorf("webpush got %d calls, want 1 (fan-out)", len(wp.rawCalls))
+	if len(wp.rawCalls) != 0 {
+		t.Errorf("webpush got %d calls, want 0 (must respect telegram-only preference)", len(wp.rawCalls))
 	}
 }
 
-func TestMultiNotifier_PartialFailureSucceeds(t *testing.T) {
+func TestMultiNotifier_ChannelFailureSurfaces(t *testing.T) {
+	// A Telegram user resolves only to Telegram; if Telegram delivery fails the
+	// error MUST surface (so the dedup claim is released and the alert retried)
+	// rather than being masked by a no-op web-push success on a channel the user
+	// never opted into. This is the regression guard for the silent-miss bug.
 	tg := &fakeNotifier{name: "telegram", notifyErr: fmt.Errorf("telegram down")}
 	wp := &fakeNotifier{name: "webpush"}
 
@@ -135,9 +142,33 @@ func TestMultiNotifier_PartialFailureSucceeds(t *testing.T) {
 	_ = mn.Register("webpush", wp)
 
 	ctx := context.Background()
-	err := mn.NotifyRaw(ctx, "100", "hello")
-	if err != nil {
-		t.Fatalf("partial failure should succeed, got: %v", err)
+	if err := mn.NotifyRaw(ctx, "100", "hello"); err == nil {
+		t.Fatal("telegram failure must surface as an error, not be masked by web-push")
+	}
+	if len(wp.rawCalls) != 0 {
+		t.Errorf("webpush got %d calls, want 0 (telegram user must not fan out to push)", len(wp.rawCalls))
+	}
+}
+
+func TestMultiNotifier_WebUserNoSubscriptionSurfaces(t *testing.T) {
+	// A web user with zero push subscriptions: webpush returns ErrNoDelivery,
+	// which must surface as an error (not silent success) so the alert is retried
+	// instead of being marked delivered.
+	wp := &fakeNotifier{name: "webpush", notifyErr: ErrNoDelivery}
+	users := &fakeUserStore{users: map[int64]*storage.User{
+		777: {ChatID: 777, Channel: "web"},
+	}}
+
+	mn := NewMultiNotifier(users, slog.Default())
+	_ = mn.Register("telegram", &fakeNotifier{name: "telegram"})
+	_ = mn.Register("webpush", wp)
+
+	err := mn.NotifyRaw(context.Background(), "777", "hello")
+	if err == nil {
+		t.Fatal("web user with no subscriptions must surface an error, not silent success")
+	}
+	if !errors.Is(err, ErrNoDelivery) {
+		t.Errorf("expected ErrNoDelivery, got %v", err)
 	}
 }
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -11,6 +11,12 @@ import (
 
 var ErrRecipientBlocked = errors.New("recipient blocked the bot")
 
+// ErrNoDelivery means a channel had no reachable target for the recipient (e.g.
+// a web user with zero push subscriptions). It must NOT be treated as a
+// successful delivery — otherwise the alert is silently dropped (dedup claim
+// kept / message ACKed) even though nothing reached the user.
+var ErrNoDelivery = errors.New("no delivery target for recipient")
+
 // MinSafeMessageLen is the minimum length a valid formatted message should
 // have. Anything shorter is almost certainly a bug (raw template syntax,
 // partial format string, or empty payload).

--- a/internal/notifier/webpush/webpush.go
+++ b/internal/notifier/webpush/webpush.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -76,7 +77,10 @@ func (n *Notifier) Notify(ctx context.Context, recipient string, listings []mode
 		return fmt.Errorf("webpush: list subscriptions for %d: %w", chatID, err)
 	}
 	if len(subs) == 0 {
-		return nil // user has not subscribed — not an error
+		// Nothing to deliver to. Signal this explicitly so the caller does not
+		// mistake it for a successful delivery (which would silently drop the
+		// alert). See notifier.ErrNoDelivery.
+		return notifier.ErrNoDelivery
 	}
 
 	payload := buildListingPayload(listings)
@@ -100,7 +104,7 @@ func (n *Notifier) NotifyRaw(ctx context.Context, recipient string, message stri
 		return fmt.Errorf("webpush: list subscriptions for %d: %w", chatID, err)
 	}
 	if len(subs) == 0 {
-		return nil
+		return notifier.ErrNoDelivery
 	}
 
 	payload := pushPayload{

--- a/internal/notifier/webpush/webpush_test.go
+++ b/internal/notifier/webpush/webpush_test.go
@@ -3,6 +3,7 @@ package webpush
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
@@ -120,8 +122,8 @@ func TestNotify_NoSubscriptions_Noop(t *testing.T) {
 		{RawListing: model.RawListing{Token: "abc", Manufacturer: "Toyota", Model: "Corolla", Year: 2021, Price: 120000}},
 	}, locale.English)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, notifier.ErrNoDelivery) {
+		t.Fatalf("expected ErrNoDelivery for user without subscriptions, got %v", err)
 	}
 	if calls.Load() != 0 {
 		t.Errorf("expected 0 send calls for user without subscriptions, got %d", calls.Load())
@@ -252,8 +254,8 @@ func TestNotifyRaw_NoSubscriptions_Noop(t *testing.T) {
 	n.sendFunc = sendFn
 
 	err := n.NotifyRaw(context.Background(), "99", "hello")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, notifier.ErrNoDelivery) {
+		t.Fatalf("expected ErrNoDelivery, got %v", err)
 	}
 	if calls.Load() != 0 {
 		t.Errorf("expected 0 calls, got %d", calls.Load())


### PR DESCRIPTION
## Fixes the critical silent-missed-alert bug (#1402) + channel fan-out (#1403)

### Problem
`MultiNotifier.resolveAll` appended `webpush` to **every** recipient regardless of their channel, and `webpush.Notify` returned **success with zero subscriptions**. Combined with "any channel succeeded ⇒ success", a Telegram user whose Telegram send failed was marked delivered by a no-op push → dedup claim kept / message acked → **alert lost silently**. It also caused duplicate sends and real-time push for digest/telegram users.

### Fix
- **`resolveAll`** now resolves to **exactly the user's platform channel** (`telegram` or `web`); no unconditional webpush fan-out. Removed the dead/redundant resolution block. Last-resort fallback retained only for unresolvable recipients.
- **`webpush.Notify`/`NotifyRaw`** return the new **`notifier.ErrNoDelivery`** when the user has 0 subscriptions, instead of `nil` — "nothing delivered" can never be mistaken for success.
- **broker consumer** handles `ErrNoDelivery` as **ack + keep dedup claim + log** (no retry storm, no silent success); `ErrRecipientBlocked`/`ErrNoChannelNotifier` still dead-letter.

### Tests
- `resolveAll`: telegram user → telegram only (no push); web user → webpush only.
- **Regression guard:** Telegram failure now **surfaces an error** (not masked).
- Web user with no subscription → surfaces `ErrNoDelivery`.
- webpush unit tests updated to expect `ErrNoDelivery` on 0 subs.
- Verified locally: `go build ./...`, `go test ./internal/notifier/... ./internal/broker/...` (all pass), `golangci-lint` clean on changed packages.

### Follow-up (not here)
A web user who never completed push opt-in is now logged as undeliverable rather than silently "delivered" — consider surfacing this in the UI / a re-prompt.

Closes #1402
Closes #1403

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>