### PR TITLE
fix: stop duplicate Telegram alerts caused by transient retries

### DIFF
--- a/internal/notifier/telegram/telegram.go
+++ b/internal/notifier/telegram/telegram.go
@@ -276,17 +276,11 @@ func (n *Notifier) sendMessageWithRetry(ctx context.Context, chatID string, para
 			params.ParseMode = ""
 			continue
 		}
-		if isTransientError(err) && attempt < telegramMaxRetries {
-			delay := telegramRetryBaseDelay * time.Duration(1<<uint(attempt))
-			n.logger.Warn("transient telegram error, retrying",
-				"chat_id", chatID, "attempt", attempt+1, "wait", delay.String(), "error", err)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(delay):
-			}
-			continue
-		}
+		// Transient errors (timeout, connection reset, EOF) are NOT retried
+		// here because the request may have been processed by Telegram — a
+		// retry would send a duplicate message. The caller's own retry
+		// mechanism (consumer reclaim / next scheduler cycle) handles
+		// redelivery at a higher level where dedup checks can run first.
 		if !isRateLimited(err) || attempt >= telegramMaxRetries {
 			return fmt.Errorf("telegram sendMessage: %w", err)
 		}
@@ -314,17 +308,7 @@ func (n *Notifier) sendPhotoWithRetry(ctx context.Context, chatID string, params
 		if recErr := recipientBlockedError(err); recErr != nil {
 			return recErr
 		}
-		if isTransientError(err) && attempt < telegramMaxRetries {
-			delay := telegramRetryBaseDelay * time.Duration(1<<uint(attempt))
-			n.logger.Warn("transient telegram error on sendPhoto, retrying",
-				"chat_id", chatID, "attempt", attempt+1, "wait", delay.String(), "error", err)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(delay):
-			}
-			continue
-		}
+		// Transient errors are not retried — see sendMessageWithRetry.
 		if !isRateLimited(err) || attempt >= telegramMaxRetries {
 			return err
 		}
@@ -480,19 +464,6 @@ func isMarkdownParseError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "can't parse") ||
 		(strings.Contains(msg, "entities") && strings.Contains(msg, "parse"))
