### PR TITLE
fix(bodytype): classify only from Yad2's structured field; drop sub-model guessing

### DIFF
--- a/internal/bodytype/bodytype.go
+++ b/internal/bodytype/bodytype.go
@@ -117,8 +117,8 @@ func yad2IDToType(id int) string {
 // text); they are matched in order. Text is tried before the numeric id because
 // the same words appear on both the search feed and the item page, whereas ids
 // are only verified for the feed. The id is a fallback for terms our vocabulary
-// doesn't recognize yet. Returns "" when nothing matches (caller should then
-// fall back to sub-model parsing).
+// doesn't recognize yet. Returns "" when Yad2 provides no recognizable body
+// type — the caller must leave body_type empty rather than guess from free text.
 func FromYad2(id int, texts ...string) string {
 	for _, t := range texts {
 		if bt := matchText(t); bt != "" {
@@ -126,18 +126,6 @@ func FromYad2(id int, texts ...string) string {
 		}
 	}
 	return yad2IDToType(id)
-}
-
-// Parse scans free-text strings (e.g. sub-model names) for body-type keywords,
-// returning the first match. Use this only as a fallback when Yad2's structured
-// bodyType field is unavailable; prefer FromYad2.
-func Parse(texts ...string) string {
-	for _, text := range texts {
-		if bt := matchText(text); bt != "" {
-			return bt
-		}
-	}
-	return ""
 }
 
 func matchText(text string) string {

--- a/internal/bodytype/bodytype_test.go
+++ b/internal/bodytype/bodytype_test.go
@@ -2,86 +2,6 @@ package bodytype
 
 import "testing"
 
-func TestParse(t *testing.T) {
-	tests := []struct {
-		name     string
-		subModel string
-		want     string
-	}{
-		// Hebrew body types
-		{"hebrew sedan", "Comfort סדאן 1.6 (132 כ״ס)", "sedan"},
-		{"hebrew hatchback geresh", "Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8 (98 כ״ס)", "hatchback"},
-		{"hebrew hatchback modified", "Excite האצ׳בק 1.6", "hatchback"},
-		{"hebrew suv jeep geresh", "Limited ג'יפ 2.0 (150 כ״ס)", "suv"},
-		{"hebrew suv jeep modified", "Sport ג׳יפ 2.5", "suv"},
-		{"hebrew crossover", "Active קרוסאובר 1.5 (115 כ״ס)", "suv"},
-		{"hebrew wagon station", "Touring סטיישן 2.0 (150 כ״ס)", "wagon"},
-		{"hebrew wagon tourer", "Luxury טורר אוט׳ 1.8", "wagon"},
-		{"hebrew coupe", "Sport קופה 2.0 (200 כ״ס)", "coupe"},
-		{"hebrew coupe alt", "RS קופא 3.0", "coupe"},
-		{"hebrew convertible cabrio", "Sport קבריולה 2.0", "convertible"},
-		{"hebrew convertible cabriolet", "קבריולט 1.8", "convertible"},
-		{"hebrew minivan", "Comfort מיניוון 2.0 (150 כ״ס)", "minivan"},
-		{"hebrew minivan alt spelling", "Comfort מיניוואן 2.0", "minivan"},
-		{"hebrew pickup", "Limited טנדר 3.0 (190 כ״ס)", "pickup"},
-
-		// Yad2 official bodyType vocabulary (previously unmatched → fell back to
-		// sub-model parsing). These are the values from the structured field.
-		{"yad2 crossover leisure", "פנאי-שטח", "suv"},
-		{"yad2 crossover leisure spaced", "פנאי שטח", "suv"},
-		{"yad2 rugged jeep", "ג'יפ שטח קשוח", "suv"},
-		{"yad2 liftback", "ליפטבק", "hatchback"},
-		{"yad2 station tourer", "סטיישן / טורר", "wagon"},
-
-		// English body types
-		{"english sedan", "Comfort sedan 1.6", "sedan"},
-		{"english hatchback", "Sport hatchback 1.4 TSI", "hatchback"},
-		{"english HB word boundary", "Sport HB 1.4", "hatchback"},
-		{"english SUV word boundary", "Premium SUV 2.0", "suv"},
-		{"english crossover", "Active crossover 1.5", "suv"},
-		{"english wagon", "Touring wagon 2.0", "wagon"},
-		{"english SW word boundary", "Comfort SW 1.6", "wagon"},
-		{"english station", "station 2.0 diesel", "wagon"},
-		{"english touring", "Grand Touring 2.5", "wagon"},
-		{"english coupe", "Sport coupe 2.0", "coupe"},
-		{"english convertible", "Sport convertible 2.0", "convertible"},
-		{"english cabrio", "Sport cabrio 1.8", "convertible"},
-		{"english minivan", "Comfort minivan 2.4", "minivan"},
-		{"english MPV word boundary", "Comfort MPV 2.0", "minivan"},
-		{"english pickup", "Limited pickup 3.0", "pickup"},
-
-		// Case insensitivity
-		{"mixed case SEDAN", "Comfort SEDAN 1.6", "sedan"},
-		{"mixed case Hatchback", "Sport Hatchback 1.4", "hatchback"},
-		{"lowercase suv", "Premium suv 2.0", "suv"},
-
-		// Word boundary: short tokens must not match inside words
-		{"SW inside word SKYVIEW", "Premium SKYVIEW 2.0", ""},
-		{"HB inside word THBIRD", "Premium THBIRD 1.8", ""},
-		{"SUV inside word INSUVERABLE", "INSUVERABLE 2.0", ""},
-
-		// No match
-		{"empty string", "", ""},
-		{"no body type keywords", "Premium אוט׳ 2.0 (165 כ״ס) [2017-2019]", ""},
-		{"just trim info", "LUXURY", ""},
-		{"engine only", "1.8 (98 כ״ס)", ""},
-
-		// Real Yad2 submodel strings
-		{"real yad2 hatchback", "Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8 (98 כ״ס)", "hatchback"},
-		{"real yad2 no body type", "Premium אוט׳ 2.0 (165 כ״ס) [2017-2019]", ""},
-		{"real yad2 sport no type", "Sport אוט׳ 1.8", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := Parse(tt.subModel)
-			if got != tt.want {
-				t.Errorf("Parse(%q) = %q, want %q", tt.subModel, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestFromYad2(t *testing.T) {
 	tests := []struct {
 		name string
@@ -98,6 +18,12 @@ func TestFromYad2(t *testing.T) {
 		{"id 7 crossover suv", 7, "פנאי-שטח", "suv"},
 		{"id 14 liftback", 14, "ליפטבק", "hatchback"},
 
+		// Official Yad2 labels for types without a verified id are matched by
+		// text (the only remaining classification path — no sub-model guessing).
+		{"convertible label", 0, "קבריולה", "convertible"},
+		{"minivan label", 0, "מיניוואן", "minivan"},
+		{"pickup label", 0, "טנדר", "pickup"},
+
 		// Text matches our vocabulary even when the id is unknown.
 		{"unknown id known text", 99, "סדאן", "sedan"},
 
@@ -105,7 +31,8 @@ func TestFromYad2(t *testing.T) {
 		// a future Yad2 wording change).
 		{"known id unrecognized text", 7, "מילה חדשה", "suv"},
 
-		// Neither resolves → empty (caller falls back to sub-model parsing).
+		// Neither the id nor the label resolves → empty. body_type stays empty;
+		// we never fall back to guessing from the sub-model.
 		{"unknown id and text", 0, "", ""},
 		{"unknown id unknown text", 99, "משהו אחר", ""},
 	}
@@ -131,28 +58,5 @@ func TestFromYad2_MatchesAcrossTexts(t *testing.T) {
 	// No text matches but a verified id does (defense-in-depth).
 	if got := FromYad2(7, "weird-value", ""); got != "suv" {
 		t.Errorf(`FromYad2(7, "weird-value", "") = %q, want "suv"`, got)
-	}
-}
-
-func TestParse_MultipleTexts(t *testing.T) {
-	tests := []struct {
-		name  string
-		texts []string
-		want  string
-	}{
-		{"english hit", []string{"Sport hatchback 1.4", "ספורט האצ'בק 1.4"}, "hatchback"},
-		{"english miss falls back to hebrew", []string{"Excite Plus", "Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8"}, "hatchback"},
-		{"both empty", []string{"", ""}, ""},
-		{"first empty second hit", []string{"", "סדאן 1.6"}, "sedan"},
-		{"single text", []string{"SUV Premium"}, "suv"},
-		{"no match in any", []string{"Excite Plus", "Premium אוט׳ 2.0"}, ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := Parse(tt.texts...)
-			if got != tt.want {
-				t.Errorf("Parse(%v) = %q, want %q", tt.texts, got, tt.want)
-			}
-		})
 	}
 }

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -318,14 +318,11 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 		listing.GearBox = "אוטומט"
 	}
 
-	// Prefer Yad2's structured bodyType field (authoritative); only guess from
-	// the free-text sub-model name when Yad2 gives us no usable classification.
-	// textFromField prefers the English variants, with the raw Hebrew text as a
-	// further fallback so we match whichever Yad2 populated.
+	// Body type comes ONLY from Yad2's structured bodyType field (id + label).
+	// We deliberately do not guess from the free-text sub-model name — that gave
+	// wrong/partial results (it only classified trims that happened to contain a
+	// body keyword). When Yad2 provides no bodyType, body_type stays empty.
 	listing.BodyType = bodytype.FromYad2(item.BodyType.ID, textFromField(item.BodyType), item.BodyType.Text)
-	if listing.BodyType == "" {
-		listing.BodyType = bodytype.Parse(subModelText, item.SubModel.Text)
-	}
 
 	listing.City = textFromField(item.Address.City)
 	listing.Area = textFromField(item.Address.Area)

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -805,7 +805,10 @@ func TestParseNextData_PreservesExplicitHPAndGearbox(t *testing.T) {
 	}
 }
 
-func TestParseNextData_ExtractsBodyTypeFromSubModel(t *testing.T) {
+// TestParseNextData_IgnoresSubModelBodyKeyword locks in that body type is never
+// inferred from the free-text sub-model: a listing whose sub-model contains a
+// body keyword (האצ'בק) but has no structured bodyType field stays empty.
+func TestParseNextData_IgnoresSubModelBodyKeyword(t *testing.T) {
 	data := []byte(`{
 		"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
 			"data":{"feed":{"feed_items":[{
@@ -829,8 +832,8 @@ func TestParseNextData_ExtractsBodyTypeFromSubModel(t *testing.T) {
 	if len(listings) != 1 {
 		t.Fatalf("expected 1 listing, got %d", len(listings))
 	}
-	if listings[0].BodyType != "hatchback" {
-		t.Errorf("BodyType = %q, want 'hatchback'", listings[0].BodyType)
+	if listings[0].BodyType != "" {
+		t.Errorf("BodyType = %q, want empty (sub-model text must not be used)", listings[0].BodyType)
 	}
 }
 
@@ -946,35 +949,6 @@ func TestParseNextData_BodyTypeUnrecognizedDirectField(t *testing.T) {
 	}
 	if listings[0].BodyType != "" {
 		t.Errorf("BodyType = %q, want empty (unrecognized value falls through)", listings[0].BodyType)
-	}
-}
-
-func TestParseNextData_BodyTypeFallsBackToHebrewText(t *testing.T) {
-	data := []byte(`{
-		"props":{"pageProps":{"dehydratedState":{"queries":[{"state":{"data":{
-			"data":{"feed":{"feed_items":[{
-				"token":"bt-hebrew-fallback",
-				"manufacturer":{"id":53,"text":"טויוטה","english_text":"Toyota"},
-				"model":{"id":10399,"text":"קורולה","english_text":"Corolla"},
-				"subModel":{"id":105280,"text":"Excite Plus היברידי אוט׳ האצ'בק 5 דל 1.8 (98 כ״ס)","english_text":"Excite Plus"},
-				"vehicleDates":{"yearOfProduction":2019},
-				"engineVolume":1798,
-				"price":87000,
-				"hand":{"id":1},
-				"metaData":{"coverImage":"https://img.yad2.co.il/test.jpg"}
-			}]}}
-		}}}]}}}
-	}`)
-
-	listings, err := parseNextData(data, nil)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if len(listings) != 1 {
-		t.Fatalf("expected 1 listing, got %d", len(listings))
-	}
-	if listings[0].BodyType != "hatchback" {
-		t.Errorf("BodyType = %q, want 'hatchback' (from Hebrew text fallback when english_text lacks body type)", listings[0].BodyType)
 	}
 }
 


### PR DESCRIPTION
## Why

The body-type filter was misleading: on the Corolla search, **3 of 10** identical sedans passed the "סדאן" filter — exactly the 3 whose sub-model text literally contained "סדאן" (`Active אוט׳ סדאן 4 דל`). The other 7 (`Sun היברידי אוט׳ 1.8`, etc.) were left unclassified because the fallback **guessed body type from the free-text sub-model name**, which only works when a trim happens to include a body keyword.

Per the decision to not rely on that heuristic, this **removes it entirely**.

## What

- Delete `bodytype.Parse` (the free-text scanner) and its only caller (the sub-model fallback in the feed parser).
- `body_type` now comes **only** from Yad2's structured `bodyType` field (id + label) via `bodytype.FromYad2`. When Yad2 provides no `bodyType`, `body_type` stays **empty** — no guessing.
- Tests: replaced the "extracts body type from sub-model" test with one that locks in the opposite (a sub-model body keyword is **ignored**); removed the Hebrew-fallback test; kept and extended `FromYad2` coverage for the official Yad2 labels (incl. convertible/minivan/pickup).

**−157 / +20 lines.** `go test ./internal/bodytype ./internal/fetcher/yad2` ✅ · `go vet` ✅ · `golangci-lint --new-from-rev=origin/main` → 0 issues ✅

## Important follow-up (behavior)

Yad2's real `bodyType` is only reachable via the gw feed / item page, both currently behind Yad2's anti-bot from the prod IP. So after this deploys, `body_type` will be **empty for most listings** until that egress is solved — the body-type filter facet effectively disappears rather than showing a misleading subset. That's the intended tradeoff ("no filter" > "wrong filter").

Two consequences to be aware of:
1. **Existing DB rows** keep their sub-model-derived `body_type` (the upsert preserves a non-empty value when the new one is empty), so the stale "3 sedans" persist until cleared. Clearing them is a separate prod step.
2. Once a trusted egress (the Worker relay / proxies) lets Yad2's `bodyType` through, classification becomes complete and correct automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved body-type matching so listings now rely on structured source data and known text labels, instead of guessing from free-text sub-model text.
  * When no reliable body-type match is available, the field now stays empty rather than being filled with an incorrect value.
  * Body-type detection is more consistent across multiple text inputs, including cases where one text value matches and another does not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->