### PR TITLE
perf(web): mobile landing smoothness — hero blur, content-visibility, idle SW & Firebase

### DIFF
--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -26,9 +26,9 @@ export function HeroSection() {
   return (
     <section className="relative flex min-h-screen items-center justify-center pt-16">
       <div className="pointer-events-none absolute inset-0 overflow-hidden will-change-transform" aria-hidden="true" style={{ transform: "translateZ(0)" }}>
-        <div className="absolute top-1/4 end-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[100px]" />
-        <div className="absolute bottom-1/3 start-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[80px]" />
-        <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[120px]" />
+        <div className="hero-blob absolute top-1/4 end-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[100px]" />
+        <div className="hero-blob absolute bottom-1/3 start-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[80px]" />
+        <div className="hero-blob absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[120px]" />
       </div>
 
       <div className="landing-grid-bg pointer-events-none absolute inset-0 opacity-[0.03]" aria-hidden="true" />

--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -63,6 +63,7 @@ describe("AuthContext", () => {
   beforeEach(() => {
     authStateCallback = null;
     mockSignOut.mockClear();
+    localStorage.clear();
   });
 
   it("stays loading=true until the lazy auth subscription emits", async () => {
@@ -139,6 +140,29 @@ describe("AuthContext", () => {
       authStateCallback?.({ uid: "u1", email: "test@example.com" });
     });
     expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it("records a session hint in localStorage when a user is present", async () => {
+    renderWithProviders();
+    await flushAuthInit();
+
+    await act(async () => {
+      authStateCallback?.({ uid: "u1", email: "test@example.com" });
+    });
+
+    expect(localStorage.getItem("cw:has-session")).toBe("1");
+  });
+
+  it("clears the session hint when auth resolves signed-out", async () => {
+    localStorage.setItem("cw:has-session", "1");
+    renderWithProviders();
+    await flushAuthInit();
+
+    await act(async () => {
+      authStateCallback?.(null);
+    });
+
+    expect(localStorage.getItem("cw:has-session")).toBeNull();
   });
 
   it("clears query cache when switching from a user to signed-out", async () => {

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -22,6 +22,31 @@ type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+const AUTH_HINT_KEY = "cw:has-session";
+
+// Best-effort flag (NOT a security boundary) recording whether the last known
+// auth state had a signed-in user. It lets a fresh page load decide whether to
+// fetch the Firebase SDK eagerly (returning user → restore session fast) or
+// defer it to idle (anonymous visitor → don't compete with landing hydration).
+// Wrapped in try/catch since localStorage throws in private mode / when storage
+// is disabled.
+function hasAuthHint(): boolean {
+  try {
+    return localStorage.getItem(AUTH_HINT_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function rememberAuthHint(hasSession: boolean): void {
+  try {
+    if (hasSession) localStorage.setItem(AUTH_HINT_KEY, "1");
+    else localStorage.removeItem(AUTH_HINT_KEY);
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -48,33 +73,50 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  // Firebase Auth (~160KB) is imported lazily so it never blocks first paint on
+  // Firebase Auth (~233KB) is imported lazily so it never blocks first paint on
   // public routes (landing, /try, auth-less visits). The auth-state subscription
   // is established as soon as the chunk resolves.
   useEffect(() => {
     let cancelled = false;
+    let idleHandle: number | null = null;
     let unsubscribe = () => {};
 
-    void (async () => {
-      const [{ auth }, { onAuthStateChanged }] = await Promise.all([
-        import("@/lib/firebase"),
-        import("firebase/auth"),
-      ]);
-      if (cancelled) return;
-      authRef.current = auth;
-      unsubscribe = onAuthStateChanged(auth, (u) => {
-        const newUid = u?.uid ?? null;
-        if (prevUidRef.current !== null && prevUidRef.current !== newUid) {
-          queryClient.clear();
-        }
-        prevUidRef.current = newUid;
-        setUser(u);
-        setLoading(false);
-      });
-    })();
+    const start = () => {
+      void (async () => {
+        const [{ auth }, { onAuthStateChanged }] = await Promise.all([
+          import("@/lib/firebase"),
+          import("firebase/auth"),
+        ]);
+        if (cancelled) return;
+        authRef.current = auth;
+        unsubscribe = onAuthStateChanged(auth, (u) => {
+          const newUid = u?.uid ?? null;
+          if (prevUidRef.current !== null && prevUidRef.current !== newUid) {
+            queryClient.clear();
+          }
+          prevUidRef.current = newUid;
+          setUser(u);
+          setLoading(false);
+          rememberAuthHint(newUid !== null);
+        });
+      })();
+    };
+
+    // Returning users (and browsers without requestIdleCallback, e.g. older
+    // Safari) load Firebase right away so a persisted session restores without
+    // delay. First-time / signed-out visitors defer the SDK to idle so its
+    // download + parse never competes with landing hydration on slow mobiles.
+    if (hasAuthHint() || !("requestIdleCallback" in window)) {
+      start();
+    } else {
+      idleHandle = requestIdleCallback(start, { timeout: 3000 });
+    }
 
     return () => {
       cancelled = true;
+      if (idleHandle !== null && "cancelIdleCallback" in window) {
+        cancelIdleCallback(idleHandle);
+      }
       unsubscribe();
     };
   }, [queryClient]);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -553,6 +553,13 @@
     will-change: auto;
     animation: none !important;
   }
+  /* HeroSection's three decorative blobs use Tailwind blur-[100px..120px].
+     Those large blur surfaces are the main scroll-jank source on phones, so
+     clamp them to a cheap radius. !important overrides the Tailwind filter
+     utility; the look stays near-identical at this size. */
+  .hero-blob {
+    filter: blur(40px) !important;
+  }
   /* Lighter frosted glass — backdrop-filter is recomputed on every scroll
      frame over the content beneath it. */
   .glass-card {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,7 +12,17 @@ import "./index.css";
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
+    // Register once the main thread is idle so the sw.js fetch never competes
+    // with lazy chunk downloads / hydration during the initial load. Falls back
+    // to a short timer where requestIdleCallback is unavailable (Safari).
+    const register = () => {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    };
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(register, { timeout: 5000 });
+    } else {
+      setTimeout(register, 3000);
+    }
   });
 }
 

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -36,27 +36,45 @@ export function LandingPage() {
     >
       <LandingNav />
       <HeroSection />
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <ProblemSolution />
-      </Suspense>
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <FeaturesSection />
-      </Suspense>
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <SmartScoreSection />
-      </Suspense>
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <HowItWorks />
-      </Suspense>
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <StatsSection />
-      </Suspense>
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <FinalCTA />
-      </Suspense>
-      <Suspense fallback={<div className="min-h-[200px]" />}>
-        <LandingFooter version={version} />
-      </Suspense>
+      {/* Below-fold sections: cv-auto lets the browser skip layout/paint for
+          off-screen content until it's scrolled near, cutting initial render
+          work. contain-intrinsic-size (from the utility) reserves space so the
+          scrollbar doesn't jump. */}
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <ProblemSolution />
+        </Suspense>
+      </div>
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <FeaturesSection />
+        </Suspense>
+      </div>
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <SmartScoreSection />
+        </Suspense>
+      </div>
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <HowItWorks />
+        </Suspense>
+      </div>
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <StatsSection />
+        </Suspense>
+      </div>
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <FinalCTA />
+        </Suspense>
+      </div>
+      <div className="cv-auto">
+        <Suspense fallback={<div className="min-h-[200px]" />}>
+          <LandingFooter version={version} />
+        </Suspense>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements the safe, visually-preserving subset of the mobile performance audit in #1417 — the changes that make the landing page smoother/faster on mobile **without altering how it looks**.

| Fix | Change | Effect | Visual impact |
|-----|--------|--------|---------------|
| **F6** | Hero blobs tagged `.hero-blob`; clamp to `blur(40px)` under `@media (pointer: coarse)` only | Removes the main mobile scroll-jank source (3 large GPU blur layers at 100–120px) | **Desktop unchanged**; mobile near-identical |
| **F9** | Wrap the 7 below-fold landing sections in the existing `cv-auto` utility | Browser skips layout/paint for off-screen sections on first render | None (`contain-intrinsic-size` reserves space) |
| **F7** | Register the service worker at `requestIdleCallback` (5s timeout) instead of on `load`; Safari `setTimeout` fallback | `sw.js` no longer contends with hydration/lazy chunks during load | None |
| **F1** | Defer the Firebase SDK to idle for anonymous visitors via a `cw:has-session` localStorage hint; returning users still load eagerly | Anonymous landing visits skip the ~233 KB SDK fetch+parse during hydration | None; no auth-flow change |

## Not in this PR (see #1417 for rationale)
- **F4 self-host fonts** — real win but needs woff2 binaries + a Hebrew (Heebo) rendering check; `font-semibold`/600 is in use so weights can't be trimmed. Deserves its own verifiable PR.
- **F2 vendor split / F3 critical-CSS** — cosmetic / low-ROI (landing is prerendered SSG, so JS isn't paint-blocking).
- **F5 brotli** — `encode br` isn't supported by stock `caddy:2-alpine`; needs a custom xcaddy build → separate infra issue.

#1417 stays open to track those.

## Review / verification
- `tsc -b` clean; `eslint` 0 errors
- **317/317 unit tests pass** (incl. 2 new tests for the Firebase session-hint set/clear)
- Production build + prerender succeed; verified in built output that `.hero-blob` is scoped to `(pointer:coarse)` (desktop keeps full blur) and all 3 blobs + 7 `cv-auto` wrappers prerender correctly

Refs #1417

Assisted-By: Claude opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Service worker registration now defers until the browser is idle, reducing initial page load impact.
  * Improved Firebase Auth session restoration with smarter lazy-loading detection.
  * Optimized lazy-loaded sections for better rendering efficiency.

* **Style**
  * Hero section blur effect now optimized for mobile and tablet devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->