-}
-
-func isTransientError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "timeout") ||
-		strings.Contains(msg, "eof") ||
-		strings.Contains(msg, "502") ||
-		strings.Contains(msg, "503") ||
-		strings.Contains(msg, "gateway")
 }
 
 func isRateLimited(err error) bool {

--- a/internal/scheduler/cross_search_dedup_test.go
+++ b/internal/scheduler/cross_search_dedup_test.go
@@ -1,0 +1,178 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// perSearchDedup mirrors the real Postgres dedup behavior: the key includes
+// searchID, so the same listing can be independently claimed for different
+// searches belonging to the same user.
+type perSearchDedup struct {
+	mu   sync.Mutex
+	seen map[perSearchDedupKey]bool
+}
+
+type perSearchDedupKey struct {
+	token    string
+	chatID   int64
+	searchID int64
+}
+
+func newPerSearchDedup() *perSearchDedup {
+	return &perSearchDedup{seen: make(map[perSearchDedupKey]bool)}
+}
+
+func (d *perSearchDedup) ClaimNew(_ context.Context, token string, chatID, searchID int64) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	key := perSearchDedupKey{token, chatID, searchID}
+	if d.seen[key] {
+		return false, nil
+	}
+	d.seen[key] = true
+	return true, nil
+}
+
+func (d *perSearchDedup) ReleaseClaim(_ context.Context, token string, chatID, searchID int64) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.seen, perSearchDedupKey{token, chatID, searchID})
+	return nil
+}
+
+func (d *perSearchDedup) Prune(_ context.Context, _ time.Duration) (int64, error) { return 0, nil }
+func (d *perSearchDedup) Close() error                                          { return nil }
+
+// TestCrossSearchDedup_SameUserOverlappingSearches verifies that a listing
+// matching multiple searches for the same user produces only one notification.
+func TestCrossSearchDedup_SameUserOverlappingSearches(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "tok-dup", ManufacturerID: 27, ModelID: 10332,
+				Manufacturer: "Mazda", Model: "3",
+				Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newPerSearchDedup()
+	n := &mockNotifier{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "search-wide", Source: "yad2",
+				Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2025, PriceMax: 200000, Active: true},
+			{ID: 2, ChatID: 100, Name: "search-narrow", Source: "yad2",
+				Manufacturer: 27, Model: 10332,
+				YearMin: 2019, YearMax: 2022, PriceMax: 150000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 1 {
+		t.Errorf("expected 1 notification (cross-search dedup), got %d", len(n.messages))
+	}
+}
+
+// TestCrossSearchDedup_DifferentUsers verifies that cross-search dedup only
+// applies within the same user — different users still get their own alerts.
+func TestCrossSearchDedup_DifferentUsers(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "tok-shared", ManufacturerID: 27, ModelID: 10332,
+				Manufacturer: "Mazda", Model: "3",
+				Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	d := newPerSearchDedup()
+	n := &mockNotifier{}
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "user1-search", Source: "yad2",
+				Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2025, PriceMax: 200000, Active: true},
+			{ID: 2, ChatID: 200, Name: "user2-search", Source: "yad2",
+				Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2025, PriceMax: 200000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 2 {
+		t.Errorf("expected 2 notifications (one per user), got %d", len(n.messages))
+	}
+}
+
+// TestCrossSearchDedup_PriceDrop verifies that a price drop matching multiple
+// searches for the same user only sends one price drop notification.
+func TestCrossSearchDedup_PriceDrop(t *testing.T) {
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "tok-pd", ManufacturerID: 27, ModelID: 10332,
+				Manufacturer: "Mazda", Model: "3",
+				Price: 85000, Year: 2020, EngineVolume: 2000, Km: 50000},
+		},
+	}
+	d := newPerSearchDedup()
+	n := &mockNotifier{}
+
+	pt := newMockPriceTracker()
+	pt.prices["tok-pd"] = 95000
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "search-a", Source: "yad2",
+				Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2025, PriceMax: 200000, Active: true},
+			{ID: 2, ChatID: 100, Name: "search-b", Source: "yad2",
+				Manufacturer: 27, Model: 10332,
+				YearMin: 2019, YearMax: 2022, PriceMax: 150000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+		SearchStore: ss,
+		Prices:      pt,
+	})
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 batch notifications for price drop, got %d", len(n.messages))
+	}
+	if len(n.rawMessages) != 1 {
+		t.Errorf("expected 1 price drop notification (cross-search dedup), got %d", len(n.rawMessages))
+	}
+	if len(n.rawMessages) > 0 {
+		msg := n.rawMessages[0].message
+		if !strings.Contains(msg, "95,000") || !strings.Contains(msg, "85,000") {
+			t.Errorf("price drop message should contain old and new prices, got:\n%s", msg)
+		}
+	}
+}

--- a/internal/scheduler/cross_search_dedup_test.go
+++ b/internal/scheduler/cross_search_dedup_test.go
@@ -74,7 +74,10 @@ func TestCrossSearchDedup_SameUserOverlappingSearches(t *testing.T) {
 		},
 	}
 
-	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	s, err := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
 
 	if err := s.runMultiTenantCycle(context.Background()); err != nil {
 		t.Fatalf("cycle: %v", err)
@@ -111,7 +114,10 @@ func TestCrossSearchDedup_DifferentUsers(t *testing.T) {
 		},
 	}
 
-	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	s, err := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{SearchStore: ss})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
 
 	if err := s.runMultiTenantCycle(context.Background()); err != nil {
 		t.Fatalf("cycle: %v", err)
@@ -151,10 +157,13 @@ func TestCrossSearchDedup_PriceDrop(t *testing.T) {
 		},
 	}
 
