### PR TITLE
feat(web): deduplicate linked users in admin dashboard

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -411,20 +411,26 @@ func (s *Server) adminListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	type userResp struct {
+	type linkedTelegramResp struct {
 		ChatID    int64  `json:"chat_id"`
 		Username  string `json:"username"`
-		Channel   string `json:"channel"`
 		ChannelID string `json:"channel_id"`
-		Active    bool   `json:"active"`
-		Tier      string `json:"tier"`
-		Language  string `json:"language"`
-		CreatedAt string `json:"created_at"`
+	}
+	type userResp struct {
+		ChatID         int64               `json:"chat_id"`
+		Username       string              `json:"username"`
+		Channel        string              `json:"channel"`
+		ChannelID      string              `json:"channel_id"`
+		Active         bool                `json:"active"`
+		Tier           string              `json:"tier"`
+		Language       string              `json:"language"`
+		CreatedAt      string              `json:"created_at"`
+		LinkedTelegram *linkedTelegramResp `json:"linked_telegram,omitempty"`
 	}
 
 	resp := make([]userResp, 0, len(users))
 	for _, u := range users {
-		resp = append(resp, userResp{
+		r := userResp{
 			ChatID:    u.ChatID,
 			Username:  u.Username,
 			Channel:   u.Channel,
@@ -433,7 +439,15 @@ func (s *Server) adminListUsers(w http.ResponseWriter, r *http.Request) {
 			Tier:      u.Tier,
 			Language:  u.Language,
 			CreatedAt: u.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
-		})
+		}
+		if u.LinkedTelegramChatID > 0 {
+			r.LinkedTelegram = &linkedTelegramResp{
+				ChatID:    u.LinkedTelegramChatID,
+				Username:  u.LinkedTelegramUsername,
+				ChannelID: u.LinkedTelegramChannelID,
+			}
+		}
+		resp = append(resp, r)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": resp, "total": len(resp)})
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -721,7 +721,7 @@ func (f *failingAdminStore) AdminDeleteSearch(_ context.Context, _ int64) error 
 	return nil
 }
 
-func (f *failingAdminStore) AdminListUsers(_ context.Context) ([]storage.User, error) {
+func (f *failingAdminStore) AdminListUsers(_ context.Context) ([]storage.AdminUserRow, error) {
 	return nil, nil
 }
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -62,6 +62,13 @@ type AdminSearchRow struct {
 	Username string
 }
 
+type AdminUserRow struct {
+	User
+	LinkedTelegramChatID    int64
+	LinkedTelegramUsername  string
+	LinkedTelegramChannelID string
+}
+
 type UserStore interface {
 	UpsertUser(ctx context.Context, chatID int64, username string) error
 	GetUser(ctx context.Context, chatID int64) (*User, error)
@@ -456,7 +463,7 @@ type AdminStore interface {
 	AdminDeleteListing(ctx context.Context, token string, chatID int64) error
 	AdminListSearches(ctx context.Context) ([]AdminSearchRow, error)
 	AdminDeleteSearch(ctx context.Context, id int64) error
-	AdminListUsers(ctx context.Context) ([]User, error)
+	AdminListUsers(ctx context.Context) ([]AdminUserRow, error)
 	AdminDeleteUser(ctx context.Context, chatID int64) error
 	VacuumDB(ctx context.Context) error
 	SyncUserActiveStatus(ctx context.Context) (activated, deactivated int64, err error)

--- a/internal/storage/postgres/admin.go
+++ b/internal/storage/postgres/admin.go
@@ -274,28 +274,29 @@ func (s *Store) AdminDeleteSearch(ctx context.Context, id int64) error {
 	return s.DeleteSearch(ctx, id, chatID)
 }
 
-func (s *Store) AdminListUsers(ctx context.Context) ([]storage.User, error) {
+func (s *Store) AdminListUsers(ctx context.Context) ([]storage.AdminUserRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT chat_id, username, state, state_data, created_at, active, language, tier,
-			tier_expires_at, trial_used, channel, channel_id
-		FROM users
-		ORDER BY created_at DESC`)
+		SELECT u.chat_id, u.username, u.state, u.state_data, u.created_at, u.active, u.language, u.tier,
+			u.tier_expires_at, u.trial_used, u.channel, u.channel_id,
+			COALESCE(tg.chat_id, 0), COALESCE(tg.username, ''), COALESCE(tg.channel_id, '')
+		FROM users u
+		LEFT JOIN users tg ON tg.linked_web_id = u.chat_id AND tg.channel = 'telegram'
+		WHERE u.linked_web_id IS NULL
+		ORDER BY u.created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("admin list users: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	return scanAdminUsers(rows)
-}
 
-func scanAdminUsers(rows *sql.Rows) ([]storage.User, error) {
-	var users []storage.User
+	var users []storage.AdminUserRow
 	for rows.Next() {
-		var u storage.User
-		if err := rows.Scan(&u.ChatID, &u.Username, &u.State, &u.StateData, &u.CreatedAt, &u.Active, &u.Language,
-			&u.Tier, &u.TierExpires, &u.TrialUsed, &u.Channel, &u.ChannelID); err != nil {
+		var r storage.AdminUserRow
+		if err := rows.Scan(&r.ChatID, &r.Username, &r.State, &r.StateData, &r.CreatedAt, &r.Active, &r.Language,
+			&r.Tier, &r.TierExpires, &r.TrialUsed, &r.Channel, &r.ChannelID,
+			&r.LinkedTelegramChatID, &r.LinkedTelegramUsername, &r.LinkedTelegramChannelID); err != nil {
 			return nil, err
 		}
-		users = append(users, u)
+		users = append(users, r)
 	}
 	return users, rows.Err()
 }

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -334,6 +334,20 @@ func (s *Store) LinkTelegramToWeb(ctx context.Context, telegramChatID, webChatID
 		return fmt.Errorf("cleanup duplicate listing history: %w", err)
 	}
 
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE seen_listings SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM seen_listings s2
+			WHERE s2.chat_id = $1 AND s2.token = seen_listings.token
+		)`,
+		telegramChatID, webChatID); err != nil {
+		return fmt.Errorf("migrate seen listings: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM seen_listings WHERE chat_id = $1`, webChatID); err != nil {
+		return fmt.Errorf("cleanup duplicate seen listings: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
@@ -450,6 +464,23 @@ func (s *Store) migrateUserData(ctx context.Context, telegramChatID, webChatID i
 		total += n
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM listing_history WHERE chat_id = $1`, webChatID); err != nil {
+		return 0, err
+	}
+
+	res, err = tx.ExecContext(ctx, `
+		UPDATE seen_listings SET chat_id = $1
+		WHERE chat_id = $2
+		AND NOT EXISTS (
+			SELECT 1 FROM seen_listings s2
+			WHERE s2.chat_id = $1 AND s2.token = seen_listings.token
+		)`, telegramChatID, webChatID)
+	if err != nil {
+		return 0, err
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM seen_listings WHERE chat_id = $1`, webChatID); err != nil {
 		return 0, err
 	}
 

--- a/web/src/components/admin/UsersTab.tsx
+++ b/web/src/components/admin/UsersTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { AlertCircle, FileSearch, RefreshCcw, RefreshCw, ToggleLeft, ToggleRight, Trash2, Users } from "lucide-react";
+import { AlertCircle, FileSearch, MessageCircle, RefreshCcw, RefreshCw, ToggleLeft, ToggleRight, Trash2, Users } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import { adminApi, type AdminUser } from "@/lib/api";
@@ -56,8 +56,9 @@ export function UsersTab() {
 
   const userSearches = useMemo(() => {
     if (!detailUser || !searchesData) return [];
+    const searchChatId = detailUser.linked_telegram?.chat_id ?? detailUser.chat_id;
     return searchesData.items.filter(
-      (s) => s.chat_id === detailUser.chat_id && s.active,
+      (s) => s.chat_id === searchChatId && s.active,
     );
   }, [detailUser, searchesData]);
 
@@ -148,6 +149,11 @@ export function UsersTab() {
                       {user.channel && (
                         <span className="text-xs text-muted-foreground">
                           {user.channel}
+                        </span>
+                      )}
+                      {user.linked_telegram && (
+                        <span className="text-xs text-muted-foreground">
+                          · טלגרם מקושר
                         </span>
                       )}
                       <span className="text-xs text-muted-foreground">
@@ -247,6 +253,24 @@ export function UsersTab() {
               </div>
             }
           >
+            {detailUser.linked_telegram && (
+              <div className="mt-4 pt-4 border-t border-border/50">
+                <div className="flex items-center gap-2 mb-3">
+                  <MessageCircle className="h-4 w-4 text-muted-foreground" />
+                  <h3 className="text-sm font-semibold">טלגרם מקושר</h3>
+                </div>
+                <div className="space-y-0.5">
+                  <div className="flex gap-3 py-2 border-b border-border/50">
+                    <span className="text-xs text-muted-foreground w-28 flex-shrink-0 mt-0.5">שם משתמש</span>
+                    <span className="text-sm text-foreground font-medium break-all">@{detailUser.linked_telegram.username}</span>
+                  </div>
+                  <div className="flex gap-3 py-2">
+                    <span className="text-xs text-muted-foreground w-28 flex-shrink-0 mt-0.5">Chat ID</span>
+                    <span className="text-sm text-foreground font-medium break-all font-mono tabular-nums">{detailUser.linked_telegram.chat_id}</span>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="mt-4 pt-4 border-t border-border/50">
               <div className="flex items-center gap-2 mb-3">
                 <FileSearch className="h-4 w-4 text-muted-foreground" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -413,6 +413,12 @@ export interface AdminSearchesResponse {
   total: number;
 }
 
+export interface AdminLinkedTelegram {
+  chat_id: number;
+  username: string;
+  channel_id: string;
+}
+
 export interface AdminUser {
   chat_id: number;
   username: string;
@@ -422,6 +428,7 @@ export interface AdminUser {
   tier: string;
   language: string;
   created_at: string;
+  linked_telegram?: AdminLinkedTelegram;
 }
 
 export interface AdminUsersResponse {


### PR DESCRIPTION
## Summary

- Deduplicate linked Telegram+web users in admin dashboard — show one entry per person instead of two
- Show linked Telegram details (username, channel ID) in user detail modal
- Fix active searches filter to query by telegram chat_id for linked users (where data lives after account linking)

## How it works

When a web user links their Telegram account, `LinkTelegramToWeb` migrates all data to the telegram chat_id. Both user rows remained in the DB, causing the admin to see duplicates.

Now `AdminListUsers` uses `WHERE u.linked_web_id IS NULL` to filter out telegram users that are already linked to a web user, and LEFT JOINs the linked telegram info onto the web user row. The frontend shows a "טלגרם מקושר" indicator and displays telegram details in the modal.

## Test plan

- [ ] Users tab shows one entry per person (no duplicates for linked accounts)
- [ ] Linked web users show "טלגרם מקושר" in the list row
- [ ] Clicking a linked user shows telegram details section in the modal
- [ ] Active searches appear correctly for linked users (queries telegram chat_id)
- [ ] Unlinked telegram-only users still appear normally
- [ ] `golangci-lint run ./...` passes
- [ ] TypeScript compiles clean

closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin user list now displays linked Telegram account indicators for users with connected accounts.
  * User detail view shows linked Telegram information including username and chat ID.
  * User active searches properly filtered based on linked Telegram account status.
  * User detail modal now closes after toggling active status for improved workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->