### PR TITLE
fix(api): reject invalid tokens instead of answering as a guest

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -462,33 +462,62 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// optionalAuthMiddleware tries to authenticate the request but does not
-// reject it when credentials are missing or invalid. If authentication
-// succeeds the resolved chatID and email are injected into the context;
-// otherwise chatID is set to 0 (guest sentinel) and the request is
-// allowed to proceed.  Handlers behind this middleware can call
-// chatIDFromContext to distinguish guests (0) from real users.
+// optionalAuthMiddleware authenticates the request when a credential is
+// offered, but allows anonymous callers through as guests (chatID 0) when none
+// is. Handlers behind it call chatIDFromContext to tell guests from real users.
+//
+// "No credential" and "a credential that does not work" are NOT the same thing.
+// A request that presents a Bearer token we cannot verify — expired, revoked,
+// malformed — is a failed authentication and gets 401, not a guest response.
+// Treating it as anonymous is how a stale token turns into silent data loss:
+// GET /searches answered `200 []`, and the caller could not distinguish "you
+// have no searches" from "your session expired". The browser extension, whose
+// token expires roughly hourly, would then scan nothing while reporting
+// success; a web client with a broken refresh would render an empty dashboard
+// instead of sending the user to log in.
 func (s *Server) optionalAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHdr := r.Header.Get("Authorization")
 		bearer := bearerFromAuthHeader(authHdr)
+		// An Authorization header we could not read a bearer token out of is
+		// still an attempt to authenticate — do not silently downgrade it.
+		credentialOffered := strings.TrimSpace(authHdr) != ""
 
 		var chatID int64
 		var userEmail string
 
