### PR TITLE
feat: finish extension-primary cutover — enrichment fix, ingest notifications, retire enricher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
               echo ".env is missing in ~/carwatch"
               exit 1
             fi
-            APP_SERVICES="postgres redis api bot-poller scraper notifier enricher"
+            APP_SERVICES="postgres redis api bot-poller scraper notifier"
             if [ -f .deploy_recreate_started ]; then
               echo "==> Found stale deploy marker; restoring previously known-good services before continuing"
               RECOVERY_TAG=$(cat prev_image_tag 2>/dev/null || echo 'none')
@@ -310,13 +310,12 @@ jobs:
             fi
 
             echo "==> Waiting for worker health checks..."
-            for svc in bot-poller scraper notifier enricher; do
+            for svc in bot-poller scraper notifier; do
               container="carwatch-$svc"
               port=$(case "$svc" in
                 bot-poller) echo 8082 ;;
                 scraper) echo 8081 ;;
                 notifier) echo 8083 ;;
-                enricher) echo 8084 ;;
               esac)
               ok=0
               for i in $(seq 1 15); do
@@ -397,7 +396,7 @@ jobs:
             PREV="${PREV##*:}"
             if [ "$PREV" != 'none' ]; then
               echo "==> Rolling back to previous image tag: $PREV"
-              APP_SERVICES="postgres redis api bot-poller scraper notifier enricher"
+              APP_SERVICES="postgres redis api bot-poller scraper notifier"
               CARWATCH_IMAGE_TAG="$PREV" docker compose -f docker-compose.prod.yaml pull $APP_SERVICES
               CARWATCH_IMAGE_TAG="$PREV" docker compose -f docker-compose.prod.yaml up -d $APP_SERVICES
 
@@ -411,13 +410,12 @@ jobs:
                 echo "==> Rollback API health check failed"
                 exit 1
               fi
-              for svc in bot-poller scraper notifier enricher; do
+              for svc in bot-poller scraper notifier; do
                 container="carwatch-$svc"
                 port=$(case "$svc" in
                   bot-poller) echo 8082 ;;
                   scraper) echo 8081 ;;
                   notifier) echo 8083 ;;
-                  enricher) echo 8084 ;;
                 esac)
                 ok=0
                 for i in $(seq 1 15); do

--- a/Makefile
+++ b/Makefile
@@ -194,14 +194,14 @@ vm-ssh: vm-check-env
 	$(SSH)
 
 vm-logs: vm-check-env
-	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 200 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait'
+	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier; do docker logs --tail 200 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait'
 
 LOGS_FILTER ?=
 logs: vm-check-env
 ifdef LOGS_FILTER
-	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 500 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait' | grep -iF --line-buffered -- "$(LOGS_FILTER)"
+	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier; do docker logs --tail 500 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait' | grep -iF --line-buffered -- "$(LOGS_FILTER)"
 else
-	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier carwatch-enricher; do docker logs --tail 200 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait'
+	$(SSH) 'for c in carwatch-api carwatch-bot-poller carwatch-scraper carwatch-notifier; do docker logs --tail 200 -f $$c 2>&1 | sed "s/^/[$$c] /" & done; wait'
 endif
 
 vm-status: vm-check-env

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ docker exec carwatch-api wget -q --spider http://localhost:8080/healthz
 docker exec carwatch-bot-poller wget -q --spider http://localhost:8082/healthz
 docker exec carwatch-scraper wget -q --spider http://localhost:8081/healthz
 docker exec carwatch-notifier wget -q --spider http://localhost:8083/healthz
-docker exec carwatch-enricher wget -q --spider http://localhost:8084/healthz
 ```
 
 If any check fails, rollback deterministically to the last known-good image tag:
@@ -75,15 +74,14 @@ if grep -q '^CARWATCH_IMAGE_TAG=' .env; then
 else
   echo "CARWATCH_IMAGE_TAG=${PREV_TAG}" >> .env
 fi
-CARWATCH_IMAGE_TAG="${PREV_TAG}" docker compose -f docker-compose.prod.yaml pull postgres redis api bot-poller scraper notifier enricher
-CARWATCH_IMAGE_TAG="${PREV_TAG}" docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier enricher
+CARWATCH_IMAGE_TAG="${PREV_TAG}" docker compose -f docker-compose.prod.yaml pull postgres redis api bot-poller scraper notifier
+CARWATCH_IMAGE_TAG="${PREV_TAG}" docker compose -f docker-compose.prod.yaml up -d postgres redis api bot-poller scraper notifier
 
 # verify rollback health
 docker exec carwatch-api wget -q --spider http://localhost:8080/healthz
 docker exec carwatch-bot-poller wget -q --spider http://localhost:8082/healthz
 docker exec carwatch-scraper wget -q --spider http://localhost:8081/healthz
 docker exec carwatch-notifier wget -q --spider http://localhost:8083/healthz
-docker exec carwatch-enricher wget -q --spider http://localhost:8084/healthz
 ```
 
 ## Configuration

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -228,48 +228,11 @@ services:
         limits:
           memory: 256M
 
