### PR TITLE
fix(web): hide refresh and instant search when the server cannot fetch

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -392,11 +392,19 @@ func (s *Server) Routes() http.Handler {
 
 	catalogChain := s.withMaxBody(catalogMux)
 
+	// --- Capabilities (no auth) ---
+	// Static, single-field, and needed before the UI renders, so it shares the
+	// unrate-limited catalog treatment.
+	capMux := http.NewServeMux()
+	capMux.HandleFunc("GET /api/v1/capabilities", s.capabilities)
+	capChain := s.withMaxBody(capMux)
+
 	// --- Top-level router ---
 	// More-specific prefixes are matched first by net/http.ServeMux.
 	top := http.NewServeMux()
 	top.Handle("/api/v1/guest/", guestChain)
 	top.Handle("/api/v1/catalog/", catalogChain)
+	top.Handle("GET /api/v1/capabilities", capChain)
 	top.Handle("GET /api/v1/me", optAuthChain)
 	top.Handle("GET /api/v1/searches", optAuthChain)
 	if s.notifs != nil {

--- a/internal/api/capabilities.go
+++ b/internal/api/capabilities.go
@@ -1,0 +1,24 @@
+package api
+
+import "net/http"
+
+// capabilitiesResponse tells the web app which optional features this
+// deployment can actually perform, so the UI can hide the ones it cannot
+// rather than offering a button that only ever returns an error.
+type capabilitiesResponse struct {
+	// LiveSearch reports whether the server can fetch listings from the source
+	// on demand. It backs the per-search refresh and the guest instant search.
+	//
+	// False whenever server-side fetching is off (see
+	// config.PollingConfig.ServerFetch): Yad2 serves its pages behind a bot
+	// challenge only a real browser clears, so those fetches cannot succeed and
+	// the handlers answer 503. Listings still arrive — via the browser
+	// extension's /ext/ingest — so the rest of the app is unaffected.
+	LiveSearch bool `json:"live_search"`
+}
+
+func (s *Server) capabilities(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, capabilitiesResponse{
+		LiveSearch: s.fetchers != nil,
+	})
+}

--- a/internal/api/capabilities_test.go
+++ b/internal/api/capabilities_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/fetcher"
+)
+
+// The UI hides its refresh / instant-search entry points when live_search is
+// false, so this flag must track whether the fetchers are actually wired.
+func TestCapabilities_ReportsLiveSearch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fetchers bool
+		want     bool
+	}{
+		{"no fetchers (server-side fetch disabled)", false, false},
+		{"fetchers wired", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{}
+			if tt.fetchers {
+				s.fetchers = fetcher.NewFactory()
+			}
+
+			rec := httptest.NewRecorder()
+			s.capabilities(rec, httptest.NewRequest(http.MethodGet, "/api/v1/capabilities", nil))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			var got capabilitiesResponse
+			if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got.LiveSearch != tt.want {
+				t.Errorf("live_search = %v, want %v", got.LiveSearch, tt.want)
+			}
+		})
+	}
+}

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { guestApi, type Capabilities } from "@/lib/api";
+
+/**
+ * Which optional features this deployment can perform. Used to hide entry
+ * points that would only ever error — see the Capabilities docs in lib/api.
+ *
+ * While the answer is unknown (loading, or the request failed) `live_search` is
+ * false, so callers never offer a feature we have not confirmed. Callers that
+ * would flash a hidden-then-shown form should branch on `isLoading` first.
+ */
+export function useCapabilities(): Capabilities & { isLoading: boolean } {
+  const { data, isPending } = useQuery({
+    queryKey: ["capabilities"],
+    queryFn: () => guestApi.capabilities(),
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  return {
+    live_search: data?.live_search ?? false,
+    isLoading: isPending,
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -645,7 +645,21 @@ export interface InstantSearchResponse {
   total: number;
 }
 
+/**
+ * Which optional features this deployment can actually perform.
+ *
+ * `live_search` is false when the server cannot fetch listings from the source
+ * on demand — Yad2 is behind a bot challenge only a real browser clears — which
+ * makes per-search refresh and guest instant search return 503. Listings still
+ * arrive via the browser extension, so everything else works. The UI hides
+ * those two entry points rather than offering a button that only ever errors.
+ */
+export interface Capabilities {
+  live_search: boolean;
+}
+
 export const guestApi = {
+  capabilities: () => fetchGuestAPI<Capabilities>("/capabilities"),
   instantSearch: (data: InstantSearchRequest) =>
     fetchGuestAPI<InstantSearchResponse>("/guest/instant-search", {
       method: "POST",

--- a/web/src/pages/ListingsPage.tsx
+++ b/web/src/pages/ListingsPage.tsx
@@ -41,6 +41,7 @@ import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { useToast } from "@/components/ui/Toast";
+import { useCapabilities } from "@/hooks/useCapabilities";
 
 const SORT_OPTIONS = [
   { value: "newest", label: "חדשים" },
@@ -56,6 +57,7 @@ const REFRESH_COOLDOWN_S = 60;
 function RefreshButton({ searchId }: { searchId: number }) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { live_search: liveSearch } = useCapabilities();
 
   const [cooldown, setCooldown] = useState(0);
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -99,6 +101,11 @@ function RefreshButton({ searchId }: { searchId: number }) {
   });
 
   const isRefreshing = refreshMutation.isPending;
+
+  // Refresh fetches from the source on demand, which this deployment cannot do
+  // (see Capabilities in lib/api). Listings still arrive via the browser
+  // extension, so hide the button rather than offer one that always errors.
+  if (!liveSearch) return null;
 
   return (
     <button

--- a/web/src/pages/TrySearchPage.test.tsx
+++ b/web/src/pages/TrySearchPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import TrySearchPage from "./TrySearchPage";
+import { guestApi } from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({
   guestApi: {
@@ -17,6 +18,7 @@ vi.mock("@/lib/api", () => ({
       ]),
     },
     instantSearch: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+    capabilities: vi.fn().mockResolvedValue({ live_search: true }),
   },
   ApiError: class ApiError extends Error {
     status: number;
@@ -48,27 +50,46 @@ describe("TrySearchPage", () => {
     sessionStorage.clear();
   });
 
-  it("renders the form with header and submit button", () => {
+  it("renders the form with header and submit button", async () => {
     renderPage();
     expect(screen.getByText("נסה חיפוש חינם")).toBeInTheDocument();
-    expect(screen.getByText("חפש עכשיו")).toBeInTheDocument();
+    expect(await screen.findByText("חפש עכשיו")).toBeInTheDocument();
   });
 
-  it("renders manufacturer and model selects", () => {
+  // Instant search needs a live server-side fetch of Yad2, which is blocked in
+  // production. Offering the form there just produces a 503, so the page must
+  // explain and route the user to the flow that works (sign up + extension).
+  it("hides the search form and explains when live search is unavailable", async () => {
+    vi.mocked(guestApi.capabilities).mockResolvedValueOnce({
+      live_search: false,
+    });
     renderPage();
-    expect(screen.getByLabelText("יצרן")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("חיפוש מיידי אינו זמין כרגע")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("חפש עכשיו")).not.toBeInTheDocument();
+    expect(screen.getByText("הירשם והתקן את התוסף")).toBeInTheDocument();
+    expect(guestApi.instantSearch).not.toHaveBeenCalled();
+  });
+
+  it("renders manufacturer and model selects", async () => {
+    renderPage();
+    expect(await screen.findByLabelText("יצרן")).toBeInTheDocument();
     expect(screen.getByLabelText("דגם")).toBeInTheDocument();
   });
 
-  it("has submit button disabled when manufacturer is not selected", () => {
+  it("has submit button disabled when manufacturer is not selected", async () => {
     renderPage();
-    const submitBtn = screen.getByText("חפש עכשיו").closest("button")!;
+    const submitBtn = (await screen.findByText("חפש עכשיו")).closest("button")!;
     expect(submitBtn).toBeDisabled();
   });
 
-  it("model select is disabled until manufacturer is chosen", () => {
+  it("model select is disabled until manufacturer is chosen", async () => {
     renderPage();
-    const modelSelect = screen.getByLabelText("דגם") as HTMLSelectElement;
+    const modelSelect = (await screen.findByLabelText(
+      "דגם",
+    )) as HTMLSelectElement;
     expect(modelSelect).toBeDisabled();
   });
 

--- a/web/src/pages/TrySearchPage.tsx
+++ b/web/src/pages/TrySearchPage.tsx
@@ -10,6 +10,7 @@ import {
   type Model,
 } from "@/lib/api";
 import { formatPrice, safeHref } from "@/lib/utils";
+import { useCapabilities } from "@/hooks/useCapabilities";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { Toggle } from "@/components/ui/toggle";
 
@@ -96,6 +97,7 @@ const STORAGE_KEY = "carwatch_try_search_form";
 
 export default function TrySearchPage() {
   useDocumentTitle("נסה חיפוש");
+  const { live_search: liveSearch, isLoading: capsLoading } = useCapabilities();
   const [form, setForm] = useState<GuestFormData>(() => {
     try {
       const saved = sessionStorage.getItem(STORAGE_KEY);
@@ -170,6 +172,59 @@ export default function TrySearchPage() {
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     search.mutate();
+  }
+
+  // Instant search fetches Yad2 live from the server, which this deployment
+  // cannot do (see Capabilities in lib/api) — the request would only ever 503.
+  // Explain that and point at the flow that does work: sign up, install the
+  // extension, and listings arrive automatically.
+  // Hold the page until we know whether live search works: rendering the form
+  // first would flash it and then yank it away.
+  if (capsLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 dir-rtl">
+        <header className="mb-8 text-center">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            נסה חיפוש חינם
+          </h1>
+        </header>
+        <div className="h-64 animate-pulse rounded-2xl bg-muted" aria-busy />
+      </div>
+    );
+  }
+
+  if (!liveSearch) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 dir-rtl">
+        <header className="mb-8 text-center">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            נסה חיפוש חינם
+          </h1>
+        </header>
+        <div
+          className="rounded-2xl border border-border bg-card p-6 text-center"
+          role="status"
+        >
+          <ShieldAlert
+            className="mx-auto mb-3 h-6 w-6 text-muted-foreground"
+            aria-hidden
+          />
+          <h2 className="text-lg font-semibold text-foreground">
+            חיפוש מיידי אינו זמין כרגע
+          </h2>
+          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+            יד2 חוסמת חיפוש ישיר מהשרת. לאחר ההרשמה, התוסף של CarWatch אוסף
+            עבורך את המודעות מהדפדפן ושולח התראה על כל מודעה חדשה.
+          </p>
+          <Link
+            to="/signup"
+            className="mt-5 inline-block rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-white shadow-lg"
+          >
+            הירשם והתקן את התוסף
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Follow-up to #1484. Two user-facing features fetch Yad2 **live from the server**, which Radware blocks — so they can only fail, yet the UI still offered them:

- **Per-search Refresh** — retried 3×, then toasted `שגיאה ברענון, נסה שוב`.
- **Guest "Try Search"** — the *signup funnel*. Submitting returned an error.

Adds `GET /api/v1/capabilities` (public, no rate limit) reporting `live_search`, true only when the fetchers are actually wired (`polling.server_fetch`).

- **ListingsPage** — `RefreshButton` renders nothing when `live_search` is false.
- **TrySearchPage** — replaces the form with an explanation and a signup CTA, pointing at the flow that *does* work: sign up, install the extension, listings arrive automatically. Holds a skeleton until the answer is known, so the form isn't flashed and then yanked away.

Unknown (loading, or the request failed) counts as **unavailable**, so the UI never offers a feature we haven't confirmed.

## Tests

- `TestCapabilities_ReportsLiveSearch` — both directions.
- `TrySearchPage` — new test asserts the unavailable state renders, the form is gone, and `instantSearch` is **never called**. Existing 4 sync tests now await the form (the page is legitimately async).
- Web suite: **328 passed** (was 327). tsc clean, 0 eslint errors.

## Review

✅ Behaviour verified against the live prod failure mode (`__NEXT_DATA__ script tag not found` on every server-side fetch).

Follow-up to #1484 (does not close it).