### PR TITLE
fix(app): exit when a listener dies, and exit cleanly on a signal

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -148,7 +148,7 @@ func run(configPath string, skipMigrate bool, logger *slog.Logger) error {
 	}
 	defer apiServer.Shutdown()
 
-	srv := app.BuildHTTPServer(cfg, h, apiServer, logger)
+	srv, srvErr := app.BuildHTTPServer(cfg, h, apiServer, logger)
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
@@ -161,8 +161,17 @@ func run(configPath string, skipMigrate bool, logger *slog.Logger) error {
 		"health", "http://"+cfg.HTTP.Bind+"/healthz",
 	)
 
-	// Block until shutdown signal.
-	<-ctx.Done()
-	logger.Info("api-server shutting down")
-	return nil
+	// Block until a shutdown signal — or until the listener dies. Without the
+	// second case a failed bind would leave this process alive and serving
+	// nothing: healthy to `restart: unless-stopped`, useless to everyone else.
+	select {
+	case <-ctx.Done():
+		logger.Info("api-server shutting down")
+		return nil
+	case err := <-srvErr:
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 }

--- a/cmd/bot-poller/main.go
+++ b/cmd/bot-poller/main.go
@@ -112,7 +112,12 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	}
 	defer func() { _ = bb.Multi.Disconnect() }()
 
-	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	// A dead health listener means Docker can never see this poller as healthy
+	// — abort rather than linger as a zombie the restart policy ignores.
+	healthSrv, healthErr := app.BuildHealthServer(healthBind, h, logger)
+	guard := app.GuardListeners(ctx, healthErr)
+	defer guard.Stop()
+	ctx = guard.Context()
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
@@ -128,7 +133,9 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	)
 
 	pollingLoop(ctx, h, func(c context.Context) { bb.TgNotifier.Bot().Start(c) }, logger)
-	return nil
+	// pollingLoop returns only on shutdown; Wrap surfaces a listener failure as
+	// the exit error so the container restarts instead of idling.
+	return guard.Wrap(nil)
 }
 
 type backoffConfig struct {

--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -120,7 +120,10 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	h := health.New()
 	h.SetVersion(version)
 
-	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	healthSrv, healthErr := app.BuildHealthServer(healthBind, h, logger)
+	guard := app.GuardListeners(ctx, healthErr)
+	defer guard.Stop()
+	ctx = guard.Context()
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -109,8 +109,12 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	h := health.New()
 	h.SetVersion(version)
 
-	// Health endpoint on a separate port.
-	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	// Health endpoint on a separate port. A dead listener means Docker can
+	// never see this worker as healthy — abort rather than linger as a zombie.
+	healthSrv, healthErr := app.BuildHealthServer(healthBind, h, logger)
+	guard := app.GuardListeners(ctx, healthErr)
+	defer guard.Stop()
+	ctx = guard.Context()
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
@@ -136,7 +140,9 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	)
 
 	consumerLoop(ctx, cons, logger)
-	return nil
+	// consumerLoop returns only on shutdown; Wrap surfaces a listener failure
+	// as the exit error so the container restarts instead of idling.
+	return guard.Wrap(nil)
 }
 
 type runner interface {

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -105,8 +105,13 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	h := health.New()
 	h.SetVersion(version)
 
-	// Health endpoint on a separate port.
-	healthSrv := app.BuildHealthServer(healthBind, h, logger)
+	// Health endpoint on a separate port. If its listener dies the scheduler
+	// keeps running but Docker can never see it as healthy, so abort the
+	// process instead and let the restart policy recover it.
+	healthSrv, healthErr := app.BuildHealthServer(healthBind, h, logger)
+	guard := app.GuardListeners(ctx, healthErr)
+	defer guard.Stop()
+	ctx = guard.Context()
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
@@ -193,5 +198,7 @@ func run(configPath, healthBind string, skipMigrate bool, logger *slog.Logger) e
 	)
 
 	h.MarkSchedulerStarted()
-	return sched.Run(ctx)
+	// Wrap: a listener failure becomes the process's exit error; a plain
+	// context cancellation is a signal-driven shutdown and exits cleanly.
+	return guard.Wrap(sched.Run(ctx))
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,10 +5,12 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	tgbot "github.com/go-telegram/bot"
@@ -320,9 +322,30 @@ func BuildPriceListService(cfg *config.Config, store *postgres.Store, logger *sl
 	return svc, cleanup, nil
 }
 
+// serve starts srv in the background and reports a listener failure on the
+// returned channel. A failed listener is fatal, not a warning: the process it
+// belongs to keeps running with nothing served — Docker sees an *unhealthy*
+// container, and `restart: unless-stopped` does not restart unhealthy
+// containers, so the zombie survives until a human notices. Callers must turn
+// this into a non-zero exit (see GuardListeners).
+//
+// The channel is buffered so the goroutine never blocks if nobody is listening,
+// and closed on a clean Shutdown so a receiver sees a nil error, not a hang.
+func serve(srv *http.Server, logger *slog.Logger, what string) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error(what+" failed", "addr", srv.Addr, "error", err)
+			errCh <- fmt.Errorf("%s (%s): %w", what, srv.Addr, err)
+		}
+	}()
+	return errCh
+}
+
 // BuildHTTPServer creates and starts the HTTP server with health, API, SPA,