-  enricher:
-    image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
-    container_name: carwatch-enricher
-    entrypoint: ["/usr/local/bin/enricher"]
-    read_only: true
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    tmpfs:
-      - /tmp:exec,uid=1000,gid=1000
-      - /dev/shm:size=128m
-      - /home/carwatch:uid=1000,gid=1000
-    networks:
-      - carwatch-net
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    volumes:
-      - ./config.yaml:/config.yaml:ro
-      - ./migrations:/migrations:ro
-    environment:
-      - TZ=Asia/Jerusalem
-      - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
-      - RELAY_SECRET=${RELAY_SECRET:-}
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8084/healthz"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
-    restart: unless-stopped
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+  # NOTE: the per-item km `enricher` service was retired once the browser
+  # extension took over ingestion (it fetches item detail + km from a real
+  # Yad2 tab; Yad2's Radware bot-manager blocks server-side item fetches).
+  # The `scraper` container is kept because its scheduler also runs digest
+  # flushing and dedup/price pruning — not just fetching.
 
   caddy:
     image: caddy:2-alpine

--- a/extension/background.js
+++ b/extension/background.js
@@ -139,6 +139,10 @@ async function ensureYad2Tab() {
   if (existing.length) {
     await chrome.storage.local.set({ yad2TabId: existing[0].id });
     await keepTabAlive(existing[0].id);
+    if (existing[0].discarded) {
+      console.warn("[CarWatch] found existing yad2 tab but it was discarded; reactivating");
+      await reloadYad2Tab(existing[0].id);
+    }
     return existing[0].id;
   }
 
@@ -213,6 +217,13 @@ function looksBlocked(r) {
   return r && r.status !== 200 ? true : b.startsWith("<");
 }
 
+// A fetch batch is unusable when executeScript returned nothing (a discarded
+// or broken tab yields an empty array, not looksBlocked-shaped results) or
+// when every result is a block/challenge page. Either warrants a tab reload.
+function batchUnusable(results) {
+  return results.length === 0 || results.every(looksBlocked);
+}
+
 // ---- known-token cache (client-side mirror of DB pre-fill) -----------------
 
 async function getKnownTokens() {
@@ -267,8 +278,8 @@ async function runFetchCycle() {
 
     // 1) Fetch each search's list feed.
     let feedResults = await fetchViaYad2Tab(tabId, activeSearches.map(buildFeedURL));
-    if (feedResults.length && feedResults.every(looksBlocked)) {
-      console.warn("[CarWatch] all feeds blocked; reloading yad2 tab and retrying");
+    if (batchUnusable(feedResults)) {
+      console.warn("[CarWatch] feed batch unusable (empty or all blocked); reloading yad2 tab and retrying");
       await reloadYad2Tab(tabId);
       feedResults = await fetchViaYad2Tab(tabId, activeSearches.map(buildFeedURL));
     }
@@ -304,11 +315,12 @@ async function runFetchCycle() {
     if (toEnrich.length) {
       const itemURLs = toEnrich.map((l) => `${GW_ITEM_URL}/${l.token}`);
       let itemResults = await fetchViaYad2Tab(tabId, itemURLs);
-      // If the whole batch came back blocked (stale clearance / discarded tab /
-      // Radware challenge), reload the tab once and retry — same recovery the
-      // feed path uses. Without this, a single bad tab state zeroes out km.
-      if (itemResults.length && itemResults.every(looksBlocked)) {
-        console.warn("[CarWatch] all item fetches blocked; reloading yad2 tab and retrying enrichment");
+      // If the batch was unusable — empty (a discarded/broken tab makes
+      // executeScript return nothing) or every result blocked (stale clearance
+      // / Radware challenge) — reload the tab once and retry, same recovery the
+      // feed path uses. Without this a single bad tab state zeroes out km.
+      if (batchUnusable(itemResults)) {
+        console.warn("[CarWatch] item batch unusable (empty or all blocked); reloading yad2 tab and retrying enrichment");
         await reloadYad2Tab(tabId);
         itemResults = await fetchViaYad2Tab(tabId, itemURLs);
       }

--- a/extension/background.js
+++ b/extension/background.js
@@ -119,7 +119,17 @@ async function ensureYad2Tab() {
   if (yad2TabId != null) {
     try {
       const t = await chrome.tabs.get(yad2TabId);
-      if (t && /yad2\.co\.il/.test(t.url || "")) return t.id;
+      if (t && /yad2\.co\.il/.test(t.url || "")) {
+        await keepTabAlive(t.id);
+        // Chrome's Memory Saver can discard an idle background tab between
+        // cycles. A discarded tab has no live page context, so executeScript
+        // fetches silently fail — reactivate it and let Radware re-clear.
+        if (t.discarded) {
+          console.warn("[CarWatch] yad2 tab was discarded; reactivating");
+          await reloadYad2Tab(t.id);
+        }
+        return t.id;
+      }
     } catch {
       // tab was closed; fall through
     }
@@ -128,14 +138,28 @@ async function ensureYad2Tab() {
   const existing = await chrome.tabs.query({ url: "*://*.yad2.co.il/*" });
   if (existing.length) {
     await chrome.storage.local.set({ yad2TabId: existing[0].id });
+    await keepTabAlive(existing[0].id);
     return existing[0].id;
   }
 
   const tab = await chrome.tabs.create({ url: YAD2_HOME, active: false, pinned: true });
   await chrome.storage.local.set({ yad2TabId: tab.id });
+  await keepTabAlive(tab.id);
   await waitForTabComplete(tab.id, 45000);
   await sleep(3500); // let the Radware JS challenge settle a clearance cookie
   return tab.id;
+}
+
+// Pin the scraping tab out of Chrome's Memory Saver reach. When the tab is
+// auto-discarded, its page context is gone and every executeScript fetch
+// (feed + km enrichment) returns nothing — the main reason enrichment lands
+// 0 km on a long-lived background tab that works fine when freshly opened.
+async function keepTabAlive(tabId) {
+  try {
+    await chrome.tabs.update(tabId, { autoDiscardable: false });
+  } catch {
+    // best-effort; older Chrome or races are non-fatal
+  }
 }
 
 async function reloadYad2Tab(tabId) {
@@ -278,10 +302,16 @@ async function runFetchCycle() {
     // Diagnostics surfaced in the popup so failures are visible without DevTools.
     let itemGot = 0, itemOk = 0, itemBlocked = 0, itemParseErr = 0, gotKm = 0, itemErr = "";
     if (toEnrich.length) {
-      const itemResults = await fetchViaYad2Tab(
-        tabId,
-        toEnrich.map((l) => `${GW_ITEM_URL}/${l.token}`),
-      );
+      const itemURLs = toEnrich.map((l) => `${GW_ITEM_URL}/${l.token}`);
+      let itemResults = await fetchViaYad2Tab(tabId, itemURLs);
+      // If the whole batch came back blocked (stale clearance / discarded tab /
+      // Radware challenge), reload the tab once and retry — same recovery the
+      // feed path uses. Without this, a single bad tab state zeroes out km.
+      if (itemResults.length && itemResults.every(looksBlocked)) {
+        console.warn("[CarWatch] all item fetches blocked; reloading yad2 tab and retrying enrichment");
+        await reloadYad2Tab(tabId);
+        itemResults = await fetchViaYad2Tab(tabId, itemURLs);
+      }
       itemGot = itemResults.length;
       for (const r of itemResults) {
         if (looksBlocked(r)) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dsionov/carwatch
 
 go 1.25.8
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	firebase.google.com/go/v4 v4.20.0

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -18,6 +18,7 @@ import (
 	fbauth "firebase.google.com/go/v4/auth"
 
 	"github.com/dsionov/carwatch/internal/botcore"
+	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/cwlog"
@@ -57,6 +58,9 @@ type Server struct {
 	saved            storage.SavedListingStore
 	hidden           storage.HiddenListingStore
 	notifs           storage.NotificationStore
+	dedup            storage.DedupStore
+	digests          storage.DigestStore
+	alertPublisher   *broker.Publisher
 	poller           PollTrigger
 	logger           *slog.Logger
 	cfg              config.APIConfig
@@ -109,17 +113,23 @@ func (s *Server) Shutdown() {
 }
 
 type Config struct {
-	Catalog          catalog.Catalog
-	Searches         storage.SearchStore
-	Listings         storage.ListingStore
-	Users            storage.UserStore
-	LinkTokens       storage.LinkTokenStore
-	Prices           storage.PriceTracker
-	Admin            storage.AdminStore
-	Saved            storage.SavedListingStore
-	Hidden           storage.HiddenListingStore
-	Notifs           storage.NotificationStore
-	PushSubs         storage.PushSubscriptionStore
+	Catalog    catalog.Catalog
+	Searches   storage.SearchStore
+	Listings   storage.ListingStore
+	Users      storage.UserStore
+	LinkTokens storage.LinkTokenStore
+	Prices     storage.PriceTracker
+	Admin      storage.AdminStore
+	Saved      storage.SavedListingStore
+	Hidden     storage.HiddenListingStore
+	Notifs     storage.NotificationStore
+	PushSubs   storage.PushSubscriptionStore
+	// Dedup, Digests and AlertPublisher wire the extension ingest path into the
+	// same notification delivery the scheduler uses. All optional: nil disables
+	// alerting from ingest (listings are still saved and shown in the web UI).
+	Dedup            storage.DedupStore
+	Digests          storage.DigestStore
+	AlertPublisher   *broker.Publisher
 	Logger           *slog.Logger
 	API              config.APIConfig
 	Push             config.PushConfig
@@ -190,6 +200,9 @@ func New(c Config) *Server {
 		saved:           c.Saved,
 		hidden:          c.Hidden,
 		notifs:          c.Notifs,
+		dedup:           c.Dedup,
+		digests:         c.Digests,
+		alertPublisher:  c.AlertPublisher,
 		pushSubs:        c.PushSubs,
 		vapidPublicKey:  c.Push.VAPIDPublicKey,
 		logger:          c.Logger,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -110,6 +110,11 @@ func (s *Server) Shutdown() {
 	if s.guestRL != nil {
 		s.guestRL.stop()
 	}
+	if s.alertPublisher != nil {
+		if err := s.alertPublisher.Close(); err != nil && s.logger != nil {
+			s.logger.Warn("failed to close alert publisher on shutdown", "error", err)
+		}
+	}
 }
 
 type Config struct {

--- a/internal/api/ingest_delivery.go
+++ b/internal/api/ingest_delivery.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/dsionov/carwatch/internal/locale"
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/scheduler"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// deliverIngestMatches notifies the user about newly matched listings that
+// arrived via the browser-extension ingest path. It reuses the same mechanics
+// as the scheduler so behaviour stays consistent:
+//
+//   - each token is claimed via the dedup store so a listing is delivered at
+//     most once per (user, search) — this is what prevents re-alerting the same
+//     cars on every 15-minute ingest cycle;
+//   - the user's delivery mode picks the transport (digest → accumulate for the
+//     scheduled flush; instant → publish to the Redis alert stream the notifier
+//     consumes);
+//   - on a delivery failure the claims are released so the listings are retried
+//     on the next ingest instead of being lost.
+//
+// It is best-effort: any error is logged, never surfaced to the extension (the
+// ingest itself already succeeded once listings are persisted).
+func (s *Server) deliverIngestMatches(ctx context.Context, sr storage.Search, listings []model.Listing, log *slog.Logger) {
+	if s.dedup == nil || len(listings) == 0 {
+		return
+	}
+	delivery := s.ingestDeliveryFor(ctx, sr, log)
+	if delivery == nil {
+		// No transport wired (no Redis publisher and not digest mode) — do not
+		// consume dedup claims we cannot act on.
+		return
+	}
+	s.claimAndDeliver(ctx, sr, listings, delivery, log)
+}
+
+// claimAndDeliver claims the new tokens, delivers them via the chosen strategy,
+// and releases claims on failure. Split out so it can be tested with a fake
+// dedup store and delivery strategy.
+func (s *Server) claimAndDeliver(ctx context.Context, sr storage.Search, listings []model.Listing, delivery scheduler.DeliveryStrategy, log *slog.Logger) {
+	newOnes := make([]model.Listing, 0, len(listings))
+	for _, l := range listings {
+		isNew, err := s.dedup.ClaimNew(ctx, l.Token, sr.ChatID, sr.ID)
+		if err != nil {
+			log.ErrorContext(ctx, "ingest delivery: dedup claim failed, skipping listing",
+				"token", l.Token, "search_id", sr.ID, "error", err)
+			continue
+		}
+		if isNew {
+			newOnes = append(newOnes, l)
+		}
+	}
+	if len(newOnes) == 0 {
+		return
+	}
+
+	if err := delivery.DeliverBatch(ctx, sr.ChatID, newOnes); err != nil {
+		log.ErrorContext(ctx, "ingest delivery: batch failed, releasing claims for retry",
+			"count", len(newOnes), "search_id", sr.ID, "error", err)
+		for _, l := range newOnes {
+			if relErr := s.dedup.ReleaseClaim(ctx, l.Token, sr.ChatID, sr.ID); relErr != nil {
+				log.ErrorContext(ctx, "ingest delivery: failed to release dedup claim",
+					"token", l.Token, "search_id", sr.ID, "error", relErr)
+			}
+		}
+		return
+	}
+	log.InfoContext(ctx, "ingest delivery: notified user of new listings",
+		"count", len(newOnes), "search_id", sr.ID, "search_name", sr.Name)
+}
+
+// ingestDeliveryFor mirrors the scheduler's per-user delivery selection.
+// Returns nil when instant delivery is requested but no alert publisher is
+// wired, so the caller skips (rather than nil-panicking on a missing notifier).
+func (s *Server) ingestDeliveryFor(ctx context.Context, sr storage.Search, log *slog.Logger) scheduler.DeliveryStrategy {
+	lang := s.userLang(ctx, sr.ChatID)
+	if s.digests != nil {
+		if mode, _, err := s.digests.GetDigestMode(ctx, sr.ChatID); err == nil && mode == "digest" {
+			return scheduler.NewDigestDelivery(s.digests, lang)
+		}
+	}
+	if s.alertPublisher == nil {
+		return nil
+	}
+	return scheduler.NewInstantDelivery(nil, lang,
+		scheduler.WithLogger(log),
+		scheduler.WithSearchContext(sr.ID, sr.Name),
+		scheduler.WithPublisher(s.alertPublisher),
+	)
+}
+
+// userLang resolves the user's language, defaulting to Hebrew.
+func (s *Server) userLang(ctx context.Context, chatID int64) locale.Lang {
+	lang := locale.Hebrew
+	if s.users != nil {
+		if u, err := s.users.GetUser(ctx, chatID); err == nil && u != nil && u.Language != "" {
+			lang = locale.Lang(u.Language)
+		}
+	}
+	return lang
+}

--- a/internal/api/ingest_delivery.go
+++ b/internal/api/ingest_delivery.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/dsionov/carwatch/internal/locale"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/notifier"
 	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/storage"
 )
@@ -59,7 +61,15 @@ func (s *Server) claimAndDeliver(ctx context.Context, sr storage.Search, listing
 	}
 
 	if err := delivery.DeliverBatch(ctx, sr.ChatID, newOnes); err != nil {
-		log.ErrorContext(ctx, "ingest delivery: batch failed, releasing claims for retry",
+		// Permanent failures (malformed message, recipient blocked the bot)
+		// will fail identically forever — keep the claims so we don't replay
+		// the same batch on every ingest. Only transient failures are retried.
+		if errors.Is(err, scheduler.ErrMalformedMessage) || errors.Is(err, notifier.ErrRecipientBlocked) {
+			log.ErrorContext(ctx, "ingest delivery: permanent failure, keeping claims (no retry)",
+				"count", len(newOnes), "search_id", sr.ID, "error", err)
+			return
+		}
+		log.ErrorContext(ctx, "ingest delivery: transient failure, releasing claims for retry",
 			"count", len(newOnes), "search_id", sr.ID, "error", err)
 		for _, l := range newOnes {
 			if relErr := s.dedup.ReleaseClaim(ctx, l.Token, sr.ChatID, sr.ID); relErr != nil {

--- a/internal/api/ingest_delivery_test.go
+++ b/internal/api/ingest_delivery_test.go
@@ -8,8 +8,28 @@ import (
 	"time"
 
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/storage"
 )
+
+// fakeDigest implements storage.DigestStore; only GetDigestMode is meaningful.
+type fakeDigest struct{ mode string }
+
+func (f *fakeDigest) GetDigestMode(context.Context, int64) (string, string, error) {
+	return f.mode, "", nil
+}
+func (f *fakeDigest) SetDigestMode(context.Context, int64, string, string) error { return nil }
+func (f *fakeDigest) AddDigestItem(context.Context, int64, string, []string) error {
+	return nil
+}
+func (f *fakeDigest) PeekDigest(context.Context, int64) ([]string, time.Time, error) {
+	return nil, time.Time{}, nil
+}
+func (f *fakeDigest) AckDigest(context.Context, int64, time.Time) error   { return nil }
+func (f *fakeDigest) PendingDigestUsers(context.Context) ([]int64, error) { return nil, nil }
+func (f *fakeDigest) DigestLastFlushed(context.Context, int64) (time.Time, error) {
+	return time.Time{}, nil
+}
 
 // fakeDedup implements storage.DedupStore; `seen` holds already-claimed tokens.
 type fakeDedup struct {
@@ -115,5 +135,15 @@ func TestIngestDeliveryFor_NilWithoutPublisher(t *testing.T) {
 	got := s.ingestDeliveryFor(context.Background(), storage.Search{ChatID: 1}, slog.Default())
 	if got != nil {
 		t.Fatalf("expected nil delivery strategy without a publisher, got %T", got)
+	}
+}
+
+// A digest-mode user gets a DigestDelivery even without an alert publisher —
+// digest items are accumulated in the store, not published to the stream.
+func TestIngestDeliveryFor_DigestMode(t *testing.T) {
+	s := &Server{digests: &fakeDigest{mode: "digest"}} // no publisher
+	got := s.ingestDeliveryFor(context.Background(), storage.Search{ChatID: 1}, slog.Default())
+	if _, ok := got.(*scheduler.DigestDelivery); !ok {
+		t.Fatalf("expected *scheduler.DigestDelivery for a digest-mode user, got %T", got)
 	}
 }

--- a/internal/api/ingest_delivery_test.go
+++ b/internal/api/ingest_delivery_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// fakeDedup implements storage.DedupStore; `seen` holds already-claimed tokens.
+type fakeDedup struct {
+	seen     map[string]bool
+	released []string
+	claimErr error
+}
+
+func (f *fakeDedup) ClaimNew(_ context.Context, token string, _, _ int64) (bool, error) {
+	if f.claimErr != nil {
+		return false, f.claimErr
+	}
+	if f.seen == nil {
+		f.seen = map[string]bool{}
+	}
+	if f.seen[token] {
+		return false, nil
+	}
+	f.seen[token] = true
+	return true, nil
+}
+
+func (f *fakeDedup) ReleaseClaim(_ context.Context, token string, _, _ int64) error {
+	f.released = append(f.released, token)
+	return nil
+}
+
+func (f *fakeDedup) Prune(context.Context, time.Duration) (int64, error) { return 0, nil }
+
+// fakeDelivery captures delivered listings and can force an error.
+type fakeDelivery struct {
+	delivered []model.Listing
+	err       error
+}
+
+func (f *fakeDelivery) DeliverBatch(_ context.Context, _ int64, listings []model.Listing) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.delivered = append(f.delivered, listings...)
+	return nil
+}
+
+func (f *fakeDelivery) DeliverRaw(context.Context, int64, string) error { return nil }
+
+func listingsWithTokens(tokens ...string) []model.Listing {
+	out := make([]model.Listing, 0, len(tokens))
+	for _, t := range tokens {
+		out = append(out, model.Listing{RawListing: model.RawListing{Token: t}})
+	}
+	return out
+}
+
+func deliveredTokens(ls []model.Listing) []string {
+	out := make([]string, 0, len(ls))
+	for _, l := range ls {
+		out = append(out, l.Token)
+	}
+	return out
+}
+
+// Only listings not already claimed are delivered — this is what stops the
+// extension re-alerting the same cars on every 15-minute ingest cycle.
+func TestClaimAndDeliver_OnlyNewListings(t *testing.T) {
+	dedup := &fakeDedup{seen: map[string]bool{"b": true}} // b already seen
+	del := &fakeDelivery{}
+	s := &Server{dedup: dedup}
+	sr := storage.Search{ID: 1, ChatID: 7, Name: "test"}
+
+	s.claimAndDeliver(context.Background(), sr, listingsWithTokens("a", "b", "c"), del, slog.Default())
+
+	got := deliveredTokens(del.delivered)
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Fatalf("expected only new listings [a c] delivered, got %v", got)
+	}
+	// A second ingest of the same tokens delivers nothing new.
+	del.delivered = nil
+	s.claimAndDeliver(context.Background(), sr, listingsWithTokens("a", "c"), del, slog.Default())
+	if len(del.delivered) != 0 {
+		t.Fatalf("expected no re-delivery of already-claimed listings, got %v", deliveredTokens(del.delivered))
+	}
+}
+
+// On delivery failure the claims are released so the listings retry next cycle.
+func TestClaimAndDeliver_ReleaseClaimsOnFailure(t *testing.T) {
+	dedup := &fakeDedup{}
+	del := &fakeDelivery{err: errors.New("publish failed")}
+	s := &Server{dedup: dedup}
+	sr := storage.Search{ID: 1, ChatID: 7}
+
+	s.claimAndDeliver(context.Background(), sr, listingsWithTokens("a", "b"), del, slog.Default())
+
+	if len(dedup.released) != 2 {
+		t.Fatalf("expected both claims released on delivery failure, got %v", dedup.released)
+	}
+}
+
+// Without a publisher (and not digest mode) there is no transport, so the
+// selection returns nil and the caller skips — never nil-panicking on a
+// missing notifier, and never consuming dedup claims it cannot act on.
+func TestIngestDeliveryFor_NilWithoutPublisher(t *testing.T) {
+	s := &Server{} // no digests, no alertPublisher, no users
+	got := s.ingestDeliveryFor(context.Background(), storage.Search{ChatID: 1}, slog.Default())
+	if got != nil {
+		t.Fatalf("expected nil delivery strategy without a publisher, got %T", got)
+	}
+}

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -351,6 +351,11 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			totalNew += len(pr.Records)
+
+			// Notify the user about genuinely new matches (dedup-gated) via the
+			// same delivery path the scheduler uses. Best-effort; never fails
+			// the ingest, which has already persisted the listings.
+			s.deliverIngestMatches(r.Context(), sr, pr.Listings, log)
 		}
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/dsionov/carwatch/internal/api"
 	cwbot "github.com/dsionov/carwatch/internal/bot"
+	"github.com/dsionov/carwatch/internal/broker"
 	"github.com/dsionov/carwatch/internal/catalog"
 	"github.com/dsionov/carwatch/internal/config"
 	"github.com/dsionov/carwatch/internal/fetcher"
@@ -248,6 +249,22 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 
 	cfg.API.AdminChatID = cfg.Telegram.AdminChatID
 	cfg.API.MaxSearches = cfg.Telegram.MaxSearches
+
+	// Alert publisher lets the extension ingest path emit notifications on the
+	// same Redis stream the scheduler uses (the notifier worker consumes it).
+	// Best-effort: if Redis is unavailable the API still serves; ingest just
+	// won't send alerts.
+	var alertPublisher *broker.Publisher
+	if cfg.Redis.Addr != "" {
+		p, err := broker.NewPublisher(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)
+		if err != nil {
+			logger.Warn("alert publisher unavailable; extension ingest will not send notifications",
+				"error", err)
+		} else {
+			alertPublisher = p
+		}
+	}
+
 	apiServer := api.New(api.Config{
 		Catalog:          dynCatalog,
 		Searches:         store,
@@ -260,6 +277,9 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		Hidden:           store,
 		Notifs:           store,
 		PushSubs:         store,
+		Dedup:            store,
+		Digests:          store,
+		AlertPublisher:   alertPublisher,
 		Logger:           logger,
 		API:              cfg.API,
 		Push:             cfg.Push,

--- a/internal/scheduler/delivery.go
+++ b/internal/scheduler/delivery.go
@@ -15,7 +15,11 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
-var errMalformedMessage = errors.New("blocked malformed message")
+// ErrMalformedMessage is returned by a delivery when the rendered message is
+// malformed and was blocked before hitting the transport. It is a permanent
+// failure — callers should not release dedup claims and retry, or they will
+// replay the same bad batch every cycle.
+var ErrMalformedMessage = errors.New("blocked malformed message")
 
 const maxBatchSize = 10
 
@@ -106,7 +110,7 @@ func (d *InstantDelivery) DeliverBatch(ctx context.Context, chatID int64, listin
 		if notifier.IsMalformedMessage(msg) {
 			d.logger.ErrorContext(ctx, "blocked delivery of malformed batch message, skipping to prevent Telegram API errors",
 				"chat_id", chatID, "msg_len", len(msg))
-			return errMalformedMessage
+			return ErrMalformedMessage
 		}
 		tokens := make([]string, 0, len(listings))
 		for _, l := range listings {
@@ -147,7 +151,7 @@ func (d *InstantDelivery) DeliverRaw(ctx context.Context, chatID int64, message 
 		d.logger.ErrorContext(ctx, "blocked delivery of malformed raw message, skipping to prevent Telegram API errors",
 			"chat_id", chatID, "msg_len", len(message),
 			"msg_preview", truncateStr(message, 200))
-		return errMalformedMessage
+		return ErrMalformedMessage
 	}
 
 	if d.publisher != nil {
@@ -197,7 +201,7 @@ func (d *DigestDelivery) DeliverBatch(ctx context.Context, chatID int64, listing
 		msg += locale.Tf(d.lang, "fmt_batch_overflow", truncated)
 	}
 	if notifier.IsMalformedMessage(msg) {
-		return errMalformedMessage
+		return ErrMalformedMessage
 	}
 	tokens := make([]string, 0, len(listings))
 	for _, l := range listings {
@@ -208,7 +212,7 @@ func (d *DigestDelivery) DeliverBatch(ctx context.Context, chatID int64, listing
 
 func (d *DigestDelivery) DeliverRaw(ctx context.Context, chatID int64, message string) error {
 	if notifier.IsMalformedMessage(message) {
-		return errMalformedMessage
+		return ErrMalformedMessage
 	}
 	// Raw digest items (e.g. price drops) carry no per-listing token.
 	return d.store.AddDigestItem(ctx, chatID, message, nil)

--- a/internal/scheduler/delivery_test.go
+++ b/internal/scheduler/delivery_test.go
@@ -348,8 +348,8 @@ func TestInstantDelivery_DeliverRaw_BlocksMalformed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := d.DeliverRaw(context.Background(), 100, tt.msg)
-			if !errors.Is(err, errMalformedMessage) {
-				t.Errorf("expected errMalformedMessage, got: %v", err)
+			if !errors.Is(err, ErrMalformedMessage) {
+				t.Errorf("expected ErrMalformedMessage, got: %v", err)
 			}
 		})
 	}
@@ -381,8 +381,8 @@ func TestDigestDelivery_DeliverRaw_BlocksMalformed(t *testing.T) {
 	d := NewDigestDelivery(ds, locale.English)
 
 	err := d.DeliverRaw(context.Background(), 100, "{{.}}")
-	if !errors.Is(err, errMalformedMessage) {
-		t.Errorf("expected errMalformedMessage, got: %v", err)
+	if !errors.Is(err, ErrMalformedMessage) {
+		t.Errorf("expected ErrMalformedMessage, got: %v", err)
 	}
 
 	ds.mu.Lock()

--- a/internal/scheduler/processing.go
+++ b/internal/scheduler/processing.go
@@ -53,7 +53,7 @@ func (s *Scheduler) deliverResults(ctx context.Context, search storage.Search, l
 	)
 
 	if err := delivery.DeliverBatch(ctx, search.ChatID, sr.newListings); err != nil {
-		if errors.Is(err, errMalformedMessage) {
+		if errors.Is(err, ErrMalformedMessage) {
 			log.WarnContext(ctx, "batch message is malformed, keeping dedup claims to prevent infinite retry",
 				"count", len(sr.newListings), "search_name", search.Name)
 			return false

--- a/scripts/health-alert.sh
+++ b/scripts/health-alert.sh
@@ -20,8 +20,8 @@ COMPOSE_DIR="${1:-/home/ubuntu/carwatch}"
 STATE_DIR="${CARWATCH_STATE_DIR:-/var/lib/carwatch}"
 STATE_FILE="${STATE_DIR}/health-alert.state"
 
-SERVICES=(api bot-poller scraper notifier enricher)
-HEALTH_PORTS=(8080 8082 8081 8083 8084)
+SERVICES=(api bot-poller scraper notifier)
+HEALTH_PORTS=(8080 8082 8081 8083)
 
 TOKEN=$(grep -oP 'TELEGRAM_BOT_TOKEN=\K[^\s]+' "${COMPOSE_DIR}/.env" 2>/dev/null || echo "")
 ADMIN_CHAT=$(grep -oP 'admin_chat_id:\s*\K[0-9]+' "${COMPOSE_DIR}/config.yaml" 2>/dev/null || echo "")

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 COMPOSE_DIR="${1:-/home/ubuntu/carwatch}"
 COMPOSE="docker compose -f ${COMPOSE_DIR}/docker-compose.prod.yaml"
 
-SERVICES=(api bot-poller scraper notifier enricher)
-HEALTH_PORTS=(8080 8082 8081 8083 8084)
+SERVICES=(api bot-poller scraper notifier)
+HEALTH_PORTS=(8080 8082 8081 8083)
 
 fail=0
 

--- a/scripts/validate-compose.sh
+++ b/scripts/validate-compose.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 COMPOSE_FILE="${1:-docker-compose.prod.yaml}"
-APP_SERVICES="api bot-poller scraper notifier enricher"
+APP_SERVICES="api bot-poller scraper notifier"
 
 # render runs `docker compose config` with the full set of required env vars.
 render() {
@@ -71,8 +71,8 @@ fi
 
 echo "==> all app services use CARWATCH_IMAGE_TAG"
 count=$(grep -c "ghcr.io/danielsio/carwatch:\${CARWATCH_IMAGE_TAG" "$COMPOSE_FILE" || true)
-if [ "$count" -ne 5 ]; then
-  echo "Expected api/bot-poller/scraper/notifier/enricher to use CARWATCH_IMAGE_TAG (found $count)"
+if [ "$count" -ne 4 ]; then
+  echo "Expected api/bot-poller/scraper/notifier to use CARWATCH_IMAGE_TAG (found $count)"
   exit 1
 fi
 


### PR DESCRIPTION
Completes the switch to the browser extension as the primary Yad2 ingestion path (follow-up to #1476).

## What & why

**1. `fix(ext)` — km enrichment lands 0 in prod.**
Enrichment works 30/30 in a clean load but produced 0 km in the user's Chrome. Root cause: Chrome's Memory Saver **discards the long-lived pinned background Yad2 tab** between cycles, so `executeScript` item fetches silently fail (a freshly-opened tab always works, which is why the feed still parsed). Fix: `keepTabAlive()` sets `autoDiscardable=false` (+ reactivates a discarded tab), and the item batch retries once (reload + refetch) when fully blocked, mirroring the feed recovery.

**2. `feat(api)` — notifications from the ingest path.**
The ingest saved listings (web UI live) but never published alerts, so Telegram/Web-Push only fired from the now-idle scheduler. `/ext/ingest` now runs the same delivery mechanics: dedup via `seen_listings.ClaimNew` (at most one alert per user/search — no re-alerting every cycle), per-user digest/instant mode, and claim-release on delivery failure. Best-effort: the alert publisher is optional and delivery never fails the ingest.

**3. `infra` — retire the km `enricher`.**
It has produced 0 enrichments since Radware blocked server-side item fetches; the extension owns enrichment now. The `scraper` container **stays** (its scheduler still runs digest flushing + dedup/price pruning).

## Testing
- New unit tests: dedup gating (only-new delivered), claim-release-on-failure, no-publisher no-op guard — all pass.
- `go vet` clean; `gofmt` clean; api+app build clean.
- Enrichment mechanism verified end-to-end by loading the extension in Playwright: feed + 30/30 item km fetched.
- Compose validated (7 services; enricher gone).

## Deploy note
Before this activates, `seen_listings` is seeded from current `listing_history` so existing listings are not re-alerted as "new" (only genuinely-new listings fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-extension ingestion can now notify you about newly matched listings, with improved retry behavior when detail fetches are blocked.
  * Extension version updated to **1.2.0**.

* **Bug Fixes**
  * Improved stability by preventing managed background tabs from being auto-discarded.
  * Ensures newly ingested matches are delivered only once per search, avoiding duplicate notifications.

* **Documentation**
  * Updated deploy/rollback verification steps to reflect the current production service set (enricher removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->