### PR TITLE
fix(scheduler): stop fetching Yad2 server-side, it cannot succeed

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -115,6 +115,21 @@ func run(configPath string, skipMigrate bool, logger *slog.Logger) error {
 
 	dynCatalog := app.BuildDynamicCatalog(ctx, fb.Yad2, logger)
 
+	// The listing fetchers only reach the API's refresh / instant-search
+	// handlers when server-side fetching actually works; see
+	// config.PollingConfig.ServerFetch. Yad2 is behind a Radware bot challenge,
+	// so those fetches fail — withholding the factory makes both handlers
+	// answer "not available" immediately instead of retrying into a 502.
+	// (fb.Yad2 still backs the dynamic catalog above, which uses a different
+	// endpoint.)
+	listingFetchers := fb.Factory
+	if !cfg.Polling.ServerFetch {
+		listingFetchers = nil
+		logger.Info("server-side source fetching is disabled; search refresh and instant search are unavailable",
+			"reason", "Yad2 blocks server-side fetches (Radware); the browser extension ingests listings instead",
+		)
+	}
+
 	h := health.New()
 	h.SetVersion(version)
 	h.SetUserCounter(store)
@@ -127,7 +142,7 @@ func run(configPath string, skipMigrate bool, logger *slog.Logger) error {
 	}
 	defer plCleanup()
 
-	apiServer, err := app.BuildAPI(cfg, store, dynCatalog, logger, fb.Factory, fb.Yad2, plSvc, logHub, logLevelVar)
+	apiServer, err := app.BuildAPI(cfg, store, dynCatalog, logger, listingFetchers, fb.Yad2, plSvc, logHub, logLevelVar)
 	if err != nil {
 		return err
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -129,6 +129,10 @@ func TestE2E_FullPipeline(t *testing.T) {
 			Interval: 1 * time.Minute,
 			Jitter:   0,
 			Timezone: "UTC",
+			// This suite drives the scheduler's fetch pipeline against a stub
+			// source, so it opts in. Production defaults this off: Yad2 blocks
+			// server-side fetches and listings arrive via the extension.
+			ServerFetch: true,
 		},
 		Telegram: config.TelegramConfig{
 			Token: "test-token",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,23 @@ type PollingConfig struct {
 	Timezone             string        `yaml:"timezone"`
 	MaxConcurrentFetches int           `yaml:"max_concurrent_fetches"`
 	EnrichGraceSeconds   int           `yaml:"enrich_grace_seconds"`
+
+	// ServerFetch enables fetching listings from the source (Yad2) directly
+	// from our servers: the scheduler's per-search polling cycle, the km
+	// enrichment queue, and the API's refresh / instant-search handlers.
+	//
+	// Defaults to false, because it does not work. Yad2 serves both its listing
+	// pages and its gw JSON API behind a Radware bot challenge that only a real
+	// browser clears, so every server-side fetch fails ("__NEXT_DATA__ script
+	// tag not found" / a 302 to the challenge). The browser extension
+	// (POST /api/v1/ext/ingest) is the sole ingestion path.
+	//
+	// Leaving it on does active harm: the scheduler retries every search every
+	// cycle, fetching nothing while hammering Yad2 from the host IP.
+	//
+	// Kept as a switch rather than deleted so the polling path can be restored
+	// if a workable server-side source appears (a proxy, an official API).
+	ServerFetch bool `yaml:"server_fetch"`
 }
 
 type ActiveHours struct {

--- a/internal/scheduler/multitenant_test.go
+++ b/internal/scheduler/multitenant_test.go
@@ -92,6 +92,48 @@ func TestRunMultiTenantCycle_NoSearches(t *testing.T) {
 	}
 }
 
+// TestRunMultiTenantCycle_ServerFetchDisabled locks in the default production
+// posture: Yad2 blocks server-side fetches (Radware), so the cycle must not
+// fetch at all. Before this, every cycle retried every search 3x against a
+// source that could only fail -- pointless load on Yad2 from the host IP.
+// Maintenance work (digests, prune) must still run.
+func TestRunMultiTenantCycle_ServerFetchDisabled(t *testing.T) {
+	f := &paramAwareFetcher{
+		fallback: []model.RawListing{
+			{Token: "a", ManufacturerID: 27, Manufacturer: "Mazda", ModelID: 10332, Model: "3", Price: 90000, Year: 2020, EngineVolume: 2000},
+		},
+	}
+	n := &mockNotifier{}
+	cfg := testConfig()
+	cfg.Polling.ServerFetch = false
+
+	ss := &mockSearchStore{
+		searches: []storage.Search{
+			{ID: 1, ChatID: 100, Name: "user1-mazda3", Source: "yad2", Manufacturer: 27, Model: 10332,
+				YearMin: 2018, YearMax: 2024, PriceMax: 150000, Active: true},
+		},
+	}
+
+	s, _ := NewWithOptions(cfg, f, newMockDedup(), n, testLogger(), Options{SearchStore: ss})
+
+	if err := s.runMultiTenantCycle(context.Background()); err != nil {
+		t.Fatalf("cycle: %v", err)
+	}
+
+	f.mu.Lock()
+	calls := len(f.calls)
+	f.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("expected 0 source fetches with server_fetch disabled, got %d", calls)
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.messages) != 0 {
+		t.Errorf("expected 0 notifications (nothing was fetched), got %d", len(n.messages))
+	}
+}
+
 func TestRunMultiTenantCycle_WithSearches(t *testing.T) {
 	f := &mockFetcher{
 		listings: []model.RawListing{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -237,11 +237,18 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	s.cfgMu.RLock()
 	logInterval := s.cfg.Polling.Interval
 	logJitter := s.cfg.Polling.Jitter
+	logServerFetch := s.cfg.Polling.ServerFetch
 	s.cfgMu.RUnlock()
 	s.logger.Info("scheduler started, entering polling loop",
 		"check_interval", logInterval.String(),
 		"jitter", logJitter.String(),
+		"server_fetch", logServerFetch,
 	)
+	if !logServerFetch {
+		s.logger.Info("server-side source fetching is disabled; listings arrive via the browser extension (/ext/ingest)",
+			"impact", "cycles run maintenance only: prune, premium expiry, digests",
+		)
+	}
 
 	sighup := make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
@@ -554,34 +561,51 @@ func (s *Scheduler) runMultiTenantCycle(ctx context.Context) error {
 	s.pruneOldData(ctx)
 	s.processExpiredPremium(ctx)
 
+	// Server-side fetching (and the enrichment queue that depends on it) only
+	// runs when it can actually work; see config.PollingConfig.ServerFetch.
+	// With it off, listings arrive via the extension's /ext/ingest instead and
+	// this cycle is purely maintenance: prune, premium expiry, digests.
+	s.cfgMu.RLock()
+	serverFetch := s.cfg.Polling.ServerFetch
+	s.cfgMu.RUnlock()
+
 	if len(searches) == 0 {
-		s.backfillUnenrichedListings(ctx)
-		s.purgeStaleEnrichMessages(ctx)
+		if serverFetch {
+			s.backfillUnenrichedListings(ctx)
+			s.purgeStaleEnrichMessages(ctx)
+		}
 		s.logger.InfoContext(ctx, "scheduler cycle completed with no active searches", "scan", cycle, "elapsed", time.Since(cycleStart).Round(time.Millisecond))
 		s.observer.RecordSuccess()
 		return nil
 	}
 
-	// Phase 3: load all searches into the percolator for reverse matching.
-	s.percolator.Load(searches)
+	var stats cycleStats
+	var fetchErr error
 
-	marketCache := s.getOrBuildMarketCache(ctx)
-	s.logger.InfoContext(ctx, "loaded active searches into percolator for reverse matching",
-		"scan", cycle,
-		"searches", len(searches),
-		"db_duration_ms", searchLoadMs,
-	)
+	if serverFetch {
+		// Phase 3: load all searches into the percolator for reverse matching.
+		s.percolator.Load(searches)
 
-	stats, fetchErr := s.fetchAndMatch(ctx, searches, marketCache)
+		marketCache := s.getOrBuildMarketCache(ctx)
+		s.logger.InfoContext(ctx, "loaded active searches into percolator for reverse matching",
+			"scan", cycle,
+			"searches", len(searches),
+			"db_duration_ms", searchLoadMs,
+		)
 
-	if s.catalogIngester != nil {
-		s.catalogIngester.Flush(ctx)
+		stats, fetchErr = s.fetchAndMatch(ctx, searches, marketCache)
+
+		if s.catalogIngester != nil {
+			s.catalogIngester.Flush(ctx)
+		}
 	}
 
 	s.processDigests(ctx)
 	s.processDailyDigests(ctx)
-	s.backfillUnenrichedListings(ctx)
-	s.purgeStaleEnrichMessages(ctx)
+	if serverFetch {
+		s.backfillUnenrichedListings(ctx)
+		s.purgeStaleEnrichMessages(ctx)
+	}
 
 	s.logger.InfoContext(ctx, "scheduler cycle completed",
 		"scan", cycle,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -159,6 +159,9 @@ func testConfig() *config.Config {
 			Interval: 1 * time.Minute,
 			Jitter:   0,
 			Timezone: "UTC",
+			// These tests exercise the polling/fetch path itself, so they opt in.
+			// Production defaults this off (Yad2 blocks server-side fetches).
+			ServerFetch: true,
 		},
 		Telegram: config.TelegramConfig{
 			Token: "test-token",


### PR DESCRIPTION
## Summary

Found while auditing the app. The scraper has been a **zombie** since Yad2 moved behind Radware: every ~16 min it fetches all 6 searches, each failing 3× with `__NEXT_DATA__ script tag not found`, then reports `listings: 0, new_matches: 0`.

Live from prod (`cycle_id 129`):

```
WARN  targeted fetch failed, skipping search  search_name="גאזז היבירידית"  error="all 3 fetch attempts failed: parse page: __NEXT_DATA__ script tag not found"
WARN  targeted fetch failed, skipping search  search_name="טויוטה קורולה  היבירידית"  ...
INFO  targeted listings fetched  listings=0  active_searches=6  duration_ms=56513
INFO  scheduler cycle completed  listings_checked=0  new_matches=0  notifications_sent=0
```

That is ~56s and ~18 requests per cycle (~90/hour) that **cannot succeed** — a steady stream of bot-detected requests to Yad2 from the host IP, which is precisely the ban risk the extension exists to avoid. It logged at `WARN`, not `ERROR`, which is why "no errors in prod" checks sailed past it.

It also published km-enrichment jobs to a Redis stream whose only consumer (the enricher) was retired, then purged them each cycle.

The same dead fetch backs the API's **refresh** and **instant-search** handlers, which retry 3× and return `502`.

## Change

`polling.server_fetch` (default **false**) — one switch for server-side source access:

- **scheduler**: skips fetch, percolator, market cache and the enrichment queue. Prune, premium expiry and digests — the work that still functions — run unchanged.
- **api-server**: withholds the fetcher factory, so refresh / instant-search take their existing `not available` path instead of retrying into a 502. The dynamic catalog keeps its Yad2 client (different endpoint).

Kept as a switch rather than deleted, so polling can be restored if a workable server-side source appears (proxy, official API).

## Tests

- New `TestRunMultiTenantCycle_ServerFetchDisabled`: asserts **0** source fetches and 0 notifications with the flag off.
- Existing polling tests opt in via `testConfig()`, so the fetch path stays covered.

## Review

✅ Verified against live prod logs; all scheduler tests pass (the 3 failures are the pre-existing pgtest/Docker-on-Windows ones, which also fail on `main`).

## Follow-up (not in this PR)

The web UI still shows Refresh / instant-search buttons that now return a clean "not available" instead of a 502. Hiding them, or wiring Refresh to trigger the extension's fetch, is a separate change.