### PR TITLE
perf(web): fix SearchCard hover jank + slow glow

### DIFF
--- a/web/src/components/SearchCard.tsx
+++ b/web/src/components/SearchCard.tsx
@@ -84,7 +84,10 @@ export function SearchCard({
   return (
     <Card
       className={cn(
-        "group card-hover transition-all duration-200",
+        // card-hover already scopes its own transition (transform/shadow/border);
+        // a stacked transition-all would repaint every property on hover — the
+        // cause of the scroll jank as cards pass under the cursor.
+        "group card-hover",
         !isActive && "opacity-75",
       )}
     >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -350,15 +350,20 @@
 }
 
 @utility card-hover {
+  /* Only the three properties that actually change on hover — never
+     transition-all, which would repaint on every unrelated change (and fire a
+     full repaint each time a card slides under the cursor while scrolling). */
   transition-property: transform, box-shadow, border-color;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 200ms;
+  transition-duration: 140ms;
 
   &:hover {
     border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-border));
     transform: translateY(-2px);
+    /* Smaller blur radius — a 24px-blur shadow is expensive to rasterise; 12px
+       reads almost the same but paints far cheaper as it fades in. */
     box-shadow:
-      0 8px 24px -8px var(--color-glow-primary),
+      0 6px 12px -6px var(--color-glow-primary),
       0 0 0 1px color-mix(in oklab, var(--color-primary) 8%, transparent);
   }
 }


### PR DESCRIPTION
## Summary

Fixes the reported roughness on the saved-searches section — scroll jank **and** the slow hover glow, which turned out to be the **same root cause** in the card hover treatment.

### Diagnosis
- **Scroll jank:** `SearchCard` stacked a redundant `transition-all duration-200` on top of `card-hover` (which already scopes its own transition). `transition-all` repaints *every* property on hover, so scrolling with the cursor over the grid fired the `translateY` + blurred-shadow transition **every time a card slid under the pointer** → repaint storm. `SearchCard` was the only one of the four `card-hover` users doing this.
- **Slow glow:** `card-hover` faded a **24px-blur** box-shadow over **200ms** — slow to register as a hover affordance, and a large-blur shadow is expensive to rasterise.

### Fix
- Removed the redundant `transition-all` from `SearchCard` (let `card-hover` own the transition).
- `card-hover`: `200ms → 140ms`, hover shadow `0 8px 24px -8px → 0 6px 12px -6px` (12px blur). Snappier and far cheaper to paint; resting state and look essentially unchanged.

Shared utility, so StatCard / FeaturesSection / StatsSection get the same snappier, cheaper hover.

### Verification
- Built CSS confirms `card-hover` → `0.14s` + `0 6px 12px -6px`.
- Lint 0 errors, **321 tests pass** (incl. `SearchesPage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated card hover animations with faster transitions and refined shadow effects for improved visual polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->