### PR TITLE
fix: dev tooling — Windows migrations, amd64 vm-bench, web-bench, ignore *.exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,13 @@ config.yaml
 /scraper
 /notifier-worker
 /bench
-/bench-arm64
+/bench-amd64
 /enricher
 /bot-poller
 /fetch-bench
 /enrich-bench
+# Windows build outputs (go build -o api-server.exe, etc.)
+*.exe
 bench-results.json
 bench-profiles/
 coverage.out

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
        vm-check-env vm-ssh vm-logs logs vm-restart vm-stop vm-start vm-status vm-smoke vm-deploy vm-deploy-all vm-sync \
        vm-backup vm-backup-list vm-pg-shell \
        vm-setup-backup vm-backup-status \
-       web-install web-dev web-build \
+       web-install web-dev web-build web-bench \
        catalog-refresh \
        bench bench-fast bench-yad2 bench-profile bench-go
 
@@ -74,7 +74,7 @@ lint:
 ci: lint test
 
 clean:
-	rm -f api-server bot-poller scraper notifier-worker bench
+	rm -f api-server bot-poller scraper notifier-worker bench bench-amd64
 	rm -rf $(COVER_DIR) bench-profiles bench-results.json
 
 web-install:
@@ -85,6 +85,15 @@ web-dev:
 
 web-build:
 	cd web && npm run build
+
+# Measure web delivery latency (app-shell / static asset / API) for the current
+# origin, or compare it against another deployment:
+#   make web-bench
+#   make web-bench BENCH_TARGETS="current=https://carwatch.duckdns.org other=https://…"
+WEB_BENCH_N ?= 25
+BENCH_TARGETS ?=
+web-bench:
+	bash scripts/web-bench.sh -n $(WEB_BENCH_N) $(BENCH_TARGETS)
 
 dev-db:
 	docker compose -f docker-compose.dev.yaml up -d
@@ -129,22 +138,23 @@ bench-profile: build-bench
 bench-go:
 	go test -bench=. -benchmem -count=3 -run='^$$' ./internal/percolator/ ./internal/scoring/
 
-# Cross-compile for Oracle ARM VM and run remotely.
+# Cross-compile for the Oracle x86_64 VM and run remotely.
+# (The Always-Free prod VM is amd64 AMD EPYC — NOT ARM, despite older docs.)
 #   make vm-bench              — all phases
 #   make vm-bench BENCH_PHASES=percolator,scoring  — specific phases
 BENCH_PHASES ?= all
 BENCH_ARGS ?=
 
 vm-bench: vm-bench-build vm-bench-upload vm-bench-run vm-bench-fetch
-	@rm -f bench-arm64
+	@rm -f bench-amd64
 
 vm-bench-build:
-	@echo "=== Cross-compiling bench for linux/arm64..."
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bench-arm64 ./cmd/bench
+	@echo "=== Cross-compiling bench for linux/amd64..."
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bench-amd64 ./cmd/bench
 
 vm-bench-upload: vm-check-env
 	@echo "=== Uploading to VM..."
-	$(SCP) bench-arm64 $(VM_USER)@$(VM_IP):$(VM_DIR)/bench
+	$(SCP) bench-amd64 $(VM_USER)@$(VM_IP):$(VM_DIR)/bench
 	$(SSH) "chmod +x $(VM_DIR)/bench && mkdir -p $(VM_DIR)/bench-output"
 
 vm-bench-run: vm-check-env

