### PR TITLE
feat(ext): retire sold listings via confirmed 404, not feed absence

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -18,6 +18,11 @@ const YAD2_HOME = "https://www.yad2.co.il/";
 // many item-detail (enrichment) calls. km/city/image are absent from most feed
 // rows, so we enrich tokens we have not resolved before.
 const MAX_ENRICH_PER_CYCLE = 30;
+// Removal check: listings we have resolved before but that the feed no longer
+// returns. Feed absence alone is NOT proof (a feed can be partial), so each
+// candidate is confirmed against its item page — a 404 means sold/delisted.
+// Bounded per cycle so a large backlog cannot spike our request volume.
+const MAX_VERIFY_PER_CYCLE = 10;
 const KNOWN_TOKENS_CAP = 3000;
 const ENRICH_DELAY_MS = 1500; // jittered inside the injected fetcher
 
@@ -221,9 +226,18 @@ async function fetchViaYad2Tab(tabId, urls) {
   return (results && results[0] && results[0].result) || [];
 }
 
+// A 404/410 from the item endpoint is Yad2 telling us the listing is gone
+// (sold or delisted) — a real answer, not a block. Keep it distinct from
+// looksBlocked: treating it as a block hides removals AND triggers pointless
+// tab reloads.
+function looksGone(r) {
+  return !!r && (r.status === 404 || r.status === 410);
+}
+
 // A response whose body is HTML (Radware "302/verifying" shell) rather than
 // JSON means the tab's clearance lapsed.
 function looksBlocked(r) {
+  if (looksGone(r)) return false;
   const b = (r && r.body ? r.body : "").trimStart();
   return r && r.status !== 200 ? true : b.startsWith("<");
 }
@@ -393,8 +407,41 @@ async function runFetchCycle() {
       `[CarWatch] enrich cacheApplied=${cachedApplied} tried=${toEnrich.length} returned=${itemGot} ok=${itemOk} blocked=${itemBlocked} parseErr=${itemParseErr} gotKm=${gotKm} ${itemErr}`,
     );
 
+    // 3) Removal check. A token we resolved before but that no feed returned
+    // this cycle is only a CANDIDATE — the feed may be partial, and acting on
+    // absence alone would retire live listings. Confirm each against its item
+    // page: 404/410 means sold or delisted. Anything else (200, or a block) is
+    // left alone and re-checked next cycle.
+    const removedTokens = [];
+    let verifyTried = 0;
+    if (!blocked) {
+      const candidates = Object.keys(cache).filter((t) => !byToken.has(t));
+      const toVerify = shuffle(candidates).slice(0, MAX_VERIFY_PER_CYCLE);
+      verifyTried = toVerify.length;
+      if (toVerify.length) {
+        const byURL = new Map(
+          toVerify.map((t) => [`${GW_ITEM_URL}/${t}`, t]),
+        );
+        const results = await fetchViaYad2Tab(tabId, [...byURL.keys()]);
+        for (const r of results) {
+          const token = byURL.get(r.url);
+          if (!token || !looksGone(r)) continue;
+          removedTokens.push(token);
+          delete cache[token];
+        }
+        if (removedTokens.length) {
+          await saveEnrichedCache(cache);
+          console.log(
+            `[CarWatch] removal: confirmed ${removedTokens.length}/${toVerify.length} gone (404)`,
+          );
+        }
+      }
+    }
+
     const listings = [...byToken.values()];
-    if (listings.length > 0) await pushListings(config, listings);
+    if (listings.length > 0 || removedTokens.length > 0) {
+      await pushListings(config, listings, removedTokens);
+    }
 
     const enriched = listings.filter((l) => (l.km || 0) > 0).length;
     setBadge(String(listings.length), blocked ? "#E65100" : "#4CAF50");
