### PR TITLE
fix: disable chromium crash reporter for read-only containers

### DIFF
--- a/internal/fetcher/yad2/rod_fetcher.go
+++ b/internal/fetcher/yad2/rod_fetcher.go
@@ -49,6 +49,8 @@ func (f *RodFetcher) ensureBrowser() error {
 		Set("disable-blink-features", "AutomationControlled").
 		Set("no-sandbox").
 		Set("disable-dev-shm-usage").
+		Set("disable-crash-reporter").
+		Set("crash-dumps-dir", "/tmp").
 		Set("headless", "new")
 
 	u, err := l.Launch()


### PR DESCRIPTION
Follow-up to #1465. Chromium's crashpad handler fails in read-only containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)