### PR TITLE
fix(bodytype): classify from Yad2's structured bodyType field

### DIFF
--- a/internal/bodytype/bodytype.go
+++ b/internal/bodytype/bodytype.go
@@ -87,29 +87,45 @@ var matchers = []matcher{
 // canonical body types. These ids were verified against live feed data and are
 // stable, so they back up text matching when Yad2 uses a term we don't yet
 // recognize. Ids 5 and 8–13 have not been observed; text matching covers them.
-var yad2IDToType = map[int]string{
-	1:  Sedan,     // סדאן
-	2:  Hatchback, // האצ'בק
-	3:  Wagon,     // סטיישן / טורר
-	4:  Coupe,     // קופה
-	6:  SUV,       // ג'יפ שטח קשוח
-	7:  SUV,       // פנאי-שטח
-	14: Hatchback, // ליפטבק (liftback)
+// Implemented as a switch (not a package-level map) so the lookup is immutable.
+func yad2IDToType(id int) string {
+	switch id {
+	case 1:
+		return Sedan // סדאן
+	case 2:
+		return Hatchback // האצ'בק
+	case 3:
+		return Wagon // סטיישן / טורר
+	case 4:
+		return Coupe // קופה
+	case 6:
+		return SUV // ג'יפ שטח קשוח
+	case 7:
+		return SUV // פנאי-שטח
+	case 14:
+		return Hatchback // ליפטבק (liftback)
+	default:
+		return ""
+	}
 }
 
-// FromYad2 classifies a listing from Yad2's own bodyType field (id + Hebrew
-// text). Yad2 sets this attribute editorially, so it is far more reliable than
-// guessing from free-text sub-model names — prefer it.
+// FromYad2 classifies a listing from Yad2's own bodyType field (id + texts).
+// Yad2 sets this attribute editorially, so it is far more reliable than guessing
+// from free-text sub-model names — prefer it.
 //
-// Text is matched first because the Hebrew text is identical across the search
-// feed and the item page, whereas numeric ids are only verified for the feed.
-// The id map is a fallback for terms our vocabulary doesn't recognize yet.
-// Returns "" when neither yields a match (caller should fall back to sub-model).
-func FromYad2(id int, text string) string {
-	if bt := matchText(text); bt != "" {
-		return bt
+// Pass every text variant Yad2 provides (e.g. english_text, textEng, Hebrew
+// text); they are matched in order. Text is tried before the numeric id because
+// the same words appear on both the search feed and the item page, whereas ids
+// are only verified for the feed. The id is a fallback for terms our vocabulary
+// doesn't recognize yet. Returns "" when nothing matches (caller should then
+// fall back to sub-model parsing).
+func FromYad2(id int, texts ...string) string {
+	for _, t := range texts {
+		if bt := matchText(t); bt != "" {
+			return bt
+		}
 	}
-	return yad2IDToType[id]
+	return yad2IDToType(id)
 }
 
 // Parse scans free-text strings (e.g. sub-model names) for body-type keywords,

--- a/internal/bodytype/bodytype.go
+++ b/internal/bodytype/bodytype.go
@@ -41,12 +41,17 @@ func word(w string) func(string) bool {
 var matchers = []matcher{
 	{Hatchback, substr("האצ'בק")},
 	{Hatchback, substr("האצ׳בק")},
+	{Hatchback, substr("ליפטבק")}, // Yad2 "ליפטבק" (liftback) — grouped with hatchback
 	{Hatchback, substr("hatchback")},
+	{Hatchback, substr("liftback")},
 	{Hatchback, word("HB")},
 
 	{Sedan, substr("סדאן")},
 	{Sedan, substr("sedan")},
 
+	{SUV, substr("פנאי-שטח")}, // Yad2 "פנאי-שטח" — the most common crossover/SUV category
+	{SUV, substr("פנאי שטח")}, // spacing variant
+	{SUV, substr("שטח קשוח")}, // Yad2 "ג'יפ שטח קשוח" (rugged off-roader)
 	{SUV, substr("קרוסאובר")},
 	{SUV, substr("crossover")},
 	{SUV, substr("ג'יפ")},
@@ -70,6 +75,7 @@ var matchers = []matcher{
 	{Convertible, substr("cabrio")},
 
 	{Minivan, substr("מיניוון")},
+	{Minivan, substr("מיניוואן")},
 	{Minivan, substr("minivan")},
 	{Minivan, word("MPV")},
 
@@ -77,16 +83,55 @@ var matchers = []matcher{
 	{Pickup, substr("pickup")},
 }
 
+// yad2IDToType maps Yad2's numeric bodyType ids (from the vehicle feed) to our
+// canonical body types. These ids were verified against live feed data and are
+// stable, so they back up text matching when Yad2 uses a term we don't yet
+// recognize. Ids 5 and 8–13 have not been observed; text matching covers them.
+var yad2IDToType = map[int]string{
+	1:  Sedan,     // סדאן
+	2:  Hatchback, // האצ'בק
+	3:  Wagon,     // סטיישן / טורר
+	4:  Coupe,     // קופה
+	6:  SUV,       // ג'יפ שטח קשוח
+	7:  SUV,       // פנאי-שטח
+	14: Hatchback, // ליפטבק (liftback)
+}
+
+// FromYad2 classifies a listing from Yad2's own bodyType field (id + Hebrew
+// text). Yad2 sets this attribute editorially, so it is far more reliable than
+// guessing from free-text sub-model names — prefer it.
+//
+// Text is matched first because the Hebrew text is identical across the search
+// feed and the item page, whereas numeric ids are only verified for the feed.
+// The id map is a fallback for terms our vocabulary doesn't recognize yet.
+// Returns "" when neither yields a match (caller should fall back to sub-model).
+func FromYad2(id int, text string) string {
+	if bt := matchText(text); bt != "" {
+		return bt
+	}
+	return yad2IDToType[id]
+}
+
+// Parse scans free-text strings (e.g. sub-model names) for body-type keywords,
+// returning the first match. Use this only as a fallback when Yad2's structured
+// bodyType field is unavailable; prefer FromYad2.
 func Parse(texts ...string) string {
 	for _, text := range texts {
-		if text == "" {
-			continue
+		if bt := matchText(text); bt != "" {
+			return bt
 		}
-		lower := strings.ToLower(text)
-		for _, m := range matchers {
-			if m.match(lower) {
-				return m.bodyType
-			}
+	}
+	return ""
+}
+
+func matchText(text string) string {
+	if text == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	for _, m := range matchers {
+		if m.match(lower) {
+			return m.bodyType
 		}
 	}
 	return ""

--- a/internal/bodytype/bodytype_test.go
+++ b/internal/bodytype/bodytype_test.go
@@ -119,6 +119,21 @@ func TestFromYad2(t *testing.T) {
 	}
 }
 
+func TestFromYad2_MatchesAcrossTexts(t *testing.T) {
+	// English variant present, Hebrew empty — must still classify.
+	if got := FromYad2(0, "Sedan", ""); got != "sedan" {
+		t.Errorf(`FromYad2(0, "Sedan", "") = %q, want "sedan"`, got)
+	}
+	// First text unrecognized, later text matches.
+	if got := FromYad2(0, "weird-value", "פנאי-שטח"); got != "suv" {
+		t.Errorf(`FromYad2(0, "weird-value", "פנאי-שטח") = %q, want "suv"`, got)
+	}
+	// No text matches but a verified id does (defense-in-depth).
+	if got := FromYad2(7, "weird-value", ""); got != "suv" {
+		t.Errorf(`FromYad2(7, "weird-value", "") = %q, want "suv"`, got)
+	}
+}
+
 func TestParse_MultipleTexts(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/bodytype/bodytype_test.go
+++ b/internal/bodytype/bodytype_test.go
@@ -22,7 +22,16 @@ func TestParse(t *testing.T) {
 		{"hebrew convertible cabrio", "Sport קבריולה 2.0", "convertible"},
 		{"hebrew convertible cabriolet", "קבריולט 1.8", "convertible"},
 		{"hebrew minivan", "Comfort מיניוון 2.0 (150 כ״ס)", "minivan"},
+		{"hebrew minivan alt spelling", "Comfort מיניוואן 2.0", "minivan"},
 		{"hebrew pickup", "Limited טנדר 3.0 (190 כ״ס)", "pickup"},
+
+		// Yad2 official bodyType vocabulary (previously unmatched → fell back to
+		// sub-model parsing). These are the values from the structured field.
+		{"yad2 crossover leisure", "פנאי-שטח", "suv"},
+		{"yad2 crossover leisure spaced", "פנאי שטח", "suv"},
+		{"yad2 rugged jeep", "ג'יפ שטח קשוח", "suv"},
+		{"yad2 liftback", "ליפטבק", "hatchback"},
+		{"yad2 station tourer", "סטיישן / טורר", "wagon"},
 
 		// English body types
 		{"english sedan", "Comfort sedan 1.6", "sedan"},
@@ -68,6 +77,43 @@ func TestParse(t *testing.T) {
 			got := Parse(tt.subModel)
 			if got != tt.want {
 				t.Errorf("Parse(%q) = %q, want %q", tt.subModel, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFromYad2(t *testing.T) {
+	tests := []struct {
+		name string
+		id   int
+		text string
+		want string
+	}{
+		// Verified Yad2 feed ids → canonical type (text matched too).
+		{"id 1 sedan", 1, "סדאן", "sedan"},
+		{"id 2 hatchback", 2, "האצ'בק", "hatchback"},
+		{"id 3 wagon", 3, "סטיישן / טורר", "wagon"},
+		{"id 4 coupe", 4, "קופה", "coupe"},
+		{"id 6 rugged suv", 6, "ג'יפ שטח קשוח", "suv"},
+		{"id 7 crossover suv", 7, "פנאי-שטח", "suv"},
+		{"id 14 liftback", 14, "ליפטבק", "hatchback"},
+
+		// Text matches our vocabulary even when the id is unknown.
+		{"unknown id known text", 99, "סדאן", "sedan"},
+
+		// Unknown text but a verified id still classifies (defense-in-depth for
+		// a future Yad2 wording change).
+		{"known id unrecognized text", 7, "מילה חדשה", "suv"},
+
+		// Neither resolves → empty (caller falls back to sub-model parsing).
+		{"unknown id and text", 0, "", ""},
+		{"unknown id unknown text", 99, "משהו אחר", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromYad2(tt.id, tt.text)
+			if got != tt.want {
+				t.Errorf("FromYad2(%d, %q) = %q, want %q", tt.id, tt.text, got, tt.want)
 			}
 		})
 	}

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -129,10 +129,8 @@ func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 	}
 
 	if d.BodyType != nil {
-		details.BodyType = bodytype.Parse(
-			firstNonEmpty(d.BodyType.TextEng, d.BodyType.Text),
-			d.BodyType.Text,
-		)
+		// Yad2's structured bodyType is authoritative; classify directly from it.
+		details.BodyType = bodytype.FromYad2(d.BodyType.ID, firstNonEmpty(d.BodyType.Text, d.BodyType.TextEng))
 	}
 
 	// Extract original ownership: try OriginalOwnership, PreviousOwnership, Ownership.

--- a/internal/fetcher/yad2/item_parser.go
+++ b/internal/fetcher/yad2/item_parser.go
@@ -129,8 +129,9 @@ func detailsFromPageData(d itemPageData) (ItemDetails, bool) {
 	}
 
 	if d.BodyType != nil {
-		// Yad2's structured bodyType is authoritative; classify directly from it.
-		details.BodyType = bodytype.FromYad2(d.BodyType.ID, firstNonEmpty(d.BodyType.Text, d.BodyType.TextEng))
+		// Yad2's structured bodyType is authoritative; classify directly from it,
+		// matching both the English and Hebrew text variants.
+		details.BodyType = bodytype.FromYad2(d.BodyType.ID, d.BodyType.TextEng, d.BodyType.Text)
 	}
 
 	// Extract original ownership: try OriginalOwnership, PreviousOwnership, Ownership.

--- a/internal/fetcher/yad2/item_parser_test.go
+++ b/internal/fetcher/yad2/item_parser_test.go
@@ -259,6 +259,26 @@ func TestParseItemPage_BodyType(t *testing.T) {
 	}
 }
 
+func TestParseItemPage_BodyTypeYad2Vocabulary(t *testing.T) {
+	// "פנאי-שטח" is Yad2's most common SUV/crossover label; the old keyword
+	// matcher missed it, leaving body type empty on the enrichment path too.
+	html := `<html><body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+  "km": 41000,
+  "bodyType": {"text": "פנאי-שטח", "id": 7}
+}}}]}}}}
+</script>
+</body></html>`
+	details, err := ParseItemPage(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if details.BodyType != "suv" {
+		t.Errorf("BodyType = %q, want suv (from Yad2 פנאי-שטח)", details.BodyType)
+	}
+}
+
 func TestParseItemPage_BodyTypeHebrewOnly(t *testing.T) {
 	html := `<html><body>
 <script id="__NEXT_DATA__" type="application/json">

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -254,7 +254,12 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 		listing.GearBox = "אוטומט"
 	}
 
-	listing.BodyType = bodytype.Parse(textFromField(item.BodyType), item.BodyType.Text, subModelText, item.SubModel.Text)
+	// Prefer Yad2's structured bodyType field (authoritative); only guess from
+	// the free-text sub-model name when Yad2 gives us no usable classification.
+	listing.BodyType = bodytype.FromYad2(item.BodyType.ID, item.BodyType.Text)
+	if listing.BodyType == "" {
+		listing.BodyType = bodytype.Parse(subModelText, item.SubModel.Text)
+	}
 
 	listing.City = textFromField(item.Address.City)
 	listing.Area = textFromField(item.Address.Area)

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -256,7 +256,9 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 
 	// Prefer Yad2's structured bodyType field (authoritative); only guess from
 	// the free-text sub-model name when Yad2 gives us no usable classification.
-	listing.BodyType = bodytype.FromYad2(item.BodyType.ID, item.BodyType.Text)
+	// textFromField prefers the English variants, with the raw Hebrew text as a
+	// further fallback so we match whichever Yad2 populated.
+	listing.BodyType = bodytype.FromYad2(item.BodyType.ID, textFromField(item.BodyType), item.BodyType.Text)
 	if listing.BodyType == "" {
 		listing.BodyType = bodytype.Parse(subModelText, item.SubModel.Text)
 	}

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -884,3 +884,70 @@ func TestParseNextData_BodyTypeFallsBackToHebrewText(t *testing.T) {
 		t.Errorf("BodyType = %q, want 'hatchback' (from Hebrew text fallback when english_text lacks body type)", listings[0].BodyType)
 	}
 }
+
+// TestParseNextData_BodyTypeYad2VocabularyOverSubModel covers the cases the old
+// keyword matcher missed: Yad2's official "פנאי-שטח" (crossover/SUV), "ג'יפ שטח
+// קשוח" and "ליפטבק" were absent from the keyword list, so they silently fell
+// back to guessing from the sub-model. The structured Yad2 field now wins.
+func TestParseNextData_BodyTypeYad2VocabularyOverSubModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		bodyType string // raw JSON for the bodyType field
+		subModel string
+		want     string
+	}{
+		{
+			name:     "crossover leisure (id 7), sub-model has no body keyword",
+			bodyType: `{"id":7,"text":"פנאי-שטח"}`,
+			subModel: "Premium אוט׳ 2.0 (165 כ״ס)",
+			want:     "suv",
+		},
+		{
+			name:     "rugged jeep (id 6)",
+			bodyType: `{"id":6,"text":"ג'יפ שטח קשוח"}`,
+			subModel: "Limited 2.8 (204 כ״ס)",
+			want:     "suv",
+		},
+		{
+			name:     "liftback (id 14) classified, not left empty",
+			bodyType: `{"id":14,"text":"ליפטבק"}`,
+			subModel: "Sport אוט׳ 1.8",
+			want:     "hatchback",
+		},
+		{
+			name:     "Yad2 SUV wins over a sub-model that says האצ'בק",
+			bodyType: `{"id":7,"text":"פנאי-שטח"}`,
+			subModel: "Cross האצ'בק 1.5",
+			want:     "suv",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(`{
+				"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
+					"data":{"feed":{"feed_items":[{
+						"token":"bt-vocab",
+						"manufacturer":{"id":27,"text":"מאזדה"},
+						"model":{"id":10332,"text":"3"},
+						"subModel":{"id":105280,"text":"` + tt.subModel + `"},
+						"bodyType":` + tt.bodyType + `,
+						"vehicleDates":{"yearOfProduction":2021},
+						"price":95000,
+						"hand":{"id":2},
+						"metaData":{"coverImage":"https://img.yad2.co.il/test.jpg"}
+					}]}}
+				}}}]}}}
+			}`)
+			listings, err := parseNextData(data, nil)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if len(listings) != 1 {
+				t.Fatalf("expected 1 listing, got %d", len(listings))
+			}
+			if listings[0].BodyType != tt.want {
+				t.Errorf("BodyType = %q, want %q", listings[0].BodyType, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The body-type filter is only as good as the stored `body_type`, and that was effectively coming from **sub-model keyword guessing** — not Yad2's own classification.

`bodytype.Parse` *did* look at Yad2's `bodyType.text` first, but its keyword list was incomplete. Verified against live feed data, Yad2's body-type vocabulary is:

| id | Hebrew | maps to |
|----|--------|---------|
| 1 | סדאן | sedan |
| 2 | האצ'בק | hatchback |
| 3 | סטיישן / טורר | wagon |
| 4 | קופה | coupe |
| 6 | ג'יפ שטח קשוח | suv |
| 7 | **פנאי-שטח** | suv |
| 14 | **ליפטבק** | hatchback |

`פנאי-שטח` (the **most common** crossover/SUV category) and `ליפטבק` had **no matcher**, so they silently fell through to parsing the free-text sub-model — which usually has no body keyword. Result: SUVs left unclassified or mis-guessed. (#1454 added the field but, because of this gap, "made no difference" for exactly these types.)

## Fix

- **`bodytype.FromYad2(id, text)`** — classify directly from Yad2's structured field. Hebrew text is matched against a vocabulary that now includes `פנאי-שטח`, `ג'יפ שטח קשוח`, `ליפטבק` (+ spelling variants), backed by a **verified `id`→type map** as defense-in-depth.
- **Text-first, id-second:** the Hebrew text is identical across the search feed and the item page, whereas ids are only verified for the feed — so text matching avoids any risk of a feed-vs-item id mismatch, and a wrong id can never produce a wrong classification.
- **Parser & enricher** now prefer `FromYad2` (authoritative) and fall back to sub-model parsing **only** when Yad2 gives no classification.

### Behaviour change vs #1454
- `{id:7,"פנאי-שטח"}` → **suv** (was: sub-model guess, usually empty)
- `{id:14,"ליפטבק"}` → **hatchback** (was: empty)
- `{id:6,"ג'יפ שטח קשוח"}` → **suv**
- Yad2 SUV now **overrides** a sub-model that misleadingly says `האצ'בק`

Existing rows self-heal on the next scrape — the upsert overwrites `body_type` whenever the incoming value is non-empty.

## Tests
- `TestFromYad2` — id map, text-wins-over-id, id-fallback for unrecognized text, empty cases.
- `TestParse` — added Yad2 vocabulary (`פנאי-שטח`, `ג'יפ שטח קשוח`, `ליפטבק`, `סטיישן / טורר`, minivan spelling).
- `TestParseNextData_BodyTypeYad2VocabularyOverSubModel` — feed path: the previously-missed types classify and override sub-model.
- `TestParseItemPage_BodyTypeYad2Vocabulary` — enrichment path covered too.

`go build ./...` ✅ · `go test ./internal/bodytype ./internal/fetcher/yad2` ✅ · `go vet` ✅ · `golangci-lint --new-from-rev=origin/main` → 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved body type recognition for more Hebrew and variant spellings, including additional SUV, hatchback, liftback, and minivan forms.
  * Added support for using structured body-type values when available, with a fallback to text-based matching.

* **Bug Fixes**
  * Reduced misclassification by prioritizing structured vehicle data over looser keyword matching.
  * Improved handling when only partial or non-standard body-type text is present.

* **Tests**
  * Expanded coverage for body-type matching and verification across multiple input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->