### PR TITLE
fix(web): make main scroll region vertical-only (kill horizontal drag)

### DIFF
--- a/web/src/components/ListingsFilterBar.tsx
+++ b/web/src/components/ListingsFilterBar.tsx
@@ -52,7 +52,7 @@ export function ListingsFilterBar({
     >
       {/* Search + advanced toggle + count */}
       <div className="flex items-center gap-2">
-        <div className="relative flex-1">
+        <div className="relative flex-1 min-w-0">
           <Search
             className="pointer-events-none absolute top-1/2 start-3 h-4 w-4 -translate-y-1/2 text-muted-foreground"
             aria-hidden

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -316,7 +316,12 @@ export function Shell() {
         <main
           id="main-content"
           className={cn(
-            "flex-1 overflow-y-auto scroll-smooth",
+            // Vertical-only scroll region: overflow-y-auto alone makes
+            // overflow-x compute to `auto`, so any incidental child overflow
+            // becomes a horizontal drag. Pin overflow-x to hidden. Intentional
+            // horizontal scrollers (e.g. the sort pills) have their own
+            // overflow-x-auto and are unaffected.
+            "flex-1 overflow-y-auto overflow-x-hidden scroll-smooth",
             "h-[100dvh]",
           )}
         >


### PR DESCRIPTION
## Problem

Follow-up to #1418. The mobile listings page no longer *clips* content, but the whole page could still be **dragged left/right** — it should only scroll vertically.

## Audit

I checked every element the listings page renders:

| Element | Verdict |
|---|---|
| Sort-pills row | already fixed in #1418 (`min-w-0`, scrolls internally) |
| Spec chips (`ListingCardBody`) | `flex flex-wrap` — wraps, fine |
| Comfortable card | `overflow-hidden` — clips its own content |
| Compact card | `min-w-0` + `truncate` + `shrink-0` — fine |
| Filter chips | `flex-wrap` — fine |
| Sidebar (mobile) | off-canvas `Sheet`, no flow width — fine |
| Sticky sort bar `-mx-4`/`px-4` | spans exactly the viewport — balanced |

Nothing is structurally too wide. The real cause is the **scroll container**: `<main>` is `overflow-y-auto`, and per the CSS overflow spec, when one axis is non-visible the other computes to **`auto`** — so `overflow-x` was `auto`. That means *any* incidental overflow (sub-pixel rounding, a transform, an unbreakable string) becomes a draggable horizontal scroll.

## Fix

- Pin `<main>` to `overflow-x-hidden` (with `overflow-y-auto`) → vertical-only scroll. Intentional horizontal scrollers (sort pills) keep their own `overflow-x-auto`; vertical `sticky` still works since the vertical scroll container is unchanged.
- Add `min-w-0` to the filter-bar search wrapper — a latent flex-shrink gap (search inputs resist shrinking below intrinsic width), same class as the #1418 bug, so no child can force the page wider even without the clip.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on changed files
- [ ] Manual (mobile): page no longer drags horizontally; sort pills still scroll within their row; sticky sort bar + mobile header still stick

🤖 Generated with [Claude Code](https://claude.com/claude-code)
