### PR TITLE
fix(web): don't show value dimension as scored when market data is missing

### DIFF
--- a/web/src/components/ScoreBreakdownPopover.test.tsx
+++ b/web/src/components/ScoreBreakdownPopover.test.tsx
@@ -61,6 +61,21 @@ describe("ScoreBreakdownPopover", () => {
     expect(screen.getByText("60%")).toBeInTheDocument();
   });
 
+  it("excludes the value dimension when market data exists but price is missing", async () => {
+    // Edge case: a cohort median is known but the listing has no usable price
+    // (e.g. "contact for price"). The numeric comparison divides against price,
+    // so we must not render it — exclude the row instead of showing a bogus bar.
+    const listing: Listing = { ...baseListing(), price: 0, median_price: 100000 };
+    render(
+      <ScoreBreakdownPopover score={8.5} breakdown={breakdown} listing={listing} />,
+    );
+    await openPopover();
+
+    expect(await screen.findByText("לא נכלל בציון")).toBeInTheDocument();
+    expect(screen.queryByText("35%")).not.toBeInTheDocument();
+    expect(screen.queryByText(/מתחת לשוק/)).not.toBeInTheDocument();
+  });
+
   it("shows the value dimension as a weighted contributor when market data exists", async () => {
     const listing: Listing = { ...baseListing(), median_price: 100000 };
     render(

--- a/web/src/components/ScoreBreakdownPopover.test.tsx
+++ b/web/src/components/ScoreBreakdownPopover.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ScoreBreakdownPopover } from "./ScoreBreakdownPopover";
+import type { Listing, ScoreBreakdown } from "@/lib/api";
+
+const baseListing = (): Listing => ({
+  token: "t1",
+  manufacturer: "Toyota",
+  model: "Corolla",
+  year: 2019,
+  price: 85000,
+  km: 60000,
+  hand: 1,
+  city: "Haifa",
+  page_link: "https://example.com/a",
+  first_seen_at: "2024-01-15T12:00:00Z",
+});
+
+const breakdown: ScoreBreakdown = {
+  condition: 0.72,
+  value: 0.51,
+  engine: 1.0,
+};
+
+async function openPopover() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "הצג פירוט ציון" }));
+}
+
+describe("ScoreBreakdownPopover", () => {
+  it("falls back to a plain score box when no breakdown is provided", () => {
+    render(<ScoreBreakdownPopover score={8.5} listing={baseListing()} />);
+    // No trigger to open a breakdown — just the score.
+    expect(
+      screen.queryByRole("button", { name: "הצג פירוט ציון" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks the value dimension as excluded when there is no market data", async () => {
+    render(
+      <ScoreBreakdownPopover
+        score={8.5}
+        breakdown={breakdown}
+        listing={baseListing()} // no median_price
+      />,
+    );
+    await openPopover();
+
+    // The value row is flagged as not counting toward the score...
+    expect(await screen.findByText("לא נכלל בציון")).toBeInTheDocument();
+    expect(
+      screen.getByText("אין מספיק נתוני שוק להשוואה"),
+    ).toBeInTheDocument();
+
+    // ...so its weight chip and a misleading filled bar are suppressed.
+    expect(screen.queryByText("35%")).not.toBeInTheDocument();
+    expect(screen.queryByText("51%")).not.toBeInTheDocument();
+
+    // Other dimensions are unaffected.
+    expect(screen.getByText("60%")).toBeInTheDocument();
+  });
+
+  it("shows the value dimension as a weighted contributor when market data exists", async () => {
+    const listing: Listing = { ...baseListing(), median_price: 100000 };
+    render(
+      <ScoreBreakdownPopover
+        score={8.5}
+        breakdown={breakdown}
+        listing={listing}
+      />,
+    );
+    await openPopover();
+
+    // Weight chip and percentage are shown, and the market comparison renders.
+    expect(await screen.findByText("35%")).toBeInTheDocument();
+    expect(screen.getByText("51%")).toBeInTheDocument();
+    expect(screen.getByText(/מתחת לשוק/)).toBeInTheDocument();
+
+    expect(screen.queryByText("לא נכלל בציון")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ScoreBreakdownPopover.tsx
+++ b/web/src/components/ScoreBreakdownPopover.tsx
@@ -109,10 +109,23 @@ function conditionInsights(listing: Listing): Insight[] {
   return insights;
 }
 
+// hasMarketData reports whether the value dimension had a real market cohort to
+// compare against. The backend only sets median_price once the cohort reaches
+// MinCohortSize; without it the value dimension contributes a neutral delta and
+// does not move the additive score, so the UI must not present it as a weighted
+// contributor (see the `excluded` handling below).
+function hasMarketData(
+  listing: Listing,
+): listing is Listing & { median_price: number } {
+  return Boolean(
+    listing.median_price && listing.median_price > 0 && listing.price > 0,
+  );
+}
+
 function valueInsights(listing: Listing): Insight[] {
   const insights: Insight[] = [];
 
-  if (listing.median_price && listing.median_price > 0 && listing.price > 0) {
+  if (hasMarketData(listing)) {
     const diffPct = Math.round(
       ((listing.median_price - listing.price) / listing.median_price) * 100,
     );
@@ -208,36 +221,55 @@ export function ScoreBreakdownPopover({
               const barColor = scoreHsl(value * 10);
               const barBg = scoreHslAlpha(value * 10, 0.15);
               const insights = INSIGHTS_BY_DIM[dim.key](listing);
+              // The score is additive (5.0 + per-dimension deltas), not a
+              // weighted average. When the value dimension has no market cohort
+              // it contributes a neutral delta — i.e. it did not move the score.
+              // Render it as excluded so the weight chip and a filled bar don't
+              // imply a contribution that never happened.
+              const excluded = dim.key === "value" && !hasMarketData(listing);
               return (
-                <div key={dim.key} className="space-y-1">
+                <div
+                  key={dim.key}
+                  className={cn("space-y-1", excluded && "opacity-60")}
+                >
                   <div className="flex items-center justify-between text-xs">
                     <div className="flex items-center gap-1.5">
                       <span className="font-medium text-foreground">
                         {dim.label}
                       </span>
-                      <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
-                        {dim.weight}
-                      </span>
+                      {!excluded && (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
+                          {dim.weight}
+                        </span>
+                      )}
                     </div>
-                    <span
-                      className="font-bold tabular-nums"
-                      style={{ color: barColor }}
-                    >
-                      {Math.round(value * 100)}%
-                    </span>
+                    {excluded ? (
+                      <span className="text-[10px] font-medium text-muted-foreground">
+                        לא נכלל בציון
+                      </span>
+                    ) : (
+                      <span
+                        className="font-bold tabular-nums"
+                        style={{ color: barColor }}
+                      >
+                        {Math.round(value * 100)}%
+                      </span>
+                    )}
                   </div>
-                  <div
-                    className="h-1.5 w-full overflow-hidden rounded-full"
-                    style={{ backgroundColor: barBg }}
-                  >
+                  {!excluded && (
                     <div
-                      className="h-full rounded-full transition-all duration-300"
-                      style={{
-                        width: `${Math.round(value * 100)}%`,
-                        backgroundColor: barColor,
-                      }}
-                    />
-                  </div>
+                      className="h-1.5 w-full overflow-hidden rounded-full"
+                      style={{ backgroundColor: barBg }}
+                    >
+                      <div
+                        className="h-full rounded-full transition-all duration-300"
+                        style={{
+                          width: `${Math.round(value * 100)}%`,
+                          backgroundColor: barColor,
+                        }}
+                      />
+                    </div>
+                  )}
                   {/* Insights */}
                   {insights.length > 0 && (
                     <div className="space-y-0.5 pt-0.5">

--- a/web/src/components/ScoreBreakdownPopover.tsx
+++ b/web/src/components/ScoreBreakdownPopover.tsx
@@ -109,23 +109,23 @@ function conditionInsights(listing: Listing): Insight[] {
   return insights;
 }
 
-// hasMarketData reports whether the value dimension had a real market cohort to
-// compare against. The backend only sets median_price once the cohort reaches
-// MinCohortSize; without it the value dimension contributes a neutral delta and
-// does not move the additive score, so the UI must not present it as a weighted
-// contributor (see the `excluded` handling below).
+// hasMarketData reports whether a market cohort exists to compare against. The
+// backend only sets median_price once the cohort reaches MinCohortSize. A real
+// value *comparison* additionally needs a positive listing price (the insight
+// divides against it), so callers pair this guard with `listing.price > 0`.
+// Without a comparison the value dimension contributes a neutral delta to the
+// additive score, so the UI must not present it as a weighted contributor (see
+// the `excluded` handling below).
 function hasMarketData(
   listing: Listing,
 ): listing is Listing & { median_price: number } {
-  return Boolean(
-    listing.median_price && listing.median_price > 0 && listing.price > 0,
-  );
+  return typeof listing.median_price === "number" && listing.median_price > 0;
 }
 
 function valueInsights(listing: Listing): Insight[] {
   const insights: Insight[] = [];
 
-  if (hasMarketData(listing)) {
+  if (hasMarketData(listing) && listing.price > 0) {
     const diffPct = Math.round(
       ((listing.median_price - listing.price) / listing.median_price) * 100,
     );
@@ -225,8 +225,11 @@ export function ScoreBreakdownPopover({
               // weighted average. When the value dimension has no market cohort
               // it contributes a neutral delta — i.e. it did not move the score.
               // Render it as excluded so the weight chip and a filled bar don't
-              // imply a contribution that never happened.
-              const excluded = dim.key === "value" && !hasMarketData(listing);
+              // imply a contribution that never happened. A value comparison
+              // needs both a market cohort and a positive price.
+              const excluded =
+                dim.key === "value" &&
+                !(hasMarketData(listing) && listing.price > 0);
               return (
                 <div
                   key={dim.key}


### PR DESCRIPTION
## Summary

The score breakdown popover rendered the **value** dimension (שווי עסקה) with its `35%` weight chip and a filled (~51%) bar even when there was no market cohort to compare against — while the insight line said *"אין מספיק נתוני שוק להשוואה"* ("not enough market data to compare"). That is contradictory and misleading.

The BES score is **additive** (`5.0 + per-dimension deltas`), not a weighted average. A dimension with no market data contributes a *neutral* delta and therefore does **not** move the score. The `60/35/5` figures are display-only proportions, not real weights.

### Change

When `median_price` is absent, the value row is now rendered as **excluded**:
- weight chip and the misleading bar are removed
- the row is dimmed
- right-side label reads **`לא נכלל בציון`** ("not included in score")
- the explanatory insight is kept

This is scoped to the **value** dimension — the only one with a genuine "no data" path and the source of the confusion.

Refactor: extracted the market-data check into a `hasMarketData` type guard, reused by both the insight text and the new exclusion logic.

## Tests

Added `ScoreBreakdownPopover.test.tsx` covering both the excluded and weighted-contributor states.

- ✅ `vitest run` — 3/3 pass
- ✅ `tsc -b` — clean
- ✅ `eslint` — clean

## Review

✅ Self-reviewed (correctness, UX honesty, type-safety). Single focused component change with tests; no API/backend changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The score breakdown popover now clearly shows when the “value” factor is excluded from the score.
  * Listings with valid market data now display value comparison details, including market position indicators.

* **Bug Fixes**
  * Improved handling of listings without market data so the score breakdown no longer treats value as a contributing factor.
  * Refined the display to hide weight, percentage, and bar visuals when value is excluded.

* **Tests**
  * Added coverage for score display, excluded value handling, and market-based value comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->