### PR TITLE
fix: parse body type from Hebrew sub-model text fallback

### DIFF
--- a/internal/bodytype/bodytype.go
+++ b/internal/bodytype/bodytype.go
@@ -77,14 +77,16 @@ var matchers = []matcher{
 	{Pickup, substr("pickup")},
 }
 
-func Parse(subModel string) string {
-	if subModel == "" {
-		return ""
-	}
-	lower := strings.ToLower(subModel)
-	for _, m := range matchers {
-		if m.match(lower) {
-			return m.bodyType
+func Parse(texts ...string) string {
+	for _, text := range texts {
+		if text == "" {
+			continue
+		}
+		lower := strings.ToLower(text)
+		for _, m := range matchers {
+			if m.match(lower) {
+				return m.bodyType
+			}
 		}
 	}
 	return ""

--- a/internal/bodytype/bodytype_test.go
+++ b/internal/bodytype/bodytype_test.go
@@ -72,3 +72,26 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestParse_MultipleTexts(t *testing.T) {
+	tests := []struct {
+		name  string
+		texts []string
+		want  string
+	}{
+		{"english hit", []string{"Sport hatchback 1.4", "ספורט האצ'בק 1.4"}, "hatchback"},
+		{"english miss falls back to hebrew", []string{"Excite Plus", "Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8"}, "hatchback"},
+		{"both empty", []string{"", ""}, ""},
+		{"first empty second hit", []string{"", "סדאן 1.6"}, "sedan"},
+		{"single text", []string{"SUV Premium"}, "suv"},
+		{"no match in any", []string{"Excite Plus", "Premium אוט׳ 2.0"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.texts...)
+			if got != tt.want {
+				t.Errorf("Parse(%v) = %q, want %q", tt.texts, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -254,7 +254,7 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 		listing.GearBox = "אוטומט"
 	}
 
-	listing.BodyType = bodytype.Parse(subModelText)
+	listing.BodyType = bodytype.Parse(subModelText, item.SubModel.Text)
 
 	listing.City = textFromField(item.Address.City)
 	listing.Area = textFromField(item.Address.Area)

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -643,3 +643,32 @@ func TestParseNextData_BodyTypeEmptyWhenNoMatch(t *testing.T) {
 		t.Errorf("BodyType = %q, want empty string", listings[0].BodyType)
 	}
 }
+
+func TestParseNextData_BodyTypeFallsBackToHebrewText(t *testing.T) {
+	data := []byte(`{
+		"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+			"data":{"feed":{"feed_items":[{
+				"token":"bt-hebrew-fallback",
+				"manufacturer":{"id":53,"text":"טויוטה","english_text":"Toyota"},
+				"model":{"id":10399,"text":"קורולה","english_text":"Corolla"},
+				"subModel":{"id":105280,"text":"Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8 (98 כ״ס)","english_text":"Excite Plus"},
+				"vehicleDates":{"yearOfProduction":2019},
+				"engineVolume":1798,
+				"price":87000,
+				"hand":{"id":1},
+				"metaData":{"coverImage":"https://img.yad2.co.il/test.jpg"}
+			}]}}
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].BodyType != "hatchback" {
+		t.Errorf("BodyType = %q, want 'hatchback' (from Hebrew text fallback when english_text lacks body type)", listings[0].BodyType)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix body type not being detected for listings where Yad2's `english_text` sub-model field omits the body type keyword (e.g., `"Excite Plus"` instead of the Hebrew `"Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8"`)
- `bodytype.Parse()` now accepts variadic texts and falls back to the Hebrew `text` field when the English text yields no match
- Fixes hatchback Corolla not showing "האצ'בק" filter chip in the UI

## Root cause

`textFromField()` prefers `english_text` over `text`. Yad2's English sub-model text often contains only the trim name (e.g., "Excite Plus") without the body type keyword, while the Hebrew `text` field contains the full description including "האצ'בק".

## Test plan

- [x] New test: `TestParse_MultipleTexts` — 6 cases covering fallback behavior
- [x] New test: `TestParseNextData_BodyTypeFallsBackToHebrewText` — integration test with Yad2-like JSON where english_text lacks body type
- [x] All existing tests still pass

closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Body type detection now considers multiple text sources, improving results when one source is incomplete.

* **Bug Fixes**
  * Better fallback behavior when the primary text doesn’t include a body type.
  * Empty inputs are now handled more gracefully, avoiding missed matches.
  * Improved handling of Hebrew and English text so the correct body type is more often identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->