### PR TITLE
fix(deploy): keep the domain up when the API is down, and fit the VM

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -8,4 +8,11 @@
 		Permissions-Policy "camera=(), microphone=(), geolocation=()"
 	}
 	reverse_proxy api:8080
+
+	# The API being down must not take the site down with it: Caddy stays up
+	# (keeping the domain and ACME renewal alive) and answers with a legible
+	# maintenance page instead of a raw gateway error or a refused connection.
+	handle_errors {
+		respond "CarWatch is temporarily unavailable — the service is restarting. Please try again in a minute." {http.error.status_code}
+	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,19 @@ ENV LDFLAGS="-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X
 RUN CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/api-server ./cmd/api-server && \
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/bot-poller ./cmd/bot-poller && \
     CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/scraper ./cmd/scraper && \
-    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier && \
-    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/enricher ./cmd/enricher && \
-    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/enrich-bench ./cmd/enrich-bench
+    CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o /bin/notifier ./cmd/notifier
 
+# Runtime. No chromium: the Chrome-based Yad2 fetcher (http.chrome_bin → rod)
+# is not used in production — the browser extension ingests listings from a real
+# Yad2 tab instead. Installing chromium here added ~1.1 GB to the image (more
+# than the production VM has RAM) for a code path prod never takes; without it
+# the image is ~327 MB. Setting http.chrome_bin in a container built from this
+# image will fail at startup, by design.
 FROM alpine:3.24
-RUN apk add --no-cache ca-certificates tzdata chromium \
-    && adduser -D -u 1000 carwatch \
-    && mkdir -p /home/carwatch/.local/share/chromium/Crashpad \
-    && chown -R carwatch:carwatch /home/carwatch
+RUN apk add --no-cache ca-certificates tzdata \
+    && adduser -D -u 1000 carwatch
 USER carwatch
-COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /bin/enricher /bin/enrich-bench /usr/local/bin/
+COPY --from=builder /bin/api-server /bin/bot-poller /bin/scraper /bin/notifier /usr/local/bin/
 COPY --from=builder /app/migrations /migrations
 HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
   CMD wget -q --spider http://localhost:8080/healthz || exit 1

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,3 +1,19 @@
+# Memory budget — the production VM has 1 GB of physical RAM.
+#
+# Limits are ceilings, not reservations: their job is to bound the blast radius
+# when something leaks, so a single sick container gets killed instead of the
+# kernel's OOM killer picking an arbitrary victim (Postgres being the worst
+# case). That only works if the ceilings FIT IN THE HOST. They must therefore
+# sum to less than physical RAM, with room left for the OS and the Docker
+# daemon (~150 MB).
+#
+#   postgres 288M + redis 80M + api 200M + scraper 96M
+#   + notifier 80M + bot-poller 80M + caddy 48M = 872M
+#
+# Keep this sum under ~900M when changing any limit below. Steady-state usage is
+# far lower (idle Go services sit at ~30 MB RSS); the headroom absorbs spikes.
+# The VM should also have 1–2 GB of swap with vm.swappiness=10 as a shock
+# absorber for brief spikes — swap is slow, but slow beats killed.
 services:
   postgres:
     image: postgres:17-alpine
@@ -25,7 +41,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 288M
 
   redis:
     image: redis:7-alpine
@@ -58,7 +74,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 80M
 
   api:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
@@ -103,7 +119,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 200M
 
   bot-poller:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
@@ -142,7 +158,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 80M
 
   scraper:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
@@ -153,10 +169,10 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # Plain /tmp: the exec-able tmpfs, /dev/shm and the writable home were all
+    # for the headless Chromium the image no longer ships (see Dockerfile).
     tmpfs:
-      - /tmp:exec,uid=1000,gid=1000
-      - /dev/shm:size=128m
-      - /home/carwatch:uid=1000,gid=1000
+      - /tmp
     networks:
       - carwatch-net
     depends_on:
@@ -186,7 +202,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 768M
+          memory: 96M
 
   notifier:
     image: ghcr.io/danielsio/carwatch:${CARWATCH_IMAGE_TAG:?CARWATCH_IMAGE_TAG must be set}
@@ -226,7 +242,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 80M
 
   # NOTE: the per-item km `enricher` service was retired once the browser
   # extension took over ingestion (it fetches item detail + km from a real
@@ -239,9 +255,15 @@ services:
     container_name: caddy
     networks:
       - carwatch-net
+    # Deliberately NOT gated on `api: condition: service_healthy`. Caddy is the
+    # only thing holding the domain and the ACME certificate: if it waits for a
+    # healthy API, then a crash-looping API (bad config, failed migration) means
+    # the domain answers nothing at all — and TLS renewal cannot run, so a long
+    # outage can end with an expired certificate on top of the original fault.
+    # Proxying to a dead upstream returns 502, which is strictly better: the
+    # site is reachable, the failure is legible, and certs keep renewing.
     depends_on:
-      api:
-        condition: service_healthy
+      - api
     ports:
       - "80:80"
       - "443:443"
@@ -257,6 +279,10 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 48M
 
 networks:
   carwatch-net:


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass (correctness, reliability, DevOps, security). Findings filed as #1490–#1509 under epic #1510; this PR closes the three infra items.

## What

Three production-hardening fixes on the 1 GB VM. No Go code changes.

**Caddy no longer waits for a healthy API** — closes #1495
It is the only thing holding the domain and the ACME certificate. Gating its startup on `api: condition: service_healthy` meant a crash-looping API served *nothing* (connection refused, not even a 502) **and** blocked cert renewal — a long outage could end with an expired certificate on top of the original fault. Now it starts regardless and serves a maintenance page via `handle_errors` when the upstream is down.

**Runtime image drops Chromium** — closes #1496
The Chrome-based Yad2 fetcher (`http.chrome_bin` → rod) is dead in production (the extension fetches from a real Yad2 tab; `chrome_bin` is set in neither `config.prod.example.yaml` nor `config.example.yaml`). The apk install added **~1.1 GB** to an image five services pull — more than the VM has RAM.

| | before | after |
|---|---|---|
| runtime image | ~1.4 GB | **327 MB** |

Retired `enricher` / `enrich-bench` binaries go with it (nothing references them — grepped Makefile, scripts, compose, CI, docs), as does the scraper's exec-able `/tmp`, `/dev/shm` and writable home, which were Chromium scaffolding.

**Memory limits now fit the host** — closes #1497
They summed to **2560M on a 1024M box**, so they bounded nothing: under pressure the kernel OOM killer picked an arbitrary victim (Postgres, worst case) instead of the limits containing the blast radius. Rightsized to **872M** total, budget documented in the compose file.

## Verification

- `scripts/validate-compose.sh` → all production compose contract checks pass.
- `docker build .` succeeds; all four binaries present and runnable (`api-server -version` → ok); `chromium` absent from the image.
- Chromium layer size measured directly (`alpine:3.24` + `apk add chromium` = 1.11 GB) rather than estimated.

## Risk

Deploy-time only. If any service turns out to need more than its new ceiling it will be OOM-killed and restart — watch `docker stats` / `dmesg` after the first deploy. The ops note recommends 1–2 GB swap with `vm.swappiness=10` as the shock absorber.

closes #1495
closes #1496
closes #1497