-// and metrics endpoints.
-func BuildHTTPServer(cfg *config.Config, h *health.Status, apiServer *api.Server, logger *slog.Logger) *http.Server {
+// and metrics endpoints. The returned channel reports a fatal listener failure.
+func BuildHTTPServer(cfg *config.Config, h *health.Status, apiServer *api.Server, logger *slog.Logger) (*http.Server, <-chan error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.PublicHandler())
 	mux.Handle("/api/v1/", apiServer.Routes())
@@ -343,17 +366,13 @@ func BuildHTTPServer(cfg *config.Config, h *health.Status, apiServer *api.Server
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
 	}
-	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error("http server failed", "error", err)
-		}
-	}()
-	return srv
+	return srv, serve(srv, logger, "http server")
 }
 
 // BuildHealthServer creates and starts a minimal HTTP server with only the
-// health endpoint, for use by headless services (scraper, notifier).
-func BuildHealthServer(bind string, h *health.Status, logger *slog.Logger) *http.Server {
+// health endpoint, for use by headless services (scraper, notifier). The
+// returned channel reports a fatal listener failure.
+func BuildHealthServer(bind string, h *health.Status, logger *slog.Logger) (*http.Server, <-chan error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.PublicHandler())
 
@@ -365,12 +384,75 @@ func BuildHealthServer(bind string, h *health.Status, logger *slog.Logger) *http
 		WriteTimeout:      10 * time.Second,
 		IdleTimeout:       30 * time.Second,
 	}
-	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error("health server failed", "error", err)
-		}
-	}()
-	return srv
+	return srv, serve(srv, logger, "health server")
+}
+
+// ListenGuard ties a service's lifetime to its listeners: when one of them
+// fails to serve, the guarded context is cancelled — unwinding whatever
+// blocking loop the service is running (scheduler, Redis consumer, bot poller)
+// — and Wrap turns the resulting shutdown into the listener's error, so the
+// process exits non-zero and Docker's restart policy takes over.
+type ListenGuard struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu  sync.Mutex
+	err error
+}
+
+// GuardListeners derives a context from parent that is cancelled as soon as any
+// of errChs reports a failure. Callers must defer Stop.
+func GuardListeners(parent context.Context, errChs ...<-chan error) *ListenGuard {
+	ctx, cancel := context.WithCancel(parent)
+	g := &ListenGuard{ctx: ctx, cancel: cancel}
+	for _, ch := range errChs {
+		go func(ch <-chan error) {
+			select {
+			case err, ok := <-ch:
+				if !ok || err == nil {
+					return // clean shutdown closed the channel
+				}
+				g.mu.Lock()
+				if g.err == nil {
+					g.err = err
+				}
+				g.mu.Unlock()
+				cancel()
+			case <-ctx.Done():
+			}
+		}(ch)
+	}
+	return g
+}
+
+// Context returns the context services should run under.
+func (g *ListenGuard) Context() context.Context { return g.ctx }
+
+// Stop releases the guard's resources.
+func (g *ListenGuard) Stop() { g.cancel() }
+
+// Err reports the listener failure that aborted the service, if any.
+func (g *ListenGuard) Err() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.err
+}
+
+// Wrap resolves a service's exit into the error the process should die with.
+//
+// A listener failure wins: whatever the service's blocking loop returned is
+// just the echo of the cancellation we triggered. Otherwise a context
+// cancellation means a signal-driven shutdown — that is a *clean* exit, not a
+// fatal error, so it resolves to nil (previously every SIGTERM logged "fatal"
+// and exited 1, making a graceful stop indistinguishable from a crash).
+func (g *ListenGuard) Wrap(runErr error) error {
+	if err := g.Err(); err != nil {
+		return err
+	}
+	if errors.Is(runErr, context.Canceled) {
+		return nil
+	}
+	return runErr
 }
 
 // NewLogHandler creates a slog.Handler, choosing between pretty (tint) and

