### PR TITLE
fix: use yad2 post date (not fetch time) for listing date & "newest" sort

### DIFF
--- a/internal/storage/postgres/helpers_test.go
+++ b/internal/storage/postgres/helpers_test.go
@@ -214,3 +214,26 @@ func TestPurgeableAllowlist(t *testing.T) {
 		}
 	}
 }
+
+func TestListingsOrderBy(t *testing.T) {
+	cases := []struct {
+		sort string
+		want string
+	}{
+		// "newest" sorts by the source post date, not the fetch time.
+		{"newest", "COALESCE(posted_at, first_seen_at) DESC, token DESC"},
+		// Empty and unknown sorts fall back to newest.
+		{"", "COALESCE(posted_at, first_seen_at) DESC, token DESC"},
+		{"bogus", "COALESCE(posted_at, first_seen_at) DESC, token DESC"},
+		{"price_asc", "CASE WHEN price <= 0 THEN 1 ELSE 0 END, price ASC, token DESC"},
+		{"price_desc", "CASE WHEN price <= 0 THEN 1 ELSE 0 END, price DESC, token DESC"},
+		{"score", "CASE WHEN fitness_score IS NULL THEN 1 ELSE 0 END, fitness_score DESC, token DESC"},
+		{"km", "CASE WHEN km <= 0 THEN 1 ELSE 0 END, km ASC, token DESC"},
+		{"year", "year DESC, token DESC"},
+	}
+	for _, tc := range cases {
+		if got := listingsOrderBy(tc.sort); got != tc.want {
+			t.Errorf("listingsOrderBy(%q) = %q, want %q", tc.sort, got, tc.want)
+		}
+	}
+}

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -383,22 +383,31 @@ func buildFilterClauses(f storage.ListingFilter, paramStart int) (string, []any,
 	return " AND " + strings.Join(clauses, " AND "), args, n
 }
 
-func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID int64, f storage.ListingFilter, limit, offset int, sort string) ([]storage.ListingRecord, error) {
-	orderBy := "first_seen_at DESC, token DESC"
+// newestOrderBy sorts by the listing's original post date on the source (yad2),
+// falling back to first_seen_at when posted_at was never captured.
+const newestOrderBy = "COALESCE(posted_at, first_seen_at) DESC, token DESC"
+
+// listingsOrderBy maps a user-facing sort key to a SQL ORDER BY clause. An
+// empty or unknown sort defaults to newest.
+func listingsOrderBy(sort string) string {
 	switch sort {
-	case "newest":
-		orderBy = "first_seen_at DESC, token DESC"
 	case "price_asc":
-		orderBy = "CASE WHEN price <= 0 THEN 1 ELSE 0 END, price ASC, token DESC"
+		return "CASE WHEN price <= 0 THEN 1 ELSE 0 END, price ASC, token DESC"
 	case "price_desc":
-		orderBy = "CASE WHEN price <= 0 THEN 1 ELSE 0 END, price DESC, token DESC"
+		return "CASE WHEN price <= 0 THEN 1 ELSE 0 END, price DESC, token DESC"
 	case "score":
-		orderBy = "CASE WHEN fitness_score IS NULL THEN 1 ELSE 0 END, fitness_score DESC, token DESC"
+		return "CASE WHEN fitness_score IS NULL THEN 1 ELSE 0 END, fitness_score DESC, token DESC"
 	case "km":
-		orderBy = "CASE WHEN km <= 0 THEN 1 ELSE 0 END, km ASC, token DESC"
+		return "CASE WHEN km <= 0 THEN 1 ELSE 0 END, km ASC, token DESC"
 	case "year":
-		orderBy = "year DESC, token DESC"
+		return "year DESC, token DESC"
+	default: // "newest" and unknown values
+		return newestOrderBy
 	}
+}
+
+func (s *Store) ListSearchListings(ctx context.Context, chatID int64, searchID int64, f storage.ListingFilter, limit, offset int, sort string) ([]storage.ListingRecord, error) {
+	orderBy := listingsOrderBy(sort)
 
 	filterSQL, filterArgs, nextParam := buildFilterClauses(f, 3)
 	args := []any{chatID, searchID}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -563,6 +563,67 @@ func TestPostgres_ListSearchListings_Filters(t *testing.T) {
 	})
 }
 
