### PR TITLE
feat(ext): switch Yad2 scraping to gateway JSON API from a real tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ A self-hosted bot that monitors Israeli car listing sites (Yad2) and sends notif
 
 ## What it does
 
-1. Polls Yad2 on a schedule (every 10-20 minutes)
+1. Ingests Yad2 car listings via a browser extension that calls Yad2's own
+   gateway JSON API from a real browser tab (see [Data flow](#data-flow))
 2. Filters results by engine size, mileage, ownership count, keywords
 3. Deduplicates using PostgreSQL so you only get notified once per listing
-4. Sends formatted notifications with specs, price, and a direct link via Telegram and Web Push
+4. Serves a web UI to browse scored listings, and sends formatted
+   notifications (specs, price, direct link) via Telegram and Web Push
 
 ## Quick start
 
@@ -88,33 +90,90 @@ docker exec carwatch-enricher wget -q --spider http://localhost:8084/healthz
 
 See [`config.example.yaml`](config.example.yaml) for all options.
 
-## Architecture
+## Data flow
 
-See [docs/architecture.md](docs/architecture.md) for the full breakdown.
+Where the data comes from, where it's processed and stored, and how it reaches
+you. Yad2 now serves listings from a Radware-protected gateway JSON API and no
+longer embeds them in server-rendered HTML, so a **browser extension** running
+in your own Chrome is the ingestion engine: it calls Yad2's gateway API from a
+real tab (carrying the browser's TLS fingerprint and Radware clearance cookie),
+which server-side scrapers can no longer do.
 
+```mermaid
+flowchart TB
+    subgraph SRC["1 · Source — Yad2 gateway API (Radware-protected)"]
+        FEED["gw.yad2.co.il/feed-search-vehicles/cars<br/>list feed → token, price, seller, dates"]
+        ITEM["gw.yad2.co.il/vehicles-item/{token}<br/>per-listing detail → mileage (km), city, images"]
+    end
+
+    subgraph ING["2 · Ingestion — Chrome extension (runs in your browser)"]
+        SW["service worker · alarm every 15 min"]
+        TAB["open yad2.co.il tab<br/>real Chrome TLS + Radware clearance cookie"]
+        PJS["parser.js<br/>parseFeed + parseItemDetail → listings"]
+        TOK["content.js + bridge.js<br/>capture Firebase auth token from the CarWatch web app"]
+    end
+
+    subgraph VM["3 · Processing and storage — Oracle Cloud VM, Jerusalem (Docker + Caddy)"]
+        CADDY["Caddy · HTTPS reverse proxy<br/>carwatch.duckdns.org"]
+        API["api (Go) · POST /api/v1/ext/ingest<br/>filter → score (fitness / deal / base price) → dedup"]
+        PG[("PostgreSQL<br/>listing_history · searches · users")]
+        REDIS[("Redis<br/>alert stream · rate-limit · caches")]
+        NOTIF["notifier · consumes alert stream"]
+        BOT["bot-poller · Telegram commands + search wizards"]
+    end
+
+    subgraph DEL["4 · Delivery"]
+        WEB["Web UI (React SPA)<br/>browse scored listings · manage searches"]
+        TG["Telegram alerts"]
+        PUSH["Web Push (VAPID)"]
+    end
+
+    SW -->|"executeScript (MAIN world)"| TAB
+    TAB -->|fetch feed| FEED
+    TAB -->|fetch item detail| ITEM
+    FEED --> PJS
+    ITEM --> PJS
+    TOK -.->|Bearer token| SW
+    PJS -->|"POST listings + Bearer token"| CADDY
+    CADDY --> API
+    API --> PG
+    API <--> REDIS
+    API --> WEB
+    CADDY --> WEB
+    BOT <--> TG
+    BOT --- PG
+    REDIS --> NOTIF
+    NOTIF --> TG
+    NOTIF --> PUSH
 ```
-Scheduler (interval + jitter + adaptive backoff)
-    |
-    v
-Fetcher -----> Parser (HTML -> JSON -> RawListing)
-    |
-    v
-Filter (engine, km, hand, keywords)
-    |
-    v
-Dedup Store (PostgreSQL: atomic claim)
-    |
-    v
-Pipeline (fitness score, deal score, base price)
-    |
-    v
-Notifier (Telegram + WebPush)
-    |
-    v
-User
-```
 
-All components communicate through interfaces, making each layer independently testable and swappable.
+**Stages**
+
+1. **Source** — Yad2's gateway API. The list feed gives one row per listing;
+   most rows omit mileage, so each is enriched with a per-item detail call.
+2. **Ingestion** — the extension's service worker wakes every 15 min, fetches
+   the feed + item details from an open Yad2 tab, parses them, and `POST`s the
+   listings to the API authenticated with a Firebase token it captured from the
+   CarWatch web app. (This replaced the old server-side `scraper`/`enricher`
+   containers, which Radware now blocks; they are stopped.)
+3. **Processing & storage** — `POST /api/v1/ext/ingest` runs each active search's
+   filter, scores every match (fitness, deal vs. market median, catalog base
+   price), deduplicates, and writes to PostgreSQL. Redis backs the alert stream,
+   rate limiting, and caches.
+4. **Delivery** — the **web UI** reads listings straight from PostgreSQL (works
+   today). **Telegram / Web Push** alerts are emitted by the `notifier`, which
+   consumes the Redis **alert stream**.
+
+> **Note — alerts vs. web UI.** The alert stream is currently published only by
+> the scheduler that drove the old `scraper` (now stopped). The extension's
+> ingest path saves listings (so the **web UI is live**) but does **not** yet
+> publish to the alert stream, so Telegram/Push alerts won't fire from it until
+> `POST /api/v1/ext/ingest` is wired to publish new matches. That is the one
+> remaining piece for full parity.
+
+See [docs/architecture.md](docs/architecture.md) for the full component
+breakdown. All components communicate through interfaces, making each layer
+independently testable and swappable.
 
 ## Project structure
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -275,25 +275,43 @@ async function runFetchCycle() {
     );
     toEnrich = shuffle(toEnrich).slice(0, MAX_ENRICH_PER_CYCLE);
 
+    // Diagnostics surfaced in the popup so failures are visible without DevTools.
+    let itemGot = 0, itemOk = 0, itemBlocked = 0, itemParseErr = 0, gotKm = 0, itemErr = "";
     if (toEnrich.length) {
       const itemResults = await fetchViaYad2Tab(
         tabId,
         toEnrich.map((l) => `${GW_ITEM_URL}/${l.token}`),
       );
+      itemGot = itemResults.length;
       for (const r of itemResults) {
-        if (looksBlocked(r)) continue;
+        if (looksBlocked(r)) {
+          itemBlocked++;
+          if (!itemErr) itemErr = `blk s${r.status}${r.error ? " " + r.error : ""}`;
+          continue;
+        }
         const parsed = parseItemDetail(r.body);
-        if (parsed.error) continue;
+        if (parsed.error) {
+          itemParseErr++;
+          if (!itemErr) itemErr = "perr:" + parsed.error;
+          continue;
+        }
+        itemOk++;
         const l = byToken.get(parsed.fields.token);
         if (!l) continue;
         for (const [k, v] of Object.entries(parsed.fields)) {
           if (k === "token") continue;
           if (v !== undefined && v !== "" && v !== 0) l[k] = v;
         }
-        if ((l.km || 0) > 0) known.add(l.token);
+        if ((l.km || 0) > 0) {
+          gotKm++;
+          known.add(l.token);
+        }
       }
       await saveKnownTokens(known);
     }
+    console.log(
+      `[CarWatch] enrich tried=${toEnrich.length} returned=${itemGot} ok=${itemOk} blocked=${itemBlocked} parseErr=${itemParseErr} gotKm=${gotKm} ${itemErr}`,
+    );
 
     const listings = [...byToken.values()];
     if (listings.length > 0) await pushListings(config, listings);
@@ -304,6 +322,7 @@ async function runFetchCycle() {
       searches: activeSearches.length,
       listings: listings.length,
       enriched,
+      diag: `feeds ${feedResults.length - blocked}/${feedResults.length} ok · enrich try:${toEnrich.length} ret:${itemGot} ok:${itemOk} blk:${itemBlocked} perr:${itemParseErr} km:${gotKm}${itemErr ? " · " + itemErr : ""}`,
       error: blocked ? `${blocked} feed(s) blocked by anti-bot` : null,
     });
   } catch (err) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -2,9 +2,24 @@ importScripts("parser.js");
 
 const ALARM_NAME = "carwatch-fetch";
 const FETCH_INTERVAL_MINUTES = 15;
-const INTER_SEARCH_DELAY_MS = 3000;
 const DEFAULT_API_URL = "https://carwatch.duckdns.org";
 const FETCH_TIMEOUT_MS = 15000;
+
+// Yad2's own gateway JSON API. We call these from within a real yad2.co.il tab
+// (MAIN world) so the request carries the browser's Radware clearance cookie +
+// Chrome TLS fingerprint — the HTML /vehicles/cars route is a Radware challenge
+// shell and cannot be scraped, and a plain background fetch (no browser
+// fingerprint) is blocked. See extension/README notes / parser.js.
+const GW_FEED_URL = "https://gw.yad2.co.il/feed-search-vehicles/cars";
+const GW_ITEM_URL = "https://gw.yad2.co.il/vehicles-item";
+const YAD2_HOME = "https://www.yad2.co.il/";
+
+// Bound per-cycle request volume: one feed call per search, plus at most this
+// many item-detail (enrichment) calls. km/city/image are absent from most feed
+// rows, so we enrich tokens we have not resolved before.
+const MAX_ENRICH_PER_CYCLE = 30;
+const KNOWN_TOKENS_CAP = 3000;
+const ENRICH_DELAY_MS = 1500; // jittered inside the injected fetcher
 
 let isRunning = false;
 
@@ -14,15 +29,11 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === ALARM_NAME) {
-    runFetchCycle();
-  }
+  if (alarm.name === ALARM_NAME) runFetchCycle();
 });
 
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.action === "fetchNow") {
-    runFetchCycle();
-  }
+  if (msg.action === "fetchNow") runFetchCycle();
 });
 
 async function getConfig() {
@@ -33,7 +44,7 @@ async function getConfig() {
   };
 }
 
-function buildYad2URL(search) {
+function buildFeedURL(search) {
   const params = new URLSearchParams();
   if (search.manufacturer_id) params.set("manufacturer", search.manufacturer_id);
   if (search.model_id) params.set("model", search.model_id);
@@ -52,7 +63,7 @@ function buildYad2URL(search) {
   if (search.photo_only) params.set("imgOnly", "1");
   params.set("Order", "1");
   params.set("page", "1");
-  return `https://www.yad2.co.il/vehicles/cars?${params}`;
+  return `${GW_FEED_URL}?${params}`;
 }
 
 function sleep(ms) {
@@ -69,6 +80,138 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = FETCH_TIMEOUT_MS)
   }
 }
 
