### PR TITLE
fix: disable rod leakless to run in read-only containers

### DIFF
--- a/internal/fetcher/yad2/rod_fetcher.go
+++ b/internal/fetcher/yad2/rod_fetcher.go
@@ -45,6 +45,7 @@ func (f *RodFetcher) ensureBrowser() error {
 	}
 
 	l := launcher.New().Bin(f.binPath).
+		Leakless(false).
 		Set("disable-blink-features", "AutomationControlled").
 		Set("no-sandbox").
 		Set("disable-dev-shm-usage").


### PR DESCRIPTION
## Why

Follow-up to #1465. The rod launcher uses a `leakless` binary written to `/tmp` which can't execute in containers with `no-new-privileges` and read-only root filesystem. The scraper crash-loops with:

```
fork/exec /tmp/leakless-amd64-.../leakless: permission denied
```

## Fix

Set `Leakless(false)` on the rod launcher. Chrome is managed by the container runtime instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)