@@ -402,7 +449,7 @@ async function runFetchCycle() {
       searches: activeSearches.length,
       listings: listings.length,
       enriched,
-      diag: `feeds ${feedResults.length - blocked}/${feedResults.length} ok · cache:${cachedApplied} · enrich try:${toEnrich.length} ret:${itemGot} ok:${itemOk} blk:${itemBlocked} perr:${itemParseErr} km:${gotKm}${itemErr ? " · " + itemErr : ""}`,
+      diag: `feeds ${feedResults.length - blocked}/${feedResults.length} ok · cache:${cachedApplied} · enrich try:${toEnrich.length} ret:${itemGot} ok:${itemOk} blk:${itemBlocked} perr:${itemParseErr} km:${gotKm} · gone:${removedTokens.length}/${verifyTried}${itemErr ? " · " + itemErr : ""}`,
       error: blocked ? `${blocked} feed(s) blocked by anti-bot` : null,
     });
   } catch (err) {
@@ -427,15 +474,27 @@ async function fetchSearches(config) {
 // cycle's ingestion would 400 and be lost.
 const MAX_INGEST_BATCH = 400;
 
-async function pushListings(config, listings) {
+async function pushListings(config, listings, removedTokens = []) {
   let last;
+  // Removed tokens ride the FIRST chunk only, so a multi-chunk push applies
+  // them exactly once. A push with no listings but pending removals still goes
+  // out, otherwise a sold-out cycle could never report anything.
+  let pendingRemoved = removedTokens;
   for (let i = 0; i < listings.length; i += MAX_INGEST_BATCH) {
-    last = await pushBatch(config, listings.slice(i, i + MAX_INGEST_BATCH));
+    last = await pushBatch(
+      config,
+      listings.slice(i, i + MAX_INGEST_BATCH),
+      pendingRemoved,
+    );
+    pendingRemoved = [];
+  }
+  if (listings.length === 0 && pendingRemoved.length > 0) {
+    last = await pushBatch(config, [], pendingRemoved);
   }
   return last;
 }
 
-async function pushBatch(config, listings) {
+async function pushBatch(config, listings, removedTokens = []) {
   for (let attempt = 0; attempt < 3; attempt++) {
     if (attempt > 0) await sleep(2000 * attempt);
     const resp = await fetchWithTimeout(
@@ -446,7 +505,7 @@ async function pushBatch(config, listings) {
           "Content-Type": "application/json",
           Authorization: `Bearer ${config.authToken}`,
         },
-        body: JSON.stringify({ listings }),
+        body: JSON.stringify({ listings, removed_tokens: removedTokens }),
       },
       30000,
     );

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -265,7 +265,11 @@ type ingestListing struct {
 }
 
 type ingestResponse struct {
-	Processed  int   `json:"processed"`
+	Processed int `json:"processed"`
+	// NewMatches is really "listings upserted by this push": the same matches
+	// are re-pushed and re-upserted every cycle, so it is NOT a count of new
+	// listings. Alert dedup happens in deliverIngestMatches, not here. Kept
+	// under its original JSON name so existing clients keep working.
 	NewMatches int   `json:"new_matches"`
 	Removed    int64 `json:"removed,omitempty"`
 }
@@ -347,7 +351,10 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	totalNew := 0
+	// Listings upserted this push. NOT the number of NEW listings: the same
+	// matches are re-pushed and re-upserted every cycle. Alert dedup lives in
+	// deliverIngestMatches (seen_listings.ClaimNew), not here.
+	totalSaved := 0
 	for _, sr := range searches {
 		if !sr.Active || (sr.Manufacturer == 0 && sr.Model == 0) {
 			continue
@@ -374,7 +381,7 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 				log.Error("save listings failed", "search_id", sr.ID, "error", err)
 				continue
 			}
-			totalNew += len(pr.Records)
+			totalSaved += len(pr.Records)
 
 			// Notify the user about genuinely new matches (dedup-gated) via the
 			// same delivery path the scheduler uses. Best-effort; never fails
@@ -418,12 +425,12 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 
 	log.Info("ingest complete",
 		"submitted", len(req.Listings), "parsed_with_km", parsedWithKm,
-		"parsed", len(raw), "new_matches", totalNew,
+		"parsed", len(raw), "saved", totalSaved,
 		"removed_reported", len(req.RemovedTokens), "removed_deleted", removed)
 
 	writeJSON(w, http.StatusOK, ingestResponse{
 		Processed:  len(raw),
-		NewMatches: totalNew,
+		NewMatches: totalSaved,
 		Removed:    removed,
 	})
 }

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -229,7 +229,15 @@ func (s *Server) refreshListings(w http.ResponseWriter, r *http.Request) {
 
 type ingestRequest struct {
 	Listings []ingestListing `json:"listings"`
+	// RemovedTokens are listings the extension CONFIRMED are gone from the
+	// source: absent from the feed *and* their item page returned 404. The
+	// confirmation matters — feed absence alone is not proof (a feed can be
+	// partial or paginated), and acting on it could retire live listings.
+	RemovedTokens []string `json:"removed_tokens,omitempty"`
 }
+
+// maxRemovedTokensPerIngest bounds the removal work one push can ask for.
+const maxRemovedTokensPerIngest = 100
 
 type ingestListing struct {
 	Token          string  `json:"token"`
@@ -257,8 +265,9 @@ type ingestListing struct {
 }
 
 type ingestResponse struct {
-	Processed  int `json:"processed"`
-	NewMatches int `json:"new_matches"`
+	Processed  int   `json:"processed"`
+	NewMatches int   `json:"new_matches"`
+	Removed    int64 `json:"removed,omitempty"`
 }
 
 func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
@@ -275,7 +284,9 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(req.Listings) == 0 {
+	// A push with no listings can still carry removals (every listing in a
+	// search sold), so only short-circuit when there is nothing at all to do.
+	if len(req.Listings) == 0 && len(req.RemovedTokens) == 0 {
 		writeJSON(w, http.StatusOK, ingestResponse{})
 		return
 	}
@@ -371,13 +382,12 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 			s.deliverIngestMatches(r.Context(), sr, pr.Listings, log)
 		}
 
-		// NOTE: removal/reconciliation (deleting a search's listings absent from
-		// the feed, as the retired scraper did) is intentionally NOT done here.
-		// The extension pushes page 1 of each feed, and the backend can't tell a
-		// complete feed from a paginated/partial one (the per-search filter
-		// decouples `filtered` from the raw feed size), so reconciling could
-		// delete valid listings. Safe removal needs the extension to signal
-		// per-search feed completeness — tracked as a follow-up.
+		// NOTE: removal is NOT inferred here from a listing's absence in this
+		// push. The extension sends page 1 of each feed, and the backend cannot
+		// tell a complete feed from a partial one, so reconciling against it
+		// could retire live listings. Removal instead arrives as
+		// req.RemovedTokens — tokens the extension confirmed are gone (404 on
+		// the item page) — and is applied once, after this loop.
 
 		// Per-search visibility: how many pushed listings matched this search,
 		// how many of those carried km, and how many were persisted. A gap
@@ -388,13 +398,33 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 			"saved", len(pr.Records))
 	}
 
+	// Retire listings the extension confirmed are gone from Yad2 (404 on the
+	// item page). Scoped to this chat, and bookmarked copies survive as
+	// removed_at ("likely sold"). Best-effort: the listings above are already
+	// saved, so a removal failure must not fail the push.
+	removed := int64(0)
+	if len(req.RemovedTokens) > 0 {
+		tokens := req.RemovedTokens
+		if len(tokens) > maxRemovedTokensPerIngest {
+			log.Warn("ingest sent more removed tokens than the cap, truncating",
+				"submitted", len(tokens), "cap", maxRemovedTokensPerIngest)
+			tokens = tokens[:maxRemovedTokensPerIngest]
+		}
+		var err error
+		if removed, err = s.listings.MarkListingsRemoved(r.Context(), chatID, tokens); err != nil {
+			log.Error("mark listings removed failed", "tokens", len(tokens), "error", err)
+		}
+	}
+
 	log.Info("ingest complete",
 		"submitted", len(req.Listings), "parsed_with_km", parsedWithKm,
-		"parsed", len(raw), "new_matches", totalNew)
+		"parsed", len(raw), "new_matches", totalNew,
+		"removed_reported", len(req.RemovedTokens), "removed_deleted", removed)
 
 	writeJSON(w, http.StatusOK, ingestResponse{
 		Processed:  len(raw),
 		NewMatches: totalNew,
+		Removed:    removed,
 	})
 }
 

--- a/internal/enricher/worker_test.go
+++ b/internal/enricher/worker_test.go
@@ -140,6 +140,15 @@ func (m *mockListingStore) DropListingByToken(_ context.Context, token string) (
 	m.droppedTokens = append(m.droppedTokens, token)
 	return 1, nil
 }
+func (m *mockListingStore) MarkListingsRemoved(_ context.Context, _ int64, tokens []string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dropErr != nil {
+		return 0, m.dropErr
+	}
+	m.droppedTokens = append(m.droppedTokens, tokens...)
+	return int64(len(tokens)), nil
+}
 func (m *mockListingStore) LookupListingIdentity(_ context.Context, _ string) (*storage.ListingIdentity, error) {
 	return &storage.ListingIdentity{}, nil
 }

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -59,6 +59,9 @@ func (s *prefillTrackingStore) DeleteStaleListings(_ context.Context, _ int64, _
 func (s *prefillTrackingStore) DropListingByToken(_ context.Context, _ string) (int64, error) {
 	return 0, nil
 }
+func (s *prefillTrackingStore) MarkListingsRemoved(_ context.Context, _ int64, tokens []string) (int64, error) {
+	return int64(len(tokens)), nil
+}
 func (s *prefillTrackingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
 	return nil, nil
 }

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -317,6 +317,9 @@ func (m *mockListingStore) DeleteStaleListings(_ context.Context, _ int64, _ int
 func (m *mockListingStore) DropListingByToken(_ context.Context, _ string) (int64, error) {
 	return 0, nil
 }
+func (m *mockListingStore) MarkListingsRemoved(_ context.Context, _ int64, tokens []string) (int64, error) {
+	return int64(len(tokens)), nil
+}
 func (m *mockListingStore) ListUnenrichedTokens(_ context.Context, _ int) ([]string, error) {
 	return m.unenrichedTokens, nil
 }

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -289,6 +289,10 @@ type ListingStore interface {
 	// Bookmarked copies are kept but flagged removed_at ("likely sold"); all
 	// other copies are hard-deleted. Returns the number of rows hard-deleted.
 	DropListingByToken(ctx context.Context, token string) (int64, error)
+	// MarkListingsRemoved does the same for a set of tokens but only for ONE
+	// chat, so an extension ingest push can never retire another user's
+	// listings. Returns the number of rows hard-deleted.
+	MarkListingsRemoved(ctx context.Context, chatID int64, tokens []string) (int64, error)
 }
 
 // DailyListingCount is the number of distinct listings first seen on a day.

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -584,6 +584,73 @@ func (s *Store) DropListingByToken(ctx context.Context, token string) (int64, er
 	return removed, nil
 }
 
+// MarkListingsRemoved retires listings the source no longer serves, for ONE
+// chat. Bookmarked copies keep their row with removed_at set ("likely sold")
+// so the user's saved car does not vanish; every other copy is hard-deleted.
+// Returns the number of rows hard-deleted.
+//
+// Scoped to chat_id on purpose: the tokens come from an extension ingest push,
+// so a buggy or hostile client must only ever be able to retire its own
+// listings, never another user's. (DropListingByToken, which is global, is an
+// admin operation.)
+func (s *Store) MarkListingsRemoved(ctx context.Context, chatID int64, tokens []string) (int64, error) {
+	if len(tokens) == 0 {
+		return 0, nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("mark removed begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	placeholders := make([]string, len(tokens))
+	args := []interface{}{chatID}
+	for i, t := range tokens {
+		placeholders[i] = fmt.Sprintf("$%d", i+2)
+		args = append(args, t)
+	}
+	tokenFilter := fmt.Sprintf(" AND token IN (%s)", strings.Join(placeholders, ","))
+
+	markArgs := make([]interface{}, len(args))
+	copy(markArgs, args)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE listing_history
+		SET removed_at = NOW()
+		WHERE chat_id = $1%s
+		  AND removed_at IS NULL
+		  AND EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, tokenFilter), markArgs...); err != nil {
+		return 0, fmt.Errorf("mark removed_at: %w", err)
+	}
+
+	deleteArgs := make([]interface{}, len(args))
+	copy(deleteArgs, args)
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		DELETE FROM listing_history
+		WHERE chat_id = $1%s
+		  AND NOT EXISTS (
+		    SELECT 1 FROM saved_listings
+		    WHERE saved_listings.token = listing_history.token
+		      AND saved_listings.chat_id = listing_history.chat_id
+		  )`, tokenFilter), deleteArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("delete removed: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("mark removed commit: %w", err)
+	}
+	return deleted, nil
+}
+
 func (s *Store) DeleteStaleListings(ctx context.Context, chatID int64, searchID int64, keepTokens []string) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/storage/postgres/listings_enrich_test.go
+++ b/internal/storage/postgres/listings_enrich_test.go
@@ -288,3 +288,68 @@ func TestPostgres_DropListingByToken(t *testing.T) {
 		t.Errorf("drop unknown token = %d, %v; want 0, nil", deleted, err)
 	}
 }
+
+func TestPostgres_MarkListingsRemoved(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	seedPgUser(t, store, 100)
+	seedPgUser(t, store, 200)
+
+	save := func(token string, chatID int64) {
+		if err := store.SaveListing(ctx, storage.ListingRecord{
+			Token: token, ChatID: chatID, SearchName: "s",
+			Manufacturer: "Toyota", Model: "Corolla", Year: 2020, Price: 80000,
+			FirstSeenAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("save %s/%d: %v", token, chatID, err)
+		}
+	}
+
+	// "sold" is held by BOTH chats: chat 100 reports it gone, chat 200 must not
+	// be touched. This is the security property — an ingest push can only ever
+	// retire the pusher's own listings.
+	save("sold", 100)
+	save("sold", 200)
+	// "sold-saved" is bookmarked by chat 100, so it must survive as "likely sold".
+	save("sold-saved", 100)
+	if err := store.SaveBookmark(ctx, 100, "sold-saved"); err != nil {
+		t.Fatalf("SaveBookmark: %v", err)
+	}
+	// "still-listed" is not reported, so it must be left alone.
+	save("still-listed", 100)
+
+	deleted, err := store.MarkListingsRemoved(ctx, 100, []string{"sold", "sold-saved"})
+	if err != nil {
+		t.Fatalf("MarkListingsRemoved: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1 (only the non-bookmarked copy for chat 100)", deleted)
+	}
+
+	if l, _ := store.GetListing(ctx, 100, "sold"); l != nil {
+		t.Error("sold should be deleted for the reporting chat")
+	}
+	if l, _ := store.GetListing(ctx, 200, "sold"); l == nil {
+		t.Error("sold must survive for chat 200 — one chat's push must not retire another's listings")
+	}
+
+	l, _ := store.GetListing(ctx, 100, "sold-saved")
+	if l == nil {
+		t.Fatal("bookmarked sold-saved should be preserved, not deleted")
+	}
+	if l.RemovedAt == nil {
+		t.Error("bookmarked sold-saved should be flagged removed_at")
+	}
+
+	if l, _ := store.GetListing(ctx, 100, "still-listed"); l == nil {
+		t.Error("still-listed was not reported and must be untouched")
+	}
+
+	// Empty and unknown token sets are no-ops.
+	if deleted, err := store.MarkListingsRemoved(ctx, 100, nil); err != nil || deleted != 0 {
+		t.Errorf("empty tokens = %d, %v; want 0, nil", deleted, err)
+	}
+	if deleted, err := store.MarkListingsRemoved(ctx, 100, []string{"never-existed"}); err != nil || deleted != 0 {
+		t.Errorf("unknown token = %d, %v; want 0, nil", deleted, err)
+	}
+}


### PR DESCRIPTION
## Problem

**Sold listings never leave the DB.** Nothing has removed a listing since the scraper was retired, so a car stays `active` forever after it is delisted — I had to clean three by hand with SQL earlier today.

The previous attempt (#1482) was **reverted for a good reason**: it inferred removal from a listing's *absence* in the extension's push. The backend cannot tell a complete feed from a partial/paginated one, so that could retire **live** listings. CodeRabbit flagged it as a data-integrity risk and it was pulled.

## Approach: infer nothing, confirm everything

Absence from the feed is only a **candidate**. The extension then **confirms** each candidate against its item page — a `404`/`410` is Yad2 explicitly stating the listing is gone. Only confirmed tokens are reported.

This is the same signal that identified the three sold listings by hand, so it's already proven against real data.

| | old (reverted) | this PR |
|---|---|---|
| Signal | absent from feed | absent **and** item page 404 |
| Can retire a live listing? | **yes** (partial feed) | no |
| Blast radius | all chats | pushing chat only |

## Changes

- **extension** — `looksGone()` splits `404/410` (a real answer) from `looksBlocked()` (a Radware challenge). These were **conflated**, which both hid removals *and* triggered pointless tab reloads. Bounded to `MAX_VERIFY_PER_CYCLE=10` per cycle, and skipped entirely when any feed was blocked, so a bad tab state can't manufacture candidates. Popup diag shows `gone:N/M`. → **v1.4.0**
- **api** — `/ext/ingest` applies `removed_tokens` (capped at 100) after the save, and no longer short-circuits an otherwise-empty push that carries removals.
- **storage** — `MarkListingsRemoved` is **scoped to the pushing `chat_id`**, so a buggy or hostile client can only retire its *own* listings, never another user's. (`DropListingByToken` is global — that's an admin op.) Bookmarked copies survive with `removed_at` set ("likely sold").

## Tests

`TestPostgres_MarkListingsRemoved` covers the security property directly: a token held by **two** chats, reported gone by one, must survive for the other. Plus bookmark preservation, untouched-listing safety, and empty/unknown no-ops.

## Review

✅ Storage scoping verified by test; extension JS syntax-checked. Requires an extension reload (**v1.4.0**) to take effect.