### PR TITLE
fix: audit — ingest chunking, manufacturer filter, created_at timezone

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -422,7 +422,20 @@ async function fetchSearches(config) {
   return resp.json();
 }
 
+// The ingest endpoint rejects > 500 listings per request, so push in chunks.
+// A user with many/broad searches can exceed that; without chunking the whole
+// cycle's ingestion would 400 and be lost.
+const MAX_INGEST_BATCH = 400;
+
 async function pushListings(config, listings) {
+  let last;
+  for (let i = 0; i < listings.length; i += MAX_INGEST_BATCH) {
+    last = await pushBatch(config, listings.slice(i, i + MAX_INGEST_BATCH));
+  }
+  return last;
+}
+
+async function pushBatch(config, listings) {
   for (let attempt = 0; attempt < 3; attempt++) {
     if (attempt > 0) await sleep(2000 * attempt);
     const resp = await fetchWithTimeout(

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -1063,20 +1063,27 @@ func TestRefreshListings_Cooldown(t *testing.T) {
 
 func TestBuildFilterCriteriaFromSearch(t *testing.T) {
 	sr := &storage.Search{
-		Model:       10226,
-		YearMin:     2020,
-		YearMax:     2024,
-		PriceMax:    200000,
-		EngineMinCC: 1800,
-		MaxKm:       100000,
-		MaxHand:     3,
-		PriceOnly:   true,
-		PhotoOnly:   true,
-		Keywords:    "automatic, sunroof",
-		ExcludeKeys: "salvage",
+		Manufacturer: 19,
+		Model:        10226,
+		YearMin:      2020,
+		YearMax:      2024,
+		PriceMax:     200000,
+		EngineMinCC:  1800,
+		MaxKm:        100000,
+		MaxHand:      3,
+		PriceOnly:    true,
+		PhotoOnly:    true,
+		Keywords:     "automatic, sunroof",
+		ExcludeKeys:  "salvage",
 	}
 	fc := model.FilterCriteriaFromSearch(sr)
 
+	// Manufacturer must carry through: the extension pushes every search's
+	// listings in one batch, so a dropped ManufacturerID lets a
+	// manufacturer-only search match every make.
+	if fc.ManufacturerID != 19 {
+		t.Errorf("ManufacturerID = %d, want 19", fc.ManufacturerID)
+	}
 	if fc.ModelID != 10226 {
 		t.Errorf("ModelID = %d, want 10226", fc.ModelID)
 	}

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -260,6 +260,15 @@ type ingestResponse struct {
 	NewMatches int `json:"new_matches"`
 }
 
+// israelTZ interprets the Yad2 feed's zone-less local timestamps; falls back to
+// UTC if the zoneinfo is unavailable.
+var israelTZ = func() *time.Location {
+	if loc, err := time.LoadLocation("Asia/Jerusalem"); err == nil {
+		return loc
+	}
+	return time.UTC
+}()
+
 func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
@@ -313,10 +322,17 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 			Commercial:     l.IsCommercial,
 		}
 		if l.CreatedAt != "" {
-			for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"} {
-				if t, err := time.Parse(layout, l.CreatedAt); err == nil {
-					rl.CreatedAt = t
-					break
+			// Zone-bearing first; then zone-less as Israel local — the Yad2 feed
+			// emits zone-less local timestamps, so parsing them as UTC would put
+			// posted_at ~2-3h early (the scraper's parseFlexTime does the same).
+			if t, err := time.Parse(time.RFC3339, l.CreatedAt); err == nil {
+				rl.CreatedAt = t
+			} else {
+				for _, layout := range []string{"2006-01-02T15:04:05", "2006-01-02"} {
+					if t, err := time.ParseInLocation(layout, l.CreatedAt, israelTZ); err == nil {
+						rl.CreatedAt = t
+						break
+					}
 				}
 			}
 		}

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dsionov/carwatch/internal/model"
 	"github.com/dsionov/carwatch/internal/scheduler"
 	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/timeutil"
 )
 
 type listingResponse struct {
@@ -260,15 +261,6 @@ type ingestResponse struct {
 	NewMatches int `json:"new_matches"`
 }
 
-// israelTZ interprets the Yad2 feed's zone-less local timestamps; falls back to
-// UTC if the zoneinfo is unavailable.
-var israelTZ = func() *time.Location {
-	if loc, err := time.LoadLocation("Asia/Jerusalem"); err == nil {
-		return loc
-	}
-	return time.UTC
-}()
-
 func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 	chatID, ok := s.requireResolvedChatID(w, r)
 	if !ok {
@@ -321,21 +313,9 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 			Description:    l.Description,
 			Commercial:     l.IsCommercial,
 		}
-		if l.CreatedAt != "" {
-			// Zone-bearing first; then zone-less as Israel local — the Yad2 feed
-			// emits zone-less local timestamps, so parsing them as UTC would put
-			// posted_at ~2-3h early (the scraper's parseFlexTime does the same).
-			if t, err := time.Parse(time.RFC3339, l.CreatedAt); err == nil {
-				rl.CreatedAt = t
-			} else {
-				for _, layout := range []string{"2006-01-02T15:04:05", "2006-01-02"} {
-					if t, err := time.ParseInLocation(layout, l.CreatedAt, israelTZ); err == nil {
-						rl.CreatedAt = t
-						break
-					}
-				}
-			}
-		}
+		// Shared with the scraper: the Yad2 feed emits zone-less local
+		// timestamps, so parsing them as UTC would put posted_at ~2-3h early.
+		rl.CreatedAt = timeutil.ParseFlexTime(l.CreatedAt)
 		raw = append(raw, rl)
 	}
 

--- a/internal/fetcher/yad2/parser.go
+++ b/internal/fetcher/yad2/parser.go
@@ -9,11 +9,11 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dsionov/carwatch/internal/bodytype"
 	"github.com/dsionov/carwatch/internal/fetcher"
 	"github.com/dsionov/carwatch/internal/model"
+	"github.com/dsionov/carwatch/internal/timeutil"
 )
 
 const challengeMarker = "Are you for real"
@@ -341,7 +341,7 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 		updatedAt = item.VehicleDates.UpdatedAt
 	}
 	if createdAt != "" {
-		listing.CreatedAt = parseFlexTime(createdAt)
+		listing.CreatedAt = timeutil.ParseFlexTime(createdAt)
 		if listing.CreatedAt.IsZero() && logger != nil {
 			// A non-empty value we cannot parse means Yad2 changed its date
 			// format. Surface it loudly: silently dropping it makes posted_at
@@ -351,7 +351,7 @@ func itemToListing(raw json.RawMessage, commercial *bool, logger *slog.Logger) (
 		}
 	}
 	if updatedAt != "" {
-		listing.UpdatedAt = parseFlexTime(updatedAt)
+		listing.UpdatedAt = timeutil.ParseFlexTime(updatedAt)
 	}
 	listing.Commercial = commercial
 	return listing, nil
@@ -392,45 +392,6 @@ func parseHand(raw json.RawMessage) int {
 		return f.ID
 	}
 	return 0
-}
-
-var israelTZ = func() *time.Location {
-	loc, err := time.LoadLocation("Asia/Jerusalem")
-	if err != nil {
-		return time.UTC
-	}
-	return loc
-}()
-
-// parseFlexTime parses the timestamp formats Yad2 has been observed to emit.
-// Yad2's feed dates are zone-less local time (e.g. "2025-02-09T10:31:37"), but
-// it has historically drifted between "Z"/offset-suffixed and fractional-second
-// variants, so we accept all of them rather than silently dropping the date.
-func parseFlexTime(s string) time.Time {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return time.Time{}
-	}
-	// Zone-bearing formats ("...Z" or "...+02:00"), with or without fractional
-	// seconds. RFC3339Nano covers the fractional case; RFC3339 the rest.
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t
-		}
-	}
-	// Zone-less formats — interpret as Israel local time, matching the feed.
-	for _, layout := range []string{
-		"2006-01-02T15:04:05.999999999",
-		"2006-01-02T15:04:05",
-		"2006-01-02 15:04:05.999999999",
-		"2006-01-02 15:04:05",
-		"2006-01-02",
-	} {
-		if t, err := time.ParseInLocation(layout, s, israelTZ); err == nil {
-			return t
-		}
-	}
-	return time.Time{}
 }
 
 func textFromField(f field) string {

--- a/internal/fetcher/yad2/parser_test.go
+++ b/internal/fetcher/yad2/parser_test.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/dsionov/carwatch/internal/fetcher"
+	"github.com/dsionov/carwatch/internal/timeutil"
 )
 
 func TestParseListingsPage_ValidHTML(t *testing.T) {
@@ -296,39 +296,6 @@ func TestParseGwFeed_MissingFeedItems(t *testing.T) {
 	}
 }
 
