### PR TITLE
fix(web): stop listing cards overflowing the viewport on iOS Safari

### DIFF
--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -41,7 +41,7 @@ export function HistoryPage() {
     return (
       <PageShell>
         <InboxTabs />
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {[1, 2, 3, 4].map((i) => (
             <ListingCardSkeleton key={i} />
           ))}
@@ -105,7 +105,7 @@ export function HistoryPage() {
         />
       ) : (
         <>
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {data.items.map((listing) => (
               <HistoryCard key={listing.token} listing={listing} />
             ))}

--- a/web/src/pages/ListingsPage.test.tsx
+++ b/web/src/pages/ListingsPage.test.tsx
@@ -115,6 +115,19 @@ describe("ListingsPage", () => {
     expect(screen.getByText("1 מודעות")).toBeInTheDocument();
   });
 
+  it("pins a single-column base on the results grid (prevents iOS Safari grid blow-out)", () => {
+    // A bare `grid` with only sm:+ column counts falls back to an implicit
+    // `auto` track on mobile. WebKit sizes that track to the card image's
+    // intrinsic width, overflowing the viewport and clipping the card. The
+    // explicit grid-cols-1 base (minmax(0,1fr)) keeps it clamped.
+    const { container } = renderPage();
+    const cardGrid = Array.from(container.querySelectorAll("div.grid")).find((g) =>
+      g.className.includes("sm:grid-cols-2"),
+    );
+    expect(cardGrid).toBeDefined();
+    expect(cardGrid?.className).toContain("grid-cols-1");
+  });
+
   it("shows empty state when no listings", () => {
     infiniteReturn = {
       ...infiniteReturn,

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -372,7 +372,7 @@ export function ListingsPage() {
 
       {/* Grid */}
       {showSkeletons ? (
-        <div className="grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div className="grid grid-cols-1 gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={`skel-${i}`}
@@ -416,7 +416,11 @@ export function ListingsPage() {
             className={cn(
               density === "compact"
                 ? "space-y-2"
-                : "grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3",
+                : // grid-cols-1 is required: a bare `grid` falls back to an implicit
+                  // `auto` track on mobile, which WebKit/iOS Safari sizes to the card
+                  // image's intrinsic width — overflowing the viewport and clipping
+                  // the card. minmax(0,1fr) from grid-cols-1 keeps it clamped.
+                  "grid grid-cols-1 gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3",
             )}
           >
             {visible.map((listing, i) => (

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -38,7 +38,7 @@ export function NotificationsPage() {
     return (
       <PageShell>
         <InboxTabs />
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {[1, 2, 3, 4].map((i) => (
             <Skeleton key={i} className="h-72 rounded-2xl" />
           ))}
@@ -96,7 +96,7 @@ export function NotificationsPage() {
         />
       ) : (
         <>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {data.items.map((listing) => (
               <NotificationCard key={listing.token} listing={listing} />
             ))}

--- a/web/src/pages/SavedPage.tsx
+++ b/web/src/pages/SavedPage.tsx
@@ -43,7 +43,7 @@ export function SavedPage() {
     return (
       <PageShell>
         <InboxTabs />
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {[1, 2].map((i) => (
             <ListingCardSkeleton key={i} />
           ))}
@@ -90,7 +90,7 @@ export function SavedPage() {
         />
       ) : (
         <>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {data.items.map((listing) => (
               <SavedCard
                 key={listing.token}

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -382,7 +382,7 @@ export default function TrySearchPage() {
       {search.isPending && (
         <div className="mt-10">
           <div className="mb-4 h-5 w-32 rounded skeleton" />
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {Array.from({ length: 6 }).map((_, i) => (
               <ListingCardSkeleton key={i} />
             ))}
@@ -427,7 +427,7 @@ export default function TrySearchPage() {
             </p>
           )}
 
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {results.map((listing) => {
               const href = safeHref(listing.page_link);
               return href ? (


### PR DESCRIPTION
## Problem

On **iPhone Safari**, listing cards on the search-results page render **wider than the screen** and get clipped (the whole card, image included, looks cut off). Reported on the search-results grid; the same bug affects history, saved, notifications and the guest try-search grids.

## Root cause

The listing-card grids set column counts only at `sm:`+ breakpoints:

```
grid gap-5 sm:gap-4 sm:grid-cols-2 xl:grid-cols-3
```

With no base column, the mobile layout falls back to an implicit **`auto`** grid track. WebKit/iOS Safari sizes that `auto` track to the card's **max-content**, which the hero `<img width={640}>` blows out — so the single column becomes **~480px on a 390px screen**. The card overflows the viewport and is clipped by `<main>`'s `overflow-x-hidden`. Chromium clamps the track, which is why it only reproduces on Safari/WebKit.

## Fix

Pin an explicit **`grid-cols-1`** base on every listing-card grid. Tailwind emits `repeat(1, minmax(0,1fr))`; the `minmax(0,…)` floor lets the track shrink to the container instead of the image's intrinsic width. Touched: `ListingsPage`, `HistoryPage`, `SavedPage`, `NotificationsPage`, `TrySearchPage` (skeleton + results grids each). Form/stat grids were left alone — they have no wide image to blow out.

## Verification

Reproduced and verified with **Playwright WebKit** at an iPhone 12 profile, rendering the real `ListingCardBody` in the real page container:

| | card width | doc.scrollWidth (vw=390) | offenders |
|---|---|---|---|
| before | **480px** (left −111 → 369) | 390 (masked by overflow-x-hidden) | grid + card + image |
| after | **353px** (16 → 369) | 390 | none |

After the fix the card lines up exactly with the filter box above it. Added a jsdom regression test asserting the results grid pins a `grid-cols-1` base (the layout itself can't be unit-tested in jsdom, which has no layout engine).

`tsc -b`, `eslint`, and `vitest` all pass.

Assisted-By: Claude opus 4.8 <noreply@anthropic.com>
Signed-off-by: Daniel Sionov <kingddd301@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated grid layouts across multiple pages (History, Listings, Notifications, Saved, and Search pages) to improve visual consistency and rendering
  * Enhanced responsive grid behavior with explicit column sizing for better display on various devices

* **Tests**
  * Added test coverage to verify grid layout behavior and single-column rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->