### PR TITLE
feat: use Yad2 pricelist as value-dimension fallback

### DIFF
--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -229,6 +229,7 @@ func (a *yad2ItemFetcherAdapter) FetchItem(ctx context.Context, token string) (e
 		ImageURL: details.ImageURL,
 		City:     details.City,
 		Area:     details.Area,
+		BodyType: details.BodyType,
 	}, nil
 }
 

--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -20,6 +20,7 @@ type ItemDetails struct {
 	ImageURL string
 	City     string
 	Area     string
+	BodyType string
 }
 
 // ItemFetcher fetches detailed data for a single listing by token.
@@ -135,6 +136,7 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 		Km:       details.Km,
 		City:     details.City,
 		ImageURL: details.ImageURL,
+		BodyType: details.BodyType,
 	}
 	if err := w.listings.BackfillListings(ctx, []storage.ListingRecord{rec}); err != nil {
 		w.logger.ErrorContext(ctx, "failed to backfill enriched data to database",

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -388,6 +388,30 @@ func TestWorker_LookupErrorReturnsError(t *testing.T) {
 	}
 }
 
+func TestWorker_EnrichesBodyType(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{
+		Km: 50000, City: "Tel Aviv", ImageURL: "https://img.yad2.co.il/test.jpg",
+		BodyType: "hatchback",
+	}}
+	ls := newMockListingStore()
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	req := broker.EnrichRequest{Token: "tok-bt", Priority: 1, Source: "match"}
+	if err := w.HandleRequest(context.Background(), req); err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if len(ls.backfilled) != 1 {
+		t.Fatalf("expected 1 backfilled record, got %d", len(ls.backfilled))
+	}
+	if ls.backfilled[0].BodyType != "hatchback" {
+		t.Errorf("backfilled body_type = %q, want hatchback", ls.backfilled[0].BodyType)
+	}
+}
+
 func TestWorker_ContextCancellation(t *testing.T) {
 	f := &mockItemFetcher{details: ItemDetails{Km: 50000}}
 	ls := newMockListingStore()

--- a/internal/fetcher/yad2/enricher.go
+++ b/internal/fetcher/yad2/enricher.go
@@ -197,6 +197,10 @@ func (e *Enricher) Enrich(ctx context.Context, listings []model.RawListing) int 
 			listings[i].OriginalOwnership = details.OriginalOwnership
 			changed = true
 		}
+		if listings[i].BodyType == "" && details.BodyType != "" {
+			listings[i].BodyType = details.BodyType
+			changed = true
+		}
 		if changed {
 			enriched++
 			e.logger.InfoContext(ctx, "enriched listing",

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/dsionov/carwatch/internal/bodytype"
 )
 
 // ItemDetails holds enrichment data parsed from an individual listing page.
@@ -15,6 +17,7 @@ type ItemDetails struct {
 	Area              string
 	OriginalOwnership string
 	CurrentOwnership  string
+	BodyType          string
 }
 
 // ParseItemPage extracts listing details (primarily km) from a Yad2 item page.
@@ -110,6 +113,7 @@ type itemPageData struct {
 			TextEng string `json:"textEng"`
 		} `json:"area"`
 	} `json:"address"`
+	BodyType          *ownershipField `json:"bodyType"`
 	CurrentOwnership  *ownershipField `json:"currentOwnership"`
 	OriginalOwnership *ownershipField `json:"originalOwnership"`
 	Ownership         *ownershipField `json:"ownership"`
@@ -122,6 +126,13 @@ func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 		ImageURL: resolveItemImageURL(d),
 		City:     firstNonEmpty(d.Address.City.TextEng, d.Address.City.Text),
 		Area:     firstNonEmpty(d.Address.Area.TextEng, d.Address.Area.Text),
+	}
+
+	if d.BodyType != nil {
+		details.BodyType = bodytype.Parse(
+			firstNonEmpty(d.BodyType.TextEng, d.BodyType.Text),
+			d.BodyType.Text,
+		)
 	}
 
 	// Extract original ownership: try OriginalOwnership, PreviousOwnership, Ownership.