-	s, _ := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
+	s, err := NewWithOptions(testConfig(), f, d, n, testLogger(), Options{
 		SearchStore: ss,
 		Prices:      pt,
 	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
 
 	if err := s.runMultiTenantCycle(context.Background()); err != nil {
 		t.Fatalf("cycle: %v", err)

--- a/internal/scheduler/cross_search_dedup_test.go
+++ b/internal/scheduler/cross_search_dedup_test.go
@@ -48,7 +48,7 @@ func (d *perSearchDedup) ReleaseClaim(_ context.Context, token string, chatID, s
 }
 
 func (d *perSearchDedup) Prune(_ context.Context, _ time.Duration) (int64, error) { return 0, nil }
-func (d *perSearchDedup) Close() error                                          { return nil }
+func (d *perSearchDedup) Close() error                                            { return nil }
 
 // TestCrossSearchDedup_SameUserOverlappingSearches verifies that a listing
 // matching multiple searches for the same user produces only one notification.

--- a/internal/scheduler/match.go
+++ b/internal/scheduler/match.go
@@ -89,6 +89,10 @@ func (s *Scheduler) matchListingsToSearches(ctx context.Context, ms *matchState)
 	hiddenCache := make(map[int64]map[string]bool)
 	priceCache := make(map[string]priceResult)
 
+	// Cross-search dedup: prevent the same listing from being delivered
+	// multiple times to the same user when overlapping searches match it.
+	userDelivered := make(map[int64]map[string]bool) // chatID -> token set
+
 	for i := range ms.raw {
 		matches := s.percolator.Match(ms.raw[i])
 		if len(matches) == 0 {
@@ -149,9 +153,16 @@ func (s *Scheduler) matchListingsToSearches(ctx context.Context, ms *matchState)
 					priceCache[ms.raw[i].Token] = pr
 				}
 				if !pr.err && pr.changed && ms.raw[i].Price < pr.oldPrice {
+					if ud := userDelivered[m.ChatID]; ud != nil && ud[ms.raw[i].Token] {
+						continue
+					}
 					ms.priceDropCandidates = append(ms.priceDropCandidates, priceDropCandidate{
 						rawIdx: i, searchID: m.SearchID, oldPrice: pr.oldPrice,
 					})
+					if userDelivered[m.ChatID] == nil {
+						userDelivered[m.ChatID] = make(map[string]bool)
+					}
+					userDelivered[m.ChatID][ms.raw[i].Token] = true
 					continue
 				}
 			}
@@ -159,6 +170,14 @@ func (s *Scheduler) matchListingsToSearches(ctx context.Context, ms *matchState)
 			if !isNew {
 				continue
 			}
+
+			if ud := userDelivered[m.ChatID]; ud != nil && ud[ms.raw[i].Token] {
+				continue
+			}
+			if userDelivered[m.ChatID] == nil {
+				userDelivered[m.ChatID] = make(map[string]bool)
+			}
+			userDelivered[m.ChatID][ms.raw[i].Token] = true
 
 			acc.result.newListings = append(acc.result.newListings, model.Listing{RawListing: ms.raw[i]})
 		}


### PR DESCRIPTION
## Summary

- **Remove transient-error retries** from `sendMessageWithRetry` and `sendPhotoWithRetry` — timeout, connection reset, EOF, 502, and 503 errors are ambiguous (Telegram may have already delivered the message), so retrying sends duplicates. Rate-limit (429) retries are kept since the server explicitly confirms no processing.
- **Add cross-search dedup** in `matchListingsToSearches` — when overlapping searches match the same listing for one user, only the first matching search delivers it (defense-in-depth).

## Root cause

`sendMessageWithRetry` retried up to 3 times on transient errors. These errors (e.g. timeout) occur *after* the request is sent to Telegram but *before* the response is received — meaning Telegram likely already delivered the message. Each retry sent a new Telegram message, causing duplicates visible in the chat.

The higher-level retry mechanisms (Redis consumer reclaim after 30s, or scheduler's next polling cycle) already handle redelivery with dedup checks, making the low-level retries both redundant and harmful.

## Test plan

- [x] All existing telegram notifier tests pass
- [x] All existing scheduler tests pass
- [x] New `TestCrossSearchDedup_*` tests verify cross-search dedup behavior
- [ ] Deploy and monitor Telegram alerts for duplicate reduction

closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate notifications when a listing matches multiple overlapping searches for the same user, including price-drop alerts.
  * Improved Telegram notification behavior by avoiding retries for transient send failures to reduce the risk of duplicate messages, while continuing to gracefully handle rate limits.

* **Tests**
  * Added coverage for cross-search deduplication across overlapping searches, different users, and price-drop scenarios (including correct old/new price formatting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->