### PR TITLE
feat(web): prerender landing page for SEO + fast first paint (#1406)

### DIFF
--- a/internal/spa/spa.go
+++ b/internal/spa/spa.go
@@ -46,7 +46,19 @@ func Handler(distFS fs.FS) http.Handler {
 			}
 		}
 
+		// SPA fallback. The landing route ("/") is prerendered into index.html
+		// for SEO and a fast first paint. Every other route is served a clean
+		// shell (app-shell.html) when one exists, so the authenticated app does
+		// not briefly flash the marketing page before the JS bundle mounts.
+		// Falls back to index.html when no prerendered shell is present.
 		w.Header().Set("Cache-Control", "no-cache")
+		if path != "" {
+			if _, err := fs.Stat(distFS, "app-shell.html"); err == nil {
+				r.URL.Path = "/app-shell.html"
+				fileServer.ServeHTTP(w, r)
+				return
+			}
+		}
 		r.URL.Path = "/"
 		fileServer.ServeHTTP(w, r)
 	})

--- a/internal/spa/spa_test.go
+++ b/internal/spa/spa_test.go
@@ -59,3 +59,44 @@ func TestHandler_ServesIndexForSPARoutes(t *testing.T) {
 		})
 	}
 }
+
+// When a prerendered build is present, "/" serves the prerendered landing
+// (index.html) while every other SPA route serves the clean app shell so the
+// app does not flash marketing content before the bundle mounts.
+func TestHandler_ServesShellForNonLandingRoutes(t *testing.T) {
+	fs := fstest.MapFS{
+		"index.html":             {Data: []byte("<html>prerendered-landing</html>")},
+		"app-shell.html":         {Data: []byte("<html>clean-shell</html>")},
+		"assets/index-abc123.js": {Data: []byte("console.log('app')")},
+	}
+
+	handler := Handler(fs)
+
+	tests := []struct {
+		path     string
+		wantBody string
+	}{
+		{"/", "<html>prerendered-landing</html>"},
+		{"/dashboard", "<html>clean-shell</html>"},
+		{"/searches/new", "<html>clean-shell</html>"},
+		{"/listings/tok-123", "<html>clean-shell</html>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+			if got := w.Body.String(); got != tt.wantBody {
+				t.Errorf("body = %q, want %q", got, tt.wantBody)
+			}
+			if got := w.Header().Get("Cache-Control"); got != "no-cache" {
+				t.Errorf("Cache-Control = %q, want no-cache", got)
+			}
+		})
+	}
+}

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/prerender-landing.mjs",
+    "build:nossg": "tsc -b && vite build",
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/web/scripts/prerender-landing.mjs
+++ b/web/scripts/prerender-landing.mjs
@@ -1,0 +1,90 @@
+// Build-time prerender of the public landing page.
+//
+// Runs after `vite build` (see the `build` npm script). It renders the landing
+// route to static HTML with react-dom/server and injects it into the built
+// `dist/index.html`, so the marketing copy/headings are present in the initial
+// HTML response (SEO + fast first paint) without any runtime/JS dependency.
+//
+// Pure Node — no headless browser — so it runs identically in local dev, CI,
+// and the Alpine Docker build stage. Lazy below-the-fold sections are resolved
+// via `renderToPipeableStream`'s `onAllReady` callback.
+//
+// A clean copy of the shell is written to `dist/app-shell.html`: the Go SPA
+// handler serves that for non-landing routes so the authenticated app never
+// briefly flashes the marketing page before the bundle mounts.
+
+import { createServer } from "vite";
+import { renderToPipeableStream } from "react-dom/server";
+import { createElement } from "react";
+import { Writable } from "node:stream";
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const indexHtmlPath = resolve(webRoot, "dist/index.html");
+const shellPath = resolve(webRoot, "dist/app-shell.html");
+const ROOT_DIV = '<div id="root"></div>';
+
+function fail(message) {
+  console.error(`[prerender] ${message}`);
+  process.exit(1);
+}
+
+if (!existsSync(indexHtmlPath)) {
+  fail("dist/index.html not found — run `vite build` first.");
+}
+
+const template = readFileSync(indexHtmlPath, "utf8");
+if (!template.includes(ROOT_DIV)) {
+  fail(`expected ${ROOT_DIV} in dist/index.html; aborting to avoid a bad write.`);
+}
+
+// Preserve the empty shell for the SPA fallback before we inject content.
+copyFileSync(indexHtmlPath, shellPath);
+
+// `ssrLoadModule` transforms TSX, the `@` alias, and CSS imports on the fly, so
+// no separate SSR bundle is needed.
+const vite = await createServer({
+  root: webRoot,
+  logLevel: "error",
+  server: { middlewareMode: true },
+  appType: "custom",
+});
+
+try {
+  const { createLandingElement } = await vite.ssrLoadModule(
+    "/src/prerender/entry-landing.tsx",
+  );
+
+  const appHtml = await new Promise((resolvePromise, reject) => {
+    let html = "";
+    const sink = new Writable({
+      write(chunk, _encoding, callback) {
+        html += chunk;
+        callback();
+      },
+    });
+    sink.on("finish", () => resolvePromise(html));
+    sink.on("error", reject);
+
+    // `onAllReady` fires once every Suspense boundary (the lazy below-the-fold
+    // sections) has resolved, giving us the complete static markup.
+    const { pipe } = renderToPipeableStream(createElement(createLandingElement), {
+      onAllReady() {
+        pipe(sink);
+      },
+      onError(error) {
+        reject(error);
+      },
+    });
+  });
+
+  const prerendered = template.replace(ROOT_DIV, `<div id="root">${appHtml}</div>`);
+  writeFileSync(indexHtmlPath, prerendered);
+  console.log(
+    `[prerender] landing → dist/index.html (+${appHtml.length} bytes); clean shell → dist/app-shell.html`,
+  );
+} finally {
+  await vite.close();
+}

