### PR TITLE
feat(web): simplify admin dashboard and add user context

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -314,6 +314,7 @@ func (s *Server) adminListSearches(w http.ResponseWriter, r *http.Request) {
 	type searchResp struct {
 		ID           int64  `json:"id"`
 		ChatID       int64  `json:"chat_id"`
+		Username     string `json:"username,omitempty"`
 		Name         string `json:"name"`
 		Source       string `json:"source"`
 		Manufacturer int    `json:"manufacturer"`
@@ -337,6 +338,7 @@ func (s *Server) adminListSearches(w http.ResponseWriter, r *http.Request) {
 		resp = append(resp, searchResp{
 			ID:           s.ID,
 			ChatID:       s.ChatID,
+			Username:     s.Username,
 			Name:         s.Name,
 			Source:       s.Source,
 			Manufacturer: s.Manufacturer,

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -713,7 +713,7 @@ func (f *failingAdminStore) AdminDeleteListing(_ context.Context, _ string, _ in
 	return nil
 }
 
-func (f *failingAdminStore) AdminListSearches(_ context.Context) ([]storage.Search, error) {
+func (f *failingAdminStore) AdminListSearches(_ context.Context) ([]storage.AdminSearchRow, error) {
 	return nil, nil
 }
 

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -827,9 +827,10 @@ func TestAdminListSearches(t *testing.T) {
 
 	var resp struct {
 		Items []struct {
-			ID     int64  `json:"id"`
-			Name   string `json:"name"`
-			Active bool   `json:"active"`
+			ID       int64  `json:"id"`
+			Name     string `json:"name"`
+			Username string `json:"username"`
+			Active   bool   `json:"active"`
 		} `json:"items"`
 		Total int `json:"total"`
 	}
@@ -844,6 +845,9 @@ func TestAdminListSearches(t *testing.T) {
 	}
 	if resp.Items[0].Name != "test-search" {
 		t.Fatalf("expected name=test-search, got %s", resp.Items[0].Name)
+	}
+	if resp.Items[0].Username != "admin" {
+		t.Fatalf("expected username=admin, got %q", resp.Items[0].Username)
 	}
 }
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -57,6 +57,11 @@ type Search struct {
 	ShareToken   string
 }
 
+type AdminSearchRow struct {
+	Search
+	Username string
+}
+
 type UserStore interface {
 	UpsertUser(ctx context.Context, chatID int64, username string) error
 	GetUser(ctx context.Context, chatID int64) (*User, error)
@@ -400,7 +405,7 @@ type AdminStore interface {
 	PurgeTable(ctx context.Context, table string) (int64, error)
 	AdminListListings(ctx context.Context, limit, offset int, searchID int64) ([]ListingRecord, int64, error)
 	AdminDeleteListing(ctx context.Context, token string, chatID int64) error
-	AdminListSearches(ctx context.Context) ([]Search, error)
+	AdminListSearches(ctx context.Context) ([]AdminSearchRow, error)
 	AdminDeleteSearch(ctx context.Context, id int64) error
 	AdminListUsers(ctx context.Context) ([]User, error)
 	AdminDeleteUser(ctx context.Context, chatID int64) error

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -241,13 +241,8 @@ func (s *Store) AdminListSearches(ctx context.Context) ([]storage.AdminSearchRow
 	var results []storage.AdminSearchRow
 	for rows.Next() {
 		var r storage.AdminSearchRow
-		if err := rows.Scan(&r.ID, &r.ChatID, &r.UserSeq, &r.Name, &r.Source, &r.Manufacturer, &r.Model,
-			&r.YearMin, &r.YearMax, &r.PriceMin, &r.PriceMax,
-			&r.EngineMinCC, &r.MaxKm, &r.MaxHand,
-			&r.Keywords, &r.ExcludeKeys, &r.SellerFilter,
-			&r.GearBox, &r.PriceOnly, &r.PhotoOnly,
-			&r.Active, &r.CreatedAt, &r.ShareToken,
-			&r.Username); err != nil {
+		dests := append(searchScanDests(&r.Search), &r.Username)
+		if err := rows.Scan(dests...); err != nil {
 			return nil, err
 		}
 		results = append(results, r)

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -223,19 +223,36 @@ func (s *Store) AdminDeleteListing(ctx context.Context, token string, chatID int
 	return err
 }
 
-func (s *Store) AdminListSearches(ctx context.Context) ([]storage.Search, error) {
+func (s *Store) AdminListSearches(ctx context.Context) ([]storage.AdminSearchRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, chat_id, user_seq, name, source, manufacturer, model, year_min, year_max,
-			COALESCE(price_min, 0), price_max, engine_min_cc, max_km, max_hand, keywords, exclude_keys,
-			COALESCE(seller_filter, 'any'), COALESCE(gear_box, ''), price_only, photo_only, active, created_at,
-			COALESCE(share_token, '')
-		FROM searches
-		ORDER BY created_at DESC`)
+		SELECT s.id, s.chat_id, s.user_seq, s.name, s.source, s.manufacturer, s.model, s.year_min, s.year_max,
+			COALESCE(s.price_min, 0), s.price_max, s.engine_min_cc, s.max_km, s.max_hand, s.keywords, s.exclude_keys,
+			COALESCE(s.seller_filter, 'any'), COALESCE(s.gear_box, ''), s.price_only, s.photo_only, s.active, s.created_at,
+			COALESCE(s.share_token, ''),
+			COALESCE(u.username, '')
+		FROM searches s
+		LEFT JOIN users u ON u.chat_id = s.chat_id
+		ORDER BY s.created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("admin list searches: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	return scanSearches(rows)
+
+	var results []storage.AdminSearchRow
+	for rows.Next() {
+		var r storage.AdminSearchRow
+		if err := rows.Scan(&r.ID, &r.ChatID, &r.UserSeq, &r.Name, &r.Source, &r.Manufacturer, &r.Model,
+			&r.YearMin, &r.YearMax, &r.PriceMin, &r.PriceMax,
+			&r.EngineMinCC, &r.MaxKm, &r.MaxHand,
+			&r.Keywords, &r.ExcludeKeys, &r.SellerFilter,
+			&r.GearBox, &r.PriceOnly, &r.PhotoOnly,
+			&r.Active, &r.CreatedAt, &r.ShareToken,
+			&r.Username); err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
 }
 
 func (s *Store) AdminDeleteSearch(ctx context.Context, id int64) error {

--- a/internal/storage/postgres/searches.go
+++ b/internal/storage/postgres/searches.go
@@ -264,16 +264,22 @@ func (s *Store) CountAllSearches(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
+func searchScanDests(s *storage.Search) []any {
+	return []any{
+		&s.ID, &s.ChatID, &s.UserSeq, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
+		&s.YearMin, &s.YearMax, &s.PriceMin, &s.PriceMax,
+		&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
+		&s.Keywords, &s.ExcludeKeys, &s.SellerFilter,
+		&s.GearBox, &s.PriceOnly, &s.PhotoOnly,
+		&s.Active, &s.CreatedAt, &s.ShareToken,
+	}
+}
+
 func scanSearches(rows *sql.Rows) ([]storage.Search, error) {
 	var searches []storage.Search
 	for rows.Next() {
 		var s storage.Search
-		if err := rows.Scan(&s.ID, &s.ChatID, &s.UserSeq, &s.Name, &s.Source, &s.Manufacturer, &s.Model,
-			&s.YearMin, &s.YearMax, &s.PriceMin, &s.PriceMax,
-			&s.EngineMinCC, &s.MaxKm, &s.MaxHand,
-			&s.Keywords, &s.ExcludeKeys, &s.SellerFilter,
-			&s.GearBox, &s.PriceOnly, &s.PhotoOnly,
-			&s.Active, &s.CreatedAt, &s.ShareToken); err != nil {
+		if err := rows.Scan(searchScanDests(&s)...); err != nil {
 			return nil, err
 		}
 		searches = append(searches, s)

--- a/web/src/components/admin/DetailModal.tsx
+++ b/web/src/components/admin/DetailModal.tsx
@@ -10,11 +10,13 @@ export function DetailModal({
   fields,
   onClose,
   actions,
+  children,
 }: {
   title: string;
   fields: { label: string; value: string | number | null | undefined }[];
   onClose: () => void;
   actions?: React.ReactNode;
+  children?: React.ReactNode;
 }) {
   return (
     <Dialog open onOpenChange={(v) => !v && onClose()}>
@@ -41,6 +43,7 @@ export function DetailModal({
             );
           })}
         </div>
+        {children}
         {actions && (
           <div className="flex justify-end mt-4 pt-4 border-t border-border/50">
             {actions}

--- a/web/src/components/admin/OverviewTab.tsx
+++ b/web/src/components/admin/OverviewTab.tsx
@@ -4,7 +4,6 @@ import {
   Cpu,
   Database,
   HardDrive,
-  Table,
   Trash2,
 } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -15,31 +14,7 @@ import { ActivityChart } from "./ActivityChart";
 import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Table as ShadcnTable,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { cn } from "@/lib/utils";
-
-const TABLE_LABELS: Record<string, string> = {
-  users: "משתמשים",
-  searches: "חיפושים",
-  listing_history: "היסטוריית מודעות",
-  price_history: "היסטוריית מחירים",
-  seen_listings: "מודעות שנצפו",
-  listing_user_seen: "מודעות סומנו כנצפו",
-  saved_listings: "מודעות שמורות",
-  hidden_listings: "מודעות מוסתרות",
-  pending_digest: "תקצירים ממתינים",
-  cycle_log: "לוג סריקות",
-  search_cycle_stats: "סטטיסטיקות חיפוש",
-  price_list_cache: "מחירון מטמון",
-  link_tokens: "טוקנים לקישור",
-};
 
 
 function StorageIndicator({ sizeBytes }: { sizeBytes: number }) {
@@ -270,48 +245,6 @@ export function OverviewTab({
             value={`${data.http.avg_duration_ms.toFixed(2)} ms`}
           />
         </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="p-6">
-        <div className="flex items-center gap-2.5 mb-5">
-          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-chart-2/10">
-            <Table className="h-[18px] w-[18px] text-chart-2" />
-          </div>
-          <h2 className="text-base font-semibold">טבלאות</h2>
-        </div>
-
-        <ShadcnTable>
-          <TableHeader>
-            <TableRow>
-              <TableHead>טבלה</TableHead>
-              <TableHead className="text-left">שורות</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {Object.entries(data.tables)
-              .sort(([, a], [, b]) => b - a)
-              .map(([table, count]) => (
-                <TableRow key={table}>
-                  <TableCell className="font-medium">
-                    <div className="flex items-center gap-2.5">
-                      <div
-                        className={cn(
-                          "h-2 w-2 rounded-full flex-shrink-0",
-                          count > 0 ? "bg-primary" : "bg-muted-foreground/30",
-                        )}
-                      />
-                      {TABLE_LABELS[table] ?? table}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-left font-mono tabular-nums">
-                    {count.toLocaleString("he-IL")}
-                  </TableCell>
-                </TableRow>
-              ))}
-          </TableBody>
-        </ShadcnTable>
         </CardContent>
       </Card>
 

--- a/web/src/components/admin/OverviewTab.tsx
+++ b/web/src/components/admin/OverviewTab.tsx
@@ -16,7 +16,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-
 function StorageIndicator({ sizeBytes }: { sizeBytes: number }) {
   const mb = sizeBytes / (1024 * 1024);
   const color =

--- a/web/src/components/admin/SearchesTab.tsx
+++ b/web/src/components/admin/SearchesTab.tsx
@@ -152,8 +152,8 @@ export function SearchesTab({ onViewListings }: { onViewListings: (searchId: num
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>
                   </div>
-                  <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
-                    #{search.chat_id}
+                  <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0 truncate max-w-[180px]" title={search.username || `#${search.chat_id}`}>
+                    {search.username || `#${search.chat_id}`}
                   </span>
                 </motion.div>
               ))}
@@ -204,6 +204,7 @@ export function SearchesTab({ onViewListings }: { onViewListings: (searchId: num
                 label: "סטטוס",
                 value: detailSearch.active ? "פעיל" : "מושהה",
               },
+              { label: "משתמש", value: detailSearch.username || null },
               { label: "Chat ID", value: detailSearch.chat_id },
               {
                 label: "נוצר",

--- a/web/src/components/admin/UsersTab.tsx
+++ b/web/src/components/admin/UsersTab.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { AlertCircle, RefreshCcw, RefreshCw, ToggleLeft, ToggleRight, Trash2, Users } from "lucide-react";
+import { useMemo, useState } from "react";
+import { AlertCircle, FileSearch, RefreshCcw, RefreshCw, ToggleLeft, ToggleRight, Trash2, Users } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import { adminApi, type AdminUser } from "@/lib/api";
@@ -7,7 +7,7 @@ import { EmptyState, Skeleton, Badge } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/components/ui/Toast";
-import { cn, relativeTime } from "@/lib/utils";
+import { cn, formatPrice, relativeTime } from "@/lib/utils";
 import { ConfirmModal } from "./ConfirmModal";
 import { DetailModal } from "./DetailModal";
 
@@ -48,6 +48,18 @@ export function UsersTab() {
       toast("שגיאה בעדכון סטטוס המשתמש", "error");
     },
   });
+
+  const { data: searchesData } = useQuery({
+    queryKey: ["admin", "searches"],
+    queryFn: adminApi.searches,
+  });
+
+  const userSearches = useMemo(() => {
+    if (!detailUser || !searchesData) return [];
+    return searchesData.items.filter(
+      (s) => s.chat_id === detailUser.chat_id && s.active,
+    );
+  }, [detailUser, searchesData]);
 
   const syncUserStatusMutation = useMutation({
     mutationFn: () => adminApi.syncUserStatus(),
@@ -234,7 +246,47 @@ export function UsersTab() {
                 </button>
               </div>
             }
-          />
+          >
+            <div className="mt-4 pt-4 border-t border-border/50">
+              <div className="flex items-center gap-2 mb-3">
+                <FileSearch className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-sm font-semibold">חיפושים פעילים</h3>
+                <span className="text-xs text-muted-foreground tabular-nums">
+                  ({userSearches.length})
+                </span>
+              </div>
+              {userSearches.length === 0 ? (
+                <p className="text-xs text-muted-foreground">אין חיפושים פעילים</p>
+              ) : (
+                <div className="space-y-1.5">
+                  {userSearches.map((s) => (
+                    <div
+                      key={s.id}
+                      className="flex items-center gap-2 rounded-lg bg-secondary/40 px-3 py-2"
+                    >
+                      <div className="h-2 w-2 rounded-full bg-success animate-pulse-soft flex-shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs font-medium truncate">
+                          {s.name || `חיפוש #${s.id}`}
+                        </p>
+                        <div className="flex items-center gap-1.5 mt-0.5">
+                          <span className="text-[11px] text-muted-foreground">{s.source}</span>
+                          {s.price_max > 0 && (
+                            <span className="text-[11px] text-muted-foreground">
+                              · עד {formatPrice(s.price_max)}
+                            </span>
+                          )}
+                          <span className="text-[11px] text-muted-foreground">
+                            · {relativeTime(s.created_at)}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </DetailModal>
         )}
       </AnimatePresence>
 

--- a/web/src/components/admin/UsersTab.tsx
+++ b/web/src/components/admin/UsersTab.tsx
@@ -49,7 +49,7 @@ export function UsersTab() {
     },
   });
 
-  const { data: searchesData } = useQuery({
+  const { data: searchesData, isLoading: searchesLoading, isError: searchesError } = useQuery({
     queryKey: ["admin", "searches"],
     queryFn: adminApi.searches,
   });
@@ -255,7 +255,11 @@ export function UsersTab() {
                   ({userSearches.length})
                 </span>
               </div>
-              {userSearches.length === 0 ? (
+              {searchesLoading ? (
+                <p className="text-xs text-muted-foreground">טוען חיפושים…</p>
+              ) : searchesError ? (
+                <p className="text-xs text-destructive">שגיאה בטעינת חיפושים</p>
+              ) : userSearches.length === 0 ? (
                 <p className="text-xs text-muted-foreground">אין חיפושים פעילים</p>
               ) : (
                 <div className="space-y-1.5">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -377,6 +377,7 @@ export interface VacuumResult {
 export interface AdminSearch {
   id: number;
   chat_id: number;
+  username?: string;
   name: string;
   source: string;
   manufacturer: number;


### PR DESCRIPTION
## Summary

- Remove the DB tables row-count section from the admin overview tab — it added clutter without actionable value
- Show user email (username) next to chat_id in the searches tab so you can identify who owns each search
- When clicking a user in the users tab, display their active searches in the detail modal

## Changes

**Backend:**
- `AdminListSearches` now LEFT JOINs the `users` table to include `username` in the response
- New `AdminSearchRow` struct wraps `Search` with a `Username` field

**Frontend:**
- `OverviewTab`: removed "טבלאות" card and related imports/constants
- `SearchesTab`: shows email instead of raw `#{chat_id}`, with fallback
- `UsersTab`: queries cached searches, filters by user's `chat_id`, renders active searches list in detail modal
- `DetailModal`: added `children` prop for extra content sections
- `api.ts`: added `username` to `AdminSearch` interface

## Review

_Pending agent review_

## Test plan

- [ ] Admin overview tab: verify tables section is gone, everything else intact
- [ ] Searches tab: each row shows email/username instead of raw chat ID
- [ ] Users tab: clicking a user shows their active searches in the modal
- [ ] Users with no active searches show "אין חיפושים פעילים" empty state
- [ ] `golangci-lint run ./...` passes
- [ ] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin search results now display associated usernames for each search record
  * User administration panel now displays active search count and search details for each user

* **Interface Updates**
  * Admin interface simplified with updated information hierarchy and display elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->