### PR TITLE
feat: add notification delivery ledger for durable alert tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ web/dist/
 firebase-service-account*.json
 *-adminsdk-*.json
 *.pem
+*.key
+ssh-key-*
 *.env
 *.env.local
 *.env.*.local

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -123,6 +123,7 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 		multi.NotifyRaw,
 		logger.With("component", "broker-consumer"),
 		broker.WithDeadLetterHook(releaseDedupClaimsOnDeadLetter(store, logger)),
+		broker.WithDeliveryHook(recordDeliveries(store, logger)),
 	)
 	if err != nil {
 		return fmt.Errorf("create redis consumer: %w", err)
@@ -205,5 +206,47 @@ func releaseDedupClaimsOnDeadLetter(dedup storage.DedupStore, logger *slog.Logge
 			"tokens", len(alert.Tokens),
 			"search_id", alert.SearchID)
 		return nil
+	}
+}
+
+// recordDeliveries persists each instant-path delivery outcome to the ledger.
+// Token-bearing alerts (new-listing batches) record one row per listing sharing
+// the Redis message id as batch_id; token-less alerts (price drops) record one
+// aggregate row. Best-effort: a ledger write failure is logged but never blocks
+// acking — the message was already delivered.
+func recordDeliveries(deliveries storage.NotificationDeliveryStore, logger *slog.Logger) broker.DeliveryHook {
+	return func(ctx context.Context, alert broker.Alert, msgID, status string) {
+		if deliveries == nil {
+			return
+		}
+		var events []storage.DeliveryEvent
+		if len(alert.Tokens) > 0 {
+			events = make([]storage.DeliveryEvent, 0, len(alert.Tokens))
+			for _, token := range alert.Tokens {
+				events = append(events, storage.DeliveryEvent{
+					ChatID:    alert.ChatID,
+					Token:     token,
+					SearchID:  alert.SearchID,
+					AlertType: "instant",
+					Status:    status,
+					BatchID:   msgID,
+				})
+			}
+		} else {
+			events = []storage.DeliveryEvent{{
+				ChatID:    alert.ChatID,
+				SearchID:  alert.SearchID,
+				AlertType: "price_drop",
+				Status:    status,
+				BatchID:   msgID,
+			}}
+		}
+
+		recCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := deliveries.RecordDeliveries(recCtx, events); err != nil {
+			logger.Error("record delivery ledger failed (best-effort)",
+				"chat_id", alert.ChatID, "status", status, "tokens", len(alert.Tokens), "error", err)
+		}
 	}
 }

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -147,18 +147,19 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	// on what it uses. The concrete *postgres.Store satisfies all of
 	// them, but typing the slots makes the dependency graph explicit.
 	var (
-		dedup        storage.DedupStore            = store
-		prices       storage.PriceTracker          = store
-		listings     storage.ListingStore          = store
-		searches     storage.SearchStore           = store
-		users        storage.UserStore             = store
-		digests      storage.DigestStore           = store
-		hidden       storage.HiddenListingStore    = store
-		market       storage.MarketStore           = store
-		priceList    storage.PriceListStore        = store
-		dailyDigests storage.DailyDigestStore      = store
-		cycleLog     storage.CycleLogStore         = store
-		cycleStats   storage.SearchCycleStatsStore = store
+		dedup      storage.DedupStore                = store
+		prices     storage.PriceTracker              = store
+		listings   storage.ListingStore              = store
+		searches   storage.SearchStore               = store
+		users      storage.UserStore                 = store
+		digests    storage.DigestStore               = store
+		hidden     storage.HiddenListingStore        = store
+		market     storage.MarketStore               = store
+		priceList  storage.PriceListStore            = store
+		dailyDgst  storage.DailyDigestStore          = store
+		cycleLog   storage.CycleLogStore             = store
+		cycleStats storage.SearchCycleStatsStore     = store
+		deliveries storage.NotificationDeliveryStore = store
 	)
 	sched, err := scheduler.NewWithOptions(cfg, fb.Caching, dedup, n, logger.With("component", "scheduler"), scheduler.Options{
 		Observer:              h,
@@ -176,9 +177,10 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 		MarketStore:           market,
 		PriceListStore:        priceList,
 		PriceListSvc:          plSvc,
-		DailyDigestStore:      dailyDigests,
+		DailyDigestStore:      dailyDgst,
 		CycleLogStore:         cycleLog,
 		SearchCycleStatsStore: cycleStats,
+		DeliveryStore:         deliveries,
 		Publisher:             pub,
 		EnrichPublisher:       enrichPub,
 	})

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -263,10 +263,10 @@ func TestE2E_DigestFlow(t *testing.T) {
 		t.Errorf("mode=%q interval=%q, want digest/1h", mode, interval)
 	}
 
