### PR TITLE
fix(ext): derive gearbox as Hebrew so enriched km isn't filtered out

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -25,8 +25,12 @@ function label(field) {
 // scraper does (parser.go subModelGearRe): the sub-model text carries an "אוט׳"
 // marker for automatics. Non-automatics stay empty, which the filter skips.
 const AUTO_GEARBOX_RE = /אוט[׳']/;
-function deriveGearBox(subModelText) {
-  return AUTO_GEARBOX_RE.test(subModelText || "") ? "אוטומט" : "";
+// Test the RAW Hebrew sub-model text (field.text), not label(): label() prefers
+// text_eng, so it would miss the Hebrew "אוט׳" marker whenever English text is
+// present and wrongly leave gearbox empty.
+function deriveGearBox(subModelField) {
+  const text = (subModelField && subModelField.text) || "";
+  return AUTO_GEARBOX_RE.test(text) ? "אוטומט" : "";
 }
 
 function fieldId(field) {
@@ -73,7 +77,7 @@ function itemToListing(item, isCommercial) {
     page_link: `https://www.yad2.co.il/vehicles/item/${token}`,
     engine_volume: sf.engine_volume || 0,
     engine_type: label(sf.engine_type),
-    gear_box: deriveGearBox(label(sf.sub_model)),
+    gear_box: deriveGearBox(sf.sub_model),
     body_type: label(sf.body_type),
     description: (md.description || "").trim(),
     is_commercial: isCommercial,
@@ -164,7 +168,7 @@ function parseItemDetail(json) {
   // Derive gearbox from the sub-model marker (Hebrew "אוטומט"), never the
   // item's English gearBox.text_eng — see deriveGearBox. Using English here
   // made enriched listings fail the backend gearbox filter and drop their km.
-  const gearBox = deriveGearBox(label(d.subModel));
+  const gearBox = deriveGearBox(d.subModel);
   if (gearBox) fields.gear_box = gearBox;
   const bodyType = label(d.bodyType);
   if (bodyType) fields.body_type = bodyType;

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -17,6 +17,18 @@ function label(field) {
   return field.text_eng || field.textEng || field.text || "";
 }
 
+// The search's gearbox is stored as the Hebrew "אוטומט" and the backend filter
+// (internal/filter/filter.go) matches on that exact string. The gw feed has no
+// clean gearbox field, and the item detail's gearBox.text_eng is English
+// ("Automatic") — using it made every enriched listing FAIL the gearbox filter
+// and get dropped (so km never saved). Derive gearbox the same way the Go
+// scraper does (parser.go subModelGearRe): the sub-model text carries an "אוט׳"
+// marker for automatics. Non-automatics stay empty, which the filter skips.
+const AUTO_GEARBOX_RE = /אוט[׳']/;
+function deriveGearBox(subModelText) {
+  return AUTO_GEARBOX_RE.test(subModelText || "") ? "אוטומט" : "";
+}
+
 function fieldId(field) {
   if (!field) return 0;
   const id = field.id;
@@ -61,7 +73,7 @@ function itemToListing(item, isCommercial) {
     page_link: `https://www.yad2.co.il/vehicles/item/${token}`,
     engine_volume: sf.engine_volume || 0,
     engine_type: label(sf.engine_type),
-    gear_box: label(sf.gear_box) || label(md.gear_box_item),
+    gear_box: deriveGearBox(label(sf.sub_model)),
     body_type: label(sf.body_type),
     description: (md.description || "").trim(),
     is_commercial: isCommercial,
@@ -149,7 +161,10 @@ function parseItemDetail(json) {
   if (d.engineVolume) fields.engine_volume = d.engineVolume;
   const engineType = label(d.engineType);
   if (engineType) fields.engine_type = engineType;
-  const gearBox = label(d.gearBox);
+  // Derive gearbox from the sub-model marker (Hebrew "אוטומט"), never the
+  // item's English gearBox.text_eng — see deriveGearBox. Using English here
+  // made enriched listings fail the backend gearbox filter and drop their km.
+  const gearBox = deriveGearBox(label(d.subModel));
   if (gearBox) fields.gear_box = gearBox;
   const bodyType = label(d.bodyType);
   if (bodyType) fields.body_type = bodyType;


### PR DESCRIPTION
## The bug
Extension-ingested listings never got km (stuck at 12/22 in prod; only pre-Radware rows from the old scraper had it). Root cause found by reproducing the exact path against live Yad2:

- The item parser set `gear_box` from `gearBox.text_eng` → **`"Automatic"`** (English).
- Searches store gearbox as the Hebrew **`אוטומט`**, and `internal/filter/filter.go` matches on that exact string (`EqualFold`).
- So every **enriched** listing (`gear_box="Automatic"`) failed the gearbox filter and was **dropped before its km could save** — while the **km-less feed** version (empty gearbox → filter skipped) passed. Classic: the km-less row persists, the km-bearing one is filtered.

## The fix
Match the Go scraper (`parser.go` `subModelGearRe`): derive gearbox from the sub-model `אוט׳` automatic marker in **both** `parseFeed` and `parseItemDetail`; never use `text_eng`. Non-automatics stay empty (filter skips, as before).

**Verified against live data:** `ii1z7274` now parses `gear_box="אוטומט"` + `km=68000`, and matches search 46 (`gear_box="אוטומט"`, max_km 70000) → passes → km saves.

Extension-only (`parser.js` + manifest → v1.2.2). No backend/deploy change.

## User action after merge
Remove + re-add the unpacked extension (clears the `known` cache so previously-"enriched" tokens get re-processed with the corrected gearbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle listing details by deriving gearbox information more consistently from the model text.
  * Refined commercial listing classification for better feed handling.
* **Chores**
  * Updated the extension version to **1.2.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->