### PR TITLE
perf(web): progressive effect optimization — smooth on mobile, rich on desktop

### DIFF
--- a/web/src/components/landing/FinalCTA.tsx
+++ b/web/src/components/landing/FinalCTA.tsx
@@ -9,8 +9,8 @@ export function FinalCTA() {
         <FadeUp>
           <div className="relative overflow-hidden rounded-3xl border border-border bg-card p-10 text-center md:p-16">
           <div className="pointer-events-none absolute inset-0">
-            <div className="absolute top-0 start-1/2 h-48 w-72 -translate-x-1/2 rounded-full bg-primary/12 blur-[80px]" />
-            <div className="absolute end-1/4 bottom-0 h-32 w-48 rounded-full bg-purple-500/8 blur-[60px]" />
+            <div className="decor-blob absolute top-0 start-1/2 h-48 w-72 -translate-x-1/2 rounded-full bg-primary/12 blur-[80px]" />
+            <div className="decor-blob absolute end-1/4 bottom-0 h-32 w-48 rounded-full bg-purple-500/8 blur-[60px]" />
           </div>
 
           <div className="landing-grid-bg-sm pointer-events-none absolute inset-0 opacity-[0.025]" />

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -26,9 +26,9 @@ export function HeroSection() {
   return (
     <section className="relative flex min-h-screen items-center justify-center pt-16">
       <div className="pointer-events-none absolute inset-0 overflow-hidden will-change-transform" aria-hidden="true" style={{ transform: "translateZ(0)" }}>
-        <div className="hero-blob absolute top-1/4 end-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[100px]" />
-        <div className="hero-blob absolute bottom-1/3 start-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[80px]" />
-        <div className="hero-blob absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[120px]" />
+        <div className="decor-blob absolute top-1/4 end-1/4 h-96 w-96 rounded-full bg-primary/10 blur-[100px]" />
+        <div className="decor-blob absolute bottom-1/3 start-1/4 h-72 w-72 rounded-full bg-purple-500/8 blur-[80px]" />
+        <div className="decor-blob absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/5 blur-[120px]" />
       </div>
 
       <div className="landing-grid-bg pointer-events-none absolute inset-0 opacity-[0.03]" aria-hidden="true" />

--- a/web/src/components/landing/SmartScoreSection.tsx
+++ b/web/src/components/landing/SmartScoreSection.tsx
@@ -127,7 +127,7 @@ export function SmartScoreSection() {
   return (
     <section className="relative overflow-hidden px-4 py-24 sm:px-6">
       <div className="pointer-events-none absolute inset-0 will-change-transform" style={{ transform: "translateZ(0)" }}>
-        <div className="absolute top-1/2 start-1/2 h-[300px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/6 blur-[80px]" />
+        <div className="decor-blob absolute top-1/2 start-1/2 h-[300px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/6 blur-[80px]" />
       </div>
 
       <div className="relative mx-auto max-w-5xl">

--- a/web/src/components/landing/StatsSection.tsx
+++ b/web/src/components/landing/StatsSection.tsx
@@ -27,7 +27,7 @@ export function StatsSection() {
       className="scroll-mt-28 px-4 py-24 sm:px-6"
     >
       <div className="relative mx-auto max-w-5xl">
-        <div className="pointer-events-none absolute -top-24 start-1/2 h-64 w-[min(90%,28rem)] -translate-x-1/2 rounded-full bg-primary/8 blur-[80px] will-change-transform" style={{ transform: "translateZ(0)" }} />
+        <div className="decor-blob pointer-events-none absolute -top-24 start-1/2 h-64 w-[min(90%,28rem)] -translate-x-1/2 rounded-full bg-primary/8 blur-[80px] will-change-transform" style={{ transform: "translateZ(0)" }} />
 
         <FadeUp>
           <div className="mb-14 text-center">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -107,7 +107,6 @@
   --animate-aurora-a: aurora-drift 20s ease-in-out infinite;
   --animate-aurora-b: aurora-drift 28s ease-in-out infinite reverse;
   --animate-aurora-c: aurora-drift 34s ease-in-out infinite;
-  --animate-text-shimmer: text-shimmer 6s linear infinite;
   --animate-scale-in: scale-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -308,10 +307,6 @@
   66% { transform: translate3d(-4%, 3%, 0) scale(1.06); }
 }
 
-@keyframes text-shimmer {
-  to { background-position: 200% center; }
-}
-
 @keyframes scale-in {
   from { opacity: 0; transform: scale(0.96) translateY(6px); }
   to { opacity: 1; transform: scale(1) translateY(0); }
@@ -320,16 +315,6 @@
 @keyframes shine-sweep {
   0% { transform: translateX(-130%) skewX(-18deg); }
   100% { transform: translateX(130%) skewX(-18deg); }
-}
-
-@property --glow-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-
-@keyframes glow-rotate {
-  to { --glow-angle: 360deg; }
 }
 
 @keyframes toast-progress {
@@ -427,7 +412,7 @@
     border-radius: inherit;
     padding: 1px;
     background: conic-gradient(
-      from var(--glow-angle),
+      from 135deg,
       transparent 0deg,
       var(--color-primary) 70deg,
       var(--color-aurora-cyan) 140deg,
@@ -439,7 +424,6 @@
       linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;
     mask-composite: exclude;
-    animation: glow-rotate 6s linear infinite;
     pointer-events: none;
   }
 }
@@ -492,11 +476,9 @@
     var(--color-violet),
     var(--color-primary)
   );
-  background-size: 200% auto;
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  animation: text-shimmer 6s linear infinite;
 }
 
 @utility aurora-blob {
@@ -553,23 +535,21 @@
     will-change: auto;
     animation: none !important;
   }
-  /* HeroSection's three decorative blobs use Tailwind blur-[100px..120px].
-     Those large blur surfaces are the main scroll-jank source on phones, so
+  /* Decorative blobs (hero + section backdrops) use Tailwind blur-[60..120px].
+     Those large blur surfaces are a primary scroll-jank source on phones, so
      clamp them to a cheap radius. !important overrides the Tailwind filter
      utility; the look stays near-identical at this size. */
-  .hero-blob {
+  .decor-blob {
     filter: blur(40px) !important;
   }
-  /* Lighter frosted glass — backdrop-filter is recomputed on every scroll
-     frame over the content beneath it. */
+  /* Drop the frosted-glass backdrop-filter entirely on mobile — re-rasterising
+     a blur over the content scrolling beneath it is the single biggest scroll
+     cost on phone GPUs. A near-opaque solid reads almost identically at this
+     size. Desktop keeps the real frosted glass (see @utility glass-card). */
   .glass-card {
-    backdrop-filter: blur(10px) saturate(1.1);
-    -webkit-backdrop-filter: blur(10px) saturate(1.1);
-  }
-  /* Purely ambient infinite loops — freeze them on battery devices. */
-  .glow-border::before,
-  .text-aurora {
-    animation: none !important;
+    background-color: color-mix(in oklab, var(--color-card) 92%, transparent);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Bucket **B** of the smoothness work: make the landing's GPU/animation effects cheap **without flattening the desktop look**. This **supersedes #1429**, which removed the effects on *all* devices — including desktop, where the GPU is fine and Lighthouse was already 99, so it traded the premium look for a metric it couldn't move.

### The split (progressive enhancement)

**Everywhere — kill always-on, paint-bound infinite loops** (they repaint every frame even when idle → wasted CPU/GPU/battery on laptops too), but keep the *static* form so the look is preserved:
- `glow-border`: rotating conic-gradient (`@property --glow-angle` + `glow-rotate`) → **static 135° gradient border**. Same colourful border, no spin.
- `text-aurora`: `text-shimmer` sweep → **static gradient text**.
- Removed the now-unused `@property`/`@keyframes` + `--animate-text-shimmer`.

**Mobile only (`@media (pointer: coarse)`)** — lean; **desktop keeps the premium look**:
- `glass-card`: `backdrop-filter` dropped entirely → near-opaque solid (re-rasterising a blur over scrolling content is the single biggest phone scroll cost). **Desktop keeps the real frosted glass.**
- `decor-blob`: generalises the existing `hero-blob` class so the section backdrop blobs (FinalCTA/SmartScore/Stats) — not just the hero — clamp to `blur(40px)` on phones. **Desktop radii unchanged.**

### Expected impact (see the percentages discussion)
- **Mobile smoothness:** ~the same as fully flattening — this is where the win is.
- **Desktop:** removes the perpetual repaint loops (battery/CPU on laptops + low-end desktops) while keeping ~95% of the look.
- **Lighthouse score:** ~unchanged — effects aren't what Lighthouse measures (mobile's 47 is JS/TBT-bound; that's a separate, bigger lever).

### Verification
- `npm run build` + prerender succeed. Built CSS confirmed: `glow-rotate`/`text-shimmer` keyframes gone; **desktop `glass-card` keeps `backdrop-filter: blur(20px)`**; coarse `glass-card` is `backdrop-filter: none` + 92% solid; `decor-blob` clamps to 40px on coarse; `glow-border` static at 135°.
- Lint 0 errors, **321 tests pass**.

Closes #1429 (superseded). Refs #1426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
