### PR TITLE
feat(web): searchable manufacturer & model pickers (trie typeahead)

### DIFF
--- a/web/src/components/SearchFormFields.tsx
+++ b/web/src/components/SearchFormFields.tsx
@@ -1,11 +1,26 @@
+import { useMemo } from "react";
 import { formatPrice } from "@/lib/utils";
 import { useManufacturers, useModels } from "@/hooks/useCatalog";
 import { Toggle } from "@/components/ui/toggle";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RangeSlider } from "@/components/ui/RangeSlider";
-import { Select } from "@/components/ui/NativeSelect";
+import { Combobox, type ComboboxOption } from "@/components/ui/Combobox";
 import { FormField } from "@/components/ui/FormField";
+import type { Manufacturer, Model } from "@/lib/api";
+
+/** Map a catalog entry to a searchable combobox option (matches both names). */
+function catalogOption(entry: Manufacturer | Model): ComboboxOption {
+  const label =
+    entry.name_he && entry.name_he !== entry.name
+      ? `${entry.name_he} (${entry.name})`
+      : entry.name;
+  return {
+    value: entry.id,
+    label,
+    keywords: [entry.name, entry.name_he].filter((k): k is string => Boolean(k)),
+  };
+}
 
 export interface SearchFormData {
   name: string;
@@ -155,6 +170,24 @@ export function VehicleFields({
   const { data: manufacturers } = useManufacturers();
   const { data: models } = useModels(form.manufacturer);
 
+  const manufacturerOptions = useMemo<ComboboxOption[]>(
+    () => [
+      { value: 0, label: "כל היצרנים" },
+      ...(manufacturers ?? []).map(catalogOption),
+    ],
+    [manufacturers],
+  );
+  const modelOptions = useMemo<ComboboxOption[]>(
+    () => [
+      {
+        value: 0,
+        label: form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים",
+      },
+      ...(models ?? []).map(catalogOption),
+    ],
+    [models, form.manufacturer],
+  );
+
   if (readOnly) {
     return null;
   }
@@ -178,39 +211,31 @@ export function VehicleFields({
 
       <div className="grid gap-4 sm:grid-cols-2">
         <FormField label="יצרן" htmlFor="mfr">
-          <Select
+          <Combobox
             id="mfr"
+            options={manufacturerOptions}
             value={form.manufacturer}
-            onChange={(e) => {
-              set("manufacturer", Number(e.target.value));
+            onChange={(v) => {
+              set("manufacturer", Number(v));
               set("model", 0);
             }}
-          >
-            <option value={0}>כל היצרנים</option>
-            {manufacturers?.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}
-              </option>
-            ))}
-          </Select>
+            placeholder="כל היצרנים"
+            searchPlaceholder="חיפוש יצרן…"
+            emptyText="לא נמצא יצרן"
+          />
         </FormField>
 
         <FormField label="דגם" htmlFor="mdl">
-          <Select
+          <Combobox
             id="mdl"
+            options={modelOptions}
             value={form.model}
             disabled={form.manufacturer === 0}
-            onChange={(e) => set("model", Number(e.target.value))}
-          >
-            <option value={0}>
-              {form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים"}
-            </option>
-            {models?.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.name_he && m.name_he !== m.name ? `${m.name_he} (${m.name})` : m.name}
-              </option>
-            ))}
-          </Select>
+            onChange={(v) => set("model", Number(v))}
+            placeholder={form.manufacturer === 0 ? "יש לבחור יצרן קודם" : "כל הדגמים"}
+            searchPlaceholder="חיפוש דגם…"
+            emptyText="לא נמצא דגם"
+          />
         </FormField>
       </div>
 

--- a/web/src/components/ui/Combobox.test.tsx
+++ b/web/src/components/ui/Combobox.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { Combobox, type ComboboxOption } from "./Combobox";
+
+const OPTIONS: ComboboxOption[] = [
+  { value: 0, label: "כל היצרנים" },
+  { value: 1, label: "טויוטה (Toyota)", keywords: ["Toyota", "טויוטה"] },
+  { value: 2, label: "לנד רובר (Land Rover)", keywords: ["Land Rover", "לנד רובר"] },
+  { value: 3, label: "מרצדס (Mercedes)", keywords: ["Mercedes", "מרצדס"] },
+];
+
+function Harness({ onChange }: { onChange?: (v: ComboboxOption["value"]) => void }) {
+  const [value, setValue] = useState<ComboboxOption["value"]>(0);
+  return (
+    <Combobox
+      options={OPTIONS}
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChange?.(v);
+      }}
+      placeholder="כל היצרנים"
+      searchPlaceholder="חיפוש יצרן…"
+      emptyText="לא נמצא יצרן"
+    />
+  );
+}
+
+describe("Combobox", () => {
+  it("shows the selected option's label in the trigger", () => {
+    render(
+      <Combobox options={OPTIONS} value={2} onChange={() => {}} />,
+    );
+    expect(screen.getByText("לנד רובר (Land Rover)")).toBeInTheDocument();
+  });
+
+  it("opens on click and lists all options", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button"));
+    await screen.findByPlaceholderText("חיפוש יצרן…");
+
+    expect(screen.getAllByRole("option")).toHaveLength(OPTIONS.length);
+  });
+
+  it("filters options through the trie as the user types (prefix of any word)", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button"));
+    const input = await screen.findByPlaceholderText("חיפוש יצרן…");
+
+    // "rover" is the second word of "Land Rover"
+    await user.type(input, "rover");
+
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent("לנד רובר");
+    });
+  });
+
+  it("matches a Hebrew prefix", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button"));
+    const input = await screen.findByPlaceholderText("חיפוש יצרן…");
+    await user.type(input, "מרצ");
+
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent("מרצדס");
+    });
+  });
+
+  it("shows the empty message when nothing matches", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button"));
+    const input = await screen.findByPlaceholderText("חיפוש יצרן…");
+    await user.type(input, "zzz");
+
+    expect(await screen.findByText("לא נמצא יצרן")).toBeInTheDocument();
+  });
+
+  it("calls onChange and reflects the selection when an option is picked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    await user.click(screen.getByRole("button"));
+    const input = await screen.findByPlaceholderText("חיפוש יצרן…");
+    await user.type(input, "toy");
+
+    await user.click(await screen.findByRole("option"));
+
+    expect(onChange).toHaveBeenCalledWith(1);
+    // trigger now shows the picked label
+    expect(screen.getByText("טויוטה (Toyota)")).toBeInTheDocument();
+  });
+
+  it("is disabled when the disabled prop is set", () => {
+    render(<Combobox options={OPTIONS} value={0} onChange={() => {}} disabled />);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/web/src/components/ui/Combobox.tsx
+++ b/web/src/components/ui/Combobox.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import {
+  Command,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { buildTrie } from "@/lib/trie";
+import { cn } from "@/lib/utils";
+
+export interface ComboboxOption {
+  value: number | string;
+  /** Text shown in the trigger and list row. */
+  label: string;
+  /** Extra strings to match on (e.g. an English name alongside a Hebrew label). */
+  keywords?: string[];
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[];
+  value: ComboboxOption["value"];
+  onChange: (value: ComboboxOption["value"]) => void;
+  /** Trigger text when nothing is selected. */
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  id?: string;
+  dir?: "rtl" | "ltr";
+  className?: string;
+}
+
+/**
+ * A searchable single-select. Typing filters the options through a word-level
+ * prefix {@link buildTrie | trie} (cmdk's built-in fuzzy filter is disabled), so
+ * a prefix of any word — in either the label or its keywords — matches.
+ */
+export function Combobox({
+  options,
+  value,
+  onChange,
+  placeholder = "בחר…",
+  searchPlaceholder = "חיפוש…",
+  emptyText = "לא נמצאו תוצאות",
+  disabled,
+  id,
+  dir = "rtl",
+  className,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const trie = useMemo(
+    () => buildTrie(options, (o) => [o.label, ...(o.keywords ?? [])]),
+    [options],
+  );
+  const results = useMemo(() => trie.search(query), [trie, query]);
+
+  const selected = options.find((o) => o.value === value);
+
+  function close() {
+    setOpen(false);
+    setQuery("");
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger
+        id={id}
+        disabled={disabled}
+        dir={dir}
+        aria-expanded={open}
+        className={cn(
+          "flex w-full items-center justify-between gap-2 rounded-xl border border-border bg-background py-2.5 ps-4 pe-3 text-sm outline-none transition-all duration-200 focus:border-primary focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+      >
+        <span className={cn("truncate", !selected && "text-muted-foreground")}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronsUpDown
+          className="h-4 w-4 shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-(--anchor-width) min-w-48 p-0"
+      >
+        <Command shouldFilter={false} dir={dir}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={searchPlaceholder}
+            dir={dir}
+            autoFocus
+          />
+          <CommandList>
+            {results.length === 0 ? (
+              <div className="py-6 text-center text-sm text-muted-foreground">
+                {emptyText}
+              </div>
+            ) : (
+              results.map((opt) => (
+                <CommandItem
+                  key={opt.value}
+                  value={String(opt.value)}
+                  onSelect={() => {
+                    onChange(opt.value);
+                    close();
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "h-4 w-4",
+                      opt.value === value ? "opacity-100" : "opacity-0",
+                    )}
+                    aria-hidden
+                  />
+                  <span className="truncate">{opt.label}</span>
+                </CommandItem>
+              ))
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/lib/trie.test.ts
+++ b/web/src/lib/trie.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { Trie, buildTrie } from "./trie";
+
+interface Make {
+  id: number;
+  name: string;
+  name_he?: string;
+}
+
+const makes: Make[] = [
+  { id: 1, name: "Toyota", name_he: "טויוטה" },
+  { id: 2, name: "Land Rover", name_he: "לנד רובר" },
+  { id: 3, name: "Mercedes-Benz", name_he: "מרצדס" },
+  { id: 4, name: "Mazda", name_he: "מאזדה" },
+];
+
+function build() {
+  return buildTrie(makes, (m) => [m.name, m.name_he]);
+}
+
+describe("Trie", () => {
+  it("returns all values for an empty or whitespace query", () => {
+    const trie = build();
+    expect(trie.search("").map((m) => m.id)).toEqual([1, 2, 3, 4]);
+    expect(trie.search("   ").map((m) => m.id)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("matches an English prefix case-insensitively", () => {
+    const trie = build();
+    expect(trie.search("toy").map((m) => m.id)).toEqual([1]);
+    expect(trie.search("TOY").map((m) => m.id)).toEqual([1]);
+  });
+
+  it("matches a Hebrew prefix", () => {
+    const trie = build();
+    expect(trie.search("מרצ").map((m) => m.id)).toEqual([3]);
+  });
+
+  it("matches a prefix of any word, not just the first", () => {
+    const trie = build();
+    // "rov" is the second word of "Land Rover"
+    expect(trie.search("rov").map((m) => m.id)).toEqual([2]);
+  });
+
+  it("splits on punctuation so 'benz' matches 'Mercedes-Benz'", () => {
+    const trie = build();
+    expect(trie.search("benz").map((m) => m.id)).toEqual([3]);
+  });
+
+  it("AND-intersects multi-word queries", () => {
+    const trie = build();
+    expect(trie.search("land rov").map((m) => m.id)).toEqual([2]);
+    // both prefixes must match the same item
+    expect(trie.search("land toy")).toEqual([]);
+  });
+
+  it("returns multiple matches in insertion order", () => {
+    const trie = build();
+    // "ma" prefixes Mercedes? no. Mazda yes. Add ambiguity:
+    expect(trie.search("ma").map((m) => m.id)).toEqual([4]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    const trie = build();
+    expect(trie.search("xyz")).toEqual([]);
+  });
+
+  it("ignores undefined keywords via buildTrie filtering", () => {
+    const trie = buildTrie(
+      [{ id: 9, name: "Kia", name_he: undefined }],
+      (m: Make) => [m.name, m.name_he],
+    );
+    expect(trie.search("ki").map((m) => m.id)).toEqual([9]);
+    expect(trie.search("").map((m) => m.id)).toEqual([9]);
+  });
+
+  it("dedupes a value indexed under overlapping keywords", () => {
+    const trie = new Trie<Make>();
+    trie.insert({ id: 1, name: "Audi" }, ["Audi", "Audi", "audi"]);
+    expect(trie.search("au").map((m) => m.id)).toEqual([1]);
+  });
+});

--- a/web/src/lib/trie.ts
+++ b/web/src/lib/trie.ts
@@ -1,0 +1,124 @@
+/**
+ * Word-level prefix trie for fast typeahead search over a small in-memory
+ * catalog (manufacturers / models). Each value is indexed under every
+ * whitespace/punctuation-separated token of its searchable strings, so typing a
+ * prefix of *any* word matches it — e.g. "rov" matches "Land Rover", and the
+ * Hebrew "מרצ" matches "מרצדס". Multi-word queries are AND-ed across tokens
+ * ("land rov" → "Land Rover"). Search is case-insensitive and returns matches in
+ * insertion order so the caller's original ordering is preserved.
+ *
+ * Why a trie rather than `Array.filter(includes)`: prefix lookups are O(prefix
+ * length) regardless of catalog size, and every node caches the set of value
+ * ids beneath it, so collecting matches for a prefix is O(matches) with no
+ * per-keystroke scan of the full list.
+ */
+
+interface TrieNode {
+  children: Map<string, TrieNode>;
+  /** Value ids whose token passes through this node (i.e. has this prefix). */
+  ids: Set<number>;
+}
+
+function createNode(): TrieNode {
+  return { children: new Map(), ids: new Set() };
+}
+
+function normalize(text: string): string {
+  return text.toLowerCase().trim();
+}
+
+/** Split a string into searchable tokens on whitespace and common separators. */
+function tokenize(text: string): string[] {
+  return normalize(text)
+    .split(/[\s/\\\-_(),.]+/)
+    .filter(Boolean);
+}
+
+function intersect(a: Set<number>, b: Set<number>): Set<number> {
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  const out = new Set<number>();
+  for (const id of small) {
+    if (large.has(id)) out.add(id);
+  }
+  return out;
+}
+
+export class Trie<T> {
+  private readonly root = createNode();
+  private readonly values: T[] = [];
+
+  /** Index `value` under each token of every provided keyword. */
+  insert(value: T, keywords: string[]): void {
+    const id = this.values.length;
+    this.values.push(value);
+    const seen = new Set<string>();
+    for (const keyword of keywords) {
+      for (const token of tokenize(keyword)) {
+        if (seen.has(token)) continue;
+        seen.add(token);
+        this.insertToken(token, id);
+      }
+    }
+  }
+
+  private insertToken(token: string, id: number): void {
+    let node = this.root;
+    node.ids.add(id);
+    for (const char of token) {
+      let next = node.children.get(char);
+      if (!next) {
+        next = createNode();
+        node.children.set(char, next);
+      }
+      node = next;
+      node.ids.add(id);
+    }
+  }
+
+  /**
+   * Return values that have a token starting with each token in `query`
+   * (AND semantics), in insertion order. An empty/whitespace query returns all
+   * values.
+   */
+  search(query: string): T[] {
+    const tokens = tokenize(query);
+    if (tokens.length === 0) return [...this.values];
+
+    let matched: Set<number> | null = null;
+    for (const token of tokens) {
+      const ids = this.collect(token);
+      matched = matched === null ? ids : intersect(matched, ids);
+      if (matched.size === 0) return [];
+    }
+
+    return [...(matched ?? [])]
+      .sort((a, b) => a - b)
+      .map((id) => this.values[id]);
+  }
+
+  /** Ids of all values whose any token starts with `prefix`. */
+  private collect(prefix: string): Set<number> {
+    let node = this.root;
+    for (const char of prefix) {
+      const next = node.children.get(char);
+      if (!next) return new Set();
+      node = next;
+    }
+    return node.ids;
+  }
+}
+
+/** Build a trie from a list, deriving each item's searchable keywords. */
+export function buildTrie<T>(
+  items: T[],
+  getKeywords: (item: T) => Array<string | undefined>,
+): Trie<T> {
+  const trie = new Trie<T>();
+  for (const item of items) {
+    const keywords = getKeywords(item).filter(
+      (k): k is string => Boolean(k),
+    );
+    trie.insert(item, keywords);
+  }
+  return trie;
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,5 +1,24 @@
 import "@testing-library/jest-dom/vitest";
 
+// jsdom lacks these APIs that base-ui/cmdk (Popover positioning, list
+// scrolling, pointer capture) rely on. Stub them so component tests can mount.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub;
+Element.prototype.scrollIntoView = () => {};
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+
 // jsdom doesn't implement matchMedia — stub it for ThemeProvider.
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
## Summary

Suggested by **Oren** 👋 — the new-search form used plain native `<select>` dropdowns for manufacturer and sub-model, so finding an entry meant scrolling a long list. This adds **type-to-search** to both, backed by a prefix **trie** (Oren's suggestion).

### Changes
- **`lib/trie.ts`** — a word-level prefix trie. Each value is indexed under every whitespace/punctuation-separated token of its searchable strings, so a prefix of *any* word matches (`rov` → "Land Rover"), in **both Hebrew and English**, case-insensitive. Multi-word queries AND-intersect (`land rov` → "Land Rover"). Every node caches the value ids beneath it, so a prefix lookup is `O(matches)` rather than a full-list scan per keystroke.
- **`components/ui/Combobox.tsx`** — a reusable searchable single-select built on the existing **Popover + cmdk `Command`** primitives, with cmdk's own fuzzy filter **disabled** so the trie does the filtering. Keyboard-navigable and accessible.
- **`SearchFormFields.tsx`** — both the manufacturer and model pickers now use `Combobox`, matching on the Hebrew label + English name. Behaviour is otherwise unchanged: `value 0` = "all", picking a manufacturer resets the model, and the model picker stays disabled until a manufacturer is chosen.

### Notes
- **No backend change** — the catalog API already returns the full manufacturer/model lists; the trie filters them client-side for instant results.
- The `Combobox` is imported only by the lazy new/edit-search route chunks, so it stays **off the landing's first-paint path** (consistent with #1407 — `vendor` stays 131 KB gz).

### Test plan
- [x] `lib/trie.test.ts` — 10 tests (English/Hebrew prefix, any-word match, punctuation split, multi-word AND, empty/no-match, dedupe)
- [x] `components/ui/Combobox.test.tsx` — 7 tests covering the real flow: open → type → trie-filter (incl. Hebrew) → empty state → select → `onChange`
- [x] **315/315** web tests pass; `tsc -b`, `eslint`, `npm run build` (incl. landing prerender) all clean
- [x] Added jsdom polyfills (`ResizeObserver`, `scrollIntoView`, pointer-capture) to `test/setup.ts` so base-ui/cmdk components can be unit-tested

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vehicle search form now features searchable combobox dropdowns for manufacturer and model selection, enabling faster filtering through available options.

* **Tests**
  * Added comprehensive test coverage for the new searchable dropdown component and underlying search utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->