### PR TITLE
fix: add writable home tmpfs for chromium crashpad in containers

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -156,6 +156,7 @@ services:
     tmpfs:
       - /tmp:exec
       - /dev/shm:size=128m
+      - /home/carwatch
     networks:
       - carwatch-net
     depends_on:
@@ -239,6 +240,7 @@ services:
     tmpfs:
       - /tmp:exec
       - /dev/shm:size=128m
+      - /home/carwatch
     networks:
       - carwatch-net
     depends_on:


### PR DESCRIPTION
Chromium's crashpad needs writable home dir. Verified on production VM — Chrome starts and DevTools responds in hardened container setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production service reliability by adding additional temporary in-memory storage for background processing.
  * Reduced risk of storage-related issues during scraping and enrichment tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->