### PR TITLE
perf(web): stop the app aurora background re-rasterising its blur every frame

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -302,10 +302,15 @@
   50% { transform: translateY(10px); }
 }
 
+/* Translate-only drift. The blobs carry a 70px blur over ~half the viewport;
+   animating scale() forced the GPU to re-rasterise that blur every frame (the
+   main app-wide scroll tax on desktop, where the coarse-pointer freeze doesn't
+   apply). A pure translate of a will-change:transform layer just repositions
+   the already-rasterised texture — same ambient motion, ~zero per-frame cost. */
 @keyframes aurora-drift {
-  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
-  33% { transform: translate3d(4%, -5%, 0) scale(1.12); }
-  66% { transform: translate3d(-4%, 3%, 0) scale(1.06); }
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  33% { transform: translate3d(5%, -6%, 0); }
+  66% { transform: translate3d(-5%, 4%, 0); }
 }
 
 @keyframes scale-in {


### PR DESCRIPTION
## Summary

Fixes the **page-wide** scroll roughness in the authenticated app (reported on the saved-searches view, but it affects every page).

### Root cause
`AuroraBackground` ([Shell.tsx:167](web/src/components/layout/Shell.tsx#L167)) sits **fixed behind all content** and renders three ~half-viewport blobs at **`blur(70px)`** that animate `transform: translate3d(...) scale(1.12)` forever (`aurora-drift`, 20–34s infinite). **Animating `scale()` on a large blurred layer forces the GPU to re-rasterise the 70px blur every frame** — a continuous, app-wide cost. On desktop the `(pointer: coarse)` freeze doesn't apply, so it runs full-blast under everything.

### Fix
Remove `scale()` from the `aurora-drift` keyframe; keep the `translate3d`. A pure translate of a `will-change: transform` layer just repositions the already-rasterised texture (no re-raster), so the **ambient drift and look are preserved** at ~zero per-frame cost.

### Why this is the dominant lever
The earlier SearchCard hover fix (#1432) was real but secondary (only bit when the cursor was over the cards). This aurora animation is always running behind the whole app, so it taxes every scroll regardless of pointer.

### Verification
- Built CSS confirms `aurora-drift` is now translate-only (no `scale`).
- Lint 0 errors, **321 tests pass**.

Follow-up levers if any roughness remains on low-end GPUs: reduce the blur radius / blob size, or freeze the drift entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