--- a/internal/app/listen_guard_test.go
+++ b/internal/app/listen_guard_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/health"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// A failed bind must be reported, not merely logged: a service whose listener
+// is dead serves nothing, yet `restart: unless-stopped` never restarts a
+// merely-unhealthy container, so the process would linger as a zombie.
+func TestBuildHealthServer_OccupiedPortReportsListenError(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer func() { _ = occupied.Close() }()
+
+	srv, errCh := BuildHealthServer(occupied.Addr().String(), health.New(), discardLogger())
+	defer func() { _ = srv.Close() }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected a listen error on an occupied port, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("listen error was never reported")
+	}
+}
+
+// A clean Shutdown closes the channel with no error, so a guard does not
+// mistake an orderly stop for a listener failure.
+func TestBuildHealthServer_CleanShutdownReportsNoError(t *testing.T) {
+	srv, errCh := BuildHealthServer("127.0.0.1:0", health.New(), discardLogger())
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("clean shutdown reported an error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("channel was not closed on clean shutdown")
+	}
+}
+
+// The guard must unwind the service: a listener failure cancels the context the
+// blocking loop (scheduler, consumer, poller) runs under.
+func TestGuardListeners_CancelsContextOnListenFailure(t *testing.T) {
+	errCh := make(chan error, 1)
+	guard := GuardListeners(context.Background(), errCh)
+	defer guard.Stop()
+
+	if guard.Context().Err() != nil {
+		t.Fatal("context cancelled before any failure")
+	}
+
+	want := errors.New("bind: address already in use")
+	errCh <- want
+
+	select {
+	case <-guard.Context().Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("guarded context was not cancelled by the listener failure")
+	}
+	if got := guard.Err(); !errors.Is(got, want) {
+		t.Fatalf("guard.Err() = %v, want %v", got, want)
+	}
+}
+
+func TestListenGuard_Wrap(t *testing.T) {
+	listenErr := errors.New("health server (0.0.0.0:8081): bind failed")
+	runErr := errors.New("scheduler exploded")
+
+	t.Run("listener failure wins over the cancellation it caused", func(t *testing.T) {
+		errCh := make(chan error, 1)
+		errCh <- listenErr
+		guard := GuardListeners(context.Background(), errCh)
+		defer guard.Stop()
+		<-guard.Context().Done()
+
+		// The blocking loop returns context.Canceled because *we* cancelled it;
+		// the real cause is the listener, and that is what the process must
+		// exit with so Docker restarts it.
+		if got := guard.Wrap(context.Canceled); !errors.Is(got, listenErr) {
+			t.Fatalf("Wrap(context.Canceled) = %v, want the listen error", got)
+		}
+	})
+
+	t.Run("signal-driven shutdown is a clean exit", func(t *testing.T) {
+		guard := GuardListeners(context.Background())
+		defer guard.Stop()
+
+		// Previously every SIGTERM returned context.Canceled up to main, which
+		// logged "fatal" and exited 1 — a graceful stop looked like a crash.
+		if got := guard.Wrap(context.Canceled); got != nil {
+			t.Fatalf("Wrap(context.Canceled) = %v, want nil for a clean shutdown", got)
+		}
+	})
+
+	t.Run("a real run error still propagates", func(t *testing.T) {
+		guard := GuardListeners(context.Background())
+		defer guard.Stop()
+
+		if got := guard.Wrap(runErr); !errors.Is(got, runErr) {
+			t.Fatalf("Wrap(runErr) = %v, want %v", got, runErr)
+		}
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		guard := GuardListeners(context.Background())
+		defer guard.Stop()
+
+		if got := guard.Wrap(nil); got != nil {
+			t.Fatalf("Wrap(nil) = %v, want nil", got)
+		}
+	})
+}


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this PR closes the process-lifecycle item.

## The bug

`ListenAndServe` ran in a goroutine whose error was **only logged**, while `main` kept blocking on `<-ctx.Done()`. A service that could not bind its port therefore **stayed alive serving nothing**. Docker marks such a container *unhealthy* — and `restart: unless-stopped` **does not restart unhealthy containers**, only exited ones. The zombie survives until a human notices.

Affects `api-server` and every headless service's health server (`scraper`, `notifier`, `bot-poller`).

## The fix

- `BuildHTTPServer` / `BuildHealthServer` now return `<-chan error` carrying the listen failure (buffered; closed with no error on a clean `Shutdown`).
- `ListenGuard` ties that channel to the service's context: a listener failure **cancels the context**, unwinding whatever blocking loop the service runs (scheduler / Redis consumer / bot poller), and `Wrap` makes the listener error the process's exit error → non-zero exit → Docker restarts it.

## Bonus fix (found while wiring it)

The headless services returned `ctx.Err()` from their run loops, so **every SIGTERM returned `context.Canceled` to main, which logged `"fatal"` and exited 1** — a graceful stop was indistinguishable from a crash. `Wrap` now resolves a signal-driven cancellation to a clean exit (0).

## Verification

End-to-end with a real Postgres and two real api-server processes:

```
instance A: RUNNING, holding port 18080 ✓
instance B on the SAME port → exit code 1 (after 1s)
  "fatal" error="http server (127.0.0.1:18080): listen tcp ...: bind: ... address ... permitted."
```

Unit tests (`internal/app/listen_guard_test.go`) cover: occupied port reports the error; clean shutdown closes the channel with no error; the guard cancels the context on failure; and each `Wrap` outcome (listener error wins over the cancellation it caused / signal shutdown → nil / real run error propagates / nil stays nil).

`go build ./...` and `go test ./internal/app/ ./cmd/...` pass. (The 3 `gofmt` hits golangci-lint reports in `cmd/bench` are pre-existing on `main` — a local CRLF artifact, verified by re-running on a clean tree.)

closes #1494