### PR TITLE
fix: clean up notification_deliveries across data-lifecycle paths

### DIFF
--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -38,6 +38,14 @@ func (s *Scheduler) pruneOldData(ctx context.Context) {
 			s.logger.Info("pruned old listing history", "count", pruned, "retention", listingHistoryRetention.String())
 		}
 	}
+	if s.stores.Deliveries != nil {
+		pruned, err := s.stores.Deliveries.PruneDeliveries(ctx, deliveryLedgerRetention)
+		if err != nil {
+			s.logger.Error("prune delivery ledger failed", "retention", deliveryLedgerRetention.String(), "error", err)
+		} else if pruned > 0 {
+			s.logger.Info("pruned old delivery ledger", "count", pruned, "retention", deliveryLedgerRetention.String())
+		}
+	}
 	s.lastPruneTime = time.Now()
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -34,6 +34,7 @@ const (
 	retryBaseDelay          = 2 * time.Second
 	priceHistoryRetention   = 90 * 24 * time.Hour
 	listingHistoryRetention = 90 * 24 * time.Hour
+	deliveryLedgerRetention = 90 * 24 * time.Hour
 	defaultMarketCacheTTL   = 30 * time.Minute
 )
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -381,6 +381,8 @@ type NotificationDeliveryStore interface {
 	// DeliveredAmong returns, for each token that has any delivery record for
 	// chatID, its most recent delivery info.
 	DeliveredAmong(ctx context.Context, chatID int64, tokens []string) (map[string]DeliveryInfo, error)
+	// PruneDeliveries removes ledger rows older than olderThan (retention).
+	PruneDeliveries(ctx context.Context, olderThan time.Duration) (int64, error)
 }
 
 type DailyDigestStore interface {

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -74,13 +74,14 @@ func quoteIdent(ident string) string {
 }
 
 var purgeable = map[string]bool{
-	"listing_history":   true,
-	"price_history":     true,
-	"seen_listings":     true,
-	"listing_user_seen": true,
-	"saved_listings":    true,
-	"hidden_listings":   true,
-	"pending_digest":    true,
+	"listing_history":         true,
+	"price_history":           true,
+	"seen_listings":           true,
+	"listing_user_seen":       true,
+	"saved_listings":          true,
+	"hidden_listings":         true,
+	"pending_digest":          true,
+	"notification_deliveries": true,
 }
 
 func (s *Store) PurgeTable(ctx context.Context, table string) (int64, error) {
@@ -101,6 +102,7 @@ var resetTables = []string{
 	"hidden_listings",
 	"seen_listings",
 	"pending_digest",
+	"notification_deliveries",
 	"listing_history",
 	"price_history",
 	"price_list_cache",
@@ -299,7 +301,7 @@ func (s *Store) AdminDeleteUser(ctx context.Context, chatID int64) error {
 	for _, table := range []string{
 		"searches", "listing_history", "seen_listings", "listing_user_seen",
 		"saved_listings", "hidden_listings",
-		"push_subscriptions", "pending_digest",
+		"push_subscriptions", "pending_digest", "notification_deliveries",
 	} {
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE chat_id = $1`, quoteIdent(table)), chatID); err != nil {
 			return fmt.Errorf("admin delete user data from %s: %w", table, err)

--- a/internal/storage/postgres/notification_deliveries.go
+++ b/internal/storage/postgres/notification_deliveries.go
@@ -184,3 +184,16 @@ func (s *Store) DeliveredAmong(ctx context.Context, chatID int64, tokens []strin
 	}
 	return out, tx.Commit()
 }
+
+// PruneDeliveries removes delivery-ledger rows older than olderThan. The ledger
+// grows one row per (listing, user, alert) and is never otherwise trimmed, so it
+// needs retention like price_history / listing_history.
+func (s *Store) PruneDeliveries(ctx context.Context, olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM notification_deliveries WHERE created_at < $1`, cutoff.UTC())
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -2294,3 +2294,65 @@ func TestPostgres_DigestDeliveriesRecorded(t *testing.T) {
 		}
 	}
 }
+
+func TestPostgres_PruneDeliveries(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// Fresh row (created_at = NOW()).
+	if err := store.RecordDeliveries(ctx, []storage.DeliveryEvent{
+		{ChatID: 7300, Token: "fresh", AlertType: "instant", Status: "sent"},
+	}); err != nil {
+		t.Fatalf("record fresh: %v", err)
+	}
+	// Stale row, backdated 100 days.
+	if _, err := store.DB().ExecContext(ctx,
+		`INSERT INTO notification_deliveries (chat_id, token, alert_type, status, created_at)
+		 VALUES ($1, $2, 'instant', 'sent', NOW() - INTERVAL '100 days')`,
+		7300, "stale"); err != nil {
+		t.Fatalf("insert stale: %v", err)
+	}
+
+	pruned, err := store.PruneDeliveries(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("PruneDeliveries: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("pruned = %d, want 1", pruned)
+	}
+
+	got, err := store.DeliveredAmong(ctx, 7300, []string{"fresh", "stale"})
+	if err != nil {
+		t.Fatalf("DeliveredAmong: %v", err)
+	}
+	if _, ok := got["stale"]; ok {
+		t.Error("stale delivery should have been pruned")
+	}
+	if _, ok := got["fresh"]; !ok {
+		t.Error("fresh delivery should survive pruning")
+	}
+}
+
+func TestPostgres_AdminDeleteUser_RemovesDeliveries(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 7400)
+
+	if err := store.RecordDeliveries(ctx, []storage.DeliveryEvent{
+		{ChatID: 7400, Token: "dtok", AlertType: "instant", Status: "sent"},
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	if err := store.AdminDeleteUser(ctx, 7400); err != nil {
+		t.Fatalf("AdminDeleteUser: %v", err)
+	}
+
+	got, err := store.DeliveredAmong(ctx, 7400, []string{"dtok"})
+	if err != nil {
+		t.Fatalf("DeliveredAmong: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected user's delivery rows removed, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1415. The `notification_deliveries` ledger was written and read but **never cleaned up**, leaving four gaps:

- **`AdminDeleteUser`** now deletes the user's `notification_deliveries` rows. The table has no FK to `users`, so nothing cascaded — deleting a user orphaned their ledger rows, which a reused `chat_id` could later inherit (stale ✓ badges / privacy).
- **`resetTables`** (admin "reset all data") and the **`purgeable`** allowlist now include `notification_deliveries` (were inconsistent with `pending_digest` etc.).
- **Retention**: added `Store.PruneDeliveries` + a 90-day prune in the scheduler maintenance loop, matching `price_history` / `listing_history`. The ledger grows one row per listing × user × alert and was previously never trimmed.

## Test plan

- [x] `go build ./...` / `go vet ./...`
- [x] Changed files gofmt-clean
- [ ] CI: new `TestPostgres_PruneDeliveries` (prunes only stale rows) and `TestPostgres_AdminDeleteUser_RemovesDeliveries` (user delete clears ledger) — run against real Postgres in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Notification delivery records are now automatically cleaned up after 90 days to maintain optimal database performance.
  * User deletion operations now ensure all associated delivery history is completely removed from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->