--- a/web/src/prerender/entry-landing.tsx
+++ b/web/src/prerender/entry-landing.tsx
@@ -1,0 +1,28 @@
+import { MemoryRouter } from "react-router";
+import type { ReactElement } from "react";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { LandingPage } from "@/pages/LandingPage";
+
+/**
+ * Build-time entry used by `scripts/prerender-landing.mjs` to render the public
+ * landing page to static HTML (SEO + fast first paint). It deliberately wraps
+ * the page in only the providers it actually consumes at render time:
+ *
+ *  - `ThemeProvider` — `LandingNav` reads it via `useTheme`. It is SSR-safe:
+ *    `getInitialTheme()` guards on `typeof window === "undefined"`.
+ *  - `MemoryRouter` — the landing renders `<Link>`s, which need a router context.
+ *
+ * No Auth/Query providers: the landing tree uses neither during render (Firebase
+ * is loaded lazily inside an effect, and `useAppVersion` fetches in an effect).
+ * The client still boots through the full provider tree in `main.tsx`; this
+ * markup is only the initial paint that React replaces on mount.
+ */
+export function createLandingElement(): ReactElement {
+  return (
+    <ThemeProvider>
+      <MemoryRouter initialEntries={["/"]}>
+        <LandingPage />
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1406. The app is a client-rendered Vite SPA, so `/` shipped an empty `<div id="root">` — all marketing copy/headings required JS to appear (weak crawlability, JS-bound first paint). This prerenders the landing to static HTML at build time.

### Approach (industry-standard for this stack, researched)
React Router v7's official path is framework-mode prerendering, but that means migrating `index.html`→`root.tsx`, `main.tsx`→`entry.client.tsx`, removing `BrowserRouter`, and reworking the build output + `embed.go` + SPA-fallback serving — a large, deploy-risky change on a just-stabilized pipeline. Since the **production build rebuilds the web app in a `node:22-alpine` Docker stage** (no browser), a Puppeteer snapshot would force `apk add chromium` across 3 environments (~300MB bloat, fragile).

Instead I used **build-time SSG via `react-dom/server`** — the same technique `vite-react-ssg` uses — which is **pure Node** (runs identically in dev, CI, and Alpine Docker) and keeps the SPA architecture + existing Go `dist/` embed intact.

### Changes
- **`scripts/prerender-landing.mjs`** — after `vite build`, renders the landing route with `renderToPipeableStream` and injects the markup into `dist/index.html`. Lazy below-the-fold sections resolve via `onAllReady`. Uses Vite `ssrLoadModule` (handles TSX/`@`-alias/CSS) — **no headless browser, no new deps**.
- **`src/prerender/entry-landing.tsx`** — wraps the page in only the providers it uses at render: `ThemeProvider` + `MemoryRouter`. The landing tree is SSR-safe (ThemeProvider guards on `typeof window`, Firebase loads lazily in an effect, all `window`/`document` access is effect-scoped).
- **Client still boots via `createRoot`** (not hydrate), so prerendered markup is cleanly replaced on mount — **no hydration-mismatch risk**; it only serves crawlers + first paint.
- **`internal/spa/spa.go`** — a clean `dist/app-shell.html` is preserved before injection; the Go SPA handler serves it for non-landing routes so the authenticated app never flashes the marketing page before the bundle mounts. Falls back to `index.html` when no shell exists (backward compatible). Covered by a new test.

### Acceptance criteria
- [x] `GET /` returns the landing headings/copy in HTML, no JS — verified over HTTP: Hebrew hero `<h1>` + all 6 section `<h2>`s present, `#root` populated.
- [ ] Lighthouse SEO ≥ 95 / improved FCP — needs a deployed run (content + meta/JSON-LD from #1395 are now in the initial HTML).

### Test plan
- [x] `npm run build` runs the prerender (pure Node) — landing injected (+61.8 KB), clean shell written
- [x] `GET /` → landing HTML; app routes → clean shell (Go test `TestHandler_ServesShellForNonLandingRoutes`)
- [x] 298/298 web tests, `tsc -b`, `eslint`, `gofmt`, `golangci-lint` all pass

> Note: a browser smoke-test (landing mounts/interactive over prerendered DOM) and a deployed Lighthouse run are recommended as a final manual check.

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)