### PR TITLE
fix: nested-interactive a11y + push icon + remove unused deps

### DIFF
--- a/internal/notifier/webpush/webpush.go
+++ b/internal/notifier/webpush/webpush.go
@@ -110,7 +110,7 @@ func (n *Notifier) NotifyRaw(ctx context.Context, recipient string, message stri
 	payload := pushPayload{
 		Title: "CarWatch",
 		Body:  message,
-		Icon:  "/icon-192.png",
+		Icon:  "/logo-192.png",
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -192,7 +192,7 @@ func (n *Notifier) deliver(ctx context.Context, chatID int64, subs []storage.Pus
 // buildListingPayload creates a push notification payload from one or more listings.
 func buildListingPayload(listings []model.Listing) pushPayload {
 	if len(listings) == 0 {
-		return pushPayload{Title: "CarWatch", Body: "New listings available", Icon: "/icon-192.png"}
+		return pushPayload{Title: "CarWatch", Body: "New listings available", Icon: "/logo-192.png"}
 	}
 
 	if len(listings) == 1 {
@@ -229,7 +229,7 @@ func buildListingPayload(listings []model.Listing) pushPayload {
 			Title: title,
 			Body:  body,
 			URL:   url,
-			Icon:  "/icon-192.png",
+			Icon:  "/logo-192.png",
 		}
 	}
 
@@ -247,7 +247,7 @@ func buildListingPayload(listings []model.Listing) pushPayload {
 	return pushPayload{
 		Title: title,
 		Body:  body,
-		Icon:  "/icon-192.png",
+		Icon:  "/logo-192.png",
 	}
 }
 

--- a/internal/notifier/webpush/webpush_test.go
+++ b/internal/notifier/webpush/webpush_test.go
@@ -168,8 +168,8 @@ func TestNotify_SingleListing_FormatsPayload(t *testing.T) {
 	if payload.URL != "/listings/tok123" {
 		t.Errorf("url = %q, want %q", payload.URL, "/listings/tok123")
 	}
-	if payload.Icon != "/icon-192.png" {
-		t.Errorf("icon = %q, want %q", payload.Icon, "/icon-192.png")
+	if payload.Icon != "/logo-192.png" {
+		t.Errorf("icon = %q, want %q", payload.Icon, "/logo-192.png")
 	}
 	// Body should contain price and km.
 	if payload.Body != "120000 NIS | 30000 km" {

--- a/web/src/components/CompactListingCard.tsx
+++ b/web/src/components/CompactListingCard.tsx
@@ -13,7 +13,6 @@ import { useListingActions } from "@/hooks/useListingActions";
 import { useSpotlight } from "@/hooks/useSpotlight";
 import { useToast } from "@/components/ui/Toast";
 
-/** Dense, scannable single-row variant of a listing — used in compact mode. */
 export const CompactListingCard = memo(function CompactListingCard({
   listing,
 }: {
@@ -38,16 +37,22 @@ export const CompactListingCard = memo(function CompactListingCard({
     .join(" · ");
 
   return (
-    <Link
-      to={`/listings/${listing.token}`}
-      state={{ listing }}
+    <div
       {...spotlight}
-      aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
       className={cn(
-        "spotlight group flex items-center gap-3 rounded-xl border border-border/40 bg-card p-2.5 transition-all duration-200 hover:border-primary/30 hover:shadow-[0_8px_28px_-12px_var(--color-glow-primary)] dir-rtl",
+        "spotlight group relative flex items-center gap-3 rounded-xl border border-border/40 bg-card p-2.5 transition-all duration-200 hover:border-primary/30 hover:shadow-[0_8px_28px_-12px_var(--color-glow-primary)] dir-rtl",
         listing.removed_at && "opacity-60",
       )}
     >
+      {/* Stretched navigation link */}
+      <Link
+        to={`/listings/${listing.token}`}
+        state={{ listing }}
+        aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
+        className="absolute inset-0 z-0 rounded-xl"
+        tabIndex={-1}
+      />
+
       <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg bg-secondary">
         {listing.image_url ? (
           <img
@@ -102,16 +107,13 @@ export const CompactListingCard = memo(function CompactListingCard({
         ) : null}
       </div>
 
-      <div className="flex shrink-0 items-center gap-0.5">
+      {/* Actions — above the stretched link */}
+      <div className="relative z-10 flex shrink-0 items-center gap-0.5">
         <button
           type="button"
           aria-label={seen ? "החזר לרשימת החדשות" : "סמן כנצפה"}
           aria-pressed={seen}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleSeen();
-          }}
+          onClick={() => toggleSeen()}
           className={cn(
             "flex h-11 w-11 items-center justify-center rounded-lg transition-colors",
             seen
@@ -125,14 +127,12 @@ export const CompactListingCard = memo(function CompactListingCard({
           type="button"
           aria-label={saved ? "הסר משמורים" : "שמור מודעה"}
           aria-pressed={saved}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
+          onClick={() =>
             toggleSaved({
               onSuccess: (next) =>
                 toast(next ? "נשמר בהצלחה" : "הוסר מהשמורים", next ? "success" : "info"),
-            });
-          }}
+            })
+          }
           className={cn(
             "flex h-11 w-11 items-center justify-center rounded-lg transition-colors",
             saved
@@ -143,6 +143,6 @@ export const CompactListingCard = memo(function CompactListingCard({
           <Bookmark className={cn("h-4 w-4", saved && "fill-current")} />
         </button>
       </div>
-    </Link>
+    </div>
   );
 });

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "next-themes"
+import { useTheme } from "@/contexts/ThemeContext"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -479,28 +479,28 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
   return (
     <Card
       {...spotlight}
-      className="spotlight group overflow-hidden transition-all duration-300 ease-out hover:border-primary/20 hover:shadow-[0_16px_48px_-12px_var(--color-glow-primary)] hover:-translate-y-0.5"
+      className="spotlight group relative overflow-hidden transition-all duration-300 ease-out hover:border-primary/20 hover:shadow-[0_16px_48px_-12px_var(--color-glow-primary)] hover:-translate-y-0.5 dir-rtl"
     >
-    <Link
-      to={`/listings/${listing.token}`}
-      state={{ listing }}
-      aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
-      className="block dir-rtl"
-    >
+      {/* Stretched navigation link — covers entire card */}
+      <Link
+        to={`/listings/${listing.token}`}
+        state={{ listing }}
+        aria-label={`${listing.manufacturer} ${listing.model} ${listing.year} - ${formatPrice(listing.price)}`}
+        className="absolute inset-0 z-0"
+        tabIndex={-1}
+      />
+
       <ListingCardBody
         listing={listing}
         hoverScale
         showBookmarkOverlay={saved}
         actions={
-          <>
+          <div className="relative z-10 flex items-center">
             <button
               type="button"
               aria-label={seen ? "החזר לרשימת החדשות" : "סמן כנצפה"}
               aria-pressed={seen}
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleSeen();
-              }}
+              onClick={() => toggleSeen()}
               className={cn(
                 "rounded-lg p-2.5 min-h-[44px] min-w-[44px] flex items-center justify-center transition-all duration-150",
                 seen
@@ -518,12 +518,11 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
               type="button"
               aria-label={saved ? "הסר משמורים" : "שמור מודעה"}
               aria-pressed={saved}
-              onClick={(e) => {
-                e.stopPropagation();
+              onClick={() =>
                 toggleSaved({
                   onSuccess: (next) => toast(next ? "נשמר בהצלחה" : "הוסר מהשמורים", next ? "success" : "info"),
-                });
-              }}
+                })
+              }
               className={cn(
                 "rounded-lg p-2.5 min-h-[44px] min-w-[44px] flex items-center justify-center transition-all duration-150",
                 saved
@@ -541,16 +540,14 @@ const ListingCard = memo(function ListingCard({ listing }: { listing: Listing })
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="פתח מודעה באתר חיצוני"
-                onClick={(e) => e.stopPropagation()}
                 className="rounded-lg p-2.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground transition-all duration-150 hover:bg-primary/5 hover:text-primary"
               >
                 <ExternalLink className="h-4 w-4" />
               </a>
             ) : null}
-          </>
+          </div>
         }
       />
-    </Link>
     </Card>
   );
 });


### PR DESCRIPTION
## Summary

Fixes 3 open issues:

### #1405 — Nested interactive elements (a11y)

Stretched-link pattern: card navigation Link is absolutely-positioned behind content, action buttons sit above with z-10. No more button/a nested inside a.

- ListingsPage ListingCard: refactored
- CompactListingCard: refactored

### #1404 — Push notification icon 404

webpush.go: 4x `/icon-192.png` → `/logo-192.png` (actual file).

### #1407 — Unused dependencies  

sonner.tsx: `next-themes` → local ThemeContext. Removed next-themes + @fontsource-variable/geist.

## Test plan

- [x] 298/298 tests pass
- [x] Build succeeds
- [x] 0 lint errors
- [ ] Keyboard tab through listing cards
- [ ] Push notifications display icon

closes #1404
closes #1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated push notification icon asset reference for proper display.

* **Refactor**
  * Improved navigation structure and interaction handling across listing cards for better maintainability.
  * Optimized theme integration for notification components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->