### PR TITLE
fix: backfill seen_listings for existing linked accounts

### DIFF
--- a/migrations/000027_backfill_seen_listings_linked.down.sql
+++ b/migrations/000027_backfill_seen_listings_linked.down.sql
@@ -1,0 +1,2 @@
+-- No-op: backfill migration cannot be meaningfully reversed.
+-- The orphaned rows under web chat_ids were invalid state.

--- a/migrations/000027_backfill_seen_listings_linked.up.sql
+++ b/migrations/000027_backfill_seen_listings_linked.up.sql
@@ -1,0 +1,24 @@
+-- Migrate orphaned seen_listings rows for already-linked accounts.
+-- When LinkTelegramToWeb ran before the seen_listings fix, dedup
+-- entries remained under the web user's chat_id, causing the scheduler
+-- to re-deliver already-seen listings under the telegram chat_id.
+
+-- Step 1: Move web user's seen_listings to the linked telegram user,
+-- skipping rows that already exist under the telegram chat_id.
+UPDATE seen_listings sl
+SET chat_id = u.chat_id
+FROM users u
+WHERE u.linked_web_id = sl.chat_id
+  AND u.channel = 'telegram'
+  AND NOT EXISTS (
+      SELECT 1 FROM seen_listings s2
+      WHERE s2.chat_id = u.chat_id AND s2.token = sl.token
+  );
+
+-- Step 2: Delete any remaining orphaned web-user rows that couldn't
+-- be migrated (duplicate token already existed under telegram chat_id).
+DELETE FROM seen_listings sl
+USING users u
+WHERE u.linked_web_id IS NOT NULL
+  AND u.channel = 'telegram'
+  AND sl.chat_id = u.linked_web_id;


### PR DESCRIPTION
## Summary

- One-time data migration to fix duplicate notifications for existing linked users
- Moves orphaned `seen_listings` dedup entries from the web user's `chat_id` to the linked telegram `chat_id`
- Deletes any remaining orphaned rows that couldn't be migrated (already existed under telegram)

## Context

PR #1443 fixed `LinkTelegramToWeb` to migrate `seen_listings` going forward, but users who linked before that fix still have orphaned dedup entries under their old web `chat_id`. This causes the scheduler to treat already-seen listings as new and re-deliver them to Telegram.

This migration runs the same UPDATE+DELETE pattern as the code fix, but as a one-shot SQL migration for all existing linked accounts.

## Test plan

- [ ] Migration applies cleanly: `migrate up` succeeds
- [ ] After migration, no `seen_listings` rows exist with `chat_id` matching any web user that has a linked telegram account
- [ ] Duplicate notifications stop for existing linked users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where listing view history data was incorrectly orphaned due to a previous linking operation.
  * Cleaned up and consolidated duplicate entries to restore data integrity across linked user accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->