### PR TITLE
fix: create writable crashpad dir for non-root chromium user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/api-server ./cmd/api-se
 
 FROM alpine:3.24
 RUN apk add --no-cache ca-certificates tzdata chromium \
-    && adduser -D -u 1000 carwatch
+    && adduser -D -u 1000 carwatch \
+    && mkdir -p /home/carwatch/.local/share/chromium/Crashpad \
+    && chown -R carwatch:carwatch /home/carwatch
 USER carwatch
 COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /bin/enricher /bin/enrich-bench /usr/local/bin/
 COPY --from=builder /app/migrations /migrations

--- a/internal/fetcher/yad2/rod_fetcher.go
+++ b/internal/fetcher/yad2/rod_fetcher.go
@@ -52,6 +52,7 @@ func (f *RodFetcher) ensureBrowser() error {
 		Set("disable-breakpad").
 		Set("no-zygote").
 		Set("disable-gpu").
+		Set("user-data-dir", "/tmp/chromium-data").
 		Set("headless", "new")
 
 	u, err := l.Launch()


### PR DESCRIPTION
Follow-up to #1468. Crashpad needs a writable database directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)