### PR TITLE
fix(web): stop mobile listings page from overflowing horizontally

### DIFF
--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -295,7 +295,7 @@ export function ListingsPage() {
       {/* Sort pills + refresh */}
       <div className="sticky top-0 z-30 -mx-4 bg-background/90 px-4 py-2 backdrop-blur-lg border-b border-border/30 will-change-transform md:static md:mx-0 md:px-0 md:bg-transparent md:backdrop-blur-none md:border-0 md:will-change-auto">
         <div className="flex items-center gap-2 dir-rtl">
-          <div className="flex flex-nowrap gap-1 flex-1 overflow-x-auto scrollbar-hide" role="radiogroup" aria-label="מיון תוצאות">
+          <div className="flex min-w-0 flex-1 flex-nowrap gap-1 overflow-x-auto scrollbar-hide" role="radiogroup" aria-label="מיון תוצאות">
             {SORT_OPTIONS.map((opt) => (
               <Button
                 key={opt.value}


### PR DESCRIPTION
## Problem

On mobile, the listings/search page renders "off" — the page heading, search field, filter chips and the active sort pill are all clipped on the **right** edge (RTL).

## Root cause

The sort-pills row in `ListingsPage` was:

```
flex flex-nowrap gap-1 flex-1 overflow-x-auto scrollbar-hide
```

A flex item's default `min-width: auto` won't let it shrink below its content size, so with no `min-w-0` the six sort pills force the row — and therefore the whole flex bar — wider than the viewport instead of scrolling internally. `<main>` is `overflow-y-auto` (which makes `overflow-x` compute to `auto`), so the page becomes horizontally scrollable; in RTL the default scroll position clips the **right** edge, cutting off everything in the content column.

## Fix

Add `min-w-0` to the scroll container so it shrinks and scrolls within itself. One-line, no behavior change beyond removing the page-wide overflow.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint src/pages/ListingsPage.tsx` clean
- [ ] Manual: mobile viewport — heading/search/chips/sort pills no longer clipped; sort pills scroll horizontally within their row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
