### PR TITLE
feat: enricher reliability improvements (dedup, cooldown, circuit breaker)

### DIFF
--- a/cmd/enrich-bench/main.go
+++ b/cmd/enrich-bench/main.go
@@ -3,9 +3,6 @@
 // and proxy settings as production.
 //
 // Limitations (see ADV review):
-//   - Runs in isolation; production has 3 concurrent Yad2 sources (enricher,
-//     inline enricher, scheduler) sharing the same proxy IPs. Apply a safety
-//     buffer on top of bench results.
 //   - Time-of-day effects are not controlled. Run during peak hours for
 //     conservative results.
 //
@@ -13,6 +10,7 @@
 //
 //	enrich-bench --config config.yaml --ramp
 //	enrich-bench --config config.yaml --delay 200ms --count 200
+//	enrich-bench --config config.yaml --delay 200ms --count 200 --concurrent 3
 package main
 
 import (
@@ -56,6 +54,7 @@ func main() {
 	delay := flag.Duration("delay", 200*time.Millisecond, "delay between fetches")
 	count := flag.Int("count", 200, "number of unique tokens to fetch")
 	ramp := flag.Bool("ramp", false, "auto ramp-down test (overrides --delay/--count)")
+	concurrent := flag.Int("concurrent", 1, "number of concurrent fetch goroutines (simulates N Yad2 consumers)")
 	flag.Parse()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -91,13 +90,18 @@ func main() {
 	}
 
 	if *ramp {
-		runRamp(ctx, fb.Yad2, tokens)
+		runRamp(ctx, fb.Yad2, tokens, *concurrent)
 	} else {
 		if len(tokens) > *count {
 			tokens = tokens[:*count]
 		}
-		results := runSustained(ctx, fb.Yad2, tokens, *delay)
-		printTotal(results, *delay)
+		var results []fetchResult
+		if *concurrent > 1 {
+			results = runSustainedConcurrent(ctx, fb.Yad2, tokens, *delay, *concurrent)
+		} else {
+			results = runSustained(ctx, fb.Yad2, tokens, *delay)
+		}
+		printTotal(results, *delay, *concurrent)
 	}
 }
 
@@ -246,7 +250,152 @@ func runSustained(ctx context.Context, f *yad2.Yad2Fetcher, tokens []string, del
 	return results
 }
 
-func runRamp(ctx context.Context, f *yad2.Yad2Fetcher, allTokens []string) {
+func runSustainedConcurrent(ctx context.Context, f *yad2.Yad2Fetcher, tokens []string, delay time.Duration, workers int) []fetchResult {
+	fmt.Printf("=== Sustained Concurrent Benchmark ===\n")
+	fmt.Printf("Delay: %v (with jitter)  Count: %d  Workers: %d\n\n", delay, len(tokens), workers)
+
+	// Split tokens across workers.
+	tokensPerWorker := len(tokens) / workers
+	remainder := len(tokens) % workers
+
+	type workerJob struct {
+		id     int
+		tokens []string
+	}
+
+	jobs := make([]workerJob, workers)
+	offset := 0
+	for i := 0; i < workers; i++ {
+		count := tokensPerWorker
+		if i < remainder {
+			count++
+		}
+		jobs[i] = workerJob{
+			id:     i + 1,
+			tokens: tokens[offset : offset+count],
+		}
+		offset += count
+	}
+
+	// Channel to collect all results.
+	resultsChan := make(chan []fetchResult, workers)
+
+	// Launch workers.
+	for _, job := range jobs {
+		go func(j workerJob) {
+			results := make([]fetchResult, 0, len(j.tokens))
+			for i, token := range j.tokens {
+				if ctx.Err() != nil {
+					break
+				}
+
+				// Independent jittered delay per worker.
+				if i > 0 {
+					wait := jitteredDelay(delay)
+					if wait > 0 {
+						select {
+						case <-ctx.Done():
+							resultsChan <- results
+							return
+						case <-time.After(wait):
+						}
+					}
+				}
+
+				fetchStart := time.Now()
+				_, err := f.FetchItem(ctx, token)
+				fetchMs := time.Since(fetchStart).Milliseconds()
+
+				r := fetchResult{token: token, fetchMs: fetchMs, wallTime: fetchStart}
+				if err != nil {
+					if errors.Is(err, fetcher.ErrChallenge) {
+						r.challenge = true
+					} else {
+						r.err = err
+					}
+				}
+				results = append(results, r)
+			}
+			resultsChan <- results
+		}(job)
+	}
+
+	// Collect results from all workers.
+	var allResults []fetchResult
+	for i := 0; i < workers; i++ {
+		workerResults := <-resultsChan
+		allResults = append(allResults, workerResults...)
+	}
+
+	// Sort by wall time to compute rolling windows correctly.
+	// Use a simple bubble sort since we're not sorting millions of items.
+	for i := 0; i < len(allResults)-1; i++ {
+		for j := 0; j < len(allResults)-i-1; j++ {
+			if allResults[j].wallTime.After(allResults[j+1].wallTime) {
+				allResults[j], allResults[j+1] = allResults[j+1], allResults[j]
+			}
+		}
+	}
+
+	// Print rolling 30s windows.
+	if len(allResults) == 0 {
+		return allResults
+	}
+
+	start := allResults[0].wallTime
+	windowStart := start
+	var wSucceeded, wChallenges, wErrors int
+	var wFetchTotal int64
+	windowNum := 0
+
+	for _, r := range allResults {
+		if r.challenge {
+			wChallenges++
+		} else if r.err != nil {
+			wErrors++
+		} else {
+			wSucceeded++
+			wFetchTotal += r.fetchMs
+		}
+
+		if r.wallTime.Sub(windowStart) >= 30*time.Second {
+			total := wSucceeded + wChallenges + wErrors
+			var avgMs float64
+			if wSucceeded > 0 {
+				avgMs = float64(wFetchTotal) / float64(wSucceeded)
+			}
+			elapsed := r.wallTime.Sub(windowStart).Seconds()
+			fmt.Printf("  %d:%02d-%d:%02d  fetched=%-3d  challenges=%-2d  errors=%-2d  avg=%3.0fms  rate=%.1f/s\n",
+				windowNum*30/60, windowNum*30%60,
+				(windowNum+1)*30/60, (windowNum+1)*30%60,
+				total, wChallenges, wErrors, avgMs, float64(total)/elapsed)
+
+			windowNum++
+			windowStart = r.wallTime
+			wSucceeded, wChallenges, wErrors, wFetchTotal = 0, 0, 0, 0
+		}
+	}
+
+	// Flush remaining window.
+	if total := wSucceeded + wChallenges + wErrors; total > 0 {
+		var avgMs float64
+		if wSucceeded > 0 {
+			avgMs = float64(wFetchTotal) / float64(wSucceeded)
+		}
+		lastTime := allResults[len(allResults)-1].wallTime
+		elapsed := lastTime.Sub(windowStart).Seconds()
+		if elapsed == 0 {
+			elapsed = 0.001 // Avoid division by zero.
+		}
+		fmt.Printf("  %d:%02d-end   fetched=%-3d  challenges=%-2d  errors=%-2d  avg=%3.0fms  rate=%.1f/s\n",
+			windowNum*30/60, windowNum*30%60,
+			total, wChallenges, wErrors, avgMs, float64(total)/elapsed)
+	}
+
+	return allResults
+}
+
+func runRamp(ctx context.Context, f *yad2.Yad2Fetcher, allTokens []string, workers int) {
 	delays := []time.Duration{
 		1000 * time.Millisecond,
 		500 * time.Millisecond,
@@ -262,7 +411,11 @@ func runRamp(ctx context.Context, f *yad2.Yad2Fetcher, allTokens []string) {
 	// sliding-window rate limits that trigger after sustained load.
 	tokensPerStep := 50
 	fmt.Printf("=== Ramp-Down Test ===\n")
-	fmt.Printf("Tokens per step: %d  Steps: %d  (jittered delays)\n\n", tokensPerStep, len(delays))
+	if workers > 1 {
+		fmt.Printf("Tokens per step: %d  Steps: %d  Workers: %d  (jittered delays)\n\n", tokensPerStep, len(delays), workers)
+	} else {
+		fmt.Printf("Tokens per step: %d  Steps: %d  (jittered delays)\n\n", tokensPerStep, len(delays))
+	}
 
 	offset := 0
 	var sweetSpot time.Duration
@@ -281,7 +434,12 @@ func runRamp(ctx context.Context, f *yad2.Yad2Fetcher, allTokens []string) {
 
 		fmt.Printf("--- Delay: %v (tokens %d-%d) ---\n", d, offset-tokensPerStep+1, offset)
 
-		results := fetchBatch(ctx, f, stepTokens, d)
+		var results []fetchResult
+		if workers > 1 {
+			results = fetchBatchConcurrent(ctx, f, stepTokens, d, workers)
+		} else {
+			results = fetchBatch(ctx, f, stepTokens, d)
+		}
 		s := summarize(results)
 
 		fmt.Printf("  Succeeded: %d/%d  Challenges: %d  Errors: %d  Avg fetch: %.0fms  Throughput: %.1f/s\n\n",
@@ -308,10 +466,19 @@ func runRamp(ctx context.Context, f *yad2.Yad2Fetcher, allTokens []string) {
 		recommended = 100 * time.Millisecond
 	}
 	fmt.Printf("Recommended base_delay:          %v (with safety buffer)\n", recommended)
-	fmt.Printf("Note: bench runs in isolation. Production has 3 concurrent\n")
-	fmt.Printf("      Yad2 sources — apply additional buffer if needed.\n")
-	fmt.Printf("\nNext step: run sustained test at the recommended delay:\n")
-	fmt.Printf("  enrich-bench --config config.yaml --delay %v --count 200\n", recommended)
+
+	if workers == 1 {
+		fmt.Printf("\nNote: ramp ran with 1 worker. Production has 3 concurrent\n")
+		fmt.Printf("      Yad2 sources. Run sustained test with --concurrent 3:\n")
+		fmt.Printf("  enrich-bench --config config.yaml --delay %v --count 200 --concurrent 3\n", recommended)
+	} else if workers < 3 {
+		fmt.Printf("\nNote: ramp ran with %d workers. Production has 3 concurrent\n", workers)
+		fmt.Printf("      Yad2 sources. Run sustained test with --concurrent 3:\n")
+		fmt.Printf("  enrich-bench --config config.yaml --delay %v --count 200 --concurrent 3\n", recommended)
+	} else {
+		fmt.Printf("\nNext step: run sustained test at the recommended delay:\n")
+		fmt.Printf("  enrich-bench --config config.yaml --delay %v --count 200 --concurrent %d\n", recommended, workers)
+	}
 }
 
 func fetchBatch(ctx context.Context, f *yad2.Yad2Fetcher, tokens []string, delay time.Duration) []fetchResult {
@@ -358,6 +525,91 @@ func fetchBatch(ctx context.Context, f *yad2.Yad2Fetcher, tokens []string, delay
 	return results
 }
 
+func fetchBatchConcurrent(ctx context.Context, f *yad2.Yad2Fetcher, tokens []string, delay time.Duration, workers int) []fetchResult {
+	// Split tokens across workers.
+	tokensPerWorker := len(tokens) / workers
+	remainder := len(tokens) % workers
+
+	type workerJob struct {
+		id     int
+		tokens []string
+	}
+
+	jobs := make([]workerJob, workers)
+	offset := 0
+	for i := 0; i < workers; i++ {
+		count := tokensPerWorker
+		if i < remainder {
+			count++
+		}
+		jobs[i] = workerJob{
+			id:     i + 1,
+			tokens: tokens[offset : offset+count],
+		}
+		offset += count
+	}
+
+	// Channel to collect all results.
+	resultsChan := make(chan []fetchResult, workers)
+
+	// Launch workers.
+	for _, job := range jobs {
+		go func(j workerJob) {
+			results := make([]fetchResult, 0, len(j.tokens))
+			for i, token := range j.tokens {
+				if ctx.Err() != nil {
+					break
+				}
+
+				// Independent jittered delay per worker.
+				if i > 0 {
+					wait := jitteredDelay(delay)
+					if wait > 0 {
+						select {
+						case <-ctx.Done():
+							resultsChan <- results
+							return
+						case <-time.After(wait):
+						}
+					}
+				}
+
+				fetchStart := time.Now()
+				_, err := f.FetchItem(ctx, token)
+				fetchMs := time.Since(fetchStart).Milliseconds()
+
+				r := fetchResult{token: token, fetchMs: fetchMs}
+				if err != nil {
+					if errors.Is(err, fetcher.ErrChallenge) {
+						r.challenge = true
+					} else {
+						r.err = err
+					}
+				}
+				results = append(results, r)
+
+				status := "ok"
+				if r.challenge {
+					status = "CHALLENGE"
+				} else if r.err != nil {
+					status = "ERR"
+				}
+				fmt.Printf("    [w%d] #%-2d  fetch=%4dms  %s\n", j.id, i+1, fetchMs, status)
+			}
+			resultsChan <- results
+		}(job)
+	}
+
+	// Collect results from all workers.
+	var allResults []fetchResult
+	for i := 0; i < workers; i++ {
+		workerResults := <-resultsChan
+		allResults = append(allResults, workerResults...)
+	}
+
+	return allResults
+}
+
 type summary struct {
 	succeeded  int
 	challenges int
@@ -388,7 +640,7 @@ func summarize(results []fetchResult) summary {
 	return s
 }
 
-func printTotal(results []fetchResult, delay time.Duration) {
+func printTotal(results []fetchResult, delay time.Duration, workers int) {
 	s := summarize(results)
 	total := len(results)
 
@@ -400,6 +652,9 @@ func printTotal(results []fetchResult, delay time.Duration) {
 	wallTime := results[len(results)-1].wallTime.Sub(results[0].wallTime) + time.Duration(results[len(results)-1].fetchMs)*time.Millisecond
 
 	fmt.Printf("\n=== TOTAL ===\n")
+	if workers > 1 {
+		fmt.Printf("Workers: %d  ", workers)
+	}
 	fmt.Printf("Succeeded: %d/%d  Challenges: %d  Errors: %d\n", s.succeeded, total, s.challenges, s.errors)
 	fmt.Printf("Avg fetch: %.0fms  Wall time: %s  Throughput: %.1f listings/sec\n",
 		s.avgFetchMs, wallTime.Round(time.Second), float64(s.succeeded)/wallTime.Seconds())
@@ -409,8 +664,19 @@ func printTotal(results []fetchResult, delay time.Duration) {
 	} else {
 		fmt.Printf("\n✓ No challenges — delay %v is safe\n", delay)
 	}
-	fmt.Println("\nNote: bench runs in isolation. Production has 3 concurrent")
-	fmt.Println("      Yad2 sources — apply additional buffer if needed.")
+
+	if workers == 1 {
+		fmt.Println("\nNote: bench ran with 1 worker. Production has 3 concurrent")
+		fmt.Println("      Yad2 sources — consider running with --concurrent 3")
+		fmt.Println("      to simulate production conditions.")
+	} else if workers < 3 {
+		fmt.Printf("\nNote: bench ran with %d workers. Production has 3 concurrent\n", workers)
+		fmt.Println("      Yad2 sources — consider running with --concurrent 3")
+		fmt.Println("      to match production conditions.")
+	} else {
+		fmt.Printf("\nNote: bench ran with %d workers matching production's\n", workers)
+		fmt.Println("      3 concurrent Yad2 sources.")
+	}
 }
 
 func discardLogger() *slog.Logger {

--- a/internal/broker/enrich.go
+++ b/internal/broker/enrich.go
@@ -116,3 +116,97 @@ func (p *EnrichPublisher) EnrichQueueLen(ctx context.Context) (int64, error) {
 	}
 	return p.client.XLen(ctx, EnrichStreamName).Result()
 }
+
+// PurgeEnrichedEntries reads the stream in batches and removes entries
+// whose tokens the checker reports as fully enriched. Returns the count
+// of purged entries.
+func (p *EnrichPublisher) PurgeEnrichedEntries(ctx context.Context, checker func(ctx context.Context, tokens []string) (map[string]bool, error)) (int, error) {
+	if p == nil || p.client == nil {
+		return 0, errors.New("enrich publisher not initialized")
+	}
+	if checker == nil {
+		return 0, errors.New("checker function is required")
+	}
+
+	const batchSize = 200
+	purged := 0
+	lastID := "-"
+
+	for {
+		// Read batch from stream
+		msgs, err := p.client.XRange(ctx, EnrichStreamName, lastID, "+").Result()
+		if err != nil {
+			return purged, err
+		}
+		if len(msgs) == 0 {
+			break
+		}
+
+		// If lastID was inclusive, skip the first message to avoid reprocessing
+		if lastID != "-" && len(msgs) > 0 && msgs[0].ID == lastID {
+			msgs = msgs[1:]
+		}
+
+		// Take up to batchSize messages
+		if len(msgs) > batchSize {
+			msgs = msgs[:batchSize]
+		}
+		if len(msgs) == 0 {
+			break
+		}
+
+		// Extract tokens from batch
+		tokens := make([]string, 0, len(msgs))
+		msgMap := make(map[string]string) // token -> msgID
+		for _, msg := range msgs {
+			data, ok := msg.Values["data"].(string)
+			if !ok {
+				continue
+			}
+			var req EnrichRequest
+			if err := json.Unmarshal([]byte(data), &req); err != nil {
+				continue
+			}
+			tokens = append(tokens, req.Token)
+			msgMap[req.Token] = msg.ID
+		}
+
+		// Check which tokens are fully enriched
+		enrichedMap, err := checker(ctx, tokens)
+		if err != nil {
+			return purged, err
+		}
+
+		// Delete enriched entries from stream and pending set
+		for token, isEnriched := range enrichedMap {
+			if isEnriched {
+				msgID, exists := msgMap[token]
+				if !exists {
+					continue
+				}
+				// XDEL the message
+				if err := p.client.XDel(ctx, EnrichStreamName, msgID).Err(); err != nil {
+					return purged, err
+				}
+				// SREM from pending set
+				if err := p.client.SRem(ctx, EnrichPendingSet, token).Err(); err != nil {
+					return purged, err
+				}
+				purged++
+			}
+		}
+
+		// Move to next batch
+		lastID = msgs[len(msgs)-1].ID
+	}
+
+	return purged, nil
+}
+
+// TrimDeadLetterStream caps the dead-letter stream to maxLen entries.
+func (p *EnrichPublisher) TrimDeadLetterStream(ctx context.Context, maxLen int64) error {
+	if p == nil || p.client == nil {
+		return errors.New("enrich publisher not initialized")
+	}
+	return p.client.XTrimMaxLen(ctx, EnrichDeadLetterStream, maxLen).Err()
+}

--- a/internal/broker/enrich.go
+++ b/internal/broker/enrich.go
@@ -17,6 +17,9 @@ const EnrichGroupName = "enricher-workers"
 // EnrichDeadLetterStream holds messages that exceeded retry limits.
 const EnrichDeadLetterStream = "carwatch:enrich:dead"
 
+// EnrichPendingSet is the Redis SET key that tracks tokens currently pending enrichment.
+const EnrichPendingSet = "carwatch:enrich:pending"
+
 // EnrichStreamMaxLen caps the enrichment stream via approximate XAdd trimming.
 // When the stream exceeds this, the OLDEST entries are silently evicted —
 // producers must therefore check EnrichQueueLen before bulk publishing (see the
@@ -57,6 +60,53 @@ func (p *EnrichPublisher) PublishEnrich(ctx context.Context, req EnrichRequest) 
 		Approx: true,
 		Values: map[string]any{"data": string(data)},
 	}).Err()
+}
+
+// PublishEnrichDedup adds an enrichment request to the stream only if the token
+// is not already pending. It returns (true, nil) if published, (false, nil) if
+// skipped due to deduplication, or (false, error) on failure.
+func (p *EnrichPublisher) PublishEnrichDedup(ctx context.Context, req EnrichRequest) (bool, error) {
+	if p == nil || p.client == nil {
+		return false, errors.New("enrich publisher not initialized")
+	}
+
+	// Check if token is already pending
+	isPending, err := p.client.SIsMember(ctx, EnrichPendingSet, req.Token).Result()
+	if err != nil {
+		return false, err
+	}
+	if isPending {
+		return false, nil
+	}
+
+	// Marshal and publish to stream
+	data, err := json.Marshal(req)
+	if err != nil {
+		return false, err
+	}
+	if err := p.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: EnrichStreamName,
+		MaxLen: EnrichStreamMaxLen,
+		Approx: true,
+		Values: map[string]any{"data": string(data)},
+	}).Err(); err != nil {
+		return false, err
+	}
+
+	// Add token to pending set
+	if err := p.client.SAdd(ctx, EnrichPendingSet, req.Token).Err(); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// RemovePending removes a token from the pending set.
+func (p *EnrichPublisher) RemovePending(ctx context.Context, token string) error {
+	if p == nil || p.client == nil {
+		return errors.New("enrich publisher not initialized")
+	}
+	return p.client.SRem(ctx, EnrichPendingSet, token).Err()
 }
 
 // EnrichQueueLen returns the current length of the enrichment stream.

--- a/internal/broker/enrich_consumer.go
+++ b/internal/broker/enrich_consumer.go
@@ -163,6 +163,7 @@ func (c *EnrichConsumer) processBatch(ctx context.Context, msgs []redis.XMessage
 			continue
 		}
 		c.ack(ctx, item.msg.ID)
+		c.removePending(ctx, item.req.Token)
 	}
 }
 
@@ -241,6 +242,7 @@ func (c *EnrichConsumer) deadLetter(ctx context.Context, id string) {
 	c.logger.Warn("enrich message dead-lettered after max retries",
 		"id", id, "token", token, "max_retries", enrichMaxRetries)
 	c.ack(ctx, id)
+	c.removePending(ctx, token)
 }
 
 func (c *EnrichConsumer) reclaimOrphans(ctx context.Context) {
@@ -321,5 +323,14 @@ func (c *EnrichConsumer) Close() error { return c.client.Close() }
 func (c *EnrichConsumer) ack(ctx context.Context, id string) {
 	if err := c.client.XAck(ctx, EnrichStreamName, EnrichGroupName, id).Err(); err != nil {
 		c.logger.Error("enrich ack failed", "id", id, "error", err)
+	}
+}
+
+func (c *EnrichConsumer) removePending(ctx context.Context, token string) {
+	if token == "" {
+		return
+	}
+	if err := c.client.SRem(ctx, EnrichPendingSet, token).Err(); err != nil {
+		c.logger.Error("remove from pending set failed", "token", token, "error", err)
 	}
 }

--- a/internal/broker/enrich_consumer_test.go
+++ b/internal/broker/enrich_consumer_test.go
@@ -199,6 +199,124 @@ func TestEnrichConsumer_ConnectionFailure(t *testing.T) {
 	}
 }
 
+func TestEnrichConsumer_AckRemovesPendingSet(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req := EnrichRequest{Token: "tok-ack-pending", Priority: 1, Source: "test"}
+	published, err := pub.PublishEnrichDedup(ctx, req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !published {
+		t.Fatal("expected token to be published")
+	}
+
+	// Verify token is in pending set
+	isMember, err := client.SIsMember(ctx, EnrichPendingSet, "tok-ack-pending").Result()
+	if err != nil {
+		t.Fatalf("sismember before: %v", err)
+	}
+	if !isMember {
+		t.Fatal("token should be in pending set before processing")
+	}
+
+	fn := func(_ context.Context, r EnrichRequest) error {
+		if r.Token != "tok-ack-pending" {
+			t.Errorf("token = %q, want tok-ack-pending", r.Token)
+		}
+		return nil
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+
+	runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = cons.Run(runCtx)
+
+	// Verify token was removed from pending set
+	isMember, err = client.SIsMember(ctx, EnrichPendingSet, "tok-ack-pending").Result()
+	if err != nil {
+		t.Fatalf("sismember after: %v", err)
+	}
+	if isMember {
+		t.Error("token should be removed from pending set after processing")
+	}
+}
+
+func TestEnrichConsumer_DeadLetterRemovesPendingSet(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req := EnrichRequest{Token: "tok-dlq-pending", Priority: 3, Source: "test"}
+	published, err := pub.PublishEnrichDedup(ctx, req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !published {
+		t.Fatal("expected token to be published")
+	}
+
+	// Verify token is in pending set
+	isMember, err := client.SIsMember(ctx, EnrichPendingSet, "tok-dlq-pending").Result()
+	if err != nil {
+		t.Fatalf("sismember before: %v", err)
+	}
+	if !isMember {
+		t.Fatal("token should be in pending set before dead-lettering")
+	}
+
+	fn := func(_ context.Context, _ EnrichRequest) error {
+		return fmt.Errorf("persistent error")
+	}
+
+	cons, err := NewEnrichConsumer(s.Addr(), "", 0, fn, testLogger())
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+	defer func() { _ = cons.Close() }()
+	cons.reclaimIdleThreshold = 0
+
+	// Initial read creates PEL entry
+	streams, err := cons.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    EnrichGroupName,
+		Consumer: cons.consumer,
+		Streams:  []string{EnrichStreamName, ">"},
+		Count:    10,
+		Block:    time.Second,
+	}).Result()
+	if err != nil {
+		t.Fatalf("xreadgroup: %v", err)
+	}
+	cons.processBatch(ctx, streams[0].Messages)
+
+	// Reclaim until dead-lettered
+	for i := 0; i < enrichMaxRetries+1; i++ {
+		cons.reclaimPending(ctx)
+	}
+
+	// Verify token was removed from pending set
+	isMember, err = client.SIsMember(ctx, EnrichPendingSet, "tok-dlq-pending").Result()
+	if err != nil {
+		t.Fatalf("sismember after: %v", err)
+	}
+	if isMember {
+		t.Error("token should be removed from pending set after dead-lettering")
+	}
+}
+
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(&discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
 }

--- a/internal/broker/enrich_test.go
+++ b/internal/broker/enrich_test.go
@@ -81,3 +81,172 @@ func TestEnrichPublisher_QueueLen(t *testing.T) {
 		t.Errorf("queue length = %d, want 5", length)
 	}
 }
+
+func TestPublishEnrichDedup_FirstPublish(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req := EnrichRequest{
+		Token:      "tok-dedup-1",
+		Priority:   1,
+		SearchIDs:  []int64{10},
+		Source:     "scheduler",
+		EnqueuedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	published, err := pub.PublishEnrichDedup(ctx, req)
+	if err != nil {
+		t.Fatalf("publish dedup: %v", err)
+	}
+	if !published {
+		t.Error("expected token to be published on first call")
+	}
+
+	// Verify message was added to stream
+	msgs, err := client.XRange(ctx, EnrichStreamName, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message in stream, got %d", len(msgs))
+	}
+
+	// Verify token was added to pending set
+	isMember, err := client.SIsMember(ctx, EnrichPendingSet, "tok-dedup-1").Result()
+	if err != nil {
+		t.Fatalf("sismember: %v", err)
+	}
+	if !isMember {
+		t.Error("expected token to be in pending set")
+	}
+}
+
+func TestPublishEnrichDedup_DuplicateSkipped(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req := EnrichRequest{
+		Token:    "tok-dedup-2",
+		Priority: 1,
+		Source:   "scheduler",
+	}
+
+	// First publish should succeed
+	published, err := pub.PublishEnrichDedup(ctx, req)
+	if err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	if !published {
+		t.Error("expected first publish to succeed")
+	}
+
+	// Second publish should be skipped
+	published2, err := pub.PublishEnrichDedup(ctx, req)
+	if err != nil {
+		t.Fatalf("second publish: %v", err)
+	}
+	if published2 {
+		t.Error("expected second publish to be skipped due to deduplication")
+	}
+
+	// Verify only 1 message in stream
+	msgs, err := client.XRange(ctx, EnrichStreamName, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message in stream, got %d", len(msgs))
+	}
+}
+
+func TestPublishEnrichDedup_DifferentTokensBothPublished(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	req1 := EnrichRequest{Token: "tok-a", Priority: 1, Source: "scheduler"}
+	req2 := EnrichRequest{Token: "tok-b", Priority: 2, Source: "scheduler"}
+
+	// Both should be published
+	ok1, err := pub.PublishEnrichDedup(ctx, req1)
+	if err != nil {
+		t.Fatalf("publish req1: %v", err)
+	}
+	if !ok1 {
+		t.Error("expected req1 to be published")
+	}
+
+	ok2, err := pub.PublishEnrichDedup(ctx, req2)
+	if err != nil {
+		t.Fatalf("publish req2: %v", err)
+	}
+	if !ok2 {
+		t.Error("expected req2 to be published")
+	}
+
+	// Verify 2 messages in stream
+	msgs, err := client.XRange(ctx, EnrichStreamName, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages in stream, got %d", len(msgs))
+	}
+
+	// Verify both tokens in pending set
+	count, err := client.SCard(ctx, EnrichPendingSet).Result()
+	if err != nil {
+		t.Fatalf("scard: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 tokens in pending set, got %d", count)
+	}
+}
+
+func TestRemovePending(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	// Add token to pending set
+	if err := client.SAdd(ctx, EnrichPendingSet, "tok-remove").Err(); err != nil {
+		t.Fatalf("sadd: %v", err)
+	}
+
+	// Verify it's there
+	isMember, err := client.SIsMember(ctx, EnrichPendingSet, "tok-remove").Result()
+	if err != nil {
+		t.Fatalf("sismember before: %v", err)
+	}
+	if !isMember {
+		t.Fatal("token should be in pending set before removal")
+	}
+
+	// Remove it
+	if err := pub.RemovePending(ctx, "tok-remove"); err != nil {
+		t.Fatalf("remove pending: %v", err)
+	}
+
+	// Verify it's gone
+	isMember, err = client.SIsMember(ctx, EnrichPendingSet, "tok-remove").Result()
+	if err != nil {
+		t.Fatalf("sismember after: %v", err)
+	}
+	if isMember {
+		t.Error("token should be removed from pending set")
+	}
+}

--- a/internal/broker/enrich_test.go
+++ b/internal/broker/enrich_test.go
@@ -250,3 +250,205 @@ func TestRemovePending(t *testing.T) {
 		t.Error("token should be removed from pending set")
 	}
 }
+
+func TestPurgeEnrichedEntries_RemovesFullyEnriched(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	// Seed stream with 3 messages
+	for i, token := range []string{"tok-1", "tok-2", "tok-3"} {
+		req := EnrichRequest{
+			Token:      token,
+			Priority:   i + 1,
+			Source:     "test",
+			EnqueuedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		if err := pub.PublishEnrich(ctx, req); err != nil {
+			t.Fatalf("publish %s: %v", token, err)
+		}
+		// Add to pending set
+		if err := client.SAdd(ctx, EnrichPendingSet, token).Err(); err != nil {
+			t.Fatalf("sadd %s: %v", token, err)
+		}
+	}
+
+	// Checker says tok-1 and tok-3 are enriched
+	checker := func(ctx context.Context, tokens []string) (map[string]bool, error) {
+		result := make(map[string]bool)
+		for _, t := range tokens {
+			result[t] = t == "tok-1" || t == "tok-3"
+		}
+		return result, nil
+	}
+
+	purged, err := pub.PurgeEnrichedEntries(ctx, checker)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if purged != 2 {
+		t.Errorf("purged = %d, want 2", purged)
+	}
+
+	// Verify stream has 1 message (tok-2)
+	msgs, err := client.XRange(ctx, EnrichStreamName, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message in stream, got %d", len(msgs))
+	}
+
+	data, ok := msgs[0].Values["data"].(string)
+	if !ok {
+		t.Fatal("expected data field")
+	}
+	var req EnrichRequest
+	if err := json.Unmarshal([]byte(data), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Token != "tok-2" {
+		t.Errorf("remaining token = %q, want tok-2", req.Token)
+	}
+
+	// Verify pending set has 1 token (tok-2)
+	count, err := client.SCard(ctx, EnrichPendingSet).Result()
+	if err != nil {
+		t.Fatalf("scard: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("pending set count = %d, want 1", count)
+	}
+	isMember, err := client.SIsMember(ctx, EnrichPendingSet, "tok-2").Result()
+	if err != nil {
+		t.Fatalf("sismember: %v", err)
+	}
+	if !isMember {
+		t.Error("tok-2 should be in pending set")
+	}
+}
+
+func TestPurgeEnrichedEntries_EmptyStream(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	checker := func(ctx context.Context, tokens []string) (map[string]bool, error) {
+		t.Error("checker should not be called for empty stream")
+		return nil, nil
+	}
+
+	purged, err := pub.PurgeEnrichedEntries(ctx, checker)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if purged != 0 {
+		t.Errorf("purged = %d, want 0", purged)
+	}
+}
+
+func TestPurgeEnrichedEntries_NoneEnriched(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	// Seed stream with 3 messages
+	for i, token := range []string{"tok-a", "tok-b", "tok-c"} {
+		req := EnrichRequest{
+			Token:      token,
+			Priority:   i + 1,
+			Source:     "test",
+			EnqueuedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		if err := pub.PublishEnrich(ctx, req); err != nil {
+			t.Fatalf("publish %s: %v", token, err)
+		}
+	}
+
+	// Checker says none are enriched
+	checker := func(ctx context.Context, tokens []string) (map[string]bool, error) {
+		result := make(map[string]bool)
+		for _, t := range tokens {
+			result[t] = false
+		}
+		return result, nil
+	}
+
+	purged, err := pub.PurgeEnrichedEntries(ctx, checker)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if purged != 0 {
+		t.Errorf("purged = %d, want 0", purged)
+	}
+
+	// Verify all 3 messages remain
+	msgs, err := client.XRange(ctx, EnrichStreamName, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Errorf("expected 3 messages in stream, got %d", len(msgs))
+	}
+}
+
+func TestTrimDeadLetterStream(t *testing.T) {
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = client.Close() }()
+
+	pub := NewEnrichPublisher(client)
+	ctx := context.Background()
+
+	// Seed DLQ with 10 entries
+	for i := range 10 {
+		req := EnrichRequest{
+			Token:      string(rune('a' + i)),
+			Priority:   1,
+			Source:     "dlq-test",
+			EnqueuedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := client.XAdd(ctx, &redis.XAddArgs{
+			Stream: EnrichDeadLetterStream,
+			Values: map[string]any{"data": string(data)},
+		}).Err(); err != nil {
+			t.Fatalf("xadd %d: %v", i, err)
+		}
+	}
+
+	// Verify 10 entries
+	len1, err := client.XLen(ctx, EnrichDeadLetterStream).Result()
+	if err != nil {
+		t.Fatalf("xlen before: %v", err)
+	}
+	if len1 != 10 {
+		t.Fatalf("expected 10 entries before trim, got %d", len1)
+	}
+
+	// Trim to 5
+	if err := pub.TrimDeadLetterStream(ctx, 5); err != nil {
+		t.Fatalf("trim: %v", err)
+	}
+
+	// Verify 5 entries remain
+	len2, err := client.XLen(ctx, EnrichDeadLetterStream).Result()
+	if err != nil {
+		t.Fatalf("xlen after: %v", err)
+	}
+	if len2 != 5 {
+		t.Errorf("expected 5 entries after trim, got %d", len2)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,7 +220,7 @@ func applyDefaults(cfg *Config) {
 		cfg.Enricher.MaxDelay = 60 * time.Second
 	}
 	if cfg.Enricher.CooldownDuration == 0 {
-		cfg.Enricher.CooldownDuration = 5 * time.Minute
+		cfg.Enricher.CooldownDuration = 15 * time.Minute
 	}
 	if cfg.Enricher.MaxPerMinute == 0 {
 		cfg.Enricher.MaxPerMinute = 60

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,10 +214,10 @@ func applyDefaults(cfg *Config) {
 		cfg.Telemetry.MetricsPath = "/metrics"
 	}
 	if cfg.Enricher.BaseDelay == 0 {
-		cfg.Enricher.BaseDelay = 300 * time.Millisecond
+		cfg.Enricher.BaseDelay = 500 * time.Millisecond
 	}
 	if cfg.Enricher.MaxDelay == 0 {
-		cfg.Enricher.MaxDelay = 60 * time.Second
+		cfg.Enricher.MaxDelay = 10 * time.Minute
 	}
 	if cfg.Enricher.CooldownDuration == 0 {
 		cfg.Enricher.CooldownDuration = 15 * time.Minute

--- a/internal/enricher/ratelimit.go
+++ b/internal/enricher/ratelimit.go
@@ -13,20 +13,26 @@ import (
 // requests and backs off on challenges, entering a cooldown period
 // when the success rate drops too low.
 type AdaptiveRateLimiter struct {
-	mu              sync.Mutex
-	baseDelay       time.Duration
-	maxDelay        time.Duration
-	cooldownDur     time.Duration
-	currentDelay    time.Duration
-	cooldownUntil   time.Time
-	windowStart     time.Time
-	windowSuccesses int
-	windowTotal     int
-	windowDuration  time.Duration
+	mu                   sync.Mutex
+	baseDelay            time.Duration
+	maxDelay             time.Duration
+	cooldownDur          time.Duration
+	currentDelay         time.Duration
+	cooldownUntil        time.Time
+	windowStart          time.Time
+	windowSuccesses      int
+	windowTotal          int
+	windowDuration       time.Duration
+	consecutiveCooldowns int
+	maxCooldownDur       time.Duration
 }
 
 // NewAdaptiveRateLimiter creates a rate limiter with the given parameters.
 func NewAdaptiveRateLimiter(baseDelay, maxDelay, cooldownDuration time.Duration) *AdaptiveRateLimiter {
+	maxCooldown := cooldownDuration * 4
+	if maxCooldown > 30*time.Minute {
+		maxCooldown = 30 * time.Minute
+	}
 	return &AdaptiveRateLimiter{
 		baseDelay:      baseDelay,
 		maxDelay:       maxDelay,
@@ -34,6 +40,7 @@ func NewAdaptiveRateLimiter(baseDelay, maxDelay, cooldownDuration time.Duration)
 		currentDelay:   baseDelay,
 		windowStart:    time.Now(),
 		windowDuration: 10 * time.Minute,
+		maxCooldownDur: maxCooldown,
 	}
 }
 
@@ -71,6 +78,7 @@ func (r *AdaptiveRateLimiter) RecordSuccess() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.consecutiveCooldowns = 0
 	windowReset := r.resetWindowIfExpired()
 	r.windowTotal++
 	r.windowSuccesses++
@@ -99,7 +107,16 @@ func (r *AdaptiveRateLimiter) RecordChallenge() {
 	}
 
 	if r.windowTotal >= 3 && r.successRate() < 0.5 {
-		r.cooldownUntil = time.Now().Add(r.cooldownDur)
+		// Only increment consecutive cooldowns if we're not already in one
+		if !time.Now().Before(r.cooldownUntil) {
+			r.consecutiveCooldowns++
+		}
+		shift := min(r.consecutiveCooldowns-1, 2) // cap at 4x base (1x, 2x, 4x)
+		escalated := r.cooldownDur * time.Duration(1<<shift)
+		if escalated > r.maxCooldownDur {
+			escalated = r.maxCooldownDur
+		}
+		r.cooldownUntil = time.Now().Add(escalated)
 	}
 }
 
@@ -115,6 +132,13 @@ func (r *AdaptiveRateLimiter) CurrentDelay() time.Duration {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.currentDelay
+}
+
+// ConsecutiveCooldowns returns the current consecutive cooldown count (for testing).
+func (r *AdaptiveRateLimiter) ConsecutiveCooldowns() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.consecutiveCooldowns
 }
 
 func (r *AdaptiveRateLimiter) successRate() float64 {

--- a/internal/enricher/ratelimit_test.go
+++ b/internal/enricher/ratelimit_test.go
@@ -127,3 +127,153 @@ func TestAdaptiveRateLimiter_NoCooldownWithHighSuccessRate(t *testing.T) {
 		t.Error("should not enter cooldown with 75% success rate")
 	}
 }
+
+func TestAdaptiveRateLimiter_ProgressiveCooldown(t *testing.T) {
+	rl := NewAdaptiveRateLimiter(10*time.Millisecond, 1*time.Second, 50*time.Millisecond)
+
+	// First cooldown trigger (3 challenges)
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+
+	if !rl.InCooldown() {
+		t.Fatal("should be in cooldown after first trigger")
+	}
+
+	// Verify first cooldown is short (~50ms) by checking it exits within reasonable time
+	time.Sleep(100 * time.Millisecond)
+	if rl.InCooldown() {
+		t.Fatal("should have exited first cooldown (base 50ms) within 100ms")
+	}
+
+	// Second cooldown trigger
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+
+	if !rl.InCooldown() {
+		t.Fatal("should be in cooldown after second trigger")
+	}
+
+	// Verify second cooldown is longer (~100ms, doubled)
+	// Should still be active after 50ms
+	time.Sleep(50 * time.Millisecond)
+	if !rl.InCooldown() {
+		t.Error("second cooldown should still be active at 50ms (expected ~100ms)")
+	}
+
+	// But should exit within 200ms total
+	time.Sleep(150 * time.Millisecond)
+	if rl.InCooldown() {
+		t.Fatal("should have exited second cooldown (doubled to ~100ms) within 200ms")
+	}
+
+	// Third cooldown trigger
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+
+	if !rl.InCooldown() {
+		t.Fatal("should be in cooldown after third trigger")
+	}
+
+	// Verify third cooldown is even longer (~200ms, quadrupled)
+	// Should still be active after 150ms
+	time.Sleep(150 * time.Millisecond)
+	if !rl.InCooldown() {
+		t.Error("third cooldown should still be active at 150ms (expected ~200ms)")
+	}
+
+	// But should exit within 300ms total
+	time.Sleep(150 * time.Millisecond)
+	if rl.InCooldown() {
+		t.Fatal("should have exited third cooldown (quadrupled to ~200ms) within 300ms")
+	}
+}
+
+func TestAdaptiveRateLimiter_CooldownResetsOnSuccess(t *testing.T) {
+	rl := NewAdaptiveRateLimiter(10*time.Millisecond, 1*time.Second, 50*time.Millisecond)
+
+	// Trigger consecutive cooldowns to escalate to level 2
+	// First cooldown
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	time.Sleep(100 * time.Millisecond) // wait for 50ms cooldown to expire
+
+	// Second cooldown
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+
+	if !rl.InCooldown() {
+		t.Fatal("should be in cooldown (second escalation)")
+	}
+
+	// Wait for second cooldown to expire (100ms)
+	time.Sleep(200 * time.Millisecond)
+
+	if rl.InCooldown() {
+		t.Fatal("should have exited second cooldown")
+	}
+
+	// Record success (should reset consecutive counter)
+	rl.RecordSuccess()
+
+	if count := rl.ConsecutiveCooldowns(); count != 0 {
+		t.Fatalf("consecutive cooldowns should be 0 after success, got %d", count)
+	}
+
+	// Build success buffer to ensure the next set of challenges triggers cooldown
+	rl.RecordSuccess()
+	rl.RecordSuccess()
+
+	// Now trigger a new cooldown - should be at base level again
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge()
+	rl.RecordChallenge() // 4 challenges to overcome 3 successes
+
+	if !rl.InCooldown() {
+		t.Fatal("should be in cooldown after challenges")
+	}
+
+	count := rl.ConsecutiveCooldowns()
+	t.Logf("consecutive cooldowns after new trigger: %d", count)
+
+	// Should be back to base duration (~50ms), not escalated (100ms)
+	// If it was still escalated, it would be >50ms
+	time.Sleep(100 * time.Millisecond)
+	if rl.InCooldown() {
+		t.Errorf("cooldown should have reset to base (~50ms), still active after 100ms suggests escalation wasn't reset (consecutive=%d)", count)
+	}
+}
+
+func TestAdaptiveRateLimiter_CooldownCapsAtMax(t *testing.T) {
+	rl := NewAdaptiveRateLimiter(10*time.Millisecond, 1*time.Second, 100*time.Millisecond)
+
+	// Trigger many consecutive cooldowns (max would be 400ms)
+	for range 10 {
+		if rl.InCooldown() {
+			// Wait for cooldown to expire before next trigger
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		rl.RecordChallenge()
+		rl.RecordChallenge()
+		rl.RecordChallenge()
+	}
+
+	// Verify duration never exceeds max (400ms)
+	cooldownEnd := rl.cooldownUntil
+	maxExpected := time.Now().Add(400 * time.Millisecond)
+	if cooldownEnd.After(maxExpected.Add(50 * time.Millisecond)) {
+		t.Errorf("cooldown duration exceeds max: %v > ~400ms", time.Until(cooldownEnd))
+	}
+
+	// Verify it actually reached the max (not stuck at some lower value)
+	minExpected := time.Now().Add(350 * time.Millisecond)
+	if cooldownEnd.Before(minExpected) {
+		t.Errorf("cooldown duration should reach max: %v < ~400ms", time.Until(cooldownEnd))
+	}
+}

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -110,6 +110,9 @@ func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]str
 	return nil, nil
 }
 func (m *mockListingStore) CountUnenrichedTokens(_ context.Context) (int64, error) { return 0, nil }
+func (m *mockListingStore) ListEnrichExhaustedTokens(_ context.Context, _ []string, _ int) (map[string]bool, error) {
+	return nil, nil
+}
 func (m *mockListingStore) PruneListings(_ context.Context, _ time.Duration) (int64, error) {
 	return 0, nil
 }

--- a/internal/scheduler/enrich_publish_test.go
+++ b/internal/scheduler/enrich_publish_test.go
@@ -268,3 +268,54 @@ func TestDualWrite_MultipleSearchesSharePublish(t *testing.T) {
 		t.Errorf("expected 2 search IDs, got %d: %v", len(reqs[0].SearchIDs), reqs[0].SearchIDs)
 	}
 }
+
+func TestDualWrite_ExhaustedTokenNotPublished(t *testing.T) {
+	enrichPub, redisSrv := newTestEnrichPublisher(t)
+
+	f := &mockFetcher{
+		listings: []model.RawListing{
+			{Token: "tok-ok", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+				Price: 90000, Year: 2020, EngineVolume: 2000, Km: 0, City: "", ImageURL: ""},
+			{Token: "tok-exhausted", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3",
+				Price: 95000, Year: 2021, EngineVolume: 2000, Km: 0, City: "", ImageURL: ""},
+		},
+	}
+	d := newMockDedup()
+	n := &mockNotifier{}
+	cfg := testConfig()
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "mazda3", Source: "yad2",
+				Manufacturer: 27, Model: 10332, YearMin: 2018, YearMax: 2024,
+				PriceMax: 150000, Active: true},
+		},
+	}
+
+	ls := &mockListingStore{
+		exhaustedTokens: map[string]bool{"tok-exhausted": true},
+	}
+
+	s, err := NewWithOptions(cfg, f, d, n, testLogger(), Options{
+		SearchStore:     ss,
+		ListingStore:    ls,
+		EnrichPublisher: enrichPub,
+	})
+	if err != nil {
+		t.Fatalf("create scheduler: %v", err)
+	}
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	reqs := readEnrichRequests(t, redisSrv)
+
+	// Only tok-ok should be published; tok-exhausted has enrich_attempts >= 10.
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 enrich request (tok-exhausted skipped), got %d", len(reqs))
+	}
+	if reqs[0].Token != "tok-ok" {
+		t.Errorf("token = %q, want tok-ok", reqs[0].Token)
+	}
+}

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -142,3 +142,42 @@ func (s *Scheduler) processExpiredPremium(ctx context.Context) {
 		)
 	}
 }
+
+func (s *Scheduler) purgeStaleEnrichMessages(ctx context.Context) {
+	if s.enrichPublisher == nil || s.stores.Listings == nil {
+		return
+	}
+
+	// Checker callback: check if tokens are fully enriched
+	checker := func(ctx context.Context, tokens []string) (map[string]bool, error) {
+		enrichmentData, err := s.stores.Listings.LookupEnrichmentData(ctx, tokens)
+		if err != nil {
+			return nil, err
+		}
+
+		result := make(map[string]bool)
+		for _, token := range tokens {
+			data, exists := enrichmentData[token]
+			if !exists {
+				result[token] = false
+				continue
+			}
+			// Consider fully enriched if Km > 0 && City != "" && ImageURL != ""
+			isEnriched := data.Km > 0 && data.City != "" && data.ImageURL != ""
+			result[token] = isEnriched
+		}
+		return result, nil
+	}
+
+	purged, err := s.enrichPublisher.PurgeEnrichedEntries(ctx, checker)
+	if err != nil {
+		s.logger.Error("purge stale enrichment messages failed", "error", err)
+		return
+	}
+	if purged > 0 {
+		s.logger.Info("purged stale enrichment messages from stream",
+			"count", purged,
+			"impact", "removed entries for tokens already fully enriched",
+		)
+	}
+}

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -89,6 +89,7 @@ func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
 	)
 
 	published := 0
+	skipped := 0
 	for _, t := range tokens {
 		req := broker.EnrichRequest{
 			Token:      t,
@@ -96,16 +97,19 @@ func (s *Scheduler) backfillUnenrichedListings(ctx context.Context) {
 			Source:     "backfill",
 			EnqueuedAt: time.Now().UTC().Format(time.RFC3339),
 		}
-		if err := s.enrichPublisher.PublishEnrich(ctx, req); err != nil {
+		ok, err := s.enrichPublisher.PublishEnrichDedup(ctx, req)
+		if err != nil {
 			s.logger.Warn("failed to publish backfill enrichment request to stream",
 				"token", t, "error", err)
-		} else {
+		} else if ok {
 			published++
+		} else {
+			skipped++
 		}
 	}
-	if published > 0 {
+	if published > 0 || skipped > 0 {
 		s.logger.Info("published backfill enrichment requests to stream",
-			"published", published, "candidates", len(tokens))
+			"published", published, "skipped_dedup", skipped, "candidates", len(tokens))
 	}
 }
 

--- a/internal/scheduler/match.go
+++ b/internal/scheduler/match.go
@@ -188,11 +188,49 @@ func (s *Scheduler) publishEnrichRequests(ctx context.Context, ms *matchState) {
 	if s.enrichPublisher == nil || len(ms.matchedIndices) == 0 {
 		return
 	}
+
+	// Collect tokens that need enrichment
+	needEnrich := make(map[string]bool)
+	var tokensToCheck []string
+	for idx := range ms.matchedIndices {
+		l := ms.raw[idx]
+		if l.Km <= 0 || l.City == "" || l.ImageURL == "" {
+			if !needEnrich[l.Token] {
+				needEnrich[l.Token] = true
+				tokensToCheck = append(tokensToCheck, l.Token)
+			}
+		}
+	}
+
+	// Check which tokens have exhausted retry attempts
+	var exhausted map[string]bool
+	if s.stores.Listings != nil && len(tokensToCheck) > 0 {
+		s.cfgMu.RLock()
+		maxAttempts := s.cfg.Enricher.MaxAttemptsPerToken
+		s.cfgMu.RUnlock()
+
+		var err error
+		exhausted, err = s.stores.Listings.ListEnrichExhaustedTokens(ctx, tokensToCheck, maxAttempts)
+		if err != nil {
+			s.logger.WarnContext(ctx, "failed to check exhausted enrich tokens, proceeding without circuit breaker",
+				"error", err)
+			exhausted = nil
+		}
+	}
+
 	published := 0
 	skipped := 0
+	exhaustedSkipped := 0
 	for idx, searchIDs := range ms.matchedIndices {
 		l := ms.raw[idx]
 		if l.Km <= 0 || l.City == "" || l.ImageURL == "" {
+			if exhausted != nil && exhausted[l.Token] {
+				exhaustedSkipped++
+				s.logger.WarnContext(ctx, "skipping enrich request for token that exhausted retry attempts",
+					"token", l.Token, "car", l.Manufacturer+" "+l.Model)
+				continue
+			}
+
 			req := broker.EnrichRequest{
 				Token:      l.Token,
 				Priority:   1,
@@ -211,9 +249,10 @@ func (s *Scheduler) publishEnrichRequests(ctx context.Context, ms *matchState) {
 			}
 		}
 	}
-	if published > 0 || skipped > 0 {
+	if published > 0 || skipped > 0 || exhaustedSkipped > 0 {
 		s.logger.InfoContext(ctx, "published enrichment requests for matched listings",
-			"published", published, "skipped_dedup", skipped, "total_matched", len(ms.matchedIndices))
+			"published", published, "skipped_dedup", skipped, "skipped_exhausted", exhaustedSkipped,
+			"total_matched", len(ms.matchedIndices))
 	}
 }
 

--- a/internal/scheduler/match.go
+++ b/internal/scheduler/match.go
@@ -189,6 +189,7 @@ func (s *Scheduler) publishEnrichRequests(ctx context.Context, ms *matchState) {
 		return
 	}
 	published := 0
+	skipped := 0
 	for idx, searchIDs := range ms.matchedIndices {
 		l := ms.raw[idx]
 		if l.Km <= 0 || l.City == "" || l.ImageURL == "" {
@@ -199,17 +200,20 @@ func (s *Scheduler) publishEnrichRequests(ctx context.Context, ms *matchState) {
 				Source:     "scheduler",
 				EnqueuedAt: time.Now().UTC().Format(time.RFC3339),
 			}
-			if err := s.enrichPublisher.PublishEnrich(ctx, req); err != nil {
+			ok, err := s.enrichPublisher.PublishEnrichDedup(ctx, req)
+			if err != nil {
 				s.logger.WarnContext(ctx, "failed to publish enrichment request to stream",
 					"token", l.Token, "car", l.Manufacturer+" "+l.Model, "error", err)
-			} else {
+			} else if ok {
 				published++
+			} else {
+				skipped++
 			}
 		}
 	}
-	if published > 0 {
+	if published > 0 || skipped > 0 {
 		s.logger.InfoContext(ctx, "published enrichment requests for matched listings",
-			"published", published, "total_matched", len(ms.matchedIndices))
+			"published", published, "skipped_dedup", skipped, "total_matched", len(ms.matchedIndices))
 	}
 }
 

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -64,6 +64,9 @@ func (s *prefillTrackingStore) ListUnenrichedTokens(_ context.Context, _ int) ([
 }
 func (s *prefillTrackingStore) CountUnenrichedTokens(_ context.Context) (int64, error)   { return 0, nil }
 func (s *prefillTrackingStore) IncrementEnrichAttempt(_ context.Context, _ string) error { return nil }
+func (s *prefillTrackingStore) ListEnrichExhaustedTokens(_ context.Context, _ []string, _ int) (map[string]bool, error) {
+	return nil, nil
+}
 func (s *prefillTrackingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
 	return &storage.ListingIdentity{}, nil
 }

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -257,6 +257,7 @@ type mockListingStore struct {
 	saved            []storage.ListingRecord
 	pruneCalls       int
 	unenrichedTokens []string
+	exhaustedTokens  map[string]bool
 }
 
 func (m *mockListingStore) SaveListing(_ context.Context, r storage.ListingRecord) error {
@@ -321,6 +322,21 @@ func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]str
 }
 func (m *mockListingStore) CountUnenrichedTokens(_ context.Context) (int64, error)   { return 0, nil }
 func (m *mockListingStore) IncrementEnrichAttempt(_ context.Context, _ string) error { return nil }
+func (m *mockListingStore) ListEnrichExhaustedTokens(_ context.Context, tokens []string, _ int) (map[string]bool, error) {
+	if m.exhaustedTokens == nil {
+		return nil, nil
+	}
+	result := make(map[string]bool)
+	for _, tok := range tokens {
+		if m.exhaustedTokens[tok] {
+			result[tok] = true
+		}
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
 func (m *mockListingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
 	return &storage.ListingIdentity{}, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -556,6 +556,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 
 	if len(searches) == 0 {
 		s.backfillUnenrichedListings(ctx)
+		s.purgeStaleEnrichMessages(ctx)
 		s.logger.InfoContext(ctx, "scheduler cycle completed with no active searches", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
 		s.observer.RecordSuccess()
 		return nil
@@ -580,6 +581,7 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.processDigests(ctx)
 	s.processDailyDigests(ctx)
 	s.backfillUnenrichedListings(ctx)
+	s.purgeStaleEnrichMessages(ctx)
 
 	s.logger.InfoContext(ctx, "scheduler cycle completed",
 		"scan", cycle,

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -276,6 +276,10 @@ type ListingStore interface {
 	CountUnenrichedTokens(ctx context.Context) (int64, error)
 	LookupListingIdentity(ctx context.Context, token string) (*ListingIdentity, error)
 	IncrementEnrichAttempt(ctx context.Context, token string) error
+	// ListEnrichExhaustedTokens returns a map of tokens (from the input slice)
+	// that have enrich_attempts >= maxAttempts. Used to skip publishing enrich
+	// requests for tokens that have exhausted retries.
+	ListEnrichExhaustedTokens(ctx context.Context, tokens []string, maxAttempts int) (map[string]bool, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
 	// DropListingByToken removes a listing that no longer exists at the source

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -730,6 +730,55 @@ func (s *Store) IncrementEnrichAttempt(ctx context.Context, token string) error 
 	return err
 }
 
+func (s *Store) ListEnrichExhaustedTokens(ctx context.Context, tokens []string, maxAttempts int) (map[string]bool, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	exhausted := make(map[string]bool, len(tokens))
+	const batchSize = 500
+
+	for start := 0; start < len(tokens); start += batchSize {
+		end := start + batchSize
+		if end > len(tokens) {
+			end = len(tokens)
+		}
+		batch := tokens[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch)+1)
+		for i, t := range batch {
+			args[i] = t
+			placeholders[i] = fmt.Sprintf("$%d", i+1)
+		}
+		args[len(batch)] = maxAttempts
+
+		q := `SELECT DISTINCT token FROM listing_history
+			WHERE token IN (` + strings.Join(placeholders, ", ") + `)
+			  AND enrich_attempts >= $` + fmt.Sprintf("%d", len(batch)+1)
+
+		rows, err := s.db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("list enrich exhausted tokens: %w", err)
+		}
+
+		for rows.Next() {
+			var tok string
+			if err := rows.Scan(&tok); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan exhausted token: %w", err)
+			}
+			exhausted[tok] = true
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("exhausted tokens rows: %w", err)
+		}
+		_ = rows.Close()
+	}
+	return exhausted, nil
+}
+
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, `


### PR DESCRIPTION
## Summary

7 improvements to fix the enricher being stuck in a challenge-backoff loop (5 successes in 24h, 228 bot challenges, 37k duplicate queue messages for 62 listings).

- **Queue dedup** — Redis SET tracks pending tokens; `PublishEnrichDedup` skips tokens already in the queue. Prevents 37k→62 duplication
- **Queue purge** — `PurgeEnrichedEntries` drains stale messages for already-enriched tokens from the stream in batches
- **Higher max_delay** — Raised from 60s to 10min so the enricher backs off far enough for IP reputation to recover
- **Progressive cooldown** — Raised from 5min to 15min base, doubles on consecutive failures (capped at 30min). Breaks the tight oscillation loop (was triggering 74 times/24h)
- **Higher base_delay** — Raised from 300ms to 500ms to account for 3 concurrent Yad2 consumers sharing the same IP
- **Token circuit breaker** — Batch-checks `enrich_attempts` before publishing match-time requests. Tokens above `MaxAttemptsPerToken` are skipped
- **Benchmark concurrent mode** — `--concurrent N` flag spawns N goroutines with independent delays to simulate production's multi-consumer setup

## Test plan

- [x] Broker tests pass (35 tests) — dedup publish, duplicate skip, pending set cleanup, purge enriched entries
- [x] Enricher tests pass (12 tests) — progressive cooldown escalation, reset on success, cap at max
- [x] Config tests pass (21 tests)
- [x] Scheduler enrichment tests — exhausted token circuit breaker
- [x] Build passes (`go build ./...`)

## Production config update needed

After deploy, update `config.yaml`:
```yaml
enricher:
  base_delay: 500ms
  max_delay: 10m
  cooldown_duration: 15m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)