-		if s.firebaseAuth != nil && bearer != "" {
+		switch {
+		case s.firebaseAuth != nil && bearer != "":
 			tok, err := s.firebaseAuth.VerifyIDToken(r.Context(), bearer)
-			if err == nil {
-				userEmail = emailFromClaims(tok)
-				id, upsertErr := s.users.UpsertWebUser(r.Context(), tok.UID, userEmail)
-				if upsertErr == nil {
-					chatID = id
-				}
+			if err != nil {
+				writeAuthError(w, "invalid or expired token")
+				return
 			}
-		} else if s.firebaseAuth == nil {
-			if s.cfg.AuthToken != "" && bearer == s.cfg.AuthToken {
-				chatID = s.cfg.DevChatID
-			} else if s.cfg.AuthToken == "" {
+			userEmail = emailFromClaims(tok)
+			id, upsertErr := s.users.UpsertWebUser(r.Context(), tok.UID, userEmail)
+			if upsertErr != nil {
+				s.logger.Error("upsert web user", "error", upsertErr)
+				writeError(w, http.StatusInternalServerError, "internal error")
+				return
+			}
+			chatID = id
+
+		case s.firebaseAuth != nil && credentialOffered:
+			// Authorization present but not a usable Bearer token.
+			writeAuthError(w, "invalid or expired token")
+			return
+
+		case s.firebaseAuth == nil:
+			// Dev auth. A configured dev token must still be presented correctly
+			// when one is offered at all.
+			if s.cfg.AuthToken != "" {
+				if bearer == s.cfg.AuthToken {
+					chatID = s.cfg.DevChatID
+				} else if credentialOffered {
+					writeAuthError(w, "invalid or expired token")
+					return
+				}
+			} else {
 				chatID = s.cfg.DevChatID
 			}
 		}
@@ -497,6 +526,14 @@ func (s *Server) optionalAuthMiddleware(next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, emailKey, userEmail)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// writeAuthError rejects a failed authentication. The WWW-Authenticate header
+// tells clients (and the extension) that the credential — not the request — is
+// what went wrong, so they re-authenticate instead of retrying blindly.
+func writeAuthError(w http.ResponseWriter, msg string) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="carwatch", error="invalid_token"`)
+	writeError(w, http.StatusUnauthorized, msg)
 }
 
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
@@ -510,7 +547,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		if s.firebaseAuth != nil && bearer != "" {
 			tok, err := s.firebaseAuth.VerifyIDToken(r.Context(), bearer)
 			if err != nil {
-				writeError(w, http.StatusUnauthorized, "invalid or missing token")
+				writeAuthError(w, "invalid or missing token")
 				return
 			}
 			userEmail = emailFromClaims(tok)
@@ -522,12 +559,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			}
 			chatID = id
 		} else if s.firebaseAuth != nil && bearer == "" {
-			writeError(w, http.StatusUnauthorized, "invalid or missing token")
+			writeAuthError(w, "invalid or missing token")
 			return
 		} else if s.firebaseAuth == nil {
 			if s.cfg.AuthToken != "" {
 				if bearer != s.cfg.AuthToken {
-					writeError(w, http.StatusUnauthorized, "invalid or missing token")
+					writeAuthError(w, "invalid or missing token")
 					return
 				}
 			}
@@ -537,7 +574,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				return
 			}
 		} else {
-			writeError(w, http.StatusUnauthorized, "invalid or missing token")
+			writeAuthError(w, "invalid or missing token")
 			return
 		}
 

--- a/internal/api/optional_auth_test.go
+++ b/internal/api/optional_auth_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/storage/pgtest"
+)
+
+// optionalAuthRoutes are the endpoints served behind optionalAuthMiddleware.
+var optionalAuthRoutes = []string{
+	"/api/v1/searches",
+	"/api/v1/me",
+	"/api/v1/notifications/count",
+}
+
+func newOptionalAuthServer(t *testing.T, verifier TokenVerifier) *Server {
+	t.Helper()
+	store := pgtest.NewStore(t)
+	return New(Config{
+		Searches:     store,
+		Listings:     store,
+		Users:        store,
+		Prices:       store,
+		Notifs:       store,
+		Logger:       slog.Default(),
+		FirebaseAuth: verifier,
+		API: config.APIConfig{
+			CORSOrigins: []string{"http://localhost:5173"},
+		},
+	})
+}
+
+// The regression this whole change exists for: an expired or otherwise
+// unverifiable token used to be treated as "anonymous", so GET /searches
+// answered `200 []`. The extension — whose Firebase token expires about hourly
+// — would then scan nothing and report success, and a web client with a broken
+// refresh would render an empty dashboard instead of sending the user to log
+// in. A credential that does not work must fail loudly.
+func TestOptionalAuth_InvalidTokenIsRejectedNotDowngradedToGuest(t *testing.T) {
+	srv := newOptionalAuthServer(t, &fakeTokenVerifier{err: errors.New("token expired")})
+
+	for _, route := range optionalAuthRoutes {
+		t.Run(route, func(t *testing.T) {
+			req := httptest.NewRequest("GET", route, nil)
+			req.Header.Set("Authorization", "Bearer expired-token")
+			w := httptest.NewRecorder()
+			srv.Routes().ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401 for an expired token, got %d: %s", w.Code, w.Body.String())
+			}
+			if got := w.Header().Get("WWW-Authenticate"); got == "" {
+				t.Error("expected a WWW-Authenticate header telling the client to re-authenticate")
+			}
+		})
+	}
+}
+
+// A malformed Authorization header is still an attempt to authenticate: it must
+// not be silently downgraded to a guest response either.
+func TestOptionalAuth_MalformedAuthHeaderIsRejected(t *testing.T) {
+	srv := newOptionalAuthServer(t, &fakeTokenVerifier{uid: "uid-123", email: "user@example.com"})
+
+	for _, hdr := range []string{"Basic dXNlcjpwYXNz", "Bearer", "garbage"} {
+		t.Run(hdr, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+			req.Header.Set("Authorization", hdr)
+			w := httptest.NewRecorder()
+			srv.Routes().ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401 for Authorization %q, got %d", hdr, w.Code)
+			}
+		})
+	}
+}
+
+// The other half of the contract: a caller offering NO credential is a guest,
+// not a failure. The public landing and try-search flows depend on this.
+func TestOptionalAuth_NoCredentialStillGetsGuestResponse(t *testing.T) {
+	srv := newOptionalAuthServer(t, &fakeTokenVerifier{uid: "uid-123", email: "user@example.com"})
+
+	req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 guest response with no Authorization header, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var searches []any
+	if err := json.Unmarshal(w.Body.Bytes(), &searches); err != nil {
+		t.Fatalf("guest response is not a JSON list: %v (%s)", err, w.Body.String())
+	}
+	if len(searches) != 0 {
+		t.Fatalf("expected an empty guest search list, got %d entries", len(searches))
+	}
+}
+
+// A valid token keeps working, of course.
+func TestOptionalAuth_ValidTokenIsAuthenticated(t *testing.T) {
+	srv := newOptionalAuthServer(t, &fakeTokenVerifier{uid: "uid-123", email: "user@example.com"})
+
+	req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+	req.Header.Set("Authorization", "Bearer good-token")
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with a valid token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// Dev auth (no Firebase configured) follows the same rule: a wrong dev token is
+// a failed authentication, while no header at all is the anonymous dev user.
+func TestOptionalAuth_DevToken(t *testing.T) {
+	store := pgtest.NewStore(t)
+	srv := New(Config{
+		Searches: store,
+		Listings: store,
+		Users:    store,
+		Prices:   store,
+		Logger:   slog.Default(),
+		API: config.APIConfig{
+			CORSOrigins: []string{"http://localhost:5173"},
+			DevChatID:   42,
+			AuthToken:   "dev-secret",
+		},
+	})
+
+	t.Run("wrong dev token is rejected", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+		req.Header.Set("Authorization", "Bearer not-the-dev-secret")
+		w := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 for a wrong dev token, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("correct dev token is accepted", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/searches", nil)
+		req.Header.Set("Authorization", "Bearer dev-secret")
+		w := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 for the correct dev token, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this PR closes the auth item.

## The bug

`optionalAuthMiddleware` treated a token it **could not verify** (expired, revoked, malformed) exactly like **no token at all**: the request proceeded as an anonymous guest, and `GET /api/v1/searches` answered `200 []`.

Callers could not distinguish *"you have no searches"* from *"your session expired"* — so a stale credential became **silent data loss**:

- The **browser extension**'s Firebase token expires roughly hourly. Once it did, the extension fetched an empty search list, scanned nothing, and reported success. (This is the mechanism behind #1490; that issue fixes the token's lifetime, this one makes the failure *visible*.)
- A **web client** whose refresh broke would render an empty dashboard instead of sending the user to log in.

## The fix

"No credential" and "a credential that does not work" are different answers:

| request | before | after |
|---|---|---|
| no `Authorization` header | `200` guest | `200` guest (unchanged) |
| valid token | `200` authenticated | `200` authenticated (unchanged) |
| **expired / invalid token** | **`200` guest 😱** | **`401` + `WWW-Authenticate`** |
| **malformed header** (`Basic …`, `Bearer`, junk) | **`200` guest** | **`401` + `WWW-Authenticate`** |

The `WWW-Authenticate` header tells clients the *credential* is what failed, so they re-authenticate rather than retry blindly. The web app's `fetchAPI` already retries a 401 with a force-refreshed token — this change makes that path actually fire. `authMiddleware` (strict routes) now sends the same header for consistency.

## Verification

New `internal/api/optional_auth_test.go` covers all three optional-auth routes (`/searches`, `/me`, `/notifications/count`):
- expired token → 401 + `WWW-Authenticate` (the regression guard)
- malformed `Authorization` → 401
- **no** credential → still a `200` guest with an empty list (the public landing / try-search flows depend on this)
- valid token → 200
- dev-auth: wrong dev token → 401, correct → 200

Full `./internal/api/` suite passes (290s, pgtest/testcontainers). `go vet` clean.

closes #1491