### PR TITLE
fix(enricher): backfill body_type for already-enriched listings

### DIFF
--- a/internal/enricher/worker.go
+++ b/internal/enricher/worker.go
@@ -67,7 +67,7 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 
 	carAttrs := w.carAttrs(ctx, req, existing)
 
-	if rec, ok := existing[req.Token]; ok && rec.Km > 0 && rec.City != "" && rec.ImageURL != "" {
+	if rec, ok := existing[req.Token]; ok && rec.Km > 0 && rec.City != "" && rec.ImageURL != "" && rec.BodyType != "" {
 		w.logger.DebugContext(ctx, "listing already enriched, skipping", carAttrs...)
 		if telemetry.EnrichSkipped != nil {
 			telemetry.EnrichSkipped.Add(ctx, 1)
@@ -146,6 +146,15 @@ func (w *Worker) HandleRequest(ctx context.Context, req broker.EnrichRequest) er
 
 	if details.Km > 0 && details.City != "" && details.ImageURL != "" {
 		w.maybeResetUnenriched(ctx)
+		if details.BodyType == "" {
+			// Core fields are present but the item page yielded no body type.
+			// Stamp the attempt (last_enrich_at) so the 1h backlog throttle and
+			// the 10-attempt cap prevent re-fetching this listing every cycle.
+			if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
+				w.logger.ErrorContext(ctx, "failed to increment enrich attempt for body-type-missing listing",
+					"token", req.Token, "error", incErr.Error())
+			}
+		}
 	} else if details.Km <= 0 {
 		if incErr := w.listings.IncrementEnrichAttempt(ctx, req.Token); incErr != nil {
 			w.logger.ErrorContext(ctx, "failed to increment enrich attempt for km-unavailable listing",

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -153,7 +153,7 @@ type discardWriter struct{}
 func (d *discardWriter) Write(p []byte) (int, error) { return len(p), nil }
 
 func TestWorker_EnrichesSuccessfully(t *testing.T) {
-	f := &mockItemFetcher{details: ItemDetails{Km: 50000, City: "Tel Aviv", ImageURL: "https://img.yad2.co.il/test.jpg"}}
+	f := &mockItemFetcher{details: ItemDetails{Km: 50000, City: "Tel Aviv", ImageURL: "https://img.yad2.co.il/test.jpg", BodyType: "sedan"}}
 	ls := newMockListingStore()
 	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
 	w := NewWorker(f, ls, rl, testWorkerLogger())
@@ -183,7 +183,7 @@ func TestWorker_EnrichesSuccessfully(t *testing.T) {
 func TestWorker_SkipsAlreadyEnriched(t *testing.T) {
 	f := &mockItemFetcher{details: ItemDetails{Km: 99999}}
 	ls := newMockListingStore()
-	ls.enrichmentData["tok-1"] = storage.EnrichmentRecord{Km: 50000, City: "Tel Aviv", ImageURL: "https://img.example/1.jpg"}
+	ls.enrichmentData["tok-1"] = storage.EnrichmentRecord{Km: 50000, City: "Tel Aviv", ImageURL: "https://img.example/1.jpg", BodyType: "sedan"}
 	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
 	w := NewWorker(f, ls, rl, testWorkerLogger())
 
@@ -207,31 +207,36 @@ func TestWorker_ContinuesWhenOnlyPartiallyEnriched(t *testing.T) {
 	}{
 		{
 			name:   "missing km",
-			record: storage.EnrichmentRecord{Km: 0, City: "Tel Aviv", ImageURL: "https://img.example/1.jpg"},
+			record: storage.EnrichmentRecord{Km: 0, City: "Tel Aviv", ImageURL: "https://img.example/1.jpg", BodyType: "sedan"},
 		},
 		{
 			name:   "missing city",
-			record: storage.EnrichmentRecord{Km: 50000, City: "", ImageURL: "https://img.example/1.jpg"},
+			record: storage.EnrichmentRecord{Km: 50000, City: "", ImageURL: "https://img.example/1.jpg", BodyType: "sedan"},
 		},
 		{
 			name:   "missing image",
-			record: storage.EnrichmentRecord{Km: 50000, City: "Tel Aviv", ImageURL: ""},
+			record: storage.EnrichmentRecord{Km: 50000, City: "Tel Aviv", ImageURL: "", BodyType: "sedan"},
+		},
+		{
+			// The case this PR fixes: core data present, only body type missing.
+			name:   "missing only body type",
+			record: storage.EnrichmentRecord{Km: 50000, City: "Tel Aviv", ImageURL: "https://img.example/1.jpg", BodyType: ""},
 		},
 		{
 			name:   "missing km and city",
-			record: storage.EnrichmentRecord{Km: 0, City: "", ImageURL: "https://img.example/1.jpg"},
+			record: storage.EnrichmentRecord{Km: 0, City: "", ImageURL: "https://img.example/1.jpg", BodyType: "sedan"},
 		},
 		{
 			name:   "missing km and image",
-			record: storage.EnrichmentRecord{Km: 0, City: "Tel Aviv", ImageURL: ""},
+			record: storage.EnrichmentRecord{Km: 0, City: "Tel Aviv", ImageURL: "", BodyType: "sedan"},
 		},
 		{
 			name:   "missing city and image",
-			record: storage.EnrichmentRecord{Km: 50000, City: "", ImageURL: ""},
+			record: storage.EnrichmentRecord{Km: 50000, City: "", ImageURL: "", BodyType: "sedan"},
 		},
 		{
 			name:   "all missing",
-			record: storage.EnrichmentRecord{Km: 0, City: "", ImageURL: ""},
+			record: storage.EnrichmentRecord{Km: 0, City: "", ImageURL: "", BodyType: ""},
 		},
 	}
 
@@ -409,6 +414,40 @@ func TestWorker_EnrichesBodyType(t *testing.T) {
 	}
 	if ls.backfilled[0].BodyType != "hatchback" {
 		t.Errorf("backfilled body_type = %q, want hatchback", ls.backfilled[0].BodyType)
+	}
+}
+
+// TestWorker_RefetchesWhenOnlyBodyTypeMissing verifies the listing is re-fetched
+// (not skipped) when only its body type is missing, and that a successful fetch
+// which still yields no body type stamps an enrich attempt — engaging the 1h
+// backlog throttle / 10-attempt cap so it isn't re-fetched every cycle.
+func TestWorker_RefetchesWhenOnlyBodyTypeMissing(t *testing.T) {
+	f := &mockItemFetcher{details: ItemDetails{
+		Km: 50000, City: "Tel Aviv", ImageURL: "https://img.yad2.co.il/x.jpg",
+		// item page yielded no body type
+	}}
+	ls := newMockListingStore()
+	ls.enrichmentData["tok-bt"] = storage.EnrichmentRecord{
+		Km: 50000, City: "Tel Aviv", ImageURL: "https://img.yad2.co.il/x.jpg", BodyType: "",
+	}
+	rl := NewAdaptiveRateLimiter(time.Millisecond, time.Second, time.Second)
+	w := NewWorker(f, ls, rl, testWorkerLogger())
+
+	if err := w.HandleRequest(context.Background(), broker.EnrichRequest{Token: "tok-bt", Source: "backfill"}); err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	f.mu.Lock()
+	calls := f.calls
+	f.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("expected 1 fetch (body type missing), got %d", calls)
+	}
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if ls.enrichAttempts["tok-bt"] != 1 {
+		t.Errorf("expected enrich attempt stamped to throttle re-fetch, got %d", ls.enrichAttempts["tok-bt"])
 	}
 }
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -210,8 +210,8 @@ type DBPoolStats struct {
 	WaitDuration       string `json:"wait_duration"`
 }
 
-// EnrichmentRecord holds km/city/image data previously learned for a listing token,
-// along with car-identifying fields for log context.
+// EnrichmentRecord holds km/city/image/body-type data previously learned for a
+// listing token, along with car-identifying fields for log context.
 type EnrichmentRecord struct {
 	Manufacturer string
 	Model        string
@@ -221,6 +221,7 @@ type EnrichmentRecord struct {
 	Km           int
 	City         string
 	ImageURL     string
+	BodyType     string
 }
 
 // ListingIdentity holds car-identifying fields for a listing token.

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -262,8 +262,7 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 			var tok, manufacturer, model, searchName, city, img, bodyType string
 			var year, price, km int
 			if err := rows.Scan(&tok, &manufacturer, &model, &year, &price, &searchName, &km, &city, &img, &bodyType); err != nil {
-				_ = rows.Close()
-				return nil, fmt.Errorf("scan enrichment data: %w", err)
+				return nil, errors.Join(fmt.Errorf("scan enrichment data: %w", err), rows.Close())
 			}
 			out[tok] = storage.EnrichmentRecord{
 				Manufacturer: manufacturer, Model: model, Year: year, Price: price, SearchName: searchName,
@@ -271,8 +270,7 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 			}
 		}
 		if err := rows.Err(); err != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("enrichment rows: %w", err)
+			return nil, errors.Join(fmt.Errorf("enrichment rows: %w", err), rows.Close())
 		}
 		_ = rows.Close()
 	}

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -73,8 +73,13 @@ const upsertListingSQL = `
 		score_engine = COALESCE(EXCLUDED.score_engine, listing_history.score_engine),
 		original_ownership = COALESCE(EXCLUDED.original_ownership, listing_history.original_ownership)`
 
+// Note: body_type is intentionally in the backlog selection but NOT in
+// unenrichedMissingFieldsWhereSQL (which drives ResetUnenrichedAttempts). This
+// lets the enricher re-fetch listings missing only a body type, while the
+// 10-attempt cap still bounds listings whose item page never yields one
+// (otherwise the reset query would keep clearing their attempts → re-fetch loop).
 const unenrichedBacklogWhereSQL = `
-(km <= 0 OR COALESCE(city, '') = '' OR COALESCE(image_url, '') = '' OR COALESCE(original_ownership, '') = '')
+(km <= 0 OR COALESCE(city, '') = '' OR COALESCE(image_url, '') = '' OR COALESCE(original_ownership, '') = '' OR COALESCE(body_type, '') = '')
 AND enrich_attempts < 10
 AND (last_enrich_at IS NULL OR last_enrich_at < NOW() - INTERVAL '1 hour')
 AND first_seen_at > NOW() - INTERVAL '7 days'`
@@ -243,7 +248,7 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 			placeholders[i] = fmt.Sprintf("$%d", i+1)
 		}
 
-		q := `SELECT DISTINCT ON (token) token, manufacturer, model, year, price, search_name, km, city, image_url
+		q := `SELECT DISTINCT ON (token) token, manufacturer, model, year, price, search_name, km, city, image_url, COALESCE(body_type, '')
 			FROM listing_history
 			WHERE token IN (` + strings.Join(placeholders, ", ") + `) AND (km > 0 OR city != '' OR image_url != '')
 			ORDER BY token, first_seen_at DESC`
@@ -254,15 +259,15 @@ func (s *Store) LookupEnrichmentData(ctx context.Context, tokens []string) (map[
 		}
 
 		for rows.Next() {
-			var tok, manufacturer, model, searchName, city, img string
+			var tok, manufacturer, model, searchName, city, img, bodyType string
 			var year, price, km int
-			if err := rows.Scan(&tok, &manufacturer, &model, &year, &price, &searchName, &km, &city, &img); err != nil {
+			if err := rows.Scan(&tok, &manufacturer, &model, &year, &price, &searchName, &km, &city, &img, &bodyType); err != nil {
 				_ = rows.Close()
 				return nil, fmt.Errorf("scan enrichment data: %w", err)
 			}
 			out[tok] = storage.EnrichmentRecord{
 				Manufacturer: manufacturer, Model: model, Year: year, Price: price, SearchName: searchName,
-				Km: km, City: city, ImageURL: img,
+				Km: km, City: city, ImageURL: img, BodyType: bodyType,
 			}
 		}
 		if err := rows.Err(); err != nil {

--- a/internal/storage/postgres/listings_enrich_test.go
+++ b/internal/storage/postgres/listings_enrich_test.go
@@ -76,13 +76,27 @@ func TestPostgres_LookupEnrichmentData(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	// en-3 is enriched for km/city/image but predates body_type — a legacy row
+	// with a NULL body_type. It must still be returned, with BodyType == ""
+	// (exercising the COALESCE(body_type, '') in LookupEnrichmentData).
+	if err := store.SaveListing(ctx, storage.ListingRecord{
+		Token: "en-3", ChatID: 100, SearchName: "search-c",
+		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
+		Km: 60000, City: "Haifa", ImageURL: "https://img/en3", FirstSeenAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DB().ExecContext(ctx,
+		`UPDATE listing_history SET body_type = NULL WHERE token = $1 AND chat_id = $2`, "en-3", int64(100)); err != nil {
+		t.Fatalf("null out body_type: %v", err)
+	}
 
-	m, err := store.LookupEnrichmentData(ctx, []string{"en-1", "en-2", "missing"})
+	m, err := store.LookupEnrichmentData(ctx, []string{"en-1", "en-2", "en-3", "missing"})
 	if err != nil {
 		t.Fatalf("LookupEnrichmentData: %v", err)
 	}
-	if len(m) != 1 {
-		t.Fatalf("expected 1 enriched token, got %d (%+v)", len(m), m)
+	if len(m) != 2 {
+		t.Fatalf("expected 2 enriched tokens, got %d (%+v)", len(m), m)
 	}
 	rec, ok := m["en-1"]
 	if !ok {
@@ -93,6 +107,17 @@ func TestPostgres_LookupEnrichmentData(t *testing.T) {
 	}
 	if rec.BodyType != "sedan" {
 		t.Errorf("enrichment record body_type = %q, want sedan", rec.BodyType)
+	}
+
+	legacy, ok := m["en-3"]
+	if !ok {
+		t.Fatal("en-3 (NULL body_type) missing from result")
+	}
+	if legacy.Km != 60000 || legacy.City != "Haifa" {
+		t.Errorf("legacy enrichment record = %+v", legacy)
+	}
+	if legacy.BodyType != "" {
+		t.Errorf("legacy body_type = %q, want \"\" (NULL coalesced)", legacy.BodyType)
 	}
 }
 

--- a/internal/storage/postgres/listings_enrich_test.go
+++ b/internal/storage/postgres/listings_enrich_test.go
@@ -65,7 +65,7 @@ func TestPostgres_LookupEnrichmentData(t *testing.T) {
 	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "en-1", ChatID: 100, SearchName: "search-a",
 		Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000,
-		Km: 50000, City: "Tel Aviv", ImageURL: "https://img/en1", FirstSeenAt: time.Now(),
+		Km: 50000, City: "Tel Aviv", ImageURL: "https://img/en1", BodyType: "sedan", FirstSeenAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -90,6 +90,9 @@ func TestPostgres_LookupEnrichmentData(t *testing.T) {
 	}
 	if rec.Km != 50000 || rec.City != "Tel Aviv" || rec.ImageURL != "https://img/en1" || rec.SearchName != "search-a" {
 		t.Errorf("enrichment record = %+v", rec)
+	}
+	if rec.BodyType != "sedan" {
+		t.Errorf("enrichment record body_type = %q, want sedan", rec.BodyType)
 	}
 }
 

--- a/internal/storage/postgres/listings_enrich_test.go
+++ b/internal/storage/postgres/listings_enrich_test.go
@@ -76,19 +76,15 @@ func TestPostgres_LookupEnrichmentData(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// en-3 is enriched for km/city/image but predates body_type — a legacy row
-	// with a NULL body_type. It must still be returned, with BodyType == ""
-	// (exercising the COALESCE(body_type, '') in LookupEnrichmentData).
+	// en-3 is enriched for km/city/image but has no body_type — the regression
+	// this PR targets. body_type is NOT NULL DEFAULT '', so the "missing" state
+	// is the empty string. It must still be returned, with BodyType == "".
 	if err := store.SaveListing(ctx, storage.ListingRecord{
 		Token: "en-3", ChatID: 100, SearchName: "search-c",
 		Manufacturer: "Mazda", Model: "3", Year: 2021, Price: 90000,
-		Km: 60000, City: "Haifa", ImageURL: "https://img/en3", FirstSeenAt: time.Now(),
+		Km: 60000, City: "Haifa", ImageURL: "https://img/en3", BodyType: "", FirstSeenAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
-	}
-	if _, err := store.DB().ExecContext(ctx,
-		`UPDATE listing_history SET body_type = NULL WHERE token = $1 AND chat_id = $2`, "en-3", int64(100)); err != nil {
-		t.Fatalf("null out body_type: %v", err)
 	}
 
 	m, err := store.LookupEnrichmentData(ctx, []string{"en-1", "en-2", "en-3", "missing"})
@@ -109,15 +105,15 @@ func TestPostgres_LookupEnrichmentData(t *testing.T) {
 		t.Errorf("enrichment record body_type = %q, want sedan", rec.BodyType)
 	}
 
-	legacy, ok := m["en-3"]
+	noBody, ok := m["en-3"]
 	if !ok {
-		t.Fatal("en-3 (NULL body_type) missing from result")
+		t.Fatal("en-3 (empty body_type) missing from result")
 	}
-	if legacy.Km != 60000 || legacy.City != "Haifa" {
-		t.Errorf("legacy enrichment record = %+v", legacy)
+	if noBody.Km != 60000 || noBody.City != "Haifa" {
+		t.Errorf("body-type-missing enrichment record = %+v", noBody)
 	}
-	if legacy.BodyType != "" {
-		t.Errorf("legacy body_type = %q, want \"\" (NULL coalesced)", legacy.BodyType)
+	if noBody.BodyType != "" {
+		t.Errorf("body_type = %q, want \"\"", noBody.BodyType)
 	}
 }
 

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -1592,11 +1592,18 @@ func TestPostgres_UnenrichedBacklogFilters(t *testing.T) {
 	save("has-city", 0, "Tel Aviv", "")
 	save("has-image", 0, "", "https://img.example/1.jpg")
 	save("has-km", 120000, "", "")
+	save("missing-bodytype", 120000, "Tel Aviv", "https://img.example/3.jpg")
 	save("fully-enriched", 120000, "Tel Aviv", "https://img.example/2.jpg")
-	// Mark fully-enriched with original_ownership so it's excluded from the backlog.
+	// fully-enriched has every enrichment field (incl. ownership + body_type), so
+	// it's excluded; missing-bodytype has everything EXCEPT body_type, so the
+	// backlog must still select it for re-enrichment.
 	if _, err := store.DB().ExecContext(ctx,
-		`UPDATE listing_history SET original_ownership = 'private' WHERE token = $1 AND chat_id = $2`, "fully-enriched", int64(100)); err != nil {
-		t.Fatalf("set original_ownership: %v", err)
+		`UPDATE listing_history SET original_ownership = 'private', body_type = 'sedan' WHERE token = $1 AND chat_id = $2`, "fully-enriched", int64(100)); err != nil {
+		t.Fatalf("set fully-enriched fields: %v", err)
+	}
+	if _, err := store.DB().ExecContext(ctx,
+		`UPDATE listing_history SET original_ownership = 'private' WHERE token = $1 AND chat_id = $2`, "missing-bodytype", int64(100)); err != nil {
+		t.Fatalf("set missing-bodytype ownership: %v", err)
 	}
 	save("maxed-attempts", 0, "", "")
 	save("cooldown", 0, "", "")
@@ -1614,9 +1621,9 @@ func TestPostgres_UnenrichedBacklogFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListUnenrichedTokens: %v", err)
 	}
-	// OR-based filter: listings missing ANY of km/city/image/original_ownership are unenriched.
-	// Excluded: fully-enriched (has all including ownership), maxed-attempts (>=10), cooldown (recent).
-	want := map[string]bool{"unenriched-ok": true, "has-city": true, "has-image": true, "has-km": true}
+	// OR-based filter: listings missing ANY of km/city/image/original_ownership/body_type are unenriched.
+	// Excluded: fully-enriched (has all incl. ownership + body_type), maxed-attempts (>=10), cooldown (recent).
+	want := map[string]bool{"unenriched-ok": true, "has-city": true, "has-image": true, "has-km": true, "missing-bodytype": true}
 	if len(tokens) != len(want) {
 		t.Fatalf("ListUnenrichedTokens returned %d tokens, want %d: %v", len(tokens), len(want), tokens)
 	}


### PR DESCRIPTION
## Why

Follow-up to #1460. Verifying #1460 in prod showed body types still weren't populating. Root cause: **the Yad2 search feed omits `bodyType`** (confirmed from a live feed sample — it has `manufacturer/model/subModel/...` but no `bodyType`). Body type is only on the **item page**, which the enricher fetches.

But the enricher never reached these listings:
- The backlog selection (`unenrichedBacklogWhereSQL`) only looked for missing `km`/`city`/`image`/`ownership`.
- The worker's "already enriched, skipping" check only required `km>0 && city && image`.

So a listing with km/city/image present but **no body type** was treated as fully enriched and never re-fetched — its `body_type` stayed empty forever, and the body-type filter facet was dead for those cars (e.g. the Corollas/Outlanders in prod).

## Fix

- `unenrichedBacklogWhereSQL` now also selects listings missing `body_type`.
- The worker skip check requires `body_type` before treating a listing as fully enriched.
- `EnrichmentRecord` / `LookupEnrichmentData` now carry `body_type` so the skip check can see it.
- When a successful item fetch yields **no** body type, stamp an enrich attempt so the existing 1h backlog throttle + 10-attempt cap prevent a re-fetch loop.

### Loop-safety detail
`body_type` is added to the **backlog** predicate but deliberately **not** to `unenrichedMissingFieldsWhereSQL`, which drives `ResetUnenrichedAttempts`. If the reset query kept clearing attempts for body-type-missing listings, the 10-attempt cap would never bound a listing whose item page genuinely never returns a body type. `CountUnenrichedTokens` uses the backlog predicate, so it stays consistent with what's actually enriched.

## Effect
Existing already-enriched listings missing a body type get re-fetched once (throttled), the item page's `מרכב` is read, and `bodytype.FromYad2` (#1460) classifies them. The rate-limit caveat from the prod investigation still applies — backfill rides the existing throttled enrich queue.

## Tests
- Worker: skip requires body type; re-fetches when only body type missing; stamps an attempt when the item page yields none.
- Storage (CI/Postgres): backlog selects a "missing only body type" listing; a fully-enriched one (incl. body type) is excluded; `LookupEnrichmentData` returns `body_type`.

`go build ./...` ✅ · `go test ./internal/enricher` ✅ · `go vet` ✅ · `golangci-lint --new-from-rev=origin/main` → 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Listings are now treated as fully enriched only when body type is also present.
  * Listings missing only body type will be rechecked instead of skipped, and a follow-up attempt is recorded to avoid repeated immediate retries.
  * The unenriched backlog now includes listings missing body type, improving coverage of incomplete records.
* **Tests**
  * Updated enrichment and backlog tests to cover body-type handling and the missing-body-type case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->