+// TestPostgres_ListSearchListings_NewestSortByPostedAt verifies the "newest"
+// sort orders by the source post date (posted_at), not the fetch time
+// (first_seen_at), and falls back to first_seen_at when posted_at is NULL.
+func TestPostgres_ListSearchListings_NewestSortByPostedAt(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+
+	searchID, _ := store.CreateSearch(ctx, storage.Search{
+		ChatID: 100, Name: "test", Source: "yad2",
+		Manufacturer: 8, Model: 10061,
+	})
+
+	now := time.Now().UTC()
+	postedRecently := now.Add(-1 * time.Hour)
+	postedLongAgo := now.Add(-30 * 24 * time.Hour)
+
+	// Fetched just now, but posted a month ago on the source.
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "old-post", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 100,
+		FirstSeenAt: now, PostedAt: &postedLongAgo,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Fetched two days ago, but posted an hour ago on the source.
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "new-post", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 100,
+		FirstSeenAt: now.Add(-2 * 24 * time.Hour), PostedAt: &postedRecently,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// No post date captured: should fall back to first_seen_at (12h ago).
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "no-post", ChatID: 100, SearchID: searchID, SearchName: "test",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 100,
+		FirstSeenAt: now.Add(-12 * time.Hour), PostedAt: nil,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.ListSearchListings(ctx, 100, searchID, storage.ListingFilter{}, 20, 0, "newest")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	wantOrder := []string{"new-post", "no-post", "old-post"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d rows, want %d", len(got), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if got[i].Token != want {
+			gotOrder := make([]string, len(got))
+			for j, l := range got {
+				gotOrder[j] = l.Token
+			}
+			t.Fatalf("newest order = %v, want %v", gotOrder, wantOrder)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Dedup
 // ---------------------------------------------------------------------------

--- a/web/src/components/ListingCardBody.test.tsx
+++ b/web/src/components/ListingCardBody.test.tsx
@@ -45,4 +45,30 @@ describe("ListingCardBody", () => {
     render(<ListingCardBody listing={baseListing()} />);
     expect(screen.queryByRole("button", { name: "עוד" })).not.toBeInTheDocument();
   });
+
+  it("shows the source post date, not the fetch date, when posted_at is present", () => {
+    const day = 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    const listing: Listing = {
+      ...baseListing(),
+      // Fetched just now, but posted ~35 days ago on the source.
+      first_seen_at: new Date(now).toISOString(),
+      posted_at: new Date(now - 35 * day).toISOString(),
+    };
+    render(<ListingCardBody listing={listing} />);
+    expect(screen.getByText("לפני חודש")).toBeInTheDocument();
+    expect(screen.queryByText("היום")).not.toBeInTheDocument();
+  });
+
+  it("falls back to first_seen_at when posted_at is absent", () => {
+    const day = 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    const listing: Listing = {
+      ...baseListing(),
+      first_seen_at: new Date(now - 35 * day).toISOString(),
+      posted_at: undefined,
+    };
+    render(<ListingCardBody listing={listing} />);
+    expect(screen.getByText("לפני חודש")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ListingCardBody.tsx
+++ b/web/src/components/ListingCardBody.tsx
@@ -219,7 +219,7 @@ export function ListingCardBody({
             {freshness === "hot" ? <Flame className="h-3 w-3" /> :
              freshness === "today" ? <Clock className="h-3 w-3" /> :
              <Clock className="h-3 w-3 opacity-50" />}
-            {relativeTime(listing.first_seen_at)}
+            {relativeTime(listing.posted_at || listing.first_seen_at)}
           </span>
         </div>
 

--- a/web/src/pages/ListingDetailPage.tsx
+++ b/web/src/pages/ListingDetailPage.tsx
@@ -336,7 +336,7 @@ function ListingDetailContent({
         <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground">
           <span className="flex items-center gap-1.5">
             <Clock className="h-3.5 w-3.5" />
-            {relativeTime(listing.first_seen_at)}
+            {relativeTime(listing.posted_at || listing.first_seen_at)}
           </span>
           {source ? (
             <span className="flex items-center gap-1.5">

--- a/web/src/pages/SearchesPage.tsx
+++ b/web/src/pages/SearchesPage.tsx
@@ -423,7 +423,7 @@ function RecentListingRow({ listing }: { listing: Listing }) {
             {listing.manufacturer} {listing.model} {listing.year}
           </p>
           <p className="text-xs text-muted-foreground">
-            {listing.city || "—"} · {relativeTime(listing.first_seen_at)}
+            {listing.city || "—"} · {relativeTime(listing.posted_at || listing.first_seen_at)}
           </p>
         </div>
         <span className="shrink-0 text-sm font-bold tabular-nums text-primary">


### PR DESCRIPTION
## Problem

Listing cards showed a relative date like "אתמול" (yesterday) / "היום" (today) based on **`first_seen_at`** — when CarWatch *fetched* the listing from yad2. For a freshly created search that's always ~now, so weeks-old listings all read as brand-new. The "newest" sort had the same flaw, ordering by fetch time rather than the real post date.

The actual yad2 post date (e.g. `פורסם ב 27/05/26`) was **already being captured** — the feed parser reads `dates.createdAt` into `posted_at` ([parser.go](internal/fetcher/yad2/parser.go), [pipeline.go](internal/scheduler/pipeline.go), migration `000021`) and the API already returns `posted_at`. It just wasn't being *used* for the visible date or the sort. The freshness badge already preferred `posted_at`; the timestamp text and the sort were never updated to match.

## Fix

- **Sort** ([listings.go](internal/storage/postgres/listings.go)): `newest` now orders by `COALESCE(posted_at, first_seen_at) DESC`, falling back to fetch time only when no post date was captured. Extracted the sort→`ORDER BY` mapping into `listingsOrderBy` for unit testing.
- **Display** (3 spots): listing cards, the detail page, and the search preview now render `relativeTime(listing.posted_at || listing.first_seen_at)`.

Because of the `COALESCE` / `||` fallback there's **no regression** for rows where `posted_at` is NULL — they still show fetch time. Existing rows self-heal: the next refresh upsert backfills `posted_at` from the feed (`posted_at = COALESCE(EXCLUDED.posted_at, …)`).

## Tests

- `TestListingsOrderBy` — unit test for the sort mapping (runs everywhere).
- `TestPostgres_ListSearchListings_NewestSortByPostedAt` — DB-gated; proves `posted_at` beats `first_seen_at` and NULL falls back.
- `ListingCardBody.test.tsx` — asserts the card shows the post date, not the fetch date, and falls back when `posted_at` is absent.
- `go test ./internal/storage/postgres/...`, `tsc -b`, `eslint`, and `vitest` all green locally.

## Note / follow-up

This assumes the yad2 **search feed** carries `dates.createdAt` (it's parsed and wired). Worth confirming in prod with `SELECT count(*), count(posted_at) FROM listing_history;` — if `posted_at` is mostly NULL, the feed isn't sending it and we'd need to also extract the post date during item-page enrichment ([item_parser.go](internal/fetcher/yad2/item_parser.go) currently doesn't parse dates). Out of scope here since the fix degrades gracefully either way.

Assisted-By: Claude opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>