### PR TITLE
fix: set uid/gid on tmpfs mounts for chromium in containers

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -154,8 +154,9 @@ services:
     cap_drop:
       - ALL
     tmpfs:
-      - /tmp:exec
+      - /tmp:exec,uid=1000,gid=1000
       - /dev/shm:size=128m
+      - /home/carwatch:uid=1000,gid=1000
     networks:
       - carwatch-net
     depends_on:
@@ -237,8 +238,9 @@ services:
     cap_drop:
       - ALL
     tmpfs:
-      - /tmp:exec
+      - /tmp:exec,uid=1000,gid=1000
       - /dev/shm:size=128m
+      - /home/carwatch:uid=1000,gid=1000
     networks:
       - carwatch-net
     depends_on:


### PR DESCRIPTION
tmpfs for /home/carwatch defaulted to root. Adding uid=1000,gid=1000 lets carwatch user write. Verified on VM — Chrome starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)