+// ---- Yad2 tab management ---------------------------------------------------
+
+function waitForTabComplete(tabId, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      chrome.tabs.onUpdated.removeListener(listener);
+      resolve();
+    };
+    const timer = setTimeout(finish, timeoutMs);
+    function listener(id, info) {
+      if (id === tabId && info.status === "complete") {
+        clearTimeout(timer);
+        finish();
+      }
+    }
+    chrome.tabs.onUpdated.addListener(listener);
+    chrome.tabs
+      .get(tabId)
+      .then((t) => {
+        if (t && t.status === "complete") {
+          clearTimeout(timer);
+          finish();
+        }
+      })
+      .catch(() => {});
+  });
+}
+
+// Returns the id of a live yad2 tab whose session has cleared Radware, creating
+// a pinned background tab if the user has none open. Reuses the same managed
+// tab across cycles so we don't spawn a new tab every 15 minutes.
+async function ensureYad2Tab() {
+  const { yad2TabId } = await chrome.storage.local.get("yad2TabId");
+  if (yad2TabId != null) {
+    try {
+      const t = await chrome.tabs.get(yad2TabId);
+      if (t && /yad2\.co\.il/.test(t.url || "")) return t.id;
+    } catch {
+      // tab was closed; fall through
+    }
+  }
+
+  const existing = await chrome.tabs.query({ url: "*://*.yad2.co.il/*" });
+  if (existing.length) {
+    await chrome.storage.local.set({ yad2TabId: existing[0].id });
+    return existing[0].id;
+  }
+
+  const tab = await chrome.tabs.create({ url: YAD2_HOME, active: false, pinned: true });
+  await chrome.storage.local.set({ yad2TabId: tab.id });
+  await waitForTabComplete(tab.id, 45000);
+  await sleep(3500); // let the Radware JS challenge settle a clearance cookie
+  return tab.id;
+}
+
+async function reloadYad2Tab(tabId) {
+  try {
+    await chrome.tabs.reload(tabId);
+    await waitForTabComplete(tabId, 45000);
+    await sleep(3500);
+  } catch (err) {
+    console.warn("[CarWatch] tab reload failed:", err);
+  }
+}
+
+// Runs inside the yad2 tab's MAIN world: fetches each gw URL with the page's
+// credentials and returns the raw text. Must be fully self-contained.
+function inPageFetchAll(urls, delayMs) {
+  return (async () => {
+    const out = [];
+    for (let i = 0; i < urls.length; i++) {
+      if (i > 0) {
+        await new Promise((r) => setTimeout(r, delayMs + Math.random() * delayMs));
+      }
+      try {
+        const resp = await fetch(urls[i], {
+          credentials: "include",
+          headers: { accept: "application/json" },
+        });
+        out.push({ url: urls[i], status: resp.status, body: await resp.text() });
+      } catch (e) {
+        out.push({ url: urls[i], status: 0, error: String(e) });
+      }
+    }
+    return out;
+  })();
+}
+
+async function fetchViaYad2Tab(tabId, urls) {
+  if (urls.length === 0) return [];
+  const results = await chrome.scripting.executeScript({
+    target: { tabId },
+    world: "MAIN",
+    func: inPageFetchAll,
+    args: [urls, ENRICH_DELAY_MS],
+  });
+  return (results && results[0] && results[0].result) || [];
+}
+
+// A response whose body is HTML (Radware "302/verifying" shell) rather than
+// JSON means the tab's clearance lapsed.
+function looksBlocked(r) {
+  const b = (r && r.body ? r.body : "").trimStart();
+  return r && r.status !== 200 ? true : b.startsWith("<");
+}
+
+// ---- known-token cache (client-side mirror of DB pre-fill) -----------------
+
+async function getKnownTokens() {
+  const { knownTokens } = await chrome.storage.local.get("knownTokens");
+  return new Set(Array.isArray(knownTokens) ? knownTokens : []);
+}
+
+async function saveKnownTokens(set) {
+  let arr = [...set];
+  if (arr.length > KNOWN_TOKENS_CAP) arr = arr.slice(arr.length - KNOWN_TOKENS_CAP);
+  await chrome.storage.local.set({ knownTokens: arr });
+}
+
+function shuffle(a) {
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// ---- main cycle ------------------------------------------------------------
+
 async function runFetchCycle() {
   if (isRunning) {
     console.log("[CarWatch] Cycle already running, skipping");
@@ -80,7 +223,7 @@ async function runFetchCycle() {
     const config = await getConfig();
     if (!config.authToken) {
       setBadge("!", "#F44");
-      await saveStatus({ error: "No auth token configured" });
+      await saveStatus({ error: "No auth token — open carwatch.duckdns.org while logged in" });
       return;
     }
 
@@ -90,54 +233,78 @@ async function runFetchCycle() {
     const activeSearches = searches.filter(
       (s) => s.active && s.manufacturer_id > 0 && s.model_id > 0,
     );
-
     if (activeSearches.length === 0) {
       setBadge("0", "#888");
       await saveStatus({ searches: 0, listings: 0, error: null });
       return;
     }
 
-    let totalListings = 0;
-    const allListings = [];
+    const tabId = await ensureYad2Tab();
 
-    for (let i = 0; i < activeSearches.length; i++) {
-      const search = activeSearches[i];
-      if (i > 0) await sleep(INTER_SEARCH_DELAY_MS);
+    // 1) Fetch each search's list feed.
+    let feedResults = await fetchViaYad2Tab(tabId, activeSearches.map(buildFeedURL));
+    if (feedResults.length && feedResults.every(looksBlocked)) {
+      console.warn("[CarWatch] all feeds blocked; reloading yad2 tab and retrying");
+      await reloadYad2Tab(tabId);
+      feedResults = await fetchViaYad2Tab(tabId, activeSearches.map(buildFeedURL));
+    }
 
-      try {
-        const url = buildYad2URL(search);
-        console.log(`[CarWatch] Fetching: ${search.name || search.id}`, url);
-
-        const resp = await fetchWithTimeout(url);
-        if (!resp.ok) {
-          console.warn(`[CarWatch] Yad2 returned ${resp.status} for search ${search.id}`);
-          continue;
-        }
-
-        const html = await resp.text();
-        const result = parseNextData(html);
-        if (result.error) {
-          console.warn(`[CarWatch] Parse error for search ${search.id}:`, result.error);
-          continue;
-        }
-
-        console.log(`[CarWatch] Found ${result.listings.length} listings for ${search.name || search.id}`);
-        totalListings += result.listings.length;
-        allListings.push(...result.listings);
-      } catch (err) {
-        console.error(`[CarWatch] Fetch error for search ${search.id}:`, err);
+    // Merge into a token->listing map, preferring the row that already has km.
+    const byToken = new Map();
+    let blocked = 0;
+    for (const r of feedResults) {
+      if (looksBlocked(r)) {
+        blocked++;
+        continue;
+      }
+      const parsed = parseFeed(r.body);
+      if (parsed.error) {
+        console.warn("[CarWatch] feed parse:", parsed.error, r.url);
+        continue;
+      }
+      for (const l of parsed.listings) {
+        const prev = byToken.get(l.token);
+        if (!prev || ((prev.km || 0) <= 0 && (l.km || 0) > 0)) byToken.set(l.token, l);
       }
     }
 
-    if (allListings.length > 0) {
-      await pushListings(config, allListings);
+    // 2) Enrich listings missing km (skip tokens we've resolved before).
+    const known = await getKnownTokens();
+    let toEnrich = [...byToken.values()].filter(
+      (l) => (l.km || 0) <= 0 && !known.has(l.token),
+    );
+    toEnrich = shuffle(toEnrich).slice(0, MAX_ENRICH_PER_CYCLE);
+
+    if (toEnrich.length) {
+      const itemResults = await fetchViaYad2Tab(
+        tabId,
+        toEnrich.map((l) => `${GW_ITEM_URL}/${l.token}`),
+      );
+      for (const r of itemResults) {
+        if (looksBlocked(r)) continue;
+        const parsed = parseItemDetail(r.body);
+        if (parsed.error) continue;
+        const l = byToken.get(parsed.fields.token);
+        if (!l) continue;
+        for (const [k, v] of Object.entries(parsed.fields)) {
+          if (k === "token") continue;
+          if (v !== undefined && v !== "" && v !== 0) l[k] = v;
+        }
+        if ((l.km || 0) > 0) known.add(l.token);
+      }
+      await saveKnownTokens(known);
     }
 
-    setBadge(String(totalListings), "#4CAF50");
+    const listings = [...byToken.values()];
+    if (listings.length > 0) await pushListings(config, listings);
+
+    const enriched = listings.filter((l) => (l.km || 0) > 0).length;
+    setBadge(String(listings.length), blocked ? "#E65100" : "#4CAF50");
     await saveStatus({
       searches: activeSearches.length,
-      listings: totalListings,
-      error: null,
+      listings: listings.length,
+      enriched,
+      error: blocked ? `${blocked} feed(s) blocked by anti-bot` : null,
     });
   } catch (err) {
     console.error("[CarWatch] Cycle error:", err);
@@ -152,7 +319,7 @@ async function fetchSearches(config) {
   const resp = await fetchWithTimeout(`${config.apiUrl}/api/v1/searches`, {
     headers: { Authorization: `Bearer ${config.authToken}` },
   });
-  if (!resp.ok) throw new Error(`API returned ${resp.status}`);
+  if (!resp.ok) throw new Error(`searches API returned ${resp.status}`);
   return resp.json();
 }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.0.2",
-  "description": "Fetches Yad2 listings in the background and pushes them to CarWatch",
-  "permissions": ["alarms", "storage"],
+  "version": "1.1.0",
+  "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
+  "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [
     "https://www.yad2.co.il/*",
+    "https://gw.yad2.co.il/*",
     "https://carwatch.duckdns.org/*"
   ],
   "background": {

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -1,124 +1,166 @@
-const BUCKET_KEYS = ["private", "commercial", "platinum", "boost", "solo"];
+// Parses Yad2's gateway JSON feed
+// (GET https://gw.yad2.co.il/feed-search-vehicles/cars?...).
+//
+// Yad2 retired the server-rendered __NEXT_DATA__ blob on the /vehicles/cars
+// HTML route (it is now a Radware bot-challenge shell), so we consume the same
+// JSON API the site's own SPA calls. The response groups ads into seller
+// buckets; each item carries all fields we need INLINE (km, city, image,
+// publish date) — no per-item enrichment required.
 
+const BUCKET_KEYS = ["private", "commercial", "platinum", "boost", "solo"];
 const COMMERCIAL_BUCKETS = new Set(["commercial", "platinum", "solo", "boost"]);
 
-function textFromField(field) {
+// Prefer the English label, fall back to Hebrew text. Handles Yad2's
+// {id, text, text_eng} field shape (text_eng is frequently null).
+function label(field) {
   if (!field) return "";
-  return field.english_text || field.textEng || field.text || "";
+  return field.text_eng || field.textEng || field.text || "";
 }
 
-function parseHand(raw) {
-  if (typeof raw === "number") return raw;
-  if (raw && typeof raw === "object" && raw.id) return raw.id;
+function fieldId(field) {
+  if (!field) return 0;
+  const id = field.id;
+  if (typeof id === "number") return id;
+  if (typeof id === "string" && id.trim() !== "") {
+    const n = Number(id);
+    return Number.isFinite(n) ? n : 0;
+  }
   return 0;
 }
 
-function resolveImageURL(item) {
-  const md = item.metaData || {};
-  return (
-    md.coverImage ||
-    md.cover_image ||
-    item.coverImage ||
-    item.cover_image ||
-    (md.images && md.images[0]) ||
-    (item.images && item.images[0]) ||
-    ""
-  );
+function resolveImage(item) {
+  const md = item.meta_data || {};
+  if (md.cover_image) return md.cover_image;
+  if (Array.isArray(md.images) && md.images.length) return md.images[0];
+  return "";
 }
 
 function itemToListing(item, isCommercial) {
   const token = item.token;
   if (!token) return null;
 
-  const year =
-    item.year_of_production ||
-    (item.vehicleDates && item.vehicleDates.yearOfProduction) ||
-    0;
+  const sf = item.search_fields || {};
+  const md = item.meta_data || {};
+  const dates = item.dates || {};
 
   const listing = {
     token,
-    manufacturer: textFromField(item.manufacturer),
-    manufacturer_id: item.manufacturer?.id || 0,
-    model: textFromField(item.model),
-    model_id: item.model?.id || 0,
-    sub_model: textFromField(item.subModel),
-    sub_model_id: item.subModel?.id || 0,
-    year,
+    manufacturer: label(sf.manufacturer),
+    manufacturer_id: fieldId(sf.manufacturer),
+    model: label(sf.model),
+    model_id: fieldId(sf.model),
+    sub_model: label(sf.sub_model),
+    sub_model_id: fieldId(sf.sub_model),
+    year: sf.year || 0,
     price: item.price || 0,
-    km: item.km || item.kilometers || 0,
-    hand: parseHand(item.hand),
-    city: textFromField(item.address?.city),
-    area: textFromField(item.address?.area),
-    image_url: resolveImageURL(item),
+    km: typeof sf.km === "number" ? sf.km : 0,
+    hand: fieldId(sf.hand),
+    city: label(item.address && item.address.city),
+    area: label(item.address && item.address.area),
+    image_url: resolveImage(item),
     page_link: `https://www.yad2.co.il/vehicles/item/${token}`,
-    engine_volume: item.engine_volume || item.engineVolume || 0,
-    engine_type: textFromField(item.engineType),
-    gear_box: textFromField(item.gearBox),
-    body_type: textFromField(item.bodyType),
-    description: item.metaData?.description || "",
+    engine_volume: sf.engine_volume || 0,
+    engine_type: label(sf.engine_type),
+    gear_box: label(sf.gear_box) || label(md.gear_box_item),
+    body_type: label(sf.body_type),
+    description: (md.description || "").trim(),
     is_commercial: isCommercial,
   };
 
-  if (item.dates?.createdAt || item.createdAt) {
-    listing.created_at = item.dates?.createdAt || item.createdAt;
+  // dates.start is the ORIGINAL publish date (unique per ad). dates.update /
+  // dates.rebounce are the feed-wide "refreshed" timestamp — do NOT use them,
+  // or every ad looks like it was posted today.
+  if (dates.start) {
+    listing.created_at = dates.start;
   }
 
   return listing;
 }
 
-function parseNextData(html) {
-  const match = html.match(
-    /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i,
-  );
-  if (!match || !match[1]) return { error: "no __NEXT_DATA__" };
-
+// Accepts the raw gw response (object or JSON string). Buckets live under
+// `.data`, but tolerate a top-level bucket object too.
+function parseFeed(json) {
   let data;
   try {
-    data = JSON.parse(match[1]);
+    data = typeof json === "string" ? JSON.parse(json) : json;
   } catch {
-    return { error: "invalid __NEXT_DATA__ JSON" };
+    return { error: "invalid feed JSON" };
   }
+  if (!data || typeof data !== "object") return { error: "empty feed" };
 
-  const queries =
-    data?.props?.pageProps?.dehydratedState?.queries || [];
+  const buckets = data.data && typeof data.data === "object" ? data.data : data;
 
-  for (const q of queries) {
-    const stateData = q?.state?.data;
-    if (!stateData) continue;
-
-    const listings = [];
-    let found = false;
-
-    for (const key of BUCKET_KEYS) {
-      const items = stateData[key];
-      if (!Array.isArray(items)) continue;
-      found = true;
-      const isCommercial = COMMERCIAL_BUCKETS.has(key);
-      for (const item of items) {
-        const listing = itemToListing(item, isCommercial);
-        if (listing) listings.push(listing);
-      }
-    }
-
-    if (found) {
-      const seen = new Set();
-      const deduped = listings.filter((l) => {
-        if (seen.has(l.token)) return false;
-        seen.add(l.token);
-        return true;
-      });
-      return { listings: deduped };
-    }
-
-    // Legacy format: data.feed.feed_items
-    const feedItems = stateData?.data?.feed?.feed_items;
-    if (Array.isArray(feedItems)) {
-      const listings = feedItems
-        .map((item) => itemToListing(item, null))
-        .filter(Boolean);
-      return { listings };
+  const listings = [];
+  let found = false;
+  for (const key of BUCKET_KEYS) {
+    const items = buckets[key];
+    if (!Array.isArray(items)) continue;
+    found = true;
+    const isCommercial = COMMERCIAL_BUCKETS.has(key);
+    for (const item of items) {
+      const listing = itemToListing(item, isCommercial);
+      if (listing) listings.push(listing);
     }
   }
 
-  return { error: "no feed items found" };
+  if (!found) return { error: "no known buckets in feed" };
+
+  const seen = new Set();
+  const deduped = listings.filter((l) => {
+    if (seen.has(l.token)) return false;
+    seen.add(l.token);
+    return true;
+  });
+  return { listings: deduped };
+}
+
+// Parses the per-item detail endpoint
+// (GET https://gw.yad2.co.il/vehicles-item/{token}) into the fields the list
+// feed omits — chiefly `km`, `city`, and `image_url`. The detail payload is
+// camelCase (vs the feed's snake_case); `label()` already tolerates both.
+// Returns only the fields that are present, so the caller can overlay them onto
+// the feed listing without wiping known values with blanks.
+function parseItemDetail(json) {
+  let d;
+  try {
+    d = typeof json === "string" ? JSON.parse(json) : json;
+  } catch {
+    return { error: "invalid item JSON" };
+  }
+  if (!d || typeof d !== "object") return { error: "empty item" };
+  d = d.data && typeof d.data === "object" ? d.data : d;
+  if (!d.token) return { error: "item missing token" };
+
+  const md = d.metaData || d.meta_data || {};
+  const vd = d.vehicleDates || {};
+  const dates = d.dates || {};
+  const fields = { token: d.token };
+
+  if (typeof d.km === "number") fields.km = d.km;
+  const city = label(d.address && d.address.city);
+  if (city) fields.city = city;
+  const area = label(d.address && d.address.area);
+  if (area) fields.area = area;
+  const image = md.coverImage || md.cover_image || (Array.isArray(md.images) && md.images[0]);
+  if (image) fields.image_url = image;
+  if (vd.yearOfProduction) fields.year = vd.yearOfProduction;
+  if (d.hand) fields.hand = fieldId(d.hand);
+  if (typeof d.price === "number" && d.price > 0) fields.price = d.price;
+  if (d.engineVolume) fields.engine_volume = d.engineVolume;
+  const engineType = label(d.engineType);
+  if (engineType) fields.engine_type = engineType;
+  const gearBox = label(d.gearBox);
+  if (gearBox) fields.gear_box = gearBox;
+  const bodyType = label(d.bodyType);
+  if (bodyType) fields.body_type = bodyType;
+  const desc = (md.description || "").trim();
+  if (desc) fields.description = desc;
+  if (dates.createdAt) fields.created_at = dates.createdAt;
+
+  return { fields };
+}
+
+// Export for Node-based tests; harmless in the service worker.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { parseFeed, parseItemDetail, itemToListing };
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -38,6 +38,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       "lastRun",
       "searches",
       "listings",
+      "enriched",
       "error",
     ]);
     statusDiv.textContent = "";
@@ -50,6 +51,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     if (data.listings !== undefined) {
       lines.push("Listings found: " + data.listings);
+    }
+    if (data.enriched !== undefined) {
+      lines.push("With mileage (km): " + data.enriched);
     }
     if (data.error) {
       lines.push("Error: " + data.error);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -39,6 +39,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       "searches",
       "listings",
       "enriched",
+      "diag",
       "error",
     ]);
     statusDiv.textContent = "";
@@ -54,6 +55,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     if (data.enriched !== undefined) {
       lines.push("With mileage (km): " + data.enriched);
+    }
+    if (data.diag) {
+      lines.push(data.diag);
     }
     if (data.error) {
       lines.push("Error: " + data.error);


### PR DESCRIPTION
## Why

Yad2 retired the server-rendered `__NEXT_DATA__` blob on the `/vehicles/cars` HTML route — it is now a **Radware Bot Manager** challenge shell (page title "Radware Page"; the docs' PerimeterX assumption is wrong). Both the VM scraper (`internal/fetcher/yad2/parser.go`) and this extension parse that blob, so **both currently return 0 listings** (prod scraper logs: `parse page: __NEXT_DATA__ script tag not found`, `listings:0` every cycle). This is the root cause of the extension "no luck".

Verified live via Playwright driving real Chrome.

## What

Consume the **same gateway JSON API the Yad2 SPA uses**, executed from inside a real `yad2.co.il` tab (MAIN world) so the request carries the browser's Radware clearance cookie + Chrome TLS fingerprint:

- **Feed:** `GET https://gw.yad2.co.il/feed-search-vehicles/cars?…` → buckets `private/commercial/platinum/boost/solo`.
- **Item (enrichment):** `GET https://gw.yad2.co.il/vehicles-item/{token}` → `km`, `city`, `image`, etc. (the feed omits km/city for most rows).

A plain background-service-worker fetch (no browser fingerprint) is blocked, and a server-side HTTP client is blocked **even with a harvested cookie** because Radware validates TLS/JA3 — so the fetch must run in a real tab.

### Changes
- `extension/parser.js`: `parseFeed()` (feed buckets) + `parseItemDetail()` (camelCase item detail).
- `extension/background.js`: ensure/reuse a pinned Yad2 tab; fetch each search's feed + bounded per-item km enrichment via `chrome.scripting.executeScript({world:"MAIN"})`; Radware-block detection with one reload+retry; resolved-token cache to bound request volume (≤ ~1 feed/search + 30 item calls per 15-min cycle).
- `extension/manifest.json`: add `scripting` + `tabs` permissions and `gw.yad2.co.il` host.
- `extension/popup.js`: show enriched (km-known) count.

No backend change: `/api/v1/ext/ingest`'s `ingestListing` already has every field, and the upsert guards km (`CASE WHEN EXCLUDED.km > 0 …`), so progressive enrichment never clobbers a known value. This path replaces both the VM scraper and the enricher for Yad2.

## Validation
End-to-end against live Yad2 (Playwright, real Chrome): feed → 44 listings (HTTP 200); enrichment → 5/5 tokens returned HTTP 200 with real km (30k/123k/49k/80k/78.9k), city, year, body_type. Feed + item parsers unit-checked against captured real responses.

## Review
_Pending `ce:review` agents + CodeRabbit per repo policy._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Yad2 listing retrieval via a gateway JSON feed with guided tab-based enrichment.
  - Popup now displays mileage (km) and additional diagnostic details when available.
  - Updated extension metadata and expanded access to gateway endpoints.
- **Bug Fixes**
  - More resilient handling of blocked/challenged responses, including automatic retry after reload.
  - Clearer status messaging when searches can’t be loaded or are unavailable.
  - Better parsing and deduplication/merging of listings across fetch cycles.
- **Documentation**
  - Updated README with the new end-to-end ingestion data flow and alerting notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->