-	if err := store.AddDigestItem(ctx, 100, "listing A"); err != nil {
+	if err := store.AddDigestItem(ctx, 100, "listing A", []string{"tokA"}); err != nil {
 		t.Fatalf("add item: %v", err)
 	}
-	if err := store.AddDigestItem(ctx, 100, "listing B"); err != nil {
+	if err := store.AddDigestItem(ctx, 100, "listing B", []string{"tokB"}); err != nil {
 		t.Fatalf("add item: %v", err)
 	}
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -39,6 +39,15 @@ type adminListingResponse struct {
 	EngineType   string   `json:"engine_type,omitempty"`
 	GearBox      string   `json:"gear_box,omitempty"`
 	Description  string   `json:"description,omitempty"`
+	// Delivered is the latest Telegram-delivery outcome for this (chat, listing).
+	// nil means no delivery was recorded (matched-only / not tracked).
+	Delivered *adminDeliveryInfo `json:"delivered,omitempty"`
+}
+
+type adminDeliveryInfo struct {
+	Status    string `json:"status"`     // sent | failed | dropped | dead_lettered
+	AlertType string `json:"alert_type"` // instant | price_drop | digest | daily
+	SentAt    string `json:"sent_at"`
 }
 
 type adminStatsResponse struct {
@@ -235,8 +244,13 @@ func (s *Server) adminListListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	searchID := int64(searchIDVal)
+	chatIDVal, ok := parseIntParam(w, r, "chat_id", 0)
+	if !ok {
+		return
+	}
+	chatID := int64(chatIDVal)
 
-	items, total, err := s.admin.AdminListListings(r.Context(), limit, offset, searchID)
+	items, total, err := s.admin.AdminListListings(r.Context(), limit, offset, searchID, chatID)
 	if err != nil {
 		s.logger.Error("admin: list listings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list listings")
@@ -245,7 +259,16 @@ func (s *Server) adminListListings(w http.ResponseWriter, r *http.Request) {
 
 	resp := make([]adminListingResponse, 0, len(items))
 	for _, l := range items {
+		var delivered *adminDeliveryInfo
+		if l.NotifiedAt != nil {
+			delivered = &adminDeliveryInfo{
+				Status:    l.NotifyStatus,
+				AlertType: l.NotifyVia,
+				SentAt:    l.NotifiedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			}
+		}
 		resp = append(resp, adminListingResponse{
+			Delivered:    delivered,
 			ChatID:       l.ChatID,
 			Token:        l.Token,
 			SearchID:     l.SearchID,

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -705,7 +705,7 @@ func (f *failingAdminStore) PurgeTable(_ context.Context, _ string) (int64, erro
 	return 0, nil
 }
 
-func (f *failingAdminStore) AdminListListings(_ context.Context, _, _ int, _ int64) ([]storage.ListingRecord, int64, error) {
+func (f *failingAdminStore) AdminListListings(_ context.Context, _, _ int, _, _ int64) ([]storage.ListingRecord, int64, error) {
 	return nil, 0, nil
 }
 

--- a/internal/bot/error_paths_test.go
+++ b/internal/bot/error_paths_test.go
@@ -183,7 +183,9 @@ func (m *errDigestStore) GetDigestMode(_ context.Context, _ int64) (string, stri
 	return m.mode, m.interval, nil
 }
 
-func (m *errDigestStore) AddDigestItem(_ context.Context, _ int64, _ string) error { return nil }
+func (m *errDigestStore) AddDigestItem(_ context.Context, _ int64, _ string, _ []string) error {
+	return nil
+}
 func (m *errDigestStore) PeekDigest(_ context.Context, _ int64) ([]string, time.Time, error) {
 	return nil, time.Time{}, nil
 }

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -239,10 +239,10 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 	} else {
 		c.logger.Warn("message dead-lettered after max retries", dlAttrs...)
 	}
+	c.ack(ctx, id)
 	if alertErr == nil {
 		c.fireDelivery(ctx, alert, id, "dead_lettered")
 	}
-	c.ack(ctx, id)
 }
 
 func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -31,11 +31,18 @@ const (
 type NotifyFunc func(ctx context.Context, recipient string, message string) error
 type DeadLetterHook func(ctx context.Context, alert Alert) error
 
+// DeliveryHook records the outcome of a delivery attempt for the persisted
+// delivery ledger. msgID is the Redis stream id (used as a batch id grouping
+// one Telegram message -> N listings). It is best-effort: it must not block
+// acking, and errors are the hook's own responsibility to log.
+type DeliveryHook func(ctx context.Context, alert Alert, msgID string, status string)
+
 // Consumer reads alerts from the Redis Stream and delivers them.
 type Consumer struct {
 	client               *redis.Client
 	notify               NotifyFunc
 	deadLetterHook       DeadLetterHook
+	deliveryHook         DeliveryHook
 	limiter              *rate.Limiter
 	logger               *slog.Logger
 	consumer             string
@@ -86,6 +93,18 @@ func NewConsumer(addr, password string, db int, notify NotifyFunc, logger *slog.
 func WithDeadLetterHook(h DeadLetterHook) func(*Consumer) {
 	return func(c *Consumer) {
 		c.deadLetterHook = h
+	}
+}
+
+func WithDeliveryHook(h DeliveryHook) func(*Consumer) {
+	return func(c *Consumer) {
+		c.deliveryHook = h
+	}
+}
+
+func (c *Consumer) fireDelivery(ctx context.Context, alert Alert, msgID, status string) {
+	if c.deliveryHook != nil {
+		c.deliveryHook(ctx, alert, msgID, status)
 	}
 }
 
@@ -220,6 +239,9 @@ func (c *Consumer) deadLetter(ctx context.Context, id string) {
 	} else {
 		c.logger.Warn("message dead-lettered after max retries", dlAttrs...)
 	}
+	if alertErr == nil {
+		c.fireDelivery(ctx, alert, id, "dead_lettered")
+	}
 	c.ack(ctx, id)
 }
 
@@ -248,6 +270,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 			c.logger.Warn("dropping alert for permanently undeliverable recipient",
 				"id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
 			c.ack(ctx, msg.ID)
+			c.fireDelivery(ctx, alert, msg.ID, "dropped")
 			return
 		}
 		if errors.Is(err, notifier.ErrNoDelivery) {
@@ -258,6 +281,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 			c.logger.Warn("no delivery target for recipient; acking without retry",
 				"id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
 			c.ack(ctx, msg.ID)
+			c.fireDelivery(ctx, alert, msg.ID, "dropped")
 			return
 		}
 		c.logger.Error("deliver alert failed", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName, "error", err)
@@ -266,6 +290,7 @@ func (c *Consumer) processMessage(ctx context.Context, msg redis.XMessage) {
 
 	c.ack(ctx, msg.ID)
 	c.logger.Info("alert delivered", "id", msg.ID, "chat_id", alert.ChatID, "search_name", alert.SearchName)
+	c.fireDelivery(ctx, alert, msg.ID, "sent")
 
 	if telemetry.QueueLag != nil {
 		if lag := messageAge(msg.ID); lag > 0 {

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -175,12 +175,17 @@ func (d *DigestDelivery) DeliverBatch(ctx context.Context, chatID int64, listing
 	if notifier.IsMalformedMessage(msg) {
 		return errMalformedMessage
 	}
-	return d.store.AddDigestItem(ctx, chatID, msg)
+	tokens := make([]string, 0, len(listings))
+	for _, l := range listings {
+		tokens = append(tokens, l.Token)
+	}
+	return d.store.AddDigestItem(ctx, chatID, msg, tokens)
 }
 
 func (d *DigestDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
 	if notifier.IsMalformedMessage(message) {
 		return errMalformedMessage
 	}
-	return d.store.AddDigestItem(ctx, chatID, message)
+	// Raw digest items (e.g. price drops) carry no per-listing token.
+	return d.store.AddDigestItem(ctx, chatID, message, nil)
 }

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -113,7 +113,7 @@ func newFailDigestStore(err error) *failDigestStore {
 	}
 }
 
-func (m *failDigestStore) AddDigestItem(_ context.Context, _ int64, _ string) error {
+func (m *failDigestStore) AddDigestItem(_ context.Context, _ int64, _ string, _ []string) error {
 	return m.addErr
 }
 

--- a/internal/scheduler/digest.go
+++ b/internal/scheduler/digest.go
@@ -190,9 +190,13 @@ func (s *Scheduler) sendDailyDigest(ctx context.Context, chatID int64) {
 	}
 
 	// Record an aggregate 'daily' delivery (no per-listing token: the daily
-	// digest is a summary, not a per-listing alert). Best-effort.
+	// digest is a summary, not a per-listing alert). Best-effort: a failure
+	// must not prevent UpdateDailyDigestLastSent, otherwise the user gets
+	// duplicate digests. Detach from the scheduler context so shutdown
+	// cannot cancel the write.
 	if s.stores.Deliveries != nil {
-		if err := s.stores.Deliveries.RecordDeliveries(ctx, []storage.DeliveryEvent{{
+		recCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		if err := s.stores.Deliveries.RecordDeliveries(recCtx, []storage.DeliveryEvent{{
 			ChatID:    chatID,
 			AlertType: "daily",
 			Status:    "sent",
@@ -200,6 +204,7 @@ func (s *Scheduler) sendDailyDigest(ctx context.Context, chatID int64) {
 			s.logger.Error("record daily digest delivery failed (best-effort)",
 				"chat_id", chatID, "error", err)
 		}
+		cancel()
 	}
 
 	if err := s.stores.DailyDigests.UpdateDailyDigestLastSent(ctx, chatID); err != nil {

--- a/internal/scheduler/digest.go
+++ b/internal/scheduler/digest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/notifier"
+	"github.com/dsionov/carwatch/internal/storage"
 )
 
 const (
@@ -186,6 +187,19 @@ func (s *Scheduler) sendDailyDigest(ctx context.Context, chatID int64) {
 	if err := s.notifier.NotifyRaw(ctx, chatIDStr, msg); err != nil {
 		s.logger.Error("send daily digest failed", "chat_id", chatID, "error", err)
 		return
+	}
+
+	// Record an aggregate 'daily' delivery (no per-listing token: the daily
+	// digest is a summary, not a per-listing alert). Best-effort.
+	if s.stores.Deliveries != nil {
+		if err := s.stores.Deliveries.RecordDeliveries(ctx, []storage.DeliveryEvent{{
+			ChatID:    chatID,
+			AlertType: "daily",
+			Status:    "sent",
+		}}); err != nil {
+			s.logger.Error("record daily digest delivery failed (best-effort)",
+				"chat_id", chatID, "error", err)
+		}
 	}
 
 	if err := s.stores.DailyDigests.UpdateDailyDigestLastSent(ctx, chatID); err != nil {

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -370,7 +370,7 @@ func (m *mockDigestStore) GetDigestMode(_ context.Context, chatID int64) (string
 	return "instant", "6h", nil
 }
 
-func (m *mockDigestStore) AddDigestItem(_ context.Context, chatID int64, payload string) error {
+func (m *mockDigestStore) AddDigestItem(_ context.Context, chatID int64, payload string, _ []string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.items[chatID] = append(m.items[chatID], digestItem{payload: payload, createdAt: time.Now()})

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -110,6 +110,7 @@ type Stores struct {
 	DailyDigests     storage.DailyDigestStore
 	CycleLog         storage.CycleLogStore
 	SearchCycleStats storage.SearchCycleStatsStore
+	Deliveries       storage.NotificationDeliveryStore
 }
 
 type searchResult struct {
@@ -138,6 +139,7 @@ type Options struct {
 	DailyDigestStore      storage.DailyDigestStore
 	CycleLogStore         storage.CycleLogStore
 	SearchCycleStatsStore storage.SearchCycleStatsStore
+	DeliveryStore         storage.NotificationDeliveryStore
 	MarketCacheTTL        time.Duration
 	Publisher             *broker.Publisher
 	EnrichPublisher       *broker.EnrichPublisher
@@ -204,6 +206,7 @@ func NewWithOptions(
 			DailyDigests:     opts.DailyDigestStore,
 			CycleLog:         opts.CycleLogStore,
 			SearchCycleStats: opts.SearchCycleStatsStore,
+			Deliveries:       opts.DeliveryStore,
 		},
 		notifier:        n,
 		logger:          logger,

--- a/internal/scheduler/scheduler_errors_test.go
+++ b/internal/scheduler/scheduler_errors_test.go
@@ -127,11 +127,11 @@ func (m *errDigestStore) GetDigestMode(ctx context.Context, chatID int64) (strin
 	return m.mockDigestStore.GetDigestMode(ctx, chatID)
 }
 
-func (m *errDigestStore) AddDigestItem(ctx context.Context, chatID int64, payload string) error {
+func (m *errDigestStore) AddDigestItem(ctx context.Context, chatID int64, payload string, tokens []string) error {
 	if m.addItemErr != nil {
 		return m.addItemErr
 	}
-	return m.mockDigestStore.AddDigestItem(ctx, chatID, payload)
+	return m.mockDigestStore.AddDigestItem(ctx, chatID, payload, tokens)
 }
 
 func (m *errDigestStore) PeekDigest(ctx context.Context, chatID int64) ([]string, time.Time, error) {

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -118,8 +118,14 @@ type PriceTracker interface {
 type DigestStore interface {
 	SetDigestMode(ctx context.Context, chatID int64, mode string, interval string) error
 	GetDigestMode(ctx context.Context, chatID int64) (mode string, interval string, err error)
-	AddDigestItem(ctx context.Context, chatID int64, payload string) error
+	// AddDigestItem queues a rendered digest payload plus the source listing
+	// tokens it covers (used to attribute the eventual send in the delivery
+	// ledger). tokens may be empty for token-less items (e.g. price drops).
+	AddDigestItem(ctx context.Context, chatID int64, payload string, tokens []string) error
 	PeekDigest(ctx context.Context, chatID int64) ([]string, time.Time, error)
+	// AckDigest is called only after a digest was successfully sent: it records
+	// a 'digest' delivery for every queued token, deletes the flushed items, and
+	// stamps digest_last_flushed — atomically.
 	AckDigest(ctx context.Context, chatID int64, before time.Time) error
 	PendingDigestUsers(ctx context.Context) ([]int64, error)
 	DigestLastFlushed(ctx context.Context, chatID int64) (time.Time, error)
@@ -158,6 +164,12 @@ type ListingRecord struct {
 	// RemovedAt: non-nil when the listing disappeared from the source but was
 	// preserved because it is bookmarked ("likely sold").
 	RemovedAt *time.Time
+	// Delivery: latest Telegram-delivery outcome for this (chat, listing) from
+	// the notification_deliveries ledger. Nil NotifiedAt = no delivery recorded
+	// (matched-only / not tracked), distinct from a 'failed'/'dropped' status.
+	NotifiedAt   *time.Time
+	NotifyVia    string // instant | price_drop | digest | daily
+	NotifyStatus string // sent | failed | dropped | dead_lettered
 }
 
 type PricePoint struct {
@@ -336,6 +348,41 @@ type DailySearchStats struct {
 	PriceTrend    float64
 }
 
+// DeliveryEvent records the outcome of attempting to send one alert to one
+// user for one listing (or an aggregate send when Token is empty).
+type DeliveryEvent struct {
+	ChatID    int64
+	Token     string // "" for aggregate sends (e.g. daily digest)
+	SearchID  int64
+	AlertType string // instant | price_drop | digest | daily
+	Channel   string // defaults to "telegram" when empty
+	Status    string // sent | failed | dropped | dead_lettered (defaults to "sent")
+	BatchID   string // groups one Telegram message -> N listings (Redis stream id)
+	Error     string
+}
+
+// DeliveryInfo is the latest delivery outcome for a (chat, token) pair.
+type DeliveryInfo struct {
+	Token     string    `json:"token"`
+	AlertType string    `json:"alert_type"`
+	Status    string    `json:"status"`
+	SentAt    time.Time `json:"sent_at"`
+}
+
+// NotificationDeliveryStore persists and reads the alert-delivery ledger
+// (notification_deliveries). This is the durable record of whether a specific
+// alert actually reached a user — distinct from listing_history, which only
+// records that a listing matched/was recorded.
+type NotificationDeliveryStore interface {
+	// RecordDeliveries upserts delivery outcomes. Repeated outcomes for the
+	// same (chat_id, token, alert_type, channel) collapse to one row with
+	// attempts incremented — making broker retries/reclaims idempotent.
+	RecordDeliveries(ctx context.Context, events []DeliveryEvent) error
+	// DeliveredAmong returns, for each token that has any delivery record for
+	// chatID, its most recent delivery info.
+	DeliveredAmong(ctx context.Context, chatID int64, tokens []string) (map[string]DeliveryInfo, error)
+}
+
 type DailyDigestStore interface {
 	SetDailyDigest(ctx context.Context, chatID int64, enabled bool, digestTime string) error
 	GetDailyDigest(ctx context.Context, chatID int64) (enabled bool, digestTime string, lastSent time.Time, err error)
@@ -398,7 +445,7 @@ type AdminStore interface {
 	CountAllListings(ctx context.Context) (int64, error)
 	TableSizes(ctx context.Context) (map[string]int64, error)
 	PurgeTable(ctx context.Context, table string) (int64, error)
-	AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]ListingRecord, int64, error)
+	AdminListListings(ctx context.Context, limit, offset int, searchID, chatID int64) ([]ListingRecord, int64, error)
 	AdminDeleteListing(ctx context.Context, token string, chatID int64) error
 	AdminListSearches(ctx context.Context) ([]Search, error)
 	AdminDeleteSearch(ctx context.Context, id int64) error

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -133,40 +133,46 @@ func (s *Store) ResetAllData(ctx context.Context) (map[string]int64, error) {
 	return counts, nil
 }
 
-func (s *Store) AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]storage.ListingRecord, int64, error) {
-	var total int64
+func (s *Store) AdminListListings(ctx context.Context, limit, offset int, searchID, chatID int64) ([]storage.ListingRecord, int64, error) {
+	var conds []string
+	var filterArgs []any
 	if searchID > 0 {
-		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM listing_history WHERE search_id = $1`, searchID).Scan(&total); err != nil {
-			return nil, 0, fmt.Errorf("count listings: %w", err)
-		}
-	} else {
-		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM listing_history`).Scan(&total); err != nil {
-			return nil, 0, fmt.Errorf("count listings: %w", err)
-		}
+		filterArgs = append(filterArgs, searchID)
+		conds = append(conds, fmt.Sprintf("lh.search_id = $%d", len(filterArgs)))
+	}
+	if chatID > 0 {
+		filterArgs = append(filterArgs, chatID)
+		conds = append(conds, fmt.Sprintf("lh.chat_id = $%d", len(filterArgs)))
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
 	}
 
-	var rows *sql.Rows
-	var err error
-	if searchID > 0 {
-		rows, err = s.db.QueryContext(ctx, `
-			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
-				km, hand, city, page_link, image_url,
-				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
-			FROM listing_history
-			WHERE search_id = $1
-			ORDER BY first_seen_at DESC
-			LIMIT $2 OFFSET $3`, searchID, limit, offset)
-	} else {
-		rows, err = s.db.QueryContext(ctx, `
-			SELECT token, chat_id, search_id, search_name, manufacturer, model, sub_model, sub_model_id, year, price,
-				km, hand, city, page_link, image_url,
-				engine_volume, horse_power, engine_type, gear_box, description,
-				is_commercial, fitness_score, median_price, cohort_size, deal_score, base_price, first_seen_at, posted_at, removed_at
-			FROM listing_history
-			ORDER BY first_seen_at DESC
-			LIMIT $1 OFFSET $2`, limit, offset)
+	var total int64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM listing_history lh`+where, filterArgs...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count listings: %w", err)
 	}
+
+	args := append([]any{}, filterArgs...)
+	args = append(args, limit, offset)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT lh.token, lh.chat_id, lh.search_id, lh.search_name, lh.manufacturer, lh.model, lh.sub_model, lh.sub_model_id, lh.year, lh.price,
+			lh.km, lh.hand, lh.city, lh.page_link, lh.image_url,
+			lh.engine_volume, lh.horse_power, lh.engine_type, lh.gear_box, lh.description,
+			lh.is_commercial, lh.fitness_score, lh.median_price, lh.cohort_size, lh.deal_score, lh.base_price, lh.first_seen_at, lh.posted_at, lh.removed_at,
+			d.status, d.alert_type, d.created_at
+		FROM listing_history lh
+		LEFT JOIN LATERAL (
+			SELECT nd.status, nd.alert_type, nd.created_at
+			FROM notification_deliveries nd
+			WHERE nd.chat_id = lh.chat_id AND nd.token = lh.token
+			ORDER BY nd.created_at DESC
+			LIMIT 1
+		) d ON true`+where+`
+		ORDER BY lh.first_seen_at DESC
+		LIMIT $`+fmt.Sprintf("%d", len(filterArgs)+1)+` OFFSET $`+fmt.Sprintf("%d", len(filterArgs)+2), args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("query listings: %w", err)
 	}
@@ -177,17 +183,24 @@ func (s *Store) AdminListListings(ctx context.Context, limit, offset int, search
 		var r storage.ListingRecord
 		var fs sql.NullFloat64
 		var ic, mp, cs, ds, bp sql.NullInt64
-		var postedAt, removedAt sql.NullTime
+		var postedAt, removedAt, notifiedAt sql.NullTime
+		var notifyStatus, notifyVia sql.NullString
 		if err := rows.Scan(
 			&r.Token, &r.ChatID, &r.SearchID, &r.SearchName,
 			&r.Manufacturer, &r.Model, &r.SubModel, &r.SubModelID, &r.Year, &r.Price,
 			&r.Km, &r.Hand, &r.City, &r.PageLink, &r.ImageURL,
 			&r.EngineVolume, &r.HorsePower, &r.EngineType, &r.GearBox, &r.Description,
 			&ic, &fs, &mp, &cs, &ds, &bp, &r.FirstSeenAt, &postedAt, &removedAt,
+			&notifyStatus, &notifyVia, &notifiedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan listing: %w", err)
 		}
 		r.IsCommercial = storage.ListingCommercialFromSQL(ic)
+		if notifiedAt.Valid {
+			r.NotifiedAt = &notifiedAt.Time
+		}
+		r.NotifyStatus = notifyStatus.String
+		r.NotifyVia = notifyVia.String
 		if postedAt.Valid {
 			r.PostedAt = &postedAt.Time
 		}

--- a/internal/storage/postgres/digest.go
+++ b/internal/storage/postgres/digest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dsionov/carwatch/internal/storage"
@@ -25,7 +26,9 @@ func (s *Store) GetDigestMode(ctx context.Context, chatID int64) (string, string
 		`SELECT digest_mode, digest_interval FROM users WHERE chat_id = $1`,
 		chatID).Scan(&mode, &interval)
 	if err == sql.ErrNoRows {
-		return "digest", "6h", nil
+		// Unknown user: mirror the schema default (instant) rather than
+		// silently batching their alerts. See migration 000025.
+		return "instant", "6h", nil
 	}
 	if err != nil {
 		return "", "", fmt.Errorf("get digest mode: %w", err)
@@ -33,10 +36,10 @@ func (s *Store) GetDigestMode(ctx context.Context, chatID int64) (string, string
 	return mode, interval, nil
 }
 
-func (s *Store) AddDigestItem(ctx context.Context, chatID int64, payload string) error {
+func (s *Store) AddDigestItem(ctx context.Context, chatID int64, payload string, tokens []string) error {
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO pending_digest (chat_id, listing_payload) VALUES ($1, $2)`,
-		chatID, payload)
+		`INSERT INTO pending_digest (chat_id, listing_payload, tokens) VALUES ($1, $2, $3)`,
+		chatID, payload, strings.Join(tokens, ","))
 	if err != nil {
 		return fmt.Errorf("add digest item: %w", err)
 	}
@@ -73,6 +76,14 @@ func (s *Store) AckDigest(ctx context.Context, chatID int64, before time.Time) e
 		return fmt.Errorf("ack digest begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+
+	// Record a 'digest' delivery for every listing token covered by the items
+	// about to be flushed, so digest-mode users get the same per-listing
+	// "delivered" visibility as instant users. AckDigest runs only after a
+	// successful send, so these are confirmed deliveries.
+	if err := s.recordDigestDeliveries(ctx, tx, chatID, before); err != nil {
+		return err
+	}
 
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM pending_digest WHERE chat_id = $1 AND created_at <= $2`,

--- a/internal/storage/postgres/notification_deliveries.go
+++ b/internal/storage/postgres/notification_deliveries.go
@@ -1,0 +1,186 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+const recordDeliverySQL = `
+	INSERT INTO notification_deliveries
+		(chat_id, token, search_id, alert_type, channel, status, batch_id, error)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	ON CONFLICT (chat_id, token, alert_type, channel) WHERE token <> ''
+	DO UPDATE SET
+		status     = EXCLUDED.status,
+		search_id  = CASE WHEN EXCLUDED.search_id > 0 THEN EXCLUDED.search_id ELSE notification_deliveries.search_id END,
+		batch_id   = CASE WHEN EXCLUDED.batch_id <> '' THEN EXCLUDED.batch_id ELSE notification_deliveries.batch_id END,
+		error      = EXCLUDED.error,
+		attempts   = notification_deliveries.attempts + 1,
+		updated_at = NOW()`
+
+// RecordDeliveries upserts each delivery outcome. Empty-token rows (aggregate
+// sends) never match the partial unique index, so they always insert.
+func (s *Store) RecordDeliveries(ctx context.Context, events []storage.DeliveryEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("record deliveries begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, recordDeliverySQL)
+	if err != nil {
+		return fmt.Errorf("record deliveries prepare: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for _, e := range events {
+		channel := e.Channel
+		if channel == "" {
+			channel = "telegram"
+		}
+		status := e.Status
+		if status == "" {
+			status = "sent"
+		}
+		if _, err := stmt.ExecContext(ctx,
+			e.ChatID, e.Token, e.SearchID, e.AlertType, channel, status, e.BatchID, e.Error); err != nil {
+			return fmt.Errorf("record deliveries exec: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("record deliveries commit: %w", err)
+	}
+	return nil
+}
+
+// recordDigestDeliveries inserts a 'digest' delivery row for every distinct
+// listing token covered by the pending_digest items for chatID at or before
+// `before`. It must run inside the AckDigest transaction so the delivery record
+// and the queue flush commit atomically.
+func (s *Store) recordDigestDeliveries(ctx context.Context, tx *sql.Tx, chatID int64, before time.Time) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT tokens FROM pending_digest WHERE chat_id = $1 AND created_at <= $2`,
+		chatID, before)
+	if err != nil {
+		return fmt.Errorf("ack digest read tokens: %w", err)
+	}
+	var csvs []string
+	for rows.Next() {
+		var csv string
+		if err := rows.Scan(&csv); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("ack digest scan tokens: %w", err)
+		}
+		csvs = append(csvs, csv)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("ack digest tokens rows: %w", err)
+	}
+	_ = rows.Close()
+
+	stmt, err := tx.PrepareContext(ctx, recordDeliverySQL)
+	if err != nil {
+		return fmt.Errorf("ack digest prepare deliveries: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	seen := make(map[string]struct{})
+	for _, csv := range csvs {
+		for _, token := range strings.Split(csv, ",") {
+			if token == "" {
+				continue
+			}
+			if _, ok := seen[token]; ok {
+				continue
+			}
+			seen[token] = struct{}{}
+			if _, err := stmt.ExecContext(ctx,
+				chatID, token, int64(0), "digest", "telegram", "sent", "", ""); err != nil {
+				return fmt.Errorf("ack digest record delivery: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// DeliveredAmong returns the most recent delivery outcome for each of the given
+// tokens that has any delivery row for chatID. Tokens with no record are absent
+// from the map (caller treats absence as "not tracked / not delivered").
+func (s *Store) DeliveredAmong(ctx context.Context, chatID int64, tokens []string) (map[string]storage.DeliveryInfo, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+	uniq := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		uniq = append(uniq, t)
+	}
+	if len(uniq) == 0 {
+		return nil, nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("begin read tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	out := make(map[string]storage.DeliveryInfo)
+	for start := 0; start < len(uniq); start += savedAmongBatchSize {
+		end := start + savedAmongBatchSize
+		if end > len(uniq) {
+			end = len(uniq)
+		}
+		batch := uniq[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, 0, 1+len(batch))
+		args = append(args, chatID)
+		for i := range batch {
+			args = append(args, batch[i])
+			placeholders[i] = fmt.Sprintf("$%d", 2+i)
+		}
+
+		q := `SELECT DISTINCT ON (token) token, alert_type, status, created_at
+			FROM notification_deliveries
+			WHERE chat_id = $1 AND token IN (` + strings.Join(placeholders, ", ") + `)
+			ORDER BY token, created_at DESC`
+		rows, err := tx.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+
+		for rows.Next() {
+			var di storage.DeliveryInfo
+			if err := rows.Scan(&di.Token, &di.AlertType, &di.Status, &di.SentAt); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			out[di.Token] = di
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	return out, tx.Commit()
+}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -30,7 +30,7 @@ func testStore(t *testing.T) *Store {
 	t.Cleanup(func() {
 		db := store.DB()
 		tables := []string{
-			"listing_user_seen", "pending_digest",
+			"listing_user_seen", "pending_digest", "notification_deliveries",
 			"saved_listings", "hidden_listings", "listing_history",
 			"seen_listings", "price_history", "push_subscriptions", "link_tokens",
 			"daily_digest", "search_cycle_stats", "cycle_log",
@@ -1640,7 +1640,7 @@ func TestPostgres_Admin(t *testing.T) {
 	}
 
 	// AdminListListings
-	items, total, err := store.AdminListListings(ctx, 1, 0, 0)
+	items, total, err := store.AdminListListings(ctx, 1, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("AdminListListings: %v", err)
 	}
@@ -1739,13 +1739,13 @@ func TestPostgres_DigestMode(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 
-	// Default for unknown user
+	// Default for unknown user mirrors the schema default (instant).
 	mode, interval, err := store.GetDigestMode(ctx, 999)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mode != "digest" || interval != "6h" {
-		t.Errorf("defaults = %q/%q, want digest/6h", mode, interval)
+	if mode != "instant" || interval != "6h" {
+		t.Errorf("defaults = %q/%q, want instant/6h", mode, interval)
 	}
 
 	seedPgUser(t, store, 3000)
@@ -1770,10 +1770,10 @@ func TestPostgres_DigestWorkflow(t *testing.T) {
 	seedPgUser(t, store, 3101)
 
 	// Add items
-	if err := store.AddDigestItem(ctx, 3100, `{"token":"a"}`); err != nil {
+	if err := store.AddDigestItem(ctx, 3100, `{"token":"a"}`, []string{"a"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AddDigestItem(ctx, 3100, `{"token":"b"}`); err != nil {
+	if err := store.AddDigestItem(ctx, 3100, `{"token":"b"}`, []string{"b"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2146,5 +2146,151 @@ func TestPostgres_SearchCycleStats(t *testing.T) {
 	}
 	if len(got6001) != 1 {
 		t.Errorf("user 6001: expected 1, got %d", len(got6001))
+	}
+}
+
+func TestPostgres_RecordDeliveries_Upsert(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	events := []storage.DeliveryEvent{
+		{ChatID: 7000, Token: "tok-a", SearchID: 1, AlertType: "instant", Status: "sent", BatchID: "batch-1"},
+		{ChatID: 7000, Token: "tok-b", SearchID: 1, AlertType: "instant", Status: "sent", BatchID: "batch-1"},
+	}
+	if err := store.RecordDeliveries(ctx, events); err != nil {
+		t.Fatalf("initial insert: %v", err)
+	}
+
+	got, err := store.DeliveredAmong(ctx, 7000, []string{"tok-a", "tok-b", "tok-missing"})
+	if err != nil {
+		t.Fatalf("DeliveredAmong: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 delivered, got %d", len(got))
+	}
+	if got["tok-a"].Status != "sent" {
+		t.Errorf("tok-a status = %q, want sent", got["tok-a"].Status)
+	}
+	if _, ok := got["tok-missing"]; ok {
+		t.Error("tok-missing should not be in map")
+	}
+
+	// Upsert: same (chat, token, type, channel) should update, not duplicate.
+	retry := []storage.DeliveryEvent{
+		{ChatID: 7000, Token: "tok-a", SearchID: 1, AlertType: "instant", Status: "failed"},
+	}
+	if err := store.RecordDeliveries(ctx, retry); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got2, err := store.DeliveredAmong(ctx, 7000, []string{"tok-a"})
+	if err != nil {
+		t.Fatalf("DeliveredAmong after upsert: %v", err)
+	}
+	if got2["tok-a"].Status != "failed" {
+		t.Errorf("tok-a status after upsert = %q, want failed", got2["tok-a"].Status)
+	}
+}
+
+func TestPostgres_RecordDeliveries_EmptyToken(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Empty-token events (aggregate sends like daily digest) should always
+	// insert without conflicting on the partial unique index.
+	for i := range 3 {
+		if err := store.RecordDeliveries(ctx, []storage.DeliveryEvent{{
+			ChatID: 7100, AlertType: "daily", Status: "sent", BatchID: fmt.Sprintf("d-%d", i),
+		}}); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	// DeliveredAmong should return nothing for empty-token rows.
+	got, err := store.DeliveredAmong(ctx, 7100, []string{""})
+	if err != nil {
+		t.Fatalf("DeliveredAmong: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 for empty tokens, got %d", len(got))
+	}
+}
+
+func TestPostgres_RecordDeliveries_Empty(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	if err := store.RecordDeliveries(ctx, nil); err != nil {
+		t.Fatalf("nil events should be a no-op: %v", err)
+	}
+	if err := store.RecordDeliveries(ctx, []storage.DeliveryEvent{}); err != nil {
+		t.Fatalf("empty events should be a no-op: %v", err)
+	}
+}
+
+func TestPostgres_DeliveredAmong_Empty(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	got, err := store.DeliveredAmong(ctx, 999, nil)
+	if err != nil {
+		t.Fatalf("nil tokens: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil map for nil tokens, got %v", got)
+	}
+
+	got2, err := store.DeliveredAmong(ctx, 999, []string{})
+	if err != nil {
+		t.Fatalf("empty tokens: %v", err)
+	}
+	if got2 != nil {
+		t.Errorf("expected nil map for empty tokens, got %v", got2)
+	}
+}
+
+func TestPostgres_DigestDeliveriesRecorded(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 7200)
+
+	// Add digest items with tokens.
+	if err := store.AddDigestItem(ctx, 7200, `payload-x`, []string{"dtok-1", "dtok-2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddDigestItem(ctx, 7200, `payload-y`, []string{"dtok-3"}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, cutoff, err := store.PeekDigest(ctx, 7200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// AckDigest should atomically record delivery rows + delete pending items.
+	if err := store.AckDigest(ctx, 7200, cutoff); err != nil {
+		t.Fatalf("AckDigest: %v", err)
+	}
+
+	// Check that deliveries were recorded for the tokens.
+	got, err := store.DeliveredAmong(ctx, 7200, []string{"dtok-1", "dtok-2", "dtok-3"})
+	if err != nil {
+		t.Fatalf("DeliveredAmong: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 delivered tokens, got %d", len(got))
+	}
+	for _, tok := range []string{"dtok-1", "dtok-2", "dtok-3"} {
+		di, ok := got[tok]
+		if !ok {
+			t.Errorf("token %q missing from deliveries", tok)
+			continue
+		}
+		if di.AlertType != "digest" {
+			t.Errorf("token %q: alert_type = %q, want digest", tok, di.AlertType)
+		}
+		if di.Status != "sent" {
+			t.Errorf("token %q: status = %q, want sent", tok, di.Status)
+		}
 	}
 }

--- a/migrations/000025_digest_default_instant.down.sql
+++ b/migrations/000025_digest_default_instant.down.sql
@@ -1,0 +1,2 @@
+-- Restore the 000024 behavior: new users default to 'digest'.
+ALTER TABLE users ALTER COLUMN digest_mode SET DEFAULT 'digest';

--- a/migrations/000025_digest_default_instant.up.sql
+++ b/migrations/000025_digest_default_instant.up.sql
@@ -1,0 +1,4 @@
+-- Revert the new-user delivery default from 'digest' (set in 000024) back to
+-- 'instant'. New users should receive immediate per-match Telegram alerts;
+-- digest remains opt-in. Existing users keep whatever mode they already chose.
+ALTER TABLE users ALTER COLUMN digest_mode SET DEFAULT 'instant';

--- a/migrations/000026_notification_deliveries.down.sql
+++ b/migrations/000026_notification_deliveries.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pending_digest DROP COLUMN IF EXISTS tokens;
+DROP TABLE IF EXISTS notification_deliveries;

--- a/migrations/000026_notification_deliveries.up.sql
+++ b/migrations/000026_notification_deliveries.up.sql
@@ -1,0 +1,50 @@
+-- Persisted Telegram (and future multi-channel) delivery ledger.
+--
+-- Until now nothing recorded whether an alert was actually SENT: listing_history
+-- records a *match* (written at scrape/match time, and also by the web browse
+-- path, before/independent of delivery), and the only delivery signal was the
+-- ephemeral notifier log. This table is the durable source of truth for
+-- "was this specific alert delivered to this user, when, how, and did it fail".
+--
+-- One row per (chat_id, token, alert_type, channel) delivery outcome. A single
+-- instant batch (one Telegram message, many listings) inserts N rows sharing a
+-- batch_id (the Redis stream message id). Aggregate sends with no per-listing
+-- attribution (daily digest) use token = '' and are excluded from the unique
+-- index so each send is its own row.
+CREATE TABLE IF NOT EXISTS notification_deliveries (
+    id          BIGSERIAL PRIMARY KEY,
+    chat_id     BIGINT      NOT NULL,
+    token       TEXT        NOT NULL DEFAULT '',
+    search_id   BIGINT      NOT NULL DEFAULT 0,
+    alert_type  TEXT        NOT NULL,                 -- instant | price_drop | digest | daily
+    channel     TEXT        NOT NULL DEFAULT 'telegram',
+    status      TEXT        NOT NULL DEFAULT 'sent',  -- sent | failed | dropped | dead_lettered
+    batch_id    TEXT        NOT NULL DEFAULT '',
+    attempts    INTEGER     NOT NULL DEFAULT 1,
+    error       TEXT        NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotency: broker reclaim/retry can reprocess the same alert. Collapse a
+-- repeated (chat, token, type, channel) outcome to one row (status/attempts
+-- updated) instead of inserting duplicate "sent" rows.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_notification_deliveries_event
+    ON notification_deliveries (chat_id, token, alert_type, channel)
+    WHERE token <> '';
+
+-- Per-listing delivered lookup for the admin indicator.
+CREATE INDEX IF NOT EXISTS idx_notification_deliveries_token_chat
+    ON notification_deliveries (token, chat_id);
+
+-- Per-user delivery feed / audit, newest first.
+CREATE INDEX IF NOT EXISTS idx_notification_deliveries_chat_created
+    ON notification_deliveries (chat_id, created_at DESC);
+
+-- Reconstruct a batch (one Telegram message -> N listings).
+CREATE INDEX IF NOT EXISTS idx_notification_deliveries_batch
+    ON notification_deliveries (batch_id) WHERE batch_id <> '';
+
+-- pending_digest stores rendered text only; carry the source tokens so a
+-- successful digest flush can attribute the send to specific listings.
+ALTER TABLE pending_digest ADD COLUMN IF NOT EXISTS tokens TEXT NOT NULL DEFAULT '';

--- a/web/src/components/admin/ListingsTab.tsx
+++ b/web/src/components/admin/ListingsTab.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
-import { adminApi, type AdminListing } from "@/lib/api";
+import { adminApi, type AdminDelivery, type AdminListing } from "@/lib/api";
 import { EmptyState, Skeleton, Badge } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,6 +22,47 @@ import { formatKm, formatPrice, relativeTime, safeHref } from "@/lib/utils";
 import { ConfirmModal } from "./ConfirmModal";
 import { DetailModal } from "./DetailModal";
 
+const ALERT_TYPE_LABELS: Record<string, string> = {
+  instant: "מיידי",
+  digest: "סיכום",
+  daily: "יומי",
+  price_drop: "ירידת מחיר",
+};
+
+const FAILED_STATUS_LABELS: Record<string, string> = {
+  dead_lettered: "נכשל סופית",
+  dropped: "לא נמסר",
+  failed: "נכשל",
+};
+
+function DeliveryBadge({ delivered }: { delivered?: AdminDelivery }) {
+  if (!delivered) {
+    return (
+      <Badge
+        variant="secondary"
+        className="text-[10px] px-1.5 py-0"
+        title="לא תועדה שליחת התראה למשתמש"
+      >
+        — לא נשלח
+      </Badge>
+    );
+  }
+  const sent = delivered.status === "sent";
+  const via = ALERT_TYPE_LABELS[delivered.alert_type] ?? delivered.alert_type;
+  const label = sent
+    ? `✓ נשלח · ${via}`
+    : `✗ ${FAILED_STATUS_LABELS[delivered.status] ?? delivered.status}`;
+  return (
+    <Badge
+      variant={sent ? "success" : "destructive"}
+      className="text-[10px] px-1.5 py-0"
+      title={`${via} · ${relativeTime(delivered.sent_at)}`}
+    >
+      {label}
+    </Badge>
+  );
+}
+
 export function ListingsTab({
   searchId,
   onClearFilter,
@@ -29,6 +70,7 @@ export function ListingsTab({
   searchId: number | null;
   onClearFilter: () => void;
 }) {
+  const [chatIdInput, setChatIdInput] = useState("");
   const [page, setPage] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [detailListing, setDetailListing] = useState<AdminListing | null>(null);
@@ -37,17 +79,22 @@ export function ListingsTab({
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
+  const chatId = /^\d+$/.test(chatIdInput.trim())
+    ? Number(chatIdInput.trim())
+    : null;
+
   useEffect(() => {
     setPage(0);
-  }, [searchId]);
+  }, [searchId, chatId]);
 
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["admin", "listings", page, searchId],
+    queryKey: ["admin", "listings", page, searchId, chatId],
     queryFn: () =>
       adminApi.listings({
         limit: pageSize,
         offset: page * pageSize,
         ...(searchId ? { search_id: searchId } : {}),
+        ...(chatId ? { chat_id: chatId } : {}),
       }),
   });
 
@@ -113,6 +160,15 @@ export function ListingsTab({
             className="pe-10 ps-4"
           />
         </div>
+        <Input
+          type="text"
+          inputMode="numeric"
+          value={chatIdInput}
+          onChange={(e) => setChatIdInput(e.target.value.replace(/\D/g, ""))}
+          placeholder="סנן לפי Chat ID..."
+          className="px-4 sm:w-44 ltr-nums"
+          aria-label="סינון לפי Chat ID"
+        />
         <Button variant="outline" size="sm" onClick={() => void refetch()}>
           <RefreshCw className="h-3.5 w-3.5" />
           רענן
@@ -209,6 +265,7 @@ export function ListingsTab({
                             {listing.fitness_score.toFixed(1)}
                           </Badge>
                         )}
+                        <DeliveryBadge delivered={listing.delivered} />
                       </div>
                     </div>
                     <div className="flex items-center gap-1.5 flex-shrink-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
@@ -337,6 +394,16 @@ export function ListingsTab({
                 value: detailListing.first_seen_at
                   ? relativeTime(detailListing.first_seen_at)
                   : null,
+              },
+              {
+                label: "התראת טלגרם",
+                value: detailListing.delivered
+                  ? `${
+                      detailListing.delivered.status === "sent"
+                        ? "✓ נשלח"
+                        : `✗ ${FAILED_STATUS_LABELS[detailListing.delivered.status] ?? detailListing.delivered.status}`
+                    } · ${ALERT_TYPE_LABELS[detailListing.delivered.alert_type] ?? detailListing.delivered.alert_type} · ${relativeTime(detailListing.delivered.sent_at)}`
+                  : "לא נשלח",
               },
               { label: "חיפוש", value: detailListing.search_name },
               { label: "Token", value: detailListing.token },

--- a/web/src/components/admin/LogsTab.tsx
+++ b/web/src/components/admin/LogsTab.tsx
@@ -105,6 +105,7 @@ export function LogsTab({ active }: { active: boolean }) {
   const [autoScroll, setAutoScroll] = useState(true);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [backendLevel, setBackendLevel] = useState("INFO");
+  const [chatIdFilter, setChatIdFilter] = useState("");
 
   const availableComponents = useMemo(
     () => Array.from(new Set(logs.map((e) => e.component))).sort(),
@@ -125,14 +126,20 @@ export function LogsTab({ active }: { active: boolean }) {
     }
   }
 
-  const filtered = useMemo(
-    () =>
-      logs.filter(
-        (e) =>
-          !excludedComponents.has(e.component) && levelFilter.has(e.level),
-      ),
-    [logs, excludedComponents, levelFilter],
-  );
+  const filtered = useMemo(() => {
+    const cid = chatIdFilter.trim();
+    return logs.filter((e) => {
+      if (excludedComponents.has(e.component) || !levelFilter.has(e.level)) {
+        return false;
+      }
+      if (cid) {
+        const inAttrs = e.attrs && String(e.attrs.chat_id ?? "") === cid;
+        const inMessage = e.message?.includes(cid);
+        if (!inAttrs && !inMessage) return false;
+      }
+      return true;
+    });
+  }, [logs, excludedComponents, levelFilter, chatIdFilter]);
 
   useEffect(() => {
     if (autoScroll && bottomRef.current) {
@@ -226,6 +233,17 @@ export function LogsTab({ active }: { active: boolean }) {
               );
             })}
           </div>
+
+          {/* Chat ID filter */}
+          <input
+            type="text"
+            inputMode="numeric"
+            value={chatIdFilter}
+            onChange={(e) => setChatIdFilter(e.target.value.replace(/\D/g, ""))}
+            placeholder="Chat ID..."
+            aria-label="סינון לוגים לפי Chat ID"
+            className="h-7 w-28 rounded-md border border-border bg-secondary/50 px-2 text-[11px] tabular-nums placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary"
+          />
         </div>
 
         <div className="flex items-center gap-2">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -334,10 +334,18 @@ export interface VitalsSummary {
   poor: number;
 }
 
+export interface AdminDelivery {
+  status: string; // sent | failed | dropped | dead_lettered
+  alert_type: string; // instant | price_drop | digest | daily
+  sent_at: string;
+}
+
 export interface AdminListing extends Listing {
   chat_id: number;
   search_id: number;
   search_name?: string;
+  /** Latest Telegram-delivery outcome; absent = no delivery recorded (matched-only). */
+  delivered?: AdminDelivery;
 }
 
 export interface AdminListingsResponse {
@@ -450,11 +458,12 @@ export interface AdminCyclesResponse {
 
 export const adminApi = {
   stats: () => fetchAPI<AdminStats>("/admin/stats"),
-  listings: (params?: ListingsParams & { search_id?: number }) => {
+  listings: (params?: ListingsParams & { search_id?: number; chat_id?: number }) => {
     const query = new URLSearchParams();
     if (params?.limit !== undefined) query.set("limit", String(params.limit));
     if (params?.offset !== undefined) query.set("offset", String(params.offset));
     if (params?.search_id) query.set("search_id", String(params.search_id));
+    if (params?.chat_id) query.set("chat_id", String(params.chat_id));
     const qs = query.toString();
     return fetchAPI<AdminListingsResponse>(`/admin/listings${qs ? `?${qs}` : ""}`);
   },


### PR DESCRIPTION
## Summary

- Adds `notification_deliveries` table + migrations (000025, 000026) for durable per-listing delivery tracking
- Records delivery outcomes (sent/failed/dropped/dead_lettered) across all alert paths: instant, digest, daily digest, price drops
- Admin API gains `chat_id` filter and LATERAL JOIN for per-listing delivery status
- Frontend adds DeliveryBadge component and Chat ID filters to ListingsTab and LogsTab
- Reverts new-user digest default from 'digest' to 'instant' (new users should get immediate alerts)
- Includes dedicated integration tests for `RecordDeliveries`, `DeliveredAmong`, upsert idempotency, and digest delivery recording

## Context

Previously reverted the half-finished "temp commit due to session limit" (69debf3), then re-implemented cleanly with:
- Proper gofmt formatting
- Dedicated test coverage (5 new test functions)
- No accidentally committed node_modules files
- Clean single commit

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Existing tests compile with updated mock signatures
- [ ] New `TestPostgres_RecordDeliveries_*` and `TestPostgres_DigestDeliveriesRecorded` tests pass against real Postgres
- [ ] Admin panel shows delivery badge on listing cards
- [ ] Chat ID filter narrows listings and logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin panel now displays Telegram delivery status for each listing
  * Added Chat ID filtering to admin listings and logs for targeted management

* **Changes**
  * New users now default to "instant" digest mode (immediate per-match alerts) instead of daily digests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->