--- a/internal/storage/postgres/migrations_source_test.go
+++ b/internal/storage/postgres/migrations_source_test.go
@@ -1,0 +1,29 @@
+package postgres
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+)
+
+// TestMigrationsSourceOpens guards cross-platform loading of the migrations
+// directory. The previous "file://" source driver could not open a Windows
+// `C:\…` path — it parsed as an invalid port, then as an unopenable path —
+// which broke `make dev` on Windows. The iofs + os.DirFS source must open the
+// real migrations dir and expose at least one migration on any OS.
+func TestMigrationsSourceOpens(t *testing.T) {
+	absPath, err := filepath.Abs(filepath.Join("..", "..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	src, err := iofs.New(os.DirFS(absPath), ".")
+	if err != nil {
+		t.Fatalf("open migrations source at %q: %v", absPath, err)
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := src.First(); err != nil {
+		t.Fatalf("expected at least one migration in %q: %v", absPath, err)
+	}
+}

--- a/internal/storage/postgres/store.go
+++ b/internal/storage/postgres/store.go
@@ -4,12 +4,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/pgx/v5"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -43,7 +44,18 @@ func New(dsn string, migrationsPath string) (*Store, error) {
 			_ = db.Close()
 			return nil, fmt.Errorf("create migrate driver: %w", err)
 		}
-		m, err := migrate.NewWithDatabaseInstance("file://"+absPath, "pgx", driver)
+		// Use the iofs source over os.DirFS rather than a "file://" URL: the
+		// file source's URL parsing is broken on Windows (a `C:\…` path parses
+		// as an invalid port, and even when slash-normalized the source can't
+		// open it), which breaks `make dev` on Windows. iofs takes an fs.FS
+		// directly — no URL, no platform-specific path munging — and still
+		// reads migrations from disk at runtime (prod mounts ./migrations).
+		src, err := iofs.New(os.DirFS(absPath), ".")
+		if err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("open migrations source: %w", err)
+		}
+		m, err := migrate.NewWithInstance("iofs", src, "pgx", driver)
 		if err != nil {
 			_ = db.Close()
 			return nil, fmt.Errorf("create migrator: %w", err)

--- a/scripts/web-bench.sh
+++ b/scripts/web-bench.sh
@@ -96,7 +96,11 @@ bench_path() {
   local ttfbs=() totals=() size="" code="" enc_cdn=""
   enc_cdn="$(probe_headers "$url" || true)"
   for _ in $(seq 1 "$SAMPLES"); do
-    read -r dns conn tls ttfb total sz hc < <(curl "${CURL_OPTS[@]}" -o /dev/null -w "$TIMEFMT" "$url" 2>/dev/null || echo "0 0 0 0 0 0 000")
+    # On failure curl still writes the -w format with zeros + http_code 000;
+    # `|| true` just keeps set -e happy. (Do NOT `|| echo ...` — TIMEFMT has no
+    # trailing newline, so the echo would concatenate onto curl's output and
+    # corrupt the read.)
+    read -r dns conn tls ttfb total sz hc < <(curl "${CURL_OPTS[@]}" -o /dev/null -w "$TIMEFMT" "$url" 2>/dev/null || true)
     ttfbs+=("$(awk -v x="$ttfb" 'BEGIN{print x*1000}')")
     totals+=("$(awk -v x="$total" 'BEGIN{print x*1000}')")
     size="$sz"; code="$hc"

--- a/scripts/web-bench.sh
+++ b/scripts/web-bench.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# web-bench.sh — measure web delivery latency for one or more origins so you can
+# compare the CURRENT setup (Oracle VM in Jerusalem, app served by the Go API
+# behind Caddy) against a FUTURE Vercel deployment of the SPA — and prove whether
+# moving the frontend actually moved the numbers.
+#
+# It separates the three timings that matter for the "should we move to Vercel?"
+# decision:
+#
+#   1. STATIC (app-shell HTML + a hashed JS asset) — this is what a CDN/Vercel
+#      edge would serve. Improvement here = the upside of moving the frontend.
+#   2. API (/healthz) — this STAYS on the Oracle backend no matter where the
+#      frontend lives. It is the control: it should NOT change between origins.
+#      If the API is the slow part, Vercel cannot help it.
+#   3. The network breakdown (DNS / TCP / TLS / TTFB) so you can see whether a
+#      difference comes from edge proximity or from server think-time.
+#
+# Each request opens a fresh connection (no keep-alive) to model distinct cold
+# visitors, and reports min / median / p95 / max over N samples — tail latency
+# is where a single small VM hurts, so the median alone would lie.
+#
+# Usage:
+#   scripts/web-bench.sh                                  # baseline: current origin
+#   scripts/web-bench.sh -n 30                            # 30 samples per endpoint
+#   scripts/web-bench.sh current=https://carwatch.duckdns.org vercel=https://carwatch.vercel.app
+#   scripts/web-bench.sh -a /assets/index-XXpart.js current=https://... vercel=https://...
+#
+# Targets are "label=url" pairs. With no targets it defaults to the current
+# origin. Requires: curl, awk, sort (present in Git Bash on Windows).
+#
+# Note: deliberately NOT using `set -e`/pipefail — curl|grep|head pipelines emit
+# benign SIGPIPE/no-match exits that would otherwise abort a perfectly good run.
+set -u
+
+SAMPLES=20
+ASSET_OVERRIDE=""
+# Paths probed on every target. The app-shell is no-cache HTML (re-fetched each
+# load); /healthz is the cheapest API round-trip.
+SHELL_PATH="/"
+API_PATH="/healthz"
+
+usage() { sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+TARGETS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n) SAMPLES="$2"; shift 2 ;;
+    -a) ASSET_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *=*) TARGETS+=("$1"); shift ;;
+    *) echo "unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+[ ${#TARGETS[@]} -eq 0 ] && TARGETS=("current=https://carwatch.duckdns.org")
+
+CURL_OPTS=(-ks --no-keepalive -H 'Accept-Encoding: br,gzip,zstd' -A 'carwatch-web-bench/1')
+TIMEFMT='%{time_namelookup} %{time_connect} %{time_appconnect} %{time_starttransfer} %{time_total} %{size_download} %{http_code}'
+
+# stats <space-separated-ms-values>  ->  "min median p95 max mean"
+stats() {
+  printf '%s\n' "$@" | sort -n | awk '
+    { v[NR]=$1; sum+=$1 }
+    END {
+      n=NR; if (n==0){ print "- - - - -"; exit }
+      p95i=int(0.95*(n-1))+1; medi=int(0.50*(n-1))+1;
+      printf "%.0f %.0f %.0f %.0f %.1f", v[1], v[medi], v[p95i], v[n], sum/n
+    }'
+}
+
+# one-off header probe: report encoding + any CDN/edge cache markers
+probe_headers() {
+  local url="$1"
+  curl "${CURL_OPTS[@]}" -I "$url" 2>/dev/null | awk '
+    BEGIN{IGNORECASE=1}
+    /^content-encoding:/  {enc=$2}
+    /^cache-control:/     {sub(/^[^:]*: */,""); cc=$0}
+    /^age:/               {age=$2}
+    /^x-vercel-cache:/    {sub(/^[^:]*: */,""); cdn="vercel:" $0}
+    /^cf-cache-status:/   {sub(/^[^:]*: */,""); cdn="cf:" $0}
+    /^x-cache:/           {sub(/^[^:]*: */,""); cdn="x-cache:" $0}
+    END{ printf "enc=%s cdn=%s", (enc?enc:"-"), (cdn?cdn:"-") }'
+}
+
+discover_asset() {
+  local base="$1"
+  # --compressed so curl decompresses the body before we grep it (the timing
+  # path below intentionally leaves bodies compressed; discovery must not).
+  curl -ks --compressed -A 'carwatch-web-bench/1' "$base/" 2>/dev/null \
+    | grep -oE '/assets/[^"]+\.(js|css)' | head -1
+}
+
+bench_path() {
+  local label="$1" base="$2" path="$3" kind="$4"
+  local url="${base%/}$path"
+  local ttfbs=() totals=() size="" code="" enc_cdn=""
+  enc_cdn="$(probe_headers "$url" || true)"
+  for _ in $(seq 1 "$SAMPLES"); do
+    read -r dns conn tls ttfb total sz hc < <(curl "${CURL_OPTS[@]}" -o /dev/null -w "$TIMEFMT" "$url" 2>/dev/null || echo "0 0 0 0 0 0 000")
+    ttfbs+=("$(awk -v x="$ttfb" 'BEGIN{print x*1000}')")
+    totals+=("$(awk -v x="$total" 'BEGIN{print x*1000}')")
+    size="$sz"; code="$hc"
+  done
+  local ts; ts="$(stats "${ttfbs[@]}")"
+  local tt; tt="$(stats "${totals[@]}")"
+  # columns: kind path  ttfb(min/med/p95/max)  total(med/p95)  size  code  enc/cdn
+  printf "  %-13s %-10s ttfb[ %-6s %-6s %-6s %-6s ]  total[ med %-6s p95 %-6s ]  %sB  %s  %s\n" \
+    "$kind" "$path" \
+    $(echo "$ts" | awk '{print $1, $2, $3, $4}') \
+    "$(echo "$tt" | awk '{print $2}')" "$(echo "$tt" | awk '{print $3}')" \
+    "$size" "$code" "$enc_cdn"
+}
+
+echo "================================================================================"
+echo " CarWatch web delivery benchmark   samples=$SAMPLES   $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+VANTAGE_JSON="$(curl -ks https://ipinfo.io/json 2>/dev/null || true)"
+V_CITY="$(printf '%s\n' "$VANTAGE_JSON" | grep '"city"'    | sed -E 's/.*: *"([^"]*)".*/\1/')"
+V_CC="$(printf '%s\n'   "$VANTAGE_JSON" | grep '"country"' | sed -E 's/.*: *"([^"]*)".*/\1/')"
+echo " vantage: ${V_CITY:-unknown}, ${V_CC:-?}"
+echo " times in ms. ttfb = time-to-first-byte (network + server think-time)."
+echo "================================================================================"
+
+for t in "${TARGETS[@]}"; do
+  label="${t%%=*}"; base="${t#*=}"
+  echo ""
+  echo "▶ $label  ($base)"
+  asset="${ASSET_OVERRIDE:-$(discover_asset "$base" || true)}"
+  bench_path "$label" "$base" "$SHELL_PATH" "app-shell"
+  if [ -n "$asset" ]; then
+    bench_path "$label" "$base" "$asset" "static-asset"
+  else
+    echo "  (no /assets/* asset discovered — pass one with -a /assets/foo.js)"
+  fi
+  bench_path "$label" "$base" "$API_PATH" "api"
+done
+
+cat <<'EOF'
+
+--------------------------------------------------------------------------------
+Reading the result:
+  • app-shell + static-asset  → what Vercel/CDN edge would serve. A real win
+    shows up here as lower ttfb (and a cdn= hit marker on repeat runs).
+  • api (/healthz)            → control. This stays on the Oracle VM in Jerusalem
+    in BOTH worlds. If it is the slow line, moving the frontend changes nothing.
+  • Compare ttfb p95/max, not just median — the small VM's pain is tail latency.
+Run the same command against both origins once Vercel is live, e.g.:
+  scripts/web-bench.sh -n 30 current=https://carwatch.duckdns.org vercel=https://<app>.vercel.app
+--------------------------------------------------------------------------------
+EOF


### PR DESCRIPTION
Salvages the still-useful half of an old WIP branch (the posted-at fix it also contained is already on `main` via #1459, so that part was dropped). All dev/ops tooling — no product-behavior or prod change.

## Changes
- **`fix(storage)`** — migrations load via `iofs`/`os.DirFS` instead of the `file://` source, which can't open a Windows `C:\…` path (parses as an invalid port) and broke `make dev` locally. Prod still reads the mounted `./migrations`, so no prod change. Adds a cross-platform test.
- **`chore(build)`** — `vm-bench` cross-compiled `GOARCH=arm64`, but the Always-Free prod VM is **amd64** (AMD EPYC) — the arm64 binary can't run there; build amd64. Add `make web-bench` + `scripts/web-bench.sh` (web delivery-latency probe). Ignore `*.exe` (Windows build outputs, e.g. the stray `api-server.exe`).

## Testing
- `TestMigrationsSourceOpens` passes (opens the real migrations dir cross-platform, no DB needed).
- `go build ./internal/storage/...` clean; `gofmt` clean; `bash -n scripts/web-bench.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `web-bench` command to measure web delivery latency for the app shell, a referenced static asset, and the health-check endpoint, including summary stats and cache/header indicators.
* **Bug Fixes**
  * Improved how database migrations are loaded to use a bundled filesystem source for more reliable discovery.
  * Added a test covering successful migration source opening.
* **Chores**
  * Updated benchmark workflow and build artifacts to use the amd64 variant, including improved cleanup.
  * Adjusted ignored benchmark directory names in `.gitignore`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->