### PR TITLE
feat: add Cloudflare Worker relay to bypass Yad2 anti-bot

### DIFF
--- a/cf-worker/relay.js
+++ b/cf-worker/relay.js
@@ -1,0 +1,65 @@
+const ALLOWED_HOSTS = ["www.yad2.co.il", "gw.yad2.co.il", "yad2.co.il"];
+
+const FORWARDED_HEADERS = [
+  "User-Agent",
+  "Accept",
+  "Accept-Language",
+  "Accept-Encoding",
+  "DNT",
+  "Cache-Control",
+];
+
+export default {
+  async fetch(request, env) {
+    const secret = request.headers.get("X-Relay-Secret");
+    if (!secret || secret !== env.RELAY_SECRET) {
+      return new Response("unauthorized", { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    const target = url.searchParams.get("target");
+    if (!target) {
+      return new Response("missing target parameter", { status: 400 });
+    }
+
+    let targetURL;
+    try {
+      targetURL = new URL(target);
+    } catch {
+      return new Response("invalid target URL", { status: 400 });
+    }
+
+    if (!ALLOWED_HOSTS.includes(targetURL.hostname)) {
+      return new Response("target host not allowed", { status: 403 });
+    }
+
+    const headers = new Headers();
+    for (const h of FORWARDED_HEADERS) {
+      const val = request.headers.get(h);
+      if (val) headers.set(h, val);
+    }
+
+    try {
+      const response = await fetch(target, {
+        method: "GET",
+        headers: headers,
+        redirect: "follow",
+      });
+
+      const responseHeaders = new Headers();
+      responseHeaders.set(
+        "Content-Type",
+        response.headers.get("Content-Type") || "application/octet-stream",
+      );
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (err) {
+      return new Response("relay fetch failed: " + err.message, {
+        status: 502,
+      });
+    }
+  },
+};

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -1,0 +1,5 @@
+name = "yad2-relay"
+main = "relay.js"
+compatibility_date = "2024-09-23"
+
+# RELAY_SECRET is set via: npx wrangler secret put RELAY_SECRET

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -88,6 +88,7 @@ services:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
       - TELEMETRY_AUTH_TOKEN=${TELEMETRY_AUTH_TOKEN:?TELEMETRY_AUTH_TOKEN must be set}
+      - RELAY_SECRET=${RELAY_SECRET:-}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz"]
       interval: 60s
@@ -168,6 +169,7 @@ services:
       - TZ=Asia/Jerusalem
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+      - RELAY_SECRET=${RELAY_SECRET:-}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081/healthz"]
       interval: 60s
@@ -248,6 +250,7 @@ services:
     environment:
       - TZ=Asia/Jerusalem
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+      - RELAY_SECRET=${RELAY_SECRET:-}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8084/healthz"]
       interval: 60s

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,7 +72,12 @@ func BuildFetchers(cfg *config.Config, logger *slog.Logger) (*FetcherBundle, err
 	yad2Logger := logger.With("component", "yad2")
 	var yad2Fetcher *yad2.Yad2Fetcher
 	var err error
-	if proxyPool != nil {
+	if cfg.HTTP.RelayURL != "" {
+		feedClient := yad2.NewRelayClient(cfg.HTTP.RelayURL, cfg.HTTP.RelaySecret, cfg.HTTP.UserAgents)
+		itemClient := yad2.NewRelayClient(cfg.HTTP.RelayURL, cfg.HTTP.RelaySecret, cfg.HTTP.UserAgents)
+		yad2Fetcher = yad2.NewFetcherWithClients(feedClient, itemClient, cfg.HTTP.UserAgents, yad2Logger)
+		logger.Info("using cloudflare relay", "relay_url", cfg.HTTP.RelayURL)
+	} else if proxyPool != nil {
 		yad2Fetcher, err = yad2.NewFetcherWithProxyPool(cfg.HTTP.UserAgents, proxyPool, yad2Logger)
 	} else {
 		yad2Fetcher, err = yad2.NewFetcher(cfg.HTTP.UserAgents, cfg.HTTP.Proxy, yad2Logger)
@@ -256,9 +261,15 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 
 // BuildPriceListService creates the pricelist HTTP client and service.
 func BuildPriceListService(cfg *config.Config, store *postgres.Store, logger *slog.Logger) (*pricelist.Service, func(), error) {
-	plClient, err := yad2.NewClient(cfg.HTTP.UserAgents, cfg.HTTP.Proxy)
-	if err != nil {
-		return nil, nil, fmt.Errorf("create pricelist client: %w", err)
+	var plClient yad2.HTTPDoer
+	if cfg.HTTP.RelayURL != "" {
+		plClient = yad2.NewRelayClient(cfg.HTTP.RelayURL, cfg.HTTP.RelaySecret, cfg.HTTP.UserAgents)
+	} else {
+		c, err := yad2.NewClient(cfg.HTTP.UserAgents, cfg.HTTP.Proxy)
+		if err != nil {
+			return nil, nil, fmt.Errorf("create pricelist client: %w", err)
+		}
+		plClient = c
 	}
 	plHTTP := pricelist.NewYad2Client(plClient)
 	svc := pricelist.NewService(store, plHTTP, logger.With("component", "api-pricelist"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,10 @@ type HTTPConfig struct {
 	// per-listing data (km, city, bodyType) and lets us skip most
 	// per-item enrichment fetches.
 	UseGwFeed bool `yaml:"use_gw_feed"`
+	// RelayURL is a Cloudflare Worker URL that proxies requests to Yad2,
+	// bypassing IP-based anti-bot blocks by using Cloudflare edge IPs.
+	RelayURL    string `yaml:"relay_url"`
+	RelaySecret string `yaml:"relay_secret"`
 }
 
 func Load(path string) (*Config, error) {
@@ -172,6 +176,9 @@ func warnHardcodedSecrets(raw string) {
 	}
 	if storage, ok := doc["storage"].(map[string]any); ok {
 		checkSecret("storage.dsn", "DATABASE_URL", storage, "dsn")
+	}
+	if httpSec, ok := doc["http"].(map[string]any); ok {
+		checkSecret("http.relay_secret", "RELAY_SECRET", httpSec, "relay_secret")
 	}
 }
 
@@ -321,6 +328,16 @@ func validate(cfg *Config) error {
 
 	if cfg.Enricher.MaxDelay < cfg.Enricher.BaseDelay {
 		return fmt.Errorf("enricher.max_delay (%s) must be >= enricher.base_delay (%s)", cfg.Enricher.MaxDelay, cfg.Enricher.BaseDelay)
+	}
+
+	if cfg.HTTP.RelayURL != "" {
+		u, err := url.Parse(cfg.HTTP.RelayURL)
+		if err != nil || u.Scheme != "https" {
+			return fmt.Errorf("http.relay_url %q: must be an HTTPS URL", cfg.HTTP.RelayURL)
+		}
+		if cfg.HTTP.RelaySecret == "" {
+			return fmt.Errorf("http.relay_secret is required when relay_url is set")
+		}
 	}
 
 	for _, origin := range cfg.API.CORSOrigins {

--- a/internal/fetcher/yad2/relay_client.go
+++ b/internal/fetcher/yad2/relay_client.go
@@ -1,0 +1,68 @@
+package yad2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// relayClient routes HTTP requests through a Cloudflare Worker relay,
+// so Yad2 sees Cloudflare edge IPs instead of the scraper's datacenter IP.
+type relayClient struct {
+	httpClient *http.Client
+	relayURL   string
+	secret     string
+	userAgents []string
+}
+
+// NewRelayClient creates a client that routes all requests through the
+// Cloudflare Worker at relayURL. The secret is sent as X-Relay-Secret
+// for authentication.
+func NewRelayClient(relayURL, secret string, userAgents []string) *relayClient {
+	return &relayClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		relayURL:   relayURL,
+		secret:     secret,
+		userAgents: userAgents,
+	}
+}
+
+func (c *relayClient) Get(ctx context.Context, targetURL string) (*HTTPResult, error) {
+	reqURL := c.relayURL + "?target=" + url.QueryEscape(targetURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("relay: create request: %w", err)
+	}
+
+	req.Header.Set("X-Relay-Secret", c.secret)
+	if len(c.userAgents) > 0 {
+		req.Header.Set("User-Agent", c.userAgents[rand.IntN(len(c.userAgents))])
+	}
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "he-IL,he;q=0.9,en-US;q=0.8,en;q=0.7")
+	req.Header.Set("DNT", "1")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("relay: execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("relay: read response: %w", err)
+	}
+
+	return &HTTPResult{
+		Body:       body,
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
+	}, nil
+}
+
+func (c *relayClient) Close() {}

--- a/internal/fetcher/yad2/relay_client_test.go
+++ b/internal/fetcher/yad2/relay_client_test.go
@@ -1,0 +1,160 @@
+package yad2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestRelayClient_RewritesURL(t *testing.T) {
+	var gotTarget, gotSecret string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTarget = r.URL.Query().Get("target")
+		gotSecret = r.Header.Get("X-Relay-Secret")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "test-secret", []string{"TestAgent/1.0"})
+	targetURL := "https://gw.yad2.co.il/feed-search-legacy/vehicles/cars?manufacturer=17&model=10188"
+
+	result, err := c.Get(context.Background(), targetURL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if result.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", result.StatusCode)
+	}
+	if gotTarget != targetURL {
+		t.Errorf("target = %q, want %q", gotTarget, targetURL)
+	}
+	if gotSecret != "test-secret" {
+		t.Errorf("secret = %q, want %q", gotSecret, "test-secret")
+	}
+}
+
+func TestRelayClient_ForwardsResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":"test"}`))
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "s", []string{"TestAgent/1.0"})
+	result, err := c.Get(context.Background(), "https://example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(result.Body) != `{"data":"test"}` {
+		t.Errorf("body = %q, want %q", result.Body, `{"data":"test"}`)
+	}
+	if result.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("content-type = %q, want application/json", result.Header.Get("Content-Type"))
+	}
+}
+
+func TestRelayClient_WorkerAuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Relay-Secret") != "correct" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "wrong", []string{"TestAgent/1.0"})
+	result, err := c.Get(context.Background(), "https://example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if result.StatusCode != 401 {
+		t.Errorf("status = %d, want 401", result.StatusCode)
+	}
+}
+
+func TestRelayClient_WorkerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("relay fetch failed: connection refused"))
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "s", []string{"TestAgent/1.0"})
+	result, err := c.Get(context.Background(), "https://example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if result.StatusCode != 502 {
+		t.Errorf("status = %d, want 502", result.StatusCode)
+	}
+}
+
+func TestRelayClient_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "s", []string{"TestAgent/1.0"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Get(ctx, "https://example.com")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestRelayClient_ComplexURLEncoding(t *testing.T) {
+	var gotTarget string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTarget = r.URL.Query().Get("target")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "s", []string{"TestAgent/1.0"})
+	targetURL := "https://gw.yad2.co.il/feed-search-legacy/vehicles/cars?manufacturer=19&model=10226&year=2019-2024&price=0-95000&km=-1-70000&hand=0-2&ownerID=1&imgOnly=1&Order=1&page=1"
+
+	_, err := c.Get(context.Background(), targetURL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	decoded, _ := url.QueryUnescape(gotTarget)
+	if decoded != targetURL {
+		t.Errorf("decoded target = %q, want %q", decoded, targetURL)
+	}
+}
+
+func TestRelayClient_ForwardsBrowserHeaders(t *testing.T) {
+	var gotUA, gotLang, gotDNT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		gotLang = r.Header.Get("Accept-Language")
+		gotDNT = r.Header.Get("DNT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewRelayClient(srv.URL, "s", []string{"Mozilla/5.0 Test"})
+	_, err := c.Get(context.Background(), "https://example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if gotUA != "Mozilla/5.0 Test" {
+		t.Errorf("User-Agent = %q, want %q", gotUA, "Mozilla/5.0 Test")
+	}
+	if gotLang == "" {
+		t.Error("Accept-Language not forwarded")
+	}
+	if gotDNT != "1" {
+		t.Errorf("DNT = %q, want %q", gotDNT, "1")
+	}
+}

--- a/internal/fetcher/yad2/yad2.go
+++ b/internal/fetcher/yad2/yad2.go
@@ -44,6 +44,19 @@ type Yad2Fetcher struct {
 // SetUseGwFeed toggles fetching the rich gw JSON feed (with HTML-page fallback).
 func (f *Yad2Fetcher) SetUseGwFeed(v bool) { f.useGwFeed = v }
 
+// NewFetcherWithClients creates a Yad2Fetcher using pre-built HTTPDoer clients.
+// Used when the caller controls the transport (e.g. routing through a relay).
+func NewFetcherWithClients(client, itemClient HTTPDoer, userAgents []string, logger *slog.Logger) *Yad2Fetcher {
+	return &Yad2Fetcher{
+		client:     client,
+		itemClient: itemClient,
+		baseURL:    defaultBaseURL,
+		gwBaseURL:  gwFeedURL,
+		logger:     logger,
+		userAgents: userAgents,
+	}
+}
+
 func NewFetcher(userAgents []string, proxy string, logger *slog.Logger) (*Yad2Fetcher, error) {
 	client, err := NewClient(userAgents, proxy)
 	if err != nil {


### PR DESCRIPTION
## Why

The Oracle Cloud VM's datacenter IP (AS31898) is permanently blocked by Yad2's Radware anti-bot. Both the HTML `__NEXT_DATA__` path and the new gw JSON feed (#1462) return challenge responses on every request. The scraper has been blind since Yad2 stripped `__NEXT_DATA__` from their HTML pages.

Paid proxies aren't an option — this project runs at zero cost. We need a free relay layer that presents trusted IPs to Yad2.

## What

A **Cloudflare Worker relay** that sits between the scraper and Yad2. The scraper sends `GET https://<worker>.workers.dev/?target=<encoded-yad2-url>` with an `X-Relay-Secret` auth header. The Worker validates the secret, allowlists Yad2 hostnames, forwards browser headers (User-Agent, Accept-Language, etc.), fetches the target, and returns the response. Yad2 sees Cloudflare edge IPs (trusted AS13335) instead of the datacenter IP.

Volume is ~12 feed requests/hour — well within the free tier (100K req/day).

### Go changes

- **`relayClient`** (`internal/fetcher/yad2/relay_client.go`): standalone `HTTPDoer` using plain `net/http` (no azuretls needed for the scraper→Worker leg). Rewrites target URLs, sets auth header, forwards browser headers.
- **`NewFetcherWithClients`** constructor on `Yad2Fetcher`: accepts pre-built `HTTPDoer` clients for when the caller controls the transport.
- **Config**: `relay_url` + `relay_secret` fields in `HTTPConfig` with HTTPS validation and hardcoded-secret warning.
- **Wiring**: `BuildFetchers()` and `BuildPriceListService()` use relay clients when configured. Precedence: relay > proxy pool > single proxy > direct.

### Worker (`cf-worker/`)

- `relay.js`: ~60 lines. Auth validation, host allowlist (`www.yad2.co.il`, `gw.yad2.co.il`), header forwarding, error handling.
- `wrangler.toml`: deploy with `npx wrangler deploy`, set secret with `npx wrangler secret put RELAY_SECRET`.

### Config format

```yaml
http:
  relay_url: "https://yad2-relay.<account>.workers.dev"
  relay_secret: "${RELAY_SECRET}"
```

Opt-in — no behavior change without `relay_url` set.

## Rollout

1. Deploy Worker: `cd cf-worker && npx wrangler deploy && npx wrangler secret put RELAY_SECRET`
2. Verify: `curl -H "X-Relay-Secret: <secret>" "https://yad2-relay.<acct>.workers.dev/?target=https%3A%2F%2Fgw.yad2.co.il%2Ffeed-search-legacy%2Fvehicles%2Fcars%3Fmanufacturer%3D17"`
3. Add `relay_url`/`relay_secret` to prod config, `RELAY_SECRET` to `.env`
4. Restart scraper/enricher/api containers

## Tests

- 7 relay client unit tests: URL rewriting, response forwarding, auth validation, context cancellation, complex URL encoding, browser header forwarding, Worker error handling
- `go build ./...` ✅ · `go test ./internal/fetcher/yad2/ ./internal/config/` ✅ · `golangci-lint` → 0 issues ✅

## Rollback

Remove `relay_url`/`relay_secret` from config → restart. Code path only activates when `relay_url != ""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)