### PR TITLE
fix: chromium launch flags for Alpine Docker containers

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -154,7 +154,7 @@ services:
     cap_drop:
       - ALL
     tmpfs:
-      - /tmp
+      - /tmp:exec
       - /dev/shm:size=128m
     networks:
       - carwatch-net
@@ -185,7 +185,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 768M
 
   notifier:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
@@ -237,7 +237,7 @@ services:
     cap_drop:
       - ALL
     tmpfs:
-      - /tmp
+      - /tmp:exec
       - /dev/shm:size=128m
     networks:
       - carwatch-net

--- a/internal/fetcher/yad2/rod_fetcher.go
+++ b/internal/fetcher/yad2/rod_fetcher.go
@@ -49,8 +49,9 @@ func (f *RodFetcher) ensureBrowser() error {
 		Set("disable-blink-features", "AutomationControlled").
 		Set("no-sandbox").
 		Set("disable-dev-shm-usage").
-		Set("disable-crash-reporter").
-		Set("crash-dumps-dir", "/tmp").
+		Set("disable-breakpad").
+		Set("no-zygote").
+		Set("disable-gpu").
 		Set("headless", "new")
 
 	u, err := l.Launch()


### PR DESCRIPTION
Follow-up to #1465, #1466, #1467. Chromium on Alpine in Docker needs:
- `--no-zygote` — avoids crashpad handler fork that fails in read-only containers
- `--disable-breakpad` — disables crash reporting entirely
- `--disable-gpu` — avoids Vulkan/EGL init errors on headless VMs
- `tmpfs /tmp:exec` — Chromium needs exec permission on temp directory

Tested: `docker run` with these flags starts DevTools listener successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)