### PR TITLE
feat(yad2): rich gw JSON feed source to cut per-item enrichment

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,6 +80,7 @@ func BuildFetchers(cfg *config.Config, logger *slog.Logger) (*FetcherBundle, err
 	if err != nil {
 		return nil, fmt.Errorf("create fetcher: %w", err)
 	}
+	yad2Fetcher.SetUseGwFeed(cfg.HTTP.UseGwFeed)
 
 	paginatingFetcher := fetcher.NewPaginatingFetcher(yad2Fetcher, cfg.HTTP.MaxPages)
 	cachingFetcher := fetcher.NewCachingFetcher(paginatingFetcher, 5*time.Minute)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,11 @@ type HTTPConfig struct {
 	Proxy      string   `yaml:"proxy"`
 	Proxies    []string `yaml:"proxies"`
 	MaxPages   int      `yaml:"max_pages"`
+	// UseGwFeed switches the listing feed source from the HTML page
+	// (lean __NEXT_DATA__) to Yad2's gw JSON API, which returns rich
+	// per-listing data (km, city, bodyType) and lets us skip most
+	// per-item enrichment fetches.
+	UseGwFeed bool `yaml:"use_gw_feed"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
@@ -116,7 +117,7 @@ func TestYad2Fetcher_Fetch_GwFeed(t *testing.T) {
 	// request from the rich JSON — including km + bodyType (no enrichment).
 	f := newTestFetcher(t, "http://unused.invalid/vehicles/cars")
 	f.gwBaseURL = server.URL
-	f.useGwFeed = true
+	f.SetUseGwFeed(true)
 
 	listings, err := f.Fetch(context.Background(), defaultParams())
 	if err != nil {
@@ -151,7 +152,7 @@ func TestYad2Fetcher_Fetch_GwFeedFallsBackToHTML(t *testing.T) {
 
 	f := newTestFetcher(t, htmlSrv.URL) // HTML fallback target
 	f.gwBaseURL = gwSrv.URL
-	f.useGwFeed = true
+	f.SetUseGwFeed(true)
 
 	listings, err := f.Fetch(context.Background(), defaultParams())
 	if err != nil {
@@ -159,6 +160,58 @@ func TestYad2Fetcher_Fetch_GwFeedFallsBackToHTML(t *testing.T) {
 	}
 	if len(listings) != 1 || listings[0].Token != "tok-1" {
 		t.Fatalf("expected HTML fallback listing tok-1, got %+v", listings)
+	}
+}
+
+func TestYad2Fetcher_Fetch_GwBlockDoesNotFallBack(t *testing.T) {
+	// A bot challenge / rate limit on the gw feed must surface directly — the
+	// HTML page is behind the same wall, so falling back would just double the
+	// load. Assert the sentinel error and that the HTML server is never hit.
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr error
+	}{
+		{
+			name: "challenge",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.WriteString(w, `<html>Are you for real</html>`)
+			},
+			wantErr: fetcher.ErrChallenge,
+		},
+		{
+			name:    "rate_limited",
+			handler: func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTooManyRequests) },
+			wantErr: fetcher.ErrRateLimited,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gwSrv := httptest.NewServer(tc.handler)
+			defer gwSrv.Close()
+			var htmlHit atomic.Bool
+			htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				htmlHit.Store(true)
+				w.Header().Set("Content-Type", "text/html")
+				_, _ = w.Write([]byte(validPageHTML()))
+			}))
+			defer htmlSrv.Close()
+
+			f := newTestFetcher(t, htmlSrv.URL)
+			f.gwBaseURL = gwSrv.URL
+			f.SetUseGwFeed(true)
+
+			listings, err := f.Fetch(context.Background(), defaultParams())
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if listings != nil {
+				t.Errorf("expected nil listings on gw block, got %+v", listings)
+			}
+			if htmlHit.Load() {
+				t.Error("HTML fallback must NOT be hit when gw is blocked")
+			}
+		})
 	}
 }
 

--- a/internal/fetcher/yad2/fetcher_test.go
+++ b/internal/fetcher/yad2/fetcher_test.go
@@ -99,6 +99,69 @@ func TestYad2Fetcher_Fetch(t *testing.T) {
 	}
 }
 
+func TestYad2Fetcher_Fetch_GwFeed(t *testing.T) {
+	const gwJSON = `{"data":{"feed":{"feed_items":[
+		{"token":"gw-x","manufacturer":{"text":"Toyota"},"model":{"text":"Corolla"},
+		 "km":66000,"price":89000,"hand":{"id":2},"bodyType":{"id":1,"text":"סדאן"},
+		 "address":{"city":{"text":"אור יהודה"}},"vehicleDates":{"yearOfProduction":2021},
+		 "metaData":{"coverImage":"https://img/x.jpg"}}
+	]}}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, gwJSON)
+	}))
+	defer server.Close()
+
+	// baseURL points nowhere usable; with useGwFeed the gw path must serve the
+	// request from the rich JSON — including km + bodyType (no enrichment).
+	f := newTestFetcher(t, "http://unused.invalid/vehicles/cars")
+	f.gwBaseURL = server.URL
+	f.useGwFeed = true
+
+	listings, err := f.Fetch(context.Background(), defaultParams())
+	if err != nil {
+		t.Fatalf("Fetch (gw): %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing, got %d", len(listings))
+	}
+	if listings[0].Km != 66000 {
+		t.Errorf("km = %d, want 66000 (from gw feed)", listings[0].Km)
+	}
+	if listings[0].BodyType != "sedan" {
+		t.Errorf("body_type = %q, want sedan (from gw feed)", listings[0].BodyType)
+	}
+	if listings[0].City != "אור יהודה" {
+		t.Errorf("city = %q, want אור יהודה", listings[0].City)
+	}
+}
+
+func TestYad2Fetcher_Fetch_GwFeedFallsBackToHTML(t *testing.T) {
+	// gw returns malformed JSON (a non-challenge failure) → Fetch must fall back
+	// to the HTML page and still return listings.
+	gwSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{ broken json`)
+	}))
+	defer gwSrv.Close()
+	htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(validPageHTML()))
+	}))
+	defer htmlSrv.Close()
+
+	f := newTestFetcher(t, htmlSrv.URL) // HTML fallback target
+	f.gwBaseURL = gwSrv.URL
+	f.useGwFeed = true
+
+	listings, err := f.Fetch(context.Background(), defaultParams())
+	if err != nil {
+		t.Fatalf("Fetch (gw fallback): %v", err)
+	}
+	if len(listings) != 1 || listings[0].Token != "tok-1" {
+		t.Fatalf("expected HTML fallback listing tok-1, got %+v", listings)
+	}
+}
+
 func TestYad2Fetcher_Fetch_GzipResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -84,6 +84,12 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 		logger.Debug("raw feed item sample", "json", string(items[0].raw))
 	}
 
+	return buildListings(items, logger), nil
+}
+
+// buildListings converts tagged feed items into de-duplicated RawListings via
+// itemToListing. Shared by the HTML (__NEXT_DATA__) and gw JSON feed parsers.
+func buildListings(items []feedTaggedItem, logger *slog.Logger) []model.RawListing {
 	listings := make([]model.RawListing, 0, len(items))
 	seen := make(map[string]struct{}, len(items))
 	skipped := 0
@@ -111,6 +117,58 @@ func parseNextData(data []byte, logger *slog.Logger) ([]model.RawListing, error)
 		)
 	}
 
+	return listings
+}
+
+// gwFeedResponse is the shape of Yad2's gw JSON feed API response.
+type gwFeedResponse struct {
+	Data struct {
+		Feed struct {
+			FeedItems []json.RawMessage `json:"feed_items"`
+		} `json:"feed"`
+	} `json:"data"`
+}
+
+// ParseGwFeed parses Yad2's gw feed API response (data.feed.feed_items). Those
+// items carry the rich fields (km, city, bodyType, gearBox) that the HTML
+// page's __NEXT_DATA__ no longer includes, so this lets us skip most per-item
+// enrichment. Field mapping is shared with the HTML feed via itemToListing.
+func ParseGwFeed(body io.Reader, logger *slog.Logger) ([]model.RawListing, error) {
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("read gw feed body: %w", err)
+	}
+	if looksLikeBotProtection(raw) {
+		return nil, fmt.Errorf("yad2 gw feed: %w", fetcher.ErrChallenge)
+	}
+
+	var resp gwFeedResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal gw feed: %w", err)
+	}
+
+	items := make([]feedTaggedItem, 0, len(resp.Data.Feed.FeedItems))
+	for _, it := range resp.Data.Feed.FeedItems {
+		items = append(items, feedTaggedItem{raw: it, commercial: nil})
+	}
+	listings := buildListings(items, logger)
+
+	if logger != nil {
+		withKm, withBody := 0, 0
+		for i := range listings {
+			if listings[i].Km > 0 {
+				withKm++
+			}
+			if listings[i].BodyType != "" {
+				withBody++
+			}
+		}
+		// Confirms the gw feed's richness in prod: with_km/with_body_type ≈
+		// listings means per-item enrichment is largely unnecessary.
+		logger.Debug("parsed gw feed",
+			"items", len(resp.Data.Feed.FeedItems), "listings", len(listings),
+			"with_km", withKm, "with_body_type", withBody)
+	}
 	return listings, nil
 }
 

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -120,11 +120,13 @@ func buildListings(items []feedTaggedItem, logger *slog.Logger) []model.RawListi
 	return listings
 }
 
-// gwFeedResponse is the shape of Yad2's gw JSON feed API response.
+// gwFeedResponse is the shape of Yad2's gw JSON feed API response. FeedItems is
+// a pointer so we can distinguish an empty feed ([] — a valid "no results")
+// from a missing/changed shape (nil — treat as an error so Fetch falls back).
 type gwFeedResponse struct {
 	Data struct {
 		Feed struct {
-			FeedItems []json.RawMessage `json:"feed_items"`
+			FeedItems *[]json.RawMessage `json:"feed_items"`
 		} `json:"feed"`
 	} `json:"data"`
 }
@@ -146,9 +148,13 @@ func ParseGwFeed(body io.Reader, logger *slog.Logger) ([]model.RawListing, error
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal gw feed: %w", err)
 	}
+	if resp.Data.Feed.FeedItems == nil {
+		return nil, fmt.Errorf("gw feed missing data.feed.feed_items")
+	}
+	feedItems := *resp.Data.Feed.FeedItems
 
-	items := make([]feedTaggedItem, 0, len(resp.Data.Feed.FeedItems))
-	for _, it := range resp.Data.Feed.FeedItems {
+	items := make([]feedTaggedItem, 0, len(feedItems))
+	for _, it := range feedItems {
 		items = append(items, feedTaggedItem{raw: it, commercial: nil})
 	}
 	listings := buildListings(items, logger)
@@ -166,7 +172,7 @@ func ParseGwFeed(body io.Reader, logger *slog.Logger) ([]model.RawListing, error
 		// Confirms the gw feed's richness in prod: with_km/with_body_type ≈
 		// listings means per-item enrichment is largely unnecessary.
 		logger.Debug("parsed gw feed",
-			"items", len(resp.Data.Feed.FeedItems), "listings", len(listings),
+			"items", len(feedItems), "listings", len(listings),
 			"with_km", withKm, "with_body_type", withBody)
 	}
 	return listings, nil

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -203,6 +203,88 @@ func TestParseNextData_FeedWithNullItems(t *testing.T) {
 	}
 }
 
+func TestParseGwFeed_RichFields(t *testing.T) {
+	// The gw feed carries the rich per-listing fields the HTML page dropped:
+	// km, city, bodyType, gearBox, dates.
+	body := `{
+		"data": {"feed": {"feed_items": [
+			{
+				"token": "gw-1",
+				"manufacturer": {"id": 53, "text": "טויוטה", "english_text": "Toyota"},
+				"model": {"id": 10399, "text": "קורולה", "english_text": "Corolla"},
+				"subModel": {"id": 117698, "text": "Sun היברידי אוט׳ 1.8 (98 כ״ס)"},
+				"vehicleDates": {"yearOfProduction": 2021},
+				"km": 66000,
+				"hand": {"id": 2, "text": "יד שנייה"},
+				"price": 89000,
+				"bodyType": {"id": 1, "text": "סדאן"},
+				"gearBox": {"id": 2, "text": "אוטומטית"},
+				"engineType": {"id": 1, "text": "היברידי בנזין"},
+				"address": {"city": {"id": 8600, "text": "אור יהודה"}, "area": {"id": 9, "text": "מרכז"}},
+				"dates": {"createdAt": "2025-02-09T10:31:37"},
+				"metaData": {"coverImage": "https://img.yad2.co.il/gw1.jpg"}
+			},
+			{"token": "", "price": 0}
+		]}}
+	}`
+
+	listings, err := ParseGwFeed(strings.NewReader(body), nil)
+	if err != nil {
+		t.Fatalf("ParseGwFeed: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("expected 1 listing (empty token skipped), got %d", len(listings))
+	}
+	l := listings[0]
+	if l.Token != "gw-1" {
+		t.Errorf("token = %q", l.Token)
+	}
+	if l.Km != 66000 {
+		t.Errorf("km = %d, want 66000 (from gw feed, no enrichment)", l.Km)
+	}
+	if l.BodyType != "sedan" {
+		t.Errorf("body_type = %q, want sedan (from bodyType id/סדאן)", l.BodyType)
+	}
+	if l.City != "אור יהודה" {
+		t.Errorf("city = %q, want אור יהודה", l.City)
+	}
+	if l.GearBox != "אוטומטית" {
+		t.Errorf("gear_box = %q, want אוטומטית", l.GearBox)
+	}
+	if l.Manufacturer != "Toyota" {
+		t.Errorf("manufacturer = %q, want Toyota", l.Manufacturer)
+	}
+	if l.Year != 2021 {
+		t.Errorf("year = %d, want 2021", l.Year)
+	}
+	if l.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be parsed from dates.createdAt")
+	}
+}
+
+func TestParseGwFeed_Challenge(t *testing.T) {
+	_, err := ParseGwFeed(strings.NewReader(`<html>are you for real</html>`), nil)
+	if !errors.Is(err, fetcher.ErrChallenge) {
+		t.Errorf("expected ErrChallenge, got %v", err)
+	}
+}
+
+func TestParseGwFeed_InvalidJSON(t *testing.T) {
+	if _, err := ParseGwFeed(strings.NewReader(`{not json`), nil); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseGwFeed_EmptyFeed(t *testing.T) {
+	listings, err := ParseGwFeed(strings.NewReader(`{"data":{"feed":{"feed_items":[]}}}`), nil)
+	if err != nil {
+		t.Fatalf("ParseGwFeed: %v", err)
+	}
+	if len(listings) != 0 {
+		t.Errorf("expected 0 listings, got %d", len(listings))
+	}
+}
+
 func TestParseFlexTime_Formats(t *testing.T) {
 	// want, when set, asserts the exact instant — guarding against a regression
 	// that parses a value in the wrong timezone (e.g. zone-less as UTC).

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -285,6 +285,17 @@ func TestParseGwFeed_EmptyFeed(t *testing.T) {
 	}
 }
 
+func TestParseGwFeed_MissingFeedItems(t *testing.T) {
+	// Missing feed_items (vs an empty array) signals an unexpected/changed shape;
+	// it must error so Fetch falls back to the HTML page instead of returning
+	// empty results.
+	for _, body := range []string{`{}`, `{"data":{"feed":{}}}`, `{"data":{}}`} {
+		if _, err := ParseGwFeed(strings.NewReader(body), nil); err == nil {
+			t.Errorf("expected error for missing feed_items in %q", body)
+		}
+	}
+}
+
 func TestParseFlexTime_Formats(t *testing.T) {
 	// want, when set, asserts the exact instant — guarding against a regression
 	// that parses a value in the wrong timezone (e.g. zone-less as UTC).

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,6 +21,12 @@ import (
 const (
 	defaultBaseURL  = "https://www.yad2.co.il/vehicles/cars"
 	maxResponseSize = 10 * 1024 * 1024 // 10 MB
+
+	// gwFeedURL is Yad2's JSON feed API. Unlike the HTML page's __NEXT_DATA__
+	// (which Yad2 stripped down to identity/price/image), it returns the rich
+	// per-listing fields — km, city, bodyType, gearBox — so we can skip most
+	// per-item enrichment fetches.
+	gwFeedURL = "https://gw.yad2.co.il/feed-search-legacy/vehicles/cars"
 )
 
 type Yad2Fetcher struct {
@@ -30,7 +37,12 @@ type Yad2Fetcher struct {
 	userAgents []string
 	proxyPool  *fetcher.ProxyPool
 	clientPool *ClientPool
+	useGwFeed  bool   // fetch the rich gw JSON feed instead of the HTML page
+	gwBaseURL  string // gw JSON feed endpoint (overridable in tests)
 }
+
+// SetUseGwFeed toggles fetching the rich gw JSON feed (with HTML-page fallback).
+func (f *Yad2Fetcher) SetUseGwFeed(v bool) { f.useGwFeed = v }
 
 func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*Yad2Fetcher, error) {
 	client, err := NewClient(userAgents, proxy)
@@ -42,7 +54,7 @@ func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*Yad2Fe
 		client.Close()
 		return nil, err
 	}
-	return &Yad2Fetcher{client: client, itemClient: ic, baseURL: defaultBaseURL, logger: logger, userAgents: userAgents}, nil
+	return &Yad2Fetcher{client: client, itemClient: ic, baseURL: defaultBaseURL, gwBaseURL: gwFeedURL, logger: logger, userAgents: userAgents}, nil
 }
 
 func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logger *slog.Logger) (*Yad2Fetcher, error) {
@@ -67,6 +79,7 @@ func NewFetcherWithProxyPool(userAgents []string, pool *fetcher.ProxyPool, logge
 		client:     client,
 		itemClient: ic,
 		baseURL:    defaultBaseURL,
+		gwBaseURL:  gwFeedURL,
 		logger:     logger,
 		userAgents: userAgents,
 		proxyPool:  pool,
@@ -201,6 +214,28 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 		}
 	}
 
+	// Prefer the rich gw JSON feed when enabled. On a bot challenge / rate
+	// limit we do NOT fall back to the HTML page in the same call (it is behind
+	// the same anti-bot and would just double the load); only a non-block
+	// failure (e.g. an unexpected JSON shape) falls through to the HTML feed.
+	if f.useGwFeed {
+		listings, gwErr := f.fetchGwFeed(ctx, client, params)
+		if gwErr == nil {
+			return listings, nil
+		}
+		if errors.Is(gwErr, fetcher.ErrChallenge) {
+			if f.proxyPool != nil && usedProxy != "" {
+				f.proxyPool.MarkUnhealthy(usedProxy)
+			}
+			return nil, gwErr
+		}
+		if errors.Is(gwErr, fetcher.ErrRateLimited) {
+			return nil, gwErr
+		}
+		f.logger.Warn("gw feed fetch failed, falling back to HTML page",
+			"manufacturer", params.Manufacturer, "model", params.Model, "error", gwErr)
+	}
+
 	reqURL := buildURL(f.baseURL, params)
 	fetchStart := time.Now()
 	f.logger.Debug("fetching listings",
@@ -252,6 +287,43 @@ func (f *Yad2Fetcher) Fetch(ctx context.Context, params model.SourceParams) ([]m
 		"status", result.StatusCode,
 		"duration_ms", time.Since(fetchStart).Milliseconds(),
 	)
+	return listings, nil
+}
+
+// fetchGwFeed fetches and parses the rich gw JSON feed for the given params.
+func (f *Yad2Fetcher) fetchGwFeed(ctx context.Context, client HTTPDoer, params model.SourceParams) ([]model.RawListing, error) {
+	gwBase := f.gwBaseURL
+	if gwBase == "" {
+		gwBase = gwFeedURL
+	}
+	reqURL := buildURL(gwBase, params)
+	start := time.Now()
+	f.logger.Debug("fetching gw feed",
+		"url", reqURL, "manufacturer", params.Manufacturer, "model", params.Model, "page", params.Page)
+
+	result, err := client.Get(ctx, reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("gw feed request: %w", err)
+	}
+	// A challenge can arrive either as a non-200 or as a 200 serving the
+	// anti-bot HTML page in place of JSON.
+	if looksLikeBotProtection(result.Body) {
+		return nil, fmt.Errorf("gw feed: %w", fetcher.ErrChallenge)
+	}
+	if result.StatusCode != http.StatusOK {
+		if result.StatusCode == http.StatusBadRequest || result.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("gw feed status %d: %w", result.StatusCode, fetcher.ErrRateLimited)
+		}
+		return nil, fmt.Errorf("gw feed unexpected status %d", result.StatusCode)
+	}
+
+	listings, err := ParseGwFeed(bytes.NewReader(result.Body), f.logger)
+	if err != nil {
+		return nil, err
+	}
+	f.logger.Debug("fetched gw feed",
+		"count", len(listings), "manufacturer", params.Manufacturer, "model", params.Model,
+		"page", params.Page, "duration_ms", time.Since(start).Milliseconds())
 	return listings, nil
 }
 


### PR DESCRIPTION
## Why

Investigating how to scale Yad2 throughput, I confirmed (from a live prod feed sample) that Yad2 **stripped** `km`/`city`/`bodyType`/`gearBox` out of the HTML page's `__NEXT_DATA__` — it now carries only identity/price/image/area (25 lean fields). That's why the scraper must fetch **each listing's item page** to enrich km/city/bodyType — and item fetches are the *dominant* Yad2 request cost (1 feed call + N item calls per search) and the bottleneck as usage grows.

Yad2's **gw JSON feed API** (`gw.yad2.co.il/feed-search-legacy/vehicles/cars`) — the same one the web grid hydrates from — still returns the **rich** per-listing data (`data.feed.feed_items[]` with km, city, bodyType, gearBox, dates). Confirmed via multiple independent working scrapers. Fetching it instead of the HTML page gives us those fields directly, **eliminating most per-item enrichment** and cutting Yad2 request volume by ~an order of magnitude per search.

## What

- **`ParseGwFeed`** parses `data.feed.feed_items`, reusing `itemToListing` (shared field mapping) via a new `buildListings` helper — so km/city/bodyType/gearBox/dates all map exactly as they do for the HTML feed.
- **`Fetch`** prefers the gw feed when `http.use_gw_feed` is set. On a bot challenge / rate limit it returns the error (no HTML double-fetch, to avoid extra load under a block); only a *non-block* failure (e.g. malformed JSON / unexpected shape) falls back to the HTML page.
- Same query-param format as the HTML feed; requests go through the existing stealth client (Radware-friendly TLS/UA). A `parsed gw feed` debug log reports `with_km`/`with_body_type` so we can confirm the feed's richness in prod.

**Flag defaults off** — merging is a no-op until `http.use_gw_feed: true` is set in config.

## Rollout / verification
1. Merge (no behavior change).
2. Set `http.use_gw_feed: true` in prod `config.yaml`, restart scraper.
3. Watch `parsed gw feed` logs: `with_km`/`with_body_type` ≈ `listings` confirms the gw feed is rich → per-item enrichment becomes largely unnecessary, and the enrich queue drains.

Caveat: gw is behind the same Radware wall, so this doesn't fix IP reputation — but it slashes the *number* of requests, which is the scaling lever (and makes a small proxy plan sufficient later).

## Tests
- `ParseGwFeed`: rich-field extraction (km/bodyType/city/gearBox/year/dates), challenge detection, invalid JSON, empty feed.
- `Fetch`: gw path returns rich listings; non-block gw failure falls back to the HTML page.

`go build ./...` ✅ · `go test ./internal/fetcher/yad2 ./internal/config ./internal/app` ✅ · `go vet` ✅ · `golangci-lint --new-from-rev=origin/main` → 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fetching listings from the richer GW feed.
  * Expanded listing data capture, including details like mileage, body type, city, gearbox, manufacturer, year, and created date.

* **Bug Fixes**
  * Improved fallback behavior so the app can continue using the existing page-based flow if the new feed is unavailable.
  * Added handling for blocked or rate-limited responses to avoid unreliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->