### PR TITLE
feat: eventual consistency — reset enrich_attempts on success

### DIFF
--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -128,6 +128,14 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		return err
 	}
 
+	if resetCount, resetErr := w.listings.ResetUnenrichedAttempts(ctx); resetErr != nil {
+		w.logger.WarnContext(ctx, "failed to reset unenriched attempt counters",
+			"error", resetErr.Error())
+	} else if resetCount > 0 {
+		w.logger.InfoContext(ctx, "reset enrich_attempts for unenriched listings after successful enrichment",
+			"reset_count", resetCount)
+	}
+
 	// Count toward the enrich_attempts cap when km is genuinely unavailable
 	// on the source page, so backfill stops re-queuing this token.
 	if details.Km <= 0 {

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
+	"time"
 
 	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/fetcher"
@@ -28,19 +30,23 @@ type ItemFetcher interface {
 // Worker processes enrichment requests from a Redis stream by fetching
 // individual listing pages and updating the database.
 type Worker struct {
-	fetcher  ItemFetcher
-	listings storage.ListingStore
-	limiter  *AdaptiveRateLimiter
-	logger   *slog.Logger
+	fetcher       ItemFetcher
+	listings      storage.ListingStore
+	limiter       *AdaptiveRateLimiter
+	logger        *slog.Logger
+	resetMu       sync.Mutex
+	lastResetAt   time.Time
+	resetInterval time.Duration
 }
 
 // NewWorker creates an enrichment worker.
 func NewWorker(f ItemFetcher, ls storage.ListingStore, rl *AdaptiveRateLimiter, logger *slog.Logger) *Worker {
 	return &Worker{
-		fetcher:  f,
-		listings: ls,
-		limiter:  rl,
-		logger:   logger,
+		fetcher:       f,
+		listings:      ls,
+		limiter:       rl,
+		logger:        logger,
+		resetInterval: 5 * time.Minute,
 	}
 }
 
@@ -129,13 +135,7 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 	}
 
 	if details.Km > 0 && details.City != "" && details.ImageURL != "" {
-		if resetCount, resetErr := w.listings.ResetUnenrichedAttempts(ctx); resetErr != nil {
-			w.logger.WarnContext(ctx, "failed to reset unenriched attempt counters",
-				"error", resetErr.Error())
-		} else if resetCount > 0 {
-			w.logger.InfoContext(ctx, "reset enrich_attempts for unenriched listings after successful enrichment",
-				"reset_count", resetCount)
-		}
+		w.maybeResetUnenriched(ctx)
 	} else if details.Km <= 0 {
 		if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
 			w.logger.ErrorContext(ctx, "failed to increment enrich attempt for km-unavailable listing",
@@ -176,4 +176,22 @@ func (w *Worker) carAttrs(ctx context.Context, req broker.EnrichRequest, existin
 	return append(attrs,
 		"manufacturer", id.Manufacturer, "model", id.Model,
 		"year", id.Year, "price", id.Price, "search_name", id.SearchName)
+}
+
+func (w *Worker) maybeResetUnenriched(ctx context.Context) {
+	w.resetMu.Lock()
+	if time.Since(w.lastResetAt) < w.resetInterval {
+		w.resetMu.Unlock()
+		return
+	}
+	w.lastResetAt = time.Now()
+	w.resetMu.Unlock()
+
+	if resetCount, err := w.listings.ResetUnenrichedAttempts(ctx); err != nil {
+		w.logger.WarnContext(ctx, "failed to reset unenriched attempt counters",
+			"error", err.Error())
+	} else if resetCount > 0 {
+		w.logger.InfoContext(ctx, "reset enrich_attempts for unenriched listings after successful enrichment",
+			"reset_count", resetCount)
+	}
 }

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -128,17 +128,15 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		return err
 	}
 
-	if resetCount, resetErr := w.listings.ResetUnenrichedAttempts(ctx); resetErr != nil {
-		w.logger.WarnContext(ctx, "failed to reset unenriched attempt counters",
-			"error", resetErr.Error())
-	} else if resetCount > 0 {
-		w.logger.InfoContext(ctx, "reset enrich_attempts for unenriched listings after successful enrichment",
-			"reset_count", resetCount)
-	}
-
-	// Count toward the enrich_attempts cap when km is genuinely unavailable
-	// on the source page, so backfill stops re-queuing this token.
-	if details.Km <= 0 {
+	if details.Km > 0 && details.City != "" && details.ImageURL != "" {
+		if resetCount, resetErr := w.listings.ResetUnenrichedAttempts(ctx); resetErr != nil {
+			w.logger.WarnContext(ctx, "failed to reset unenriched attempt counters",
+				"error", resetErr.Error())
+		} else if resetCount > 0 {
+			w.logger.InfoContext(ctx, "reset enrich_attempts for unenriched listings after successful enrichment",
+				"reset_count", resetCount)
+		}
+	} else if details.Km <= 0 {
 		if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
 			w.logger.ErrorContext(ctx, "failed to increment enrich attempt for km-unavailable listing",
 				"token", req.Token, "error", incErr.Error())

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -37,6 +37,8 @@ type mockListingStore struct {
 	lookupErr      error
 	incrementErr   error
 	dropErr        error
+	resetCalled    bool
+	resetErr       error
 }
 
 func newMockListingStore() *mockListingStore {
@@ -82,7 +84,13 @@ func (m *mockListingStore) IncrementEnrichAttempt(_ context.Context, token strin
 }
 
 func (m *mockListingStore) ResetUnenrichedAttempts(_ context.Context) (int64, error) {
-	return 0, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resetCalled = true
+	if m.resetErr != nil {
+		return 0, m.resetErr
+	}
+	return 1, nil
 }
 
 func (m *mockListingStore) SaveListing(_ context.Context, _ storage.ListingRecord) error { return nil }

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -81,6 +81,10 @@ func (m *mockListingStore) IncrementEnrichAttempt(_ context.Context, token strin
 	return nil
 }
 
+func (m *mockListingStore) ResetUnenrichedAttempts(_ context.Context) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockListingStore) SaveListing(_ context.Context, _ storage.ListingRecord) error { return nil }
 func (m *mockListingStore) SaveListings(_ context.Context, _ []storage.ListingRecord) error {
 	return nil

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -64,6 +64,9 @@ func (s *prefillTrackingStore) ListUnenrichedTokens(_ context.Context, _ int) ([
 }
 func (s *prefillTrackingStore) CountUnenrichedTokens(_ context.Context) (int64, error)   { return 0, nil }
 func (s *prefillTrackingStore) IncrementEnrichAttempt(_ context.Context, _ string) error { return nil }
+func (s *prefillTrackingStore) ResetUnenrichedAttempts(_ context.Context) (int64, error) {
+	return 0, nil
+}
 func (s *prefillTrackingStore) ListEnrichExhaustedTokens(_ context.Context, _ []string, _ int) (map[string]bool, error) {
 	return nil, nil
 }

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -322,6 +322,9 @@ func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]str
 }
 func (m *mockListingStore) CountUnenrichedTokens(_ context.Context) (int64, error)   { return 0, nil }
 func (m *mockListingStore) IncrementEnrichAttempt(_ context.Context, _ string) error { return nil }
+func (m *mockListingStore) ResetUnenrichedAttempts(_ context.Context) (int64, error) {
+	return 0, nil
+}
 func (m *mockListingStore) ListEnrichExhaustedTokens(_ context.Context, tokens []string, _ int) (map[string]bool, error) {
 	if m.exhaustedTokens == nil {
 		return nil, nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -280,6 +280,7 @@ type ListingStore interface {
 	// that have enrich_attempts >= maxAttempts. Used to skip publishing enrich
 	// requests for tokens that have exhausted retries.
 	ListEnrichExhaustedTokens(ctx context.Context, tokens []string, maxAttempts int) (map[string]bool, error)
+	ResetUnenrichedAttempts(ctx context.Context) (int64, error)
 	PruneListings(ctx context.Context, olderThan time.Duration) (int64, error)
 	DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error)
 	// DropListingByToken removes a listing that no longer exists at the source

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -779,6 +779,19 @@ func (s *Store) ListEnrichExhaustedTokens(ctx context.Context, tokens []string, 
 	return exhausted, nil
 }
 
+func (s *Store) ResetUnenrichedAttempts(ctx context.Context) (int64, error) {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE listing_history SET enrich_attempts = 0
+		 WHERE (`+unenrichedMissingFieldsWhereSQL+`)
+		   AND enrich_attempts > 0
+		   AND enrich_attempts < 30
+		   AND first_seen_at > NOW() - INTERVAL '7 days'`)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, `

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -784,8 +784,7 @@ func (s *Store) ResetUnenrichedAttempts(ctx context.Context) (int64, error) {
 		`UPDATE listing_history SET enrich_attempts = 0
 		 WHERE (`+unenrichedMissingFieldsWhereSQL+`)
 		   AND enrich_attempts > 0
-		   AND enrich_attempts < 30
-		   AND first_seen_at > NOW() - INTERVAL '7 days'`)
+		   AND enrich_attempts < 30`)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary

Implements **Reset on Global Success** strategy for enricher eventual consistency.

When any listing is successfully enriched, all unenriched listings have their `enrich_attempts` counter reset to 0. This unblocks tokens that were capped during transient bot-detection episodes, since a successful enrichment proves Yad2 is accessible.

- Tokens with `enrich_attempts >= 30` are excluded (structural failures)
- The existing cap of 10 still gates retries during active bot detection
- Recovery time after a transient outage: 12-36 minutes (next backfill cycle)

## Why this approach

3 strategies were evaluated by independent architect agents:
- **Exponential Backoff by Attempts** (score: 7.0) — over-engineered, models failures as independent when they're correlated
- **Reset on Global Success** (score: 8.75) — correctly models global bot detection, simplest implementation
- **Priority Queue with Aging** (score: 6.5) — most complex, days-long recovery

## Test plan

- [x] `go build ./...` clean
- [x] All mock interfaces updated (3 files)
- [x] Enricher and scheduler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After a successful listing detail backfill, unenriched retry counters are now automatically reset when the listing is fully enriched.
  * Listings that were previously stuck due to repeated unenriched enrichment attempts can recover and process normally in subsequent runs.
* **Tests**
  * Updated scheduler/enricher test mocks to support the new reset behavior.
* **Chores**
  * Added a new `ResetUnenrichedAttempts` capability across the storage layer and worker processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->