-func TestParseFlexTime_Formats(t *testing.T) {
-	// want, when set, asserts the exact instant — guarding against a regression
-	// that parses a value in the wrong timezone (e.g. zone-less as UTC).
-	tests := []struct {
-		name string
-		in   string
-		zero bool
-		want time.Time
-	}{
-		{"zoneless seconds (current feed)", "2025-02-09T10:31:37", false, time.Date(2025, 2, 9, 10, 31, 37, 0, israelTZ)},
-		{"zoneless with millis", "2025-02-09T10:31:37.123", false, time.Date(2025, 2, 9, 10, 31, 37, 123_000_000, israelTZ)},
-		{"rfc3339 Z", "2025-02-09T10:31:37Z", false, time.Date(2025, 2, 9, 10, 31, 37, 0, time.UTC)},
-		{"rfc3339 offset", "2025-02-09T10:31:37+02:00", false, time.Date(2025, 2, 9, 8, 31, 37, 0, time.UTC)},
-		{"rfc3339 Z with millis", "2025-02-09T10:31:37.123Z", false, time.Date(2025, 2, 9, 10, 31, 37, 123_000_000, time.UTC)},
-		{"space separated", "2025-02-09 10:31:37", false, time.Date(2025, 2, 9, 10, 31, 37, 0, israelTZ)},
-		{"date only", "2025-02-09", false, time.Date(2025, 2, 9, 0, 0, 0, 0, israelTZ)},
-		{"surrounding whitespace", "  2025-02-09T10:31:37  ", false, time.Date(2025, 2, 9, 10, 31, 37, 0, israelTZ)},
-		{"empty", "", true, time.Time{}},
-		{"garbage", "not-a-date", true, time.Time{}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parseFlexTime(tt.in)
-			if got.IsZero() != tt.zero {
-				t.Fatalf("parseFlexTime(%q) zero=%v, want zero=%v", tt.in, got.IsZero(), tt.zero)
-			}
-			if !tt.want.IsZero() && !got.Equal(tt.want) {
-				t.Errorf("parseFlexTime(%q) = %v, want %v", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
 // TestParseNextData_PostedAtUsesOriginalCreatedAt locks in the real Yad2 feed
 // semantics: dates.createdAt is the per-listing original publish date, while
 // dates.updatedAt / rebouncedAt are a single feed-wide "refreshed" timestamp.
@@ -364,11 +331,11 @@ func TestParseNextData_PostedAtUsesOriginalCreatedAt(t *testing.T) {
 	if l.CreatedAt.IsZero() {
 		t.Fatal("CreatedAt should be set from dates.createdAt")
 	}
-	if want := parseFlexTime("2025-02-09T10:31:37"); !l.CreatedAt.Equal(want) {
+	if want := timeutil.ParseFlexTime("2025-02-09T10:31:37"); !l.CreatedAt.Equal(want) {
 		t.Errorf("CreatedAt = %v, want original createdAt %v", l.CreatedAt, want)
 	}
-	if l.CreatedAt.Equal(parseFlexTime("2025-02-14T21:30:57")) ||
-		l.CreatedAt.Equal(parseFlexTime("2025-02-14T23:30:57")) {
+	if l.CreatedAt.Equal(timeutil.ParseFlexTime("2025-02-14T21:30:57")) ||
+		l.CreatedAt.Equal(timeutil.ParseFlexTime("2025-02-14T23:30:57")) {
 		t.Error("CreatedAt must not equal the feed-wide updatedAt/rebouncedAt bump stamp")
 	}
 	if l.UpdatedAt.IsZero() {

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -27,6 +27,12 @@ func Apply(criteria model.FilterCriteria, listings []model.RawListing) []model.R
 }
 
 func matches(c model.FilterCriteria, l model.RawListing) bool {
+	// Manufacturer must match when set. This matters for the extension ingest
+	// path, where one push carries listings from ALL of a user's searches, so a
+	// manufacturer-only search (ModelID == 0) would otherwise match every make.
+	if c.ManufacturerID > 0 && l.ManufacturerID != c.ManufacturerID {
+		return false
+	}
 	if c.ModelID > 0 && l.ModelID != c.ModelID {
 		return false
 	}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -25,6 +25,27 @@ func TestApply(t *testing.T) {
 			want: []string{"b"},
 		},
 		{
+			name:     "manufacturer filter",
+			criteria: model.FilterCriteria{ManufacturerID: 19},
+			listings: []model.RawListing{
+				{Token: "a", ManufacturerID: 19},
+				{Token: "b", ManufacturerID: 21},
+			},
+			want: []string{"a"},
+		},
+		{
+			// A manufacturer-only search (no ModelID) must not match other makes
+			// — the case the extension's combined push exposes.
+			name:     "manufacturer-only search excludes other makes",
+			criteria: model.FilterCriteria{ManufacturerID: 19, ModelID: 0},
+			listings: []model.RawListing{
+				{Token: "a", ManufacturerID: 19, ModelID: 100},
+				{Token: "b", ManufacturerID: 21, ModelID: 200},
+				{Token: "c", ManufacturerID: 19, ModelID: 300},
+			},
+			want: []string{"a", "c"},
+		},
+		{
 			name:     "engine max filter",
 			criteria: model.FilterCriteria{EngineMaxCC: 2100},
 			listings: []model.RawListing{

--- a/internal/model/params.go
+++ b/internal/model/params.go
@@ -12,18 +12,19 @@ import (
 // replaces both.
 func FilterCriteriaFromSearch(s *storage.Search) FilterCriteria {
 	criteria := FilterCriteria{
-		ModelID:      s.Model,
-		YearMin:      s.YearMin,
-		YearMax:      s.YearMax,
-		PriceMin:     s.PriceMin,
-		PriceMax:     s.PriceMax,
-		EngineMinCC:  float64(s.EngineMinCC),
-		MaxKm:        s.MaxKm,
-		MaxHand:      s.MaxHand,
-		GearBox:      s.GearBox,
-		SellerFilter: s.SellerFilter,
-		PriceOnly:    s.PriceOnly,
-		PhotoOnly:    s.PhotoOnly,
+		ManufacturerID: s.Manufacturer,
+		ModelID:        s.Model,
+		YearMin:        s.YearMin,
+		YearMax:        s.YearMax,
+		PriceMin:       s.PriceMin,
+		PriceMax:       s.PriceMax,
+		EngineMinCC:    float64(s.EngineMinCC),
+		MaxKm:          s.MaxKm,
+		MaxHand:        s.MaxHand,
+		GearBox:        s.GearBox,
+		SellerFilter:   s.SellerFilter,
+		PriceOnly:      s.PriceOnly,
+		PhotoOnly:      s.PhotoOnly,
 	}
 
 	if s.Keywords != "" {
@@ -82,19 +83,20 @@ type SourceParams struct {
 // FilterCriteria defines the criteria used to filter raw listings
 // after they are fetched from a source.
 type FilterCriteria struct {
-	ModelID      int
-	YearMin      int
-	YearMax      int
-	PriceMin     int
-	PriceMax     int
-	EngineMinCC  float64
-	EngineMaxCC  float64
-	MaxKm        int
-	MaxHand      int
-	Keywords     []string
-	ExcludeKeys  []string
-	GearBox      string
-	SellerFilter string
-	PriceOnly    bool
-	PhotoOnly    bool
+	ManufacturerID int
+	ModelID        int
+	YearMin        int
+	YearMax        int
+	PriceMin       int
+	PriceMax       int
+	EngineMinCC    float64
+	EngineMaxCC    float64
+	MaxKm          int
+	MaxHand        int
+	Keywords       []string
+	ExcludeKeys    []string
+	GearBox        string
+	SellerFilter   string
+	PriceOnly      bool
+	PhotoOnly      bool
 }

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -1,24 +1,57 @@
+// Package timeutil holds the timestamp parsing shared by the two paths that
+// ingest Yad2 listings — the scraper (internal/fetcher/yad2) and the extension
+// ingest endpoint (internal/api). Both read the same feed, so they must agree
+// on how its dates are interpreted; keeping one implementation here stops them
+// from drifting apart.
 package timeutil
 
 import (
-	"fmt"
+	"strings"
 	"time"
 )
 
-var flexibleFormats = []string{
-	"2006-01-02 15:04:05.999999999",
-	"2006-01-02 15:04:05.999999999-07:00",
-	"2006-01-02 15:04:05",
-	time.RFC3339Nano,
-	time.RFC3339,
-	"2006-01-02T15:04:05",
-}
+// IsraelTZ interprets the Yad2 feed's zone-less local timestamps. Falls back to
+// UTC if the zoneinfo database is unavailable.
+var IsraelTZ = func() *time.Location {
+	loc, err := time.LoadLocation("Asia/Jerusalem")
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}()
 
-func ParseFlexible(s string) (time.Time, error) {
-	for _, layout := range flexibleFormats {
+// ParseFlexTime parses the timestamp formats Yad2 has been observed to emit.
+// Yad2's feed dates are zone-less local time (e.g. "2025-02-09T10:31:37"), but
+// it has historically drifted between "Z"/offset-suffixed and fractional-second
+// variants, so we accept all of them rather than silently dropping the date.
+//
+// Zone-less values MUST be read as Israel local time: parsing them as UTC puts
+// posted_at ~2-3h early for every listing.
+//
+// Returns the zero time when s is empty or unparseable.
+func ParseFlexTime(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	// Zone-bearing formats ("...Z" or "...+02:00"), with or without fractional
+	// seconds. RFC3339Nano covers the fractional case; RFC3339 the rest.
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
 		if t, err := time.Parse(layout, s); err == nil {
-			return t, nil
+			return t
 		}
 	}
-	return time.Time{}, fmt.Errorf("unrecognized time format: %q", s)
+	// Zone-less formats — interpret as Israel local time, matching the feed.
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	} {
+		if t, err := time.ParseInLocation(layout, s, IsraelTZ); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -5,94 +5,49 @@ import (
 	"time"
 )
 
-func TestParseFlexible_ValidFormats(t *testing.T) {
+func TestParseFlexTime_Formats(t *testing.T) {
+	// want, when set, asserts the exact instant — guarding against a regression
+	// that parses a value in the wrong timezone (e.g. zone-less as UTC).
 	tests := []struct {
-		name   string
-		input  string
-		expect time.Time
+		name string
+		in   string
+		zero bool
+		want time.Time
 	}{
-		{
-			name:   "datetime with fractional seconds",
-			input:  "2024-03-15 10:30:45.123456789",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 123456789, time.UTC),
-		},
-		{
-			name:   "datetime with timezone offset",
-			input:  "2024-03-15 10:30:45.123-05:00",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 123000000, time.FixedZone("", -5*3600)),
-		},
-		{
-			name:   "datetime without fractional seconds",
-			input:  "2024-03-15 10:30:45",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.UTC),
-		},
-		{
-			name:   "RFC3339Nano",
-			input:  "2024-03-15T10:30:45.123456789Z",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 123456789, time.UTC),
-		},
-		{
-			name:   "RFC3339",
-			input:  "2024-03-15T10:30:45Z",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.UTC),
-		},
-		{
-			name:   "RFC3339 with offset",
-			input:  "2024-03-15T10:30:45+03:00",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.FixedZone("", 3*3600)),
-		},
-		{
-			name:   "ISO datetime without timezone",
-			input:  "2024-03-15T10:30:45",
-			expect: time.Date(2024, 3, 15, 10, 30, 45, 0, time.UTC),
-		},
+		{"zoneless seconds (current feed)", "2025-02-09T10:31:37", false, time.Date(2025, 2, 9, 10, 31, 37, 0, IsraelTZ)},
+		{"zoneless with millis", "2025-02-09T10:31:37.123", false, time.Date(2025, 2, 9, 10, 31, 37, 123_000_000, IsraelTZ)},
+		{"rfc3339 Z", "2025-02-09T10:31:37Z", false, time.Date(2025, 2, 9, 10, 31, 37, 0, time.UTC)},
+		{"rfc3339 offset", "2025-02-09T10:31:37+02:00", false, time.Date(2025, 2, 9, 8, 31, 37, 0, time.UTC)},
+		{"rfc3339 Z with millis", "2025-02-09T10:31:37.123Z", false, time.Date(2025, 2, 9, 10, 31, 37, 123_000_000, time.UTC)},
+		{"space separated", "2025-02-09 10:31:37", false, time.Date(2025, 2, 9, 10, 31, 37, 0, IsraelTZ)},
+		{"space separated with nanos", "2025-02-09 10:31:37.5", false, time.Date(2025, 2, 9, 10, 31, 37, 500_000_000, IsraelTZ)},
+		{"date only", "2025-02-09", false, time.Date(2025, 2, 9, 0, 0, 0, 0, IsraelTZ)},
+		{"surrounding whitespace", "  2025-02-09T10:31:37  ", false, time.Date(2025, 2, 9, 10, 31, 37, 0, IsraelTZ)},
+		{"empty", "", true, time.Time{}},
+		{"garbage", "not-a-date", true, time.Time{}},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseFlexible(tt.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			got := ParseFlexTime(tt.in)
+			if got.IsZero() != tt.zero {
+				t.Fatalf("ParseFlexTime(%q) zero=%v, want zero=%v", tt.in, got.IsZero(), tt.zero)
 			}
-			if !got.Equal(tt.expect) {
-				t.Errorf("got %v, want %v", got, tt.expect)
+			if !tt.want.IsZero() && !got.Equal(tt.want) {
+				t.Errorf("ParseFlexTime(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestParseFlexible_InvalidFormats(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"empty string", ""},
-		{"plain date no time", "2024-03-15"},
-		{"garbage", "not-a-date"},
-		{"US format", "03/15/2024"},
-		{"unix timestamp", "1710500000"},
+// TestParseFlexTime_ZonelessIsNotUTC is the regression guard for the bug this
+// package exists to prevent: a zone-less feed timestamp read as UTC lands
+// ~2-3h early. Israel is UTC+2 (winter) / UTC+3 (summer), never UTC.
+func TestParseFlexTime_ZonelessIsNotUTC(t *testing.T) {
+	got := ParseFlexTime("2025-02-09T10:31:37")
+	if asUTC := time.Date(2025, 2, 9, 10, 31, 37, 0, time.UTC); got.Equal(asUTC) {
+		t.Errorf("zone-less timestamp parsed as UTC (%v) — must be Israel local time", got)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseFlexible(tt.input)
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if got := err.Error(); len(got) == 0 {
-				t.Error("error message should not be empty")
-			}
-		})
-	}
-}
-
-func TestParseFlexible_FirstMatchWins(t *testing.T) {
-	input := "2024-03-15 10:30:45.500000000"
-	got, err := ParseFlexible(input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Nanosecond() != 500000000 {
-		t.Errorf("expected fractional seconds to be preserved, got ns=%d", got.Nanosecond())
+	if _, offset := got.Zone(); offset == 0 {
+		t.Errorf("zone-less timestamp has zero UTC offset, want Israel local offset")
 	}
 }


### PR DESCRIPTION
Full-app bug audit. Baseline was clean — `go vet`, `go build`, `golangci-lint`, `web` lint (0 errors) + tests (327 pass), and zero prod errors/panics. Manual review of the extension + backend ingest paths surfaced **3 real bugs**, all fixed + tested:

1. **`fix(ext)` — ingest push had no size cap.** `/ext/ingest` rejects >500 listings (400), but the extension pushed all deduped listings in one request. A user with enough searches/results would 400, retry 3×, throw, and **lose the whole cycle's ingestion**. Now chunked at 400. (Latent for the current 4-search setup ~160.)
2. **`fix(filter)` — filter never checked manufacturer.** It matched on `ModelID` only. The retired scraper fetched per-search (one make in `raw`), but the extension pushes **all** searches' listings in one batch — so a manufacturer-only search (`ModelID == 0`) would match every make. Added `ManufacturerID` to `FilterCriteria` + the check; all sources already populate `RawListing.ManufacturerID`, so model searches are unaffected. Tested.
3. **`fix(api)` — `created_at` parsed as UTC.** Yad2's feed is zone-less local; the ingest handler used `time.Parse` (UTC), landing `posted_at` ~2-3h early for every extension listing. Now parsed in `Asia/Jerusalem` (matching the scraper). (Active, but cosmetic.)

## Verified
`go build ./...` + `go vet` clean; `gofmt` clean; filter/model tests pass incl. new manufacturer cases. (The one local test failure is the Docker-only `pgtest`, which runs in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manufacturer-specific filtering, including searches by manufacturer without selecting a model.

- **Bug Fixes**
  - Improved parsing of feed timestamps to interpret zoneless Israel-local times correctly.
  - Improved ingest reliability for large imports by sending listings in smaller batches instead of a single large request.

- **Maintenance**
  - Updated the browser extension to version 1.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->