### PR TITLE
feat: add Chrome extension to replace VM-based Yad2 scraper

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -4,6 +4,9 @@ const ALARM_NAME = "carwatch-fetch";
 const FETCH_INTERVAL_MINUTES = 15;
 const INTER_SEARCH_DELAY_MS = 3000;
 const DEFAULT_API_URL = "https://carwatch.duckdns.org";
+const FETCH_TIMEOUT_MS = 15000;
+
+let isRunning = false;
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.alarms.create(ALARM_NAME, { periodInMinutes: FETCH_INTERVAL_MINUTES });
@@ -56,17 +59,33 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function fetchWithTimeout(url, options = {}, timeoutMs = FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(id);
+  }
+}
+
 async function runFetchCycle() {
-  const config = await getConfig();
-  if (!config.authToken) {
-    setBadge("!", "#F44");
-    await saveStatus({ error: "No auth token configured" });
+  if (isRunning) {
+    console.log("[CarWatch] Cycle already running, skipping");
     return;
   }
-
-  setBadge("...", "#888");
+  isRunning = true;
 
   try {
+    const config = await getConfig();
+    if (!config.authToken) {
+      setBadge("!", "#F44");
+      await saveStatus({ error: "No auth token configured" });
+      return;
+    }
+
+    setBadge("...", "#888");
+
     const searches = await fetchSearches(config);
     const activeSearches = searches.filter(
       (s) => s.active && s.manufacturer_id > 0 && s.model_id > 0,
@@ -89,7 +108,7 @@ async function runFetchCycle() {
         const url = buildYad2URL(search);
         console.log(`[CarWatch] Fetching: ${search.name || search.id}`, url);
 
-        const resp = await fetch(url);
+        const resp = await fetchWithTimeout(url);
         if (!resp.ok) {
           console.warn(`[CarWatch] Yad2 returned ${resp.status} for search ${search.id}`);
           continue;
@@ -124,11 +143,13 @@ async function runFetchCycle() {
     console.error("[CarWatch] Cycle error:", err);
     setBadge("!", "#F44");
     await saveStatus({ error: err.message });
+  } finally {
+    isRunning = false;
   }
 }
 
 async function fetchSearches(config) {
-  const resp = await fetch(`${config.apiUrl}/api/v1/searches`, {
+  const resp = await fetchWithTimeout(`${config.apiUrl}/api/v1/searches`, {
     headers: { Authorization: `Bearer ${config.authToken}` },
   });
   if (!resp.ok) throw new Error(`API returned ${resp.status}`);
@@ -136,21 +157,31 @@ async function fetchSearches(config) {
 }
 
 async function pushListings(config, listings) {
-  const resp = await fetch(`${config.apiUrl}/api/v1/ext/ingest`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.authToken}`,
-    },
-    body: JSON.stringify({ listings }),
-  });
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Ingest failed: ${resp.status} ${text}`);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await sleep(2000 * attempt);
+    const resp = await fetchWithTimeout(
+      `${config.apiUrl}/api/v1/ext/ingest`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.authToken}`,
+        },
+        body: JSON.stringify({ listings }),
+      },
+      30000,
+    );
+    if (resp.ok) {
+      const result = await resp.json();
+      console.log("[CarWatch] Ingest result:", result);
+      return result;
+    }
+    if (attempt === 2) {
+      const text = await resp.text();
+      throw new Error(`Ingest failed: ${resp.status} ${text}`);
+    }
+    console.warn(`[CarWatch] Ingest attempt ${attempt + 1} failed: ${resp.status}`);
   }
-  const result = await resp.json();
-  console.log("[CarWatch] Ingest result:", result);
-  return result;
 }
 
 function setBadge(text, color) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,166 @@
+importScripts("parser.js");
+
+const ALARM_NAME = "carwatch-fetch";
+const FETCH_INTERVAL_MINUTES = 15;
+const INTER_SEARCH_DELAY_MS = 3000;
+const DEFAULT_API_URL = "https://carwatch.duckdns.org";
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create(ALARM_NAME, { periodInMinutes: FETCH_INTERVAL_MINUTES });
+  console.log("[CarWatch] Alarm set: every", FETCH_INTERVAL_MINUTES, "minutes");
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === ALARM_NAME) {
+    runFetchCycle();
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.action === "fetchNow") {
+    runFetchCycle();
+  }
+});
+
+async function getConfig() {
+  const data = await chrome.storage.sync.get(["apiUrl", "authToken"]);
+  return {
+    apiUrl: data.apiUrl || DEFAULT_API_URL,
+    authToken: data.authToken || "",
+  };
+}
+
+function buildYad2URL(search) {
+  const params = new URLSearchParams();
+  if (search.manufacturer_id) params.set("manufacturer", search.manufacturer_id);
+  if (search.model_id) params.set("model", search.model_id);
+  if (search.year_min || search.year_max) {
+    params.set("year", `${search.year_min || 2000}-${search.year_max || 2030}`);
+  }
+  if (search.price_min || search.price_max) {
+    params.set("price", `${search.price_min || 0}-${search.price_max || 9999999}`);
+  }
+  if (search.max_km) params.set("km", `-1-${search.max_km}`);
+  if (search.max_hand) params.set("hand", `0-${search.max_hand}`);
+  if (search.engine_min_cc) params.set("engineval", `${search.engine_min_cc}--1`);
+  if (search.seller_filter === "private") params.set("ownerID", "1");
+  else if (["commercial", "dealer"].includes(search.seller_filter))
+    params.set("ownerID", "2");
+  if (search.photo_only) params.set("imgOnly", "1");
+  params.set("Order", "1");
+  params.set("page", "1");
+  return `https://www.yad2.co.il/vehicles/cars?${params}`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runFetchCycle() {
+  const config = await getConfig();
+  if (!config.authToken) {
+    setBadge("!", "#F44");
+    await saveStatus({ error: "No auth token configured" });
+    return;
+  }
+
+  setBadge("...", "#888");
+
+  try {
+    const searches = await fetchSearches(config);
+    const activeSearches = searches.filter(
+      (s) => s.active && s.manufacturer_id > 0 && s.model_id > 0,
+    );
+
+    if (activeSearches.length === 0) {
+      setBadge("0", "#888");
+      await saveStatus({ searches: 0, listings: 0, error: null });
+      return;
+    }
+
+    let totalListings = 0;
+    const allListings = [];
+
+    for (let i = 0; i < activeSearches.length; i++) {
+      const search = activeSearches[i];
+      if (i > 0) await sleep(INTER_SEARCH_DELAY_MS);
+
+      try {
+        const url = buildYad2URL(search);
+        console.log(`[CarWatch] Fetching: ${search.name || search.id}`, url);
+
+        const resp = await fetch(url);
+        if (!resp.ok) {
+          console.warn(`[CarWatch] Yad2 returned ${resp.status} for search ${search.id}`);
+          continue;
+        }
+
+        const html = await resp.text();
+        const result = parseNextData(html);
+        if (result.error) {
+          console.warn(`[CarWatch] Parse error for search ${search.id}:`, result.error);
+          continue;
+        }
+
+        console.log(`[CarWatch] Found ${result.listings.length} listings for ${search.name || search.id}`);
+        totalListings += result.listings.length;
+        allListings.push(...result.listings);
+      } catch (err) {
+        console.error(`[CarWatch] Fetch error for search ${search.id}:`, err);
+      }
+    }
+
+    if (allListings.length > 0) {
+      await pushListings(config, allListings);
+    }
+
+    setBadge(String(totalListings), "#4CAF50");
+    await saveStatus({
+      searches: activeSearches.length,
+      listings: totalListings,
+      error: null,
+    });
+  } catch (err) {
+    console.error("[CarWatch] Cycle error:", err);
+    setBadge("!", "#F44");
+    await saveStatus({ error: err.message });
+  }
+}
+
+async function fetchSearches(config) {
+  const resp = await fetch(`${config.apiUrl}/api/v1/searches`, {
+    headers: { Authorization: `Bearer ${config.authToken}` },
+  });
+  if (!resp.ok) throw new Error(`API returned ${resp.status}`);
+  return resp.json();
+}
+
+async function pushListings(config, listings) {
+  const resp = await fetch(`${config.apiUrl}/api/v1/ext/ingest`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.authToken}`,
+    },
+    body: JSON.stringify({ listings }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Ingest failed: ${resp.status} ${text}`);
+  }
+  const result = await resp.json();
+  console.log("[CarWatch] Ingest result:", result);
+  return result;
+}
+
+function setBadge(text, color) {
+  chrome.action.setBadgeText({ text });
+  chrome.action.setBadgeBackgroundColor({ color });
+}
+
+async function saveStatus(status) {
+  await chrome.storage.local.set({
+    lastRun: new Date().toISOString(),
+    ...status,
+  });
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "CarWatch Scraper",
+  "version": "1.0.0",
+  "description": "Fetches Yad2 listings in the background and pushes them to CarWatch",
+  "permissions": ["alarms", "storage"],
+  "host_permissions": [
+    "https://www.yad2.co.il/*",
+    "https://carwatch.duckdns.org/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "CarWatch Scraper"
+  }
+}

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -1,0 +1,124 @@
+const BUCKET_KEYS = ["private", "commercial", "platinum", "boost", "solo"];
+
+const COMMERCIAL_BUCKETS = new Set(["commercial", "platinum", "solo", "boost"]);
+
+function textFromField(field) {
+  if (!field) return "";
+  return field.english_text || field.textEng || field.text || "";
+}
+
+function parseHand(raw) {
+  if (typeof raw === "number") return raw;
+  if (raw && typeof raw === "object" && raw.id) return raw.id;
+  return 0;
+}
+
+function resolveImageURL(item) {
+  const md = item.metaData || {};
+  return (
+    md.coverImage ||
+    md.cover_image ||
+    item.coverImage ||
+    item.cover_image ||
+    (md.images && md.images[0]) ||
+    (item.images && item.images[0]) ||
+    ""
+  );
+}
+
+function itemToListing(item, isCommercial) {
+  const token = item.token;
+  if (!token) return null;
+
+  const year =
+    item.year_of_production ||
+    (item.vehicleDates && item.vehicleDates.yearOfProduction) ||
+    0;
+
+  const listing = {
+    token,
+    manufacturer: textFromField(item.manufacturer),
+    manufacturer_id: item.manufacturer?.id || 0,
+    model: textFromField(item.model),
+    model_id: item.model?.id || 0,
+    sub_model: textFromField(item.subModel),
+    sub_model_id: item.subModel?.id || 0,
+    year,
+    price: item.price || 0,
+    km: item.km || item.kilometers || 0,
+    hand: parseHand(item.hand),
+    city: textFromField(item.address?.city),
+    area: textFromField(item.address?.area),
+    image_url: resolveImageURL(item),
+    page_link: `https://www.yad2.co.il/vehicles/item/${token}`,
+    engine_volume: item.engine_volume || item.engineVolume || 0,
+    engine_type: textFromField(item.engineType),
+    gear_box: textFromField(item.gearBox),
+    body_type: textFromField(item.bodyType),
+    description: item.metaData?.description || "",
+    is_commercial: isCommercial,
+  };
+
+  if (item.dates?.createdAt || item.createdAt) {
+    listing.created_at = item.dates?.createdAt || item.createdAt;
+  }
+
+  return listing;
+}
+
+function parseNextData(html) {
+  const match = html.match(
+    /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i,
+  );
+  if (!match || !match[1]) return { error: "no __NEXT_DATA__" };
+
+  let data;
+  try {
+    data = JSON.parse(match[1]);
+  } catch {
+    return { error: "invalid __NEXT_DATA__ JSON" };
+  }
+
+  const queries =
+    data?.props?.pageProps?.dehydratedState?.queries || [];
+
+  for (const q of queries) {
+    const stateData = q?.state?.data;
+    if (!stateData) continue;
+
+    const listings = [];
+    let found = false;
+
+    for (const key of BUCKET_KEYS) {
+      const items = stateData[key];
+      if (!Array.isArray(items)) continue;
+      found = true;
+      const isCommercial = COMMERCIAL_BUCKETS.has(key);
+      for (const item of items) {
+        const listing = itemToListing(item, isCommercial);
+        if (listing) listings.push(listing);
+      }
+    }
+
+    if (found) {
+      const seen = new Set();
+      const deduped = listings.filter((l) => {
+        if (seen.has(l.token)) return false;
+        seen.add(l.token);
+        return true;
+      });
+      return { listings: deduped };
+    }
+
+    // Legacy format: data.feed.feed_items
+    const feedItems = stateData?.data?.feed?.feed_items;
+    if (Array.isArray(feedItems)) {
+      const listings = feedItems
+        .map((item) => itemToListing(item, null))
+        .filter(Boolean);
+      return { listings };
+    }
+  }
+
+  return { error: "no feed items found" };
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { width: 320px; font-family: -apple-system, BlinkMacSystemFont, sans-serif; padding: 16px; margin: 0; color: #1a1a2e; }
+    h2 { margin: 0 0 12px; font-size: 16px; }
+    label { display: block; font-size: 12px; color: #666; margin-top: 10px; }
+    input { width: 100%; padding: 6px 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; box-sizing: border-box; margin-top: 2px; }
+    .status { margin-top: 14px; padding: 10px; background: #f5f5f5; border-radius: 6px; font-size: 12px; }
+    .status div { margin: 2px 0; }
+    .error { color: #d32f2f; }
+    .ok { color: #2e7d32; }
+    button { margin-top: 12px; width: 100%; padding: 8px; border: none; border-radius: 4px; background: #1a73e8; color: white; font-size: 13px; cursor: pointer; }
+    button:hover { background: #1557b0; }
+    button:disabled { background: #ccc; cursor: default; }
+    .save-msg { font-size: 11px; color: #2e7d32; margin-top: 4px; display: none; }
+  </style>
+</head>
+<body>
+  <h2>CarWatch Scraper</h2>
+
+  <label>API URL</label>
+  <input type="url" id="apiUrl" placeholder="https://carwatch.duckdns.org">
+
+  <label>Auth Token</label>
+  <input type="password" id="authToken" placeholder="Firebase ID token">
+  <div class="save-msg" id="saveMsg">Saved</div>
+
+  <button id="saveBtn">Save</button>
+  <button id="fetchBtn">Fetch Now</button>
+
+  <div class="status" id="status">Loading...</div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,70 @@
+document.addEventListener("DOMContentLoaded", async () => {
+  const apiUrlInput = document.getElementById("apiUrl");
+  const authTokenInput = document.getElementById("authToken");
+  const saveBtn = document.getElementById("saveBtn");
+  const fetchBtn = document.getElementById("fetchBtn");
+  const statusDiv = document.getElementById("status");
+  const saveMsg = document.getElementById("saveMsg");
+
+  const config = await chrome.storage.sync.get(["apiUrl", "authToken"]);
+  apiUrlInput.value = config.apiUrl || "https://carwatch.duckdns.org";
+  authTokenInput.value = config.authToken || "";
+
+  saveBtn.addEventListener("click", async () => {
+    await chrome.storage.sync.set({
+      apiUrl: apiUrlInput.value.replace(/\/+$/, ""),
+      authToken: authTokenInput.value,
+    });
+    saveMsg.style.display = "block";
+    setTimeout(() => (saveMsg.style.display = "none"), 2000);
+  });
+
+  fetchBtn.addEventListener("click", () => {
+    fetchBtn.disabled = true;
+    fetchBtn.textContent = "Fetching...";
+    chrome.runtime.sendMessage({ action: "fetchNow" });
+    setTimeout(() => {
+      fetchBtn.disabled = false;
+      fetchBtn.textContent = "Fetch Now";
+      refreshStatus();
+    }, 10000);
+  });
+
+  refreshStatus();
+
+  async function refreshStatus() {
+    const data = await chrome.storage.local.get([
+      "lastRun",
+      "searches",
+      "listings",
+      "error",
+    ]);
+    let html = "";
+    if (data.lastRun) {
+      const ago = timeSince(new Date(data.lastRun));
+      html += `<div>Last run: <strong>${ago} ago</strong></div>`;
+    }
+    if (data.searches !== undefined) {
+      html += `<div>Searches: ${data.searches}</div>`;
+    }
+    if (data.listings !== undefined) {
+      html += `<div class="ok">Listings found: ${data.listings}</div>`;
+    }
+    if (data.error) {
+      html += `<div class="error">Error: ${data.error}</div>`;
+    }
+    if (!html) {
+      html = "No data yet. Click Fetch Now to start.";
+    }
+    statusDiv.innerHTML = html;
+  }
+
+  function timeSince(date) {
+    const seconds = Math.floor((new Date() - date) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ${minutes % 60}m`;
+  }
+});

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -39,24 +39,30 @@ document.addEventListener("DOMContentLoaded", async () => {
       "listings",
       "error",
     ]);
-    let html = "";
+    statusDiv.textContent = "";
+    const lines = [];
     if (data.lastRun) {
-      const ago = timeSince(new Date(data.lastRun));
-      html += `<div>Last run: <strong>${ago} ago</strong></div>`;
+      lines.push(`Last run: ${timeSince(new Date(data.lastRun))} ago`);
     }
     if (data.searches !== undefined) {
-      html += `<div>Searches: ${data.searches}</div>`;
+      lines.push(`Searches: ${data.searches}`);
     }
     if (data.listings !== undefined) {
-      html += `<div class="ok">Listings found: ${data.listings}</div>`;
+      lines.push(`Listings found: ${data.listings}`);
     }
     if (data.error) {
-      html += `<div class="error">Error: ${data.error}</div>`;
+      lines.push(`Error: ${data.error}`);
     }
-    if (!html) {
-      html = "No data yet. Click Fetch Now to start.";
+    if (lines.length === 0) {
+      lines.push("No data yet. Click Fetch Now to start.");
     }
-    statusDiv.innerHTML = html;
+    for (const line of lines) {
+      const div = document.createElement("div");
+      div.textContent = line;
+      if (line.startsWith("Error:")) div.className = "error";
+      if (line.startsWith("Listings")) div.className = "ok";
+      statusDiv.appendChild(div);
+    }
   }
 
   function timeSince(date) {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -273,6 +273,7 @@ func (s *Server) Routes() http.Handler {
 	authMux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
 	authMux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
 	authMux.HandleFunc("GET /api/v1/listings/{token}/price-history", s.listingPriceHistory)
+	authMux.HandleFunc("POST /api/v1/ext/ingest", s.ingestListings)
 
 	if s.cycleStats != nil {
 		authMux.HandleFunc("GET /api/v1/searches/cycle-stats", s.listSearchCycleStats)

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -313,8 +313,11 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 			Commercial:     l.IsCommercial,
 		}
 		if l.CreatedAt != "" {
-			if t, err := time.Parse(time.RFC3339, l.CreatedAt); err == nil {
-				rl.CreatedAt = t
+			for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"} {
+				if t, err := time.Parse(layout, l.CreatedAt); err == nil {
+					rl.CreatedAt = t
+					break
+				}
 			}
 		}
 		raw = append(raw, rl)

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -222,6 +223,139 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 		Items:   toListingResponses(listings, savedMap, seenMap),
 		Total:   total,
 		Removed: removed,
+	})
+}
+
+type ingestRequest struct {
+	Listings []ingestListing `json:"listings"`
+}
+
+type ingestListing struct {
+	Token          string  `json:"token"`
+	Manufacturer   string  `json:"manufacturer"`
+	ManufacturerID int     `json:"manufacturer_id"`
+	Model          string  `json:"model"`
+	ModelID        int     `json:"model_id"`
+	SubModel       string  `json:"sub_model"`
+	SubModelID     int     `json:"sub_model_id"`
+	BodyType       string  `json:"body_type"`
+	Year           int     `json:"year"`
+	Price          int     `json:"price"`
+	Km             int     `json:"km"`
+	Hand           int     `json:"hand"`
+	City           string  `json:"city"`
+	Area           string  `json:"area"`
+	ImageURL       string  `json:"image_url"`
+	PageLink       string  `json:"page_link"`
+	EngineVolume   float64 `json:"engine_volume"`
+	EngineType     string  `json:"engine_type"`
+	GearBox        string  `json:"gear_box"`
+	Description    string  `json:"description"`
+	IsCommercial   *bool   `json:"is_commercial"`
+	CreatedAt      string  `json:"created_at"`
+}
+
+type ingestResponse struct {
+	Processed  int `json:"processed"`
+	NewMatches int `json:"new_matches"`
+}
+
+func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
+	chatID, ok := s.requireResolvedChatID(w, r)
+	if !ok {
+		return
+	}
+
+	log := s.handlerLogger(r, "op", "ingest")
+
+	var req ingestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if len(req.Listings) == 0 {
+		writeJSON(w, http.StatusOK, ingestResponse{})
+		return
+	}
+
+	if len(req.Listings) > 500 {
+		writeError(w, http.StatusBadRequest, "too many listings (max 500)")
+		return
+	}
+
+	raw := make([]model.RawListing, 0, len(req.Listings))
+	for _, l := range req.Listings {
+		if l.Token == "" {
+			continue
+		}
+		rl := model.RawListing{
+			Token:          l.Token,
+			Manufacturer:   l.Manufacturer,
+			ManufacturerID: l.ManufacturerID,
+			Model:          l.Model,
+			ModelID:        l.ModelID,
+			SubModel:       l.SubModel,
+			SubModelID:     l.SubModelID,
+			BodyType:       l.BodyType,
+			Year:           l.Year,
+			Price:          l.Price,
+			Km:             l.Km,
+			Hand:           l.Hand,
+			City:           l.City,
+			Area:           l.Area,
+			ImageURL:       l.ImageURL,
+			PageLink:       l.PageLink,
+			EngineVolume:   l.EngineVolume,
+			EngineType:     l.EngineType,
+			GearBox:        l.GearBox,
+			Description:    l.Description,
+			Commercial:     l.IsCommercial,
+		}
+		if l.CreatedAt != "" {
+			if t, err := time.Parse(time.RFC3339, l.CreatedAt); err == nil {
+				rl.CreatedAt = t
+			}
+		}
+		raw = append(raw, rl)
+	}
+
+	searches, err := s.searches.ListSearches(r.Context(), chatID)
+	if err != nil {
+		log.Error("list searches failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list searches")
+		return
+	}
+
+	totalNew := 0
+	for _, sr := range searches {
+		if !sr.Active || (sr.Manufacturer == 0 && sr.Model == 0) {
+			continue
+		}
+
+		criteria := model.FilterCriteriaFromSearch(&sr)
+		filtered := filter.Apply(criteria, raw)
+		if len(filtered) == 0 {
+			continue
+		}
+
+		params := scheduler.ProcessParamsFromSearch(sr, nil)
+		params.ChatID = chatID
+		pr := s.pipeline.Process(r.Context(), filtered, params)
+		if len(pr.Records) > 0 {
+			if err := s.listings.SaveListings(r.Context(), pr.Records); err != nil {
+				log.Error("save listings failed", "search_id", sr.ID, "error", err)
+				continue
+			}
+			totalNew += len(pr.Records)
+		}
+	}
+
+	log.Info("ingest complete", "submitted", len(req.Listings), "parsed", len(raw), "new_matches", totalNew)
+
+	writeJSON(w, http.StatusOK, ingestResponse{
+		Processed:  len(raw),
+		NewMatches: totalNew,
 	})
 }
 


### PR DESCRIPTION
## Why

Yad2's Radware anti-bot blocks all datacenter IPs — the VM scraper is dead. Every bypass (stealth HTTP, Cloudflare relay, fresh IP, headless Chrome) fails. Only a real browser from a residential IP passes.

A Chrome extension runs in the user's browser — residential IP, real TLS, Radware already solved. It replaces the VM scraper entirely.

## What

### Chrome Extension (`extension/`)

- **Manifest V3** service worker with `alarms` permission
- **Background fetch**: every 15 minutes, fetches active searches from API, builds Yad2 URLs, parses `__NEXT_DATA__`, pushes to API
- **Parser**: JS port of the Go `extractItems()` + `itemToListing()` logic — handles both bucket format (`private`/`commercial`/etc.) and legacy `feed_items`
- **Popup**: config (API URL + auth token) + status (last run, listings count, errors) + manual "Fetch Now" button
- **Rate control**: 3-second delay between Yad2 fetches

### API Endpoint

`POST /api/v1/ext/ingest` — accepts raw listings from the extension:
- Auth required (Firebase token)
- Matches listings against all user's active searches using existing `filter.Apply`
- Runs through scoring pipeline (`ListingPipeline.Process`)
- Saves via existing `SaveListings` upsert
- Returns `{processed, new_matches}`

## How to use

1. Merge this PR, deploy API
2. Go to `chrome://extensions` → Load unpacked → select `extension/`
3. Click extension icon → set API URL and Firebase auth token
4. Click "Fetch Now" or wait 15 minutes

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint` → 0 issues
- [x] Existing tests pass
- [ ] Load extension in Chrome, verify Yad2 fetch + API push works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Manifest V3 browser extension with a popup to configure an API URL and auth token, manually trigger fetches, and view run status.
  * Introduced automated background scraping with scheduled and on-demand fetches, aggregating results and sending them for ingestion.
  * Added a new authenticated API endpoint to ingest scraped listings and match them against active searches.
* **Bug Fixes**
  * Improved robustness of parsing and deduplication of listings across different page structures.
  * Added safer fetch behavior with timeouts, per-page failure handling, and ingest retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->