@@ -149,7 +160,7 @@ func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 	}
 
 	return details, details.Km > 0 || details.ImageURL != "" || details.City != "" || details.Area != "" ||
-		details.OriginalOwnership != "" || details.CurrentOwnership != ""
+		details.OriginalOwnership != "" || details.CurrentOwnership != "" || details.BodyType != ""
 }
 
 // normalizeOwnership canonicalizes a Hebrew or English ownership string to one

--- a/internal/fetcher/yad2/item_parser_test.go
+++ b/internal/fetcher/yad2/item_parser_test.go
@@ -241,6 +241,59 @@ func TestParseItemPage_OwnershipFallbackToOwnership(t *testing.T) {
 	}
 }
 
+func TestParseItemPage_BodyType(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 33000,
+  "bodyType": {"text": "האצ'בק", "textEng": "Hatchback", "id": 5}
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.BodyType != "hatchback" {
+		t.Errorf("BodyType = %q, want hatchback", details.BodyType)
+	}
+}
+
+func TestParseItemPage_BodyTypeHebrewOnly(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 50000,
+  "bodyType": {"text": "סדאן", "id": 1}
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.BodyType != "sedan" {
+		t.Errorf("BodyType = %q, want sedan", details.BodyType)
+	}
+}
+
+func TestParseItemPage_BodyTypeAbsent(t *testing.T) {
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 80000
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.BodyType != "" {
+		t.Errorf("BodyType = %q, want empty when field absent", details.BodyType)
+	}
+}
+
 func TestParseItemPage_ImagesArrayFallback(t *testing.T) {
 	html := `<html><body>
 <script id="__NEXT_DATA__" type="application/json">

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -254,7 +254,7 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 		listing.GearBox = "אוטומט"
 	}
 
-	listing.BodyType = bodytype.Parse(subModelText, item.SubModel.Text)
+	listing.BodyType = bodytype.Parse(textFromField(item.BodyType), item.BodyType.Text, subModelText, item.SubModel.Text)
 
 	listing.City = textFromField(item.Address.City)
 	listing.Area = textFromField(item.Address.Area)
@@ -375,6 +375,7 @@ type feedItem struct {
 	HorsePower      int             `json:"horsePower"`
 	EngineType      field           `json:"engineType"`
 	GearBox         field           `json:"gearBox"`
+	BodyType        field           `json:"bodyType"`
 	Km              int             `json:"km"`
 	Hand            json.RawMessage `json:"hand"`
 	Price           int             `json:"price"`

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -617,6 +617,65 @@ func TestParseNextData_ExtractsBodyTypeFromSubModel(t *testing.T) {
 	}
 }
 
+func TestParseNextData_BodyTypeFromDirectField(t *testing.T) {
+	data := []byte(`{
+		"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+			"data":{"feed":{"feed_items":[{
+				"token":"bt-direct",
+				"manufacturer":{"id":27,"text":"מאזדה"},
+				"model":{"id":10332,"text":"3"},
+				"subModel":{"id":105280,"text":"LUXURY"},
+				"bodyType":{"id":5,"text":"סדאן","english_text":"Sedan"},
+				"vehicleDates":{"yearOfProduction":2021},
+				"engineVolume":1998,
+				"price":95000,
+				"hand":{"id":2},
+				"metaData":{"coverImage":"https://img.yad2.co.il/test.jpg"}
+			}]}}
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].BodyType != "sedan" {
+		t.Errorf("BodyType = %q, want 'sedan' (from direct bodyType field)", listings[0].BodyType)
+	}
+}
+
+func TestParseNextData_BodyTypeDirectFieldOverridesSubModel(t *testing.T) {
+	data := []byte(`{
+		"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+			"data":{"feed":{"feed_items":[{
+				"token":"bt-override",
+				"manufacturer":{"id":27,"text":"מאזדה"},
+				"model":{"id":10332,"text":"3"},
+				"subModel":{"id":105280,"text":"Premium אוט׳ האצ'בק 2.0 (165 כ״ס)"},
+				"bodyType":{"id":1,"text":"סדאן","english_text":"Sedan"},
+				"vehicleDates":{"yearOfProduction":2021},
+				"price":95000,
+				"hand":{"id":2},
+				"metaData":{"coverImage":"https://img.yad2.co.il/test.jpg"}
+			}]}}
+		}}}]}}}
+	}`)
+
+	listings, err := parseNextData(data, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].BodyType != "sedan" {
+		t.Errorf("BodyType = %q, want 'sedan' (direct field takes priority over subModel text)", listings[0].BodyType)
+	}
+}
+
 func TestParseNextData_BodyTypeEmptyWhenNoMatch(t *testing.T) {
 	data := []byte(`{
 		"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -75,10 +75,10 @@ type ProcessResult struct {
 // Steps performed:
 //  1. Prefill km/city/image from DB (if listings store is available)
 //  2. Inline enrichment — fetch missing data from source (if inline enricher is set)
-//  3. Compute fitness score
-//  4. Compute deal score (if market cache is available)
-//  5. Detect suspicious listings (if market cache is available)
-//  6. Enrich with base price (if pricelist service is available)
+//  3. Enrich with base price (if pricelist service is available)
+//  4. Compute fitness score (uses base price as value-dimension fallback when market data is thin)
+//  5. Compute deal score (if market cache is available)
+//  6. Detect suspicious listings (if market cache is available)
 //  7. Build ListingRecords
 func (p *ListingPipeline) Process(ctx context.Context, raw []model.RawListing, params ProcessParams) ProcessResult {
 	log := p.logger.With("op", "pipeline", "search_id", params.SearchID, "chat_id", params.ChatID, "search_name", params.SearchName)
@@ -120,6 +120,10 @@ func (p *ListingPipeline) scoreAndEnrich(ctx context.Context, l model.RawListing
 		medianPrice, medianKm, cohort, marketOK = params.MarketCache.Lookup(l.Manufacturer, l.Model, l.Year)
 	}
 
+	// Enrich with base price before scoring so the value dimension can
+	// use it as a fallback when market median data is unavailable.
+	p.enrichWithBasePrice(ctx, &listing, log)
+
 	fp := scoring.FitnessParams{
 		Price:             l.Price,
 		Km:                l.Km,
@@ -139,6 +143,9 @@ func (p *ListingPipeline) scoreAndEnrich(ctx context.Context, l model.RawListing
 		fp.MedianPrice = medianPrice
 		fp.MedianKm = medianKm
 	}
+	if listing.BasePrice != nil {
+		fp.BasePrice = *listing.BasePrice
+	}
 
 	detailed := scoring.FitnessScoreDetailed(fp)
 	listing.FitnessScore = detailed.Total
@@ -157,9 +164,6 @@ func (p *ListingPipeline) scoreAndEnrich(ctx context.Context, l model.RawListing
 		}
 		listing.SuspiciousReasons = scoring.DetectSuspicious(l, medianPrice)
 	}
-
-	// Enrich with base price.
-	p.enrichWithBasePrice(ctx, &listing, log)
 
 	return listing
 }
@@ -279,13 +283,14 @@ func (p *ListingPipeline) inlineEnrich(ctx context.Context, listings []model.Raw
 	}
 
 	type snapshot struct {
-		km    int
-		city  string
-		image string
+		km       int
+		city     string
+		image    string
+		bodyType string
 	}
 	before := make([]snapshot, len(listings))
 	for i := range listings {
-		before[i] = snapshot{listings[i].Km, listings[i].City, listings[i].ImageURL}
+		before[i] = snapshot{listings[i].Km, listings[i].City, listings[i].ImageURL, listings[i].BodyType}
 	}
 
 	log.InfoContext(ctx, "starting inline enrichment",
@@ -306,12 +311,13 @@ func (p *ListingPipeline) inlineEnrich(ctx context.Context, listings []model.Raw
 
 	var backfill []storage.ListingRecord
 	for i := range listings {
-		if listings[i].Km != before[i].km || listings[i].City != before[i].city || listings[i].ImageURL != before[i].image {
+		if listings[i].Km != before[i].km || listings[i].City != before[i].city || listings[i].ImageURL != before[i].image || listings[i].BodyType != before[i].bodyType {
 			backfill = append(backfill, storage.ListingRecord{
 				Token:    listings[i].Token,
 				Km:       listings[i].Km,
 				City:     listings[i].City,
 				ImageURL: listings[i].ImageURL,
+				BodyType: listings[i].BodyType,
 			})
 		}
 	}

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -276,6 +276,15 @@ const (
 	budgetLowPenalty   = 0.5
 	budgetOverPenalty  = 1.0
 
+	// Pricelist (BasePrice) fallback — wider tolerance, dampened bounds
+	basePriceNeutralLo      = 0.88
+	basePriceNeutralHi      = 1.10
+	basePriceMaxBonus       = 1.8
+	basePriceMaxPenalty     = -2.8
+	basePriceNeutralPenalty = 0.2
+	basePriceOverpaySpan    = 0.30
+	basePriceKmAdjFactor    = 0.12
+
 	// Engine delta
 	engineDeltaMax = 0.1
 
@@ -301,6 +310,7 @@ type FitnessParams struct {
 
 	MedianPrice int
 	MedianKm    int
+	BasePrice   int
 
 	IsCommercial      bool
 	OriginalOwnership string
@@ -479,6 +489,47 @@ func computeValueDelta(p FitnessParams, carAge int, condScore01 float64) (delta 
 		if delta > 0 && condScore01 < valCondGateThreshold {
 			delta *= condScore01 / valCondGateThreshold
 		}
+	} else if p.BasePrice > 0 {
+		adjExpected := float64(p.BasePrice) * basePriceDiscount(carAge)
+
+		if p.Km > 0 && carAge > 0 {
+			expectedKm := float64(carAge) * expectedKmPerYear
+			kmDeltaPct := (expectedKm - float64(p.Km)) / expectedKm
+			adjExpected *= clampRange(1.0+kmDeltaPct*basePriceKmAdjFactor, 0.70, 1.30)
+		}
+
+		expectedHands := 1.0 + float64(carAge)/handExpectedRate
+		if p.Hand == 1 && carAge >= 3 {
+			adjExpected *= (1.0 + handFirstPricePremium)
+		} else if p.Hand > 0 && float64(p.Hand) > expectedHands {
+			excess := float64(p.Hand) - expectedHands
+			adjExpected *= math.Max(0.85, 1.0-excess*handExcessPriceDisc)
+		}
+
+		switch p.OriginalOwnership {
+		case "lease":
+			adjExpected *= (1.0 - leaseOriginPriceDisc)
+		case "rental":
+			adjExpected *= (1.0 - rentalOriginPriceDisc)
+		}
+
+		ratio := float64(p.Price) / adjExpected
+
+		switch {
+		case ratio < 0.75:
+			delta = basePriceMaxBonus
+		case ratio < basePriceNeutralLo:
+			delta = basePriceMaxBonus * (basePriceNeutralLo - ratio) / (basePriceNeutralLo - 0.75)
+		case ratio <= basePriceNeutralHi:
+			delta = -basePriceNeutralPenalty * (ratio - basePriceNeutralLo) / (basePriceNeutralHi - basePriceNeutralLo)
+		default:
+			overpay := (ratio - basePriceNeutralHi) / basePriceOverpaySpan
+			delta = clampRange(-basePriceNeutralPenalty-(-basePriceMaxPenalty-basePriceNeutralPenalty)*math.Pow(math.Min(overpay, 1.0), 0.7), basePriceMaxPenalty, -basePriceNeutralPenalty)
+		}
+
+		if delta > 0 && condScore01 < valCondGateThreshold {
+			delta *= condScore01 / valCondGateThreshold
+		}
 	} else if p.PriceMax > 0 {
 		headroom := 1.0 - float64(p.Price)/float64(p.PriceMax)
 		switch {
@@ -498,6 +549,19 @@ func computeValueDelta(p FitnessParams, carAge int, condScore01 float64) (delta 
 	delta = clampRange(delta, valDeltaMin, valDeltaMax)
 	score01 = clamp01(0.5 + delta/5.0)
 	return delta, score01
+}
+
+func basePriceDiscount(carAge int) float64 {
+	switch {
+	case carAge <= 1:
+		return 0.97
+	case carAge <= 3:
+		return 0.94
+	case carAge <= 6:
+		return 0.90
+	default:
+		return 0.85
+	}
 }
 
 func computeEngineDelta(engineVolume float64, engineMinCC int) (delta float64, score01 float64) {

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -478,6 +478,113 @@ func TestComputeValueDelta_BudgetFallback(t *testing.T) {
 	})
 }
 
+func TestComputeValueDelta_PricelistFallback(t *testing.T) {
+	stubCurrentYear(t, 2026)
+
+	t.Run("below pricelist bonus", func(t *testing.T) {
+		p := FitnessParams{
+			Price: 65000, Year: 2019, Km: 80000, Hand: 2,
+			BasePrice: 100000,
+		}
+		delta, _ := computeValueDelta(p, 7, 0.8)
+		if delta < 0.5 {
+			t.Errorf("below-pricelist delta=%.3f, want >= 0.5", delta)
+		}
+	})
+
+	t.Run("at pricelist neutral", func(t *testing.T) {
+		p := FitnessParams{
+			Price: 85000, Year: 2019, Km: 105000, Hand: 2,
+			BasePrice: 100000,
+		}
+		delta, _ := computeValueDelta(p, 7, 0.5)
+		if delta < -0.5 || delta > 0.5 {
+			t.Errorf("at-pricelist delta=%.3f, want near zero", delta)
+		}
+	})
+
+	t.Run("above pricelist penalty", func(t *testing.T) {
+		p := FitnessParams{
+			Price: 110000, Year: 2019, Km: 105000, Hand: 2,
+			BasePrice: 100000,
+		}
+		delta, _ := computeValueDelta(p, 7, 0.5)
+		if delta > -0.2 {
+			t.Errorf("above-pricelist delta=%.3f, want <= -0.2", delta)
+		}
+	})
+
+	t.Run("low km adjusts expected price up", func(t *testing.T) {
+		base := FitnessParams{
+			Price: 80000, Year: 2022, Km: 60000, Hand: 1,
+			BasePrice: 100000,
+		}
+		lowKm := FitnessParams{
+			Price: 80000, Year: 2022, Km: 20000, Hand: 1,
+			BasePrice: 100000,
+		}
+		baseDelta, _ := computeValueDelta(base, 4, 0.8)
+		lowKmDelta, _ := computeValueDelta(lowKm, 4, 0.8)
+		if lowKmDelta <= baseDelta {
+			t.Errorf("low-km car should score better: lowKm=%.3f, normal=%.3f", lowKmDelta, baseDelta)
+		}
+	})
+
+	t.Run("pricelist preferred over budget", func(t *testing.T) {
+		withBase := FitnessParams{
+			Price: 95000, Year: 2022, Km: 50000, Hand: 1,
+			BasePrice: 100000, PriceMax: 120000,
+		}
+		budgetOnly := FitnessParams{
+			Price: 95000, Year: 2022, Km: 50000, Hand: 1,
+			PriceMax: 120000,
+		}
+		baseDelta, _ := computeValueDelta(withBase, 4, 0.5)
+		budgetDelta, _ := computeValueDelta(budgetOnly, 4, 0.5)
+		if baseDelta == budgetDelta {
+			t.Errorf("pricelist and budget should produce different deltas: base=%.3f, budget=%.3f", baseDelta, budgetDelta)
+		}
+	})
+
+	t.Run("dampened vs market mode", func(t *testing.T) {
+		viaMedian := FitnessParams{
+			Price: 60000, Year: 2022, Km: 50000, Hand: 1,
+			MedianPrice: 85000, MedianKm: 60000,
+		}
+		viaPricelist := FitnessParams{
+			Price: 60000, Year: 2022, Km: 50000, Hand: 1,
+			BasePrice: 100000,
+		}
+		medianDelta, _ := computeValueDelta(viaMedian, 4, 0.8)
+		pricelistDelta, _ := computeValueDelta(viaPricelist, 4, 0.8)
+		if pricelistDelta >= medianDelta {
+			t.Errorf("pricelist mode should be dampened: pricelist=%.3f, median=%.3f", pricelistDelta, medianDelta)
+		}
+	})
+}
+
+func TestBasePriceDiscount(t *testing.T) {
+	tests := []struct {
+		age  int
+		want float64
+	}{
+		{0, 0.97},
+		{1, 0.97},
+		{2, 0.94},
+		{3, 0.94},
+		{4, 0.90},
+		{6, 0.90},
+		{7, 0.85},
+		{15, 0.85},
+	}
+	for _, tt := range tests {
+		got := basePriceDiscount(tt.age)
+		if got != tt.want {
+			t.Errorf("basePriceDiscount(%d) = %.2f, want %.2f", tt.age, got, tt.want)
+		}
+	}
+}
+
 func TestComputeEngineDelta(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -195,8 +195,9 @@ const backfillListingSQL = `
 	UPDATE listing_history SET
 		km = CASE WHEN $2 > 0 AND listing_history.km <= 0 THEN $2 ELSE listing_history.km END,
 		city = CASE WHEN $3 != '' AND listing_history.city = '' THEN $3 ELSE listing_history.city END,
-		image_url = CASE WHEN $4 != '' AND listing_history.image_url = '' THEN $4 ELSE listing_history.image_url END
-	WHERE token = $1 AND (listing_history.km <= 0 OR listing_history.city = '' OR listing_history.image_url = '')`
+		image_url = CASE WHEN $4 != '' AND listing_history.image_url = '' THEN $4 ELSE listing_history.image_url END,
+		body_type = CASE WHEN $5 != '' AND listing_history.body_type = '' THEN $5 ELSE listing_history.body_type END
+	WHERE token = $1 AND (listing_history.km <= 0 OR listing_history.city = '' OR listing_history.image_url = '' OR listing_history.body_type = '')`
 
 func (s *Store) BackfillListings(ctx context.Context, records []storage.ListingRecord) error {
 	if len(records) == 0 {
@@ -213,7 +214,7 @@ func (s *Store) BackfillListings(ctx context.Context, records []storage.ListingR
 	}
 	defer func() { _ = stmt.Close() }()
 	for _, r := range records {
-		if _, err := stmt.ExecContext(ctx, r.Token, r.Km, r.City, r.ImageURL); err != nil {
+		if _, err := stmt.ExecContext(ctx, r.Token, r.Km, r.City, r.ImageURL, r.BodyType); err != nil {
 			return fmt.Errorf("backfill exec: %w", err)
 		}
 	}

--- a/web/src/components/ScoreBreakdownPopover.test.tsx
+++ b/web/src/components/ScoreBreakdownPopover.test.tsx
@@ -94,4 +94,40 @@ describe("ScoreBreakdownPopover", () => {
 
     expect(screen.queryByText("לא נכלל בציון")).not.toBeInTheDocument();
   });
+
+  it("shows value dimension with pricelist comparison when only base_price exists", async () => {
+    const listing: Listing = { ...baseListing(), base_price: 120000 };
+    render(
+      <ScoreBreakdownPopover
+        score={7.0}
+        breakdown={breakdown}
+        listing={listing}
+      />,
+    );
+    await openPopover();
+
+    expect(await screen.findByText("35%")).toBeInTheDocument();
+    expect(screen.getByText(/מול מחירון/)).toBeInTheDocument();
+    expect(screen.getByText(/מתחת למחירון/)).toBeInTheDocument();
+    expect(screen.queryByText("לא נכלל בציון")).not.toBeInTheDocument();
+  });
+
+  it("prefers market median over pricelist when both exist", async () => {
+    const listing: Listing = {
+      ...baseListing(),
+      median_price: 100000,
+      base_price: 120000,
+    };
+    render(
+      <ScoreBreakdownPopover
+        score={8.5}
+        breakdown={breakdown}
+        listing={listing}
+      />,
+    );
+    await openPopover();
+
+    expect(await screen.findByText(/מול חציון/)).toBeInTheDocument();
+    expect(screen.queryByText(/מול מחירון/)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/ScoreBreakdownPopover.tsx
+++ b/web/src/components/ScoreBreakdownPopover.tsx
@@ -113,13 +113,22 @@ function conditionInsights(listing: Listing): Insight[] {
 // backend only sets median_price once the cohort reaches MinCohortSize. A real
 // value *comparison* additionally needs a positive listing price (the insight
 // divides against it), so callers pair this guard with `listing.price > 0`.
-// Without a comparison the value dimension contributes a neutral delta to the
-// additive score, so the UI must not present it as a weighted contributor (see
-// the `excluded` handling below).
 function hasMarketData(
   listing: Listing,
 ): listing is Listing & { median_price: number } {
   return typeof listing.median_price === "number" && listing.median_price > 0;
+}
+
+function hasBasePrice(
+  listing: Listing,
+): listing is Listing & { base_price: number } {
+  return typeof listing.base_price === "number" && listing.base_price > 0;
+}
+
+function hasValueReference(listing: Listing): boolean {
+  return (
+    (hasMarketData(listing) || hasBasePrice(listing)) && listing.price > 0
+  );
 }
 
 function valueInsights(listing: Listing): Insight[] {
@@ -142,6 +151,29 @@ function valueInsights(listing: Listing): Insight[] {
     } else {
       insights.push({
         text: `${-diffPct}% מעל השוק`,
+        sentiment: "negative",
+      });
+    }
+  } else if (hasBasePrice(listing) && listing.price > 0) {
+    const diffPct = Math.round(
+      ((listing.base_price - listing.price) / listing.base_price) * 100,
+    );
+
+    insights.push({
+      text: `${fmtNum(listing.price)} ₪ מול מחירון ${fmtNum(listing.base_price)} ₪`,
+      sentiment: "neutral",
+    });
+
+    if (diffPct > 5) {
+      insights.push({
+        text: `${diffPct}% מתחת למחירון`,
+        sentiment: "positive",
+      });
+    } else if (diffPct >= -5) {
+      insights.push({ text: "קרוב למחירון", sentiment: "neutral" });
+    } else {
+      insights.push({
+        text: `${-diffPct}% מעל המחירון`,
         sentiment: "negative",
       });
     }
@@ -228,8 +260,7 @@ export function ScoreBreakdownPopover({
               // imply a contribution that never happened. A value comparison
               // needs both a market cohort and a positive price.
               const excluded =
-                dim.key === "value" &&
-                !(hasMarketData(listing) && listing.price > 0);
+                dim.key === "value" && !hasValueReference(listing);
               return (
                 <div
                   key={dim.key}


### PR DESCRIPTION
## Summary

The value dimension (שווי עסקה) in the fitness score previously fell back to a crude budget-headroom heuristic when fewer than 10 comparable listings existed. This made the score unreliable for niche models, rare trims, and luxury cars. Users saw "אין מספיק נתוני שוק להשוואה" and a meaningless value score.

This PR introduces the Yad2 pricelist (מחירון) as a **Tier 2 fallback** between market median and budget headroom:

- **Tier 1 — Market median** (unchanged): ≥10 comparable listings
- **Tier 2 — Pricelist (NEW)**: age-discounted, km/hand-adjusted reference with wider neutral zone and dampened bounds
- **Tier 3 — Budget headroom** (unchanged): last resort

### Scoring parameters

| Parameter | Market Median | Pricelist |
|-----------|:---:|:---:|
| Neutral zone | 0.92–1.05 | 0.88–1.10 |
| Max bonus | 2.5 | 1.8 |
| Max penalty | -3.5 | -2.8 |
| Km baseline | cohort median | 15k/yr × age |
| Age discount | — | 3–15% by age |

### Frontend

The popover now shows "₪X מול מחירון ₪Y" with percentage diff when pricelist data is available, replacing the uninformative "אין מספיק נתוני שוק" message. The `excluded` state only applies when neither median nor pricelist exists.

## Test plan

- [x] 6 new Go tests for pricelist tier (`TestComputeValueDelta_PricelistFallback`)
- [x] 8 new Go tests for age discount (`TestBasePriceDiscount`)
- [x] 2 new frontend tests (pricelist comparison display, median-over-pricelist priority)
- [x] All existing scoring tests pass unchanged
- [x] `golangci-lint` clean
- [ ] CI passes

closes #1456