### PR TITLE
fix(storage): retain by last seen, and stop letting a missing price erase one

### DIFF
--- a/internal/storage/postgres/dedup.go
+++ b/internal/storage/postgres/dedup.go
@@ -6,19 +6,34 @@ import (
 	"time"
 )
 
+// ClaimNew records that (token, chat_id, search_id) has been seen and reports
+// whether this claim is the first one — i.e. whether the user should be alerted
+// about this listing for this search.
+//
+// A re-observation is not a no-op: it refreshes last_seen_at, which is what the
+// prune retains the claim by. The extension re-pushes every still-matching
+// listing every cycle, so a live listing's claim is renewed for as long as its
+// ad is up; only listings that have actually disappeared from the source age
+// out of the retention window. (Before this, a claim expired on a fixed timer
+// from first sight, and the next push re-alerted the user about a car they had
+// already been shown.)
+//
+// The insert-or-touch is a single statement so it stays atomic under concurrent
+// pushes. `xmax = 0` is true only for a freshly inserted row — an ON CONFLICT
+// update leaves the previous tuple's xmax behind — which is how we tell a new
+// claim from a renewed one now that both affect a row.
 func (s *Store) ClaimNew(ctx context.Context, token string, chatID int64, searchID int64) (bool, error) {
-	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO seen_listings (token, chat_id, search_id) VALUES ($1, $2, $3)
-		ON CONFLICT (token, chat_id, search_id) DO NOTHING`,
-		token, chatID, searchID)
+	var inserted bool
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO seen_listings (token, chat_id, search_id, first_seen_at, last_seen_at)
+		VALUES ($1, $2, $3, NOW(), NOW())
+		ON CONFLICT (token, chat_id, search_id) DO UPDATE SET last_seen_at = NOW()
+		RETURNING (xmax = 0)`,
+		token, chatID, searchID).Scan(&inserted)
 	if err != nil {
 		return false, fmt.Errorf("claim new: %w", err)
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("claim new rows affected: %w", err)
-	}
-	return rows > 0, nil
+	return inserted, nil
 }
 
 func (s *Store) ReleaseClaim(ctx context.Context, token string, chatID int64, searchID int64) error {
@@ -31,10 +46,15 @@ func (s *Store) ReleaseClaim(ctx context.Context, token string, chatID int64, se
 	return nil
 }
 
+// Prune drops dedup claims for listings nobody has seen for olderThan — i.e.
+// listings that have been gone from the source that long. It deliberately does
+// NOT prune by first_seen_at: a listing that is still live is still being
+// re-claimed every cycle, and expiring its claim would re-alert the user about
+// a car they have already been shown.
 func (s *Store) Prune(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx,
-		`DELETE FROM seen_listings WHERE first_seen_at < $1`,
+		`DELETE FROM seen_listings WHERE last_seen_at < $1`,
 		cutoff)
 	if err != nil {
 		return 0, fmt.Errorf("prune seen listings: %w", err)

--- a/internal/storage/postgres/listings.go
+++ b/internal/storage/postgres/listings.go
@@ -49,9 +49,16 @@ const upsertListingSQL = `
 		sub_model_id = CASE WHEN EXCLUDED.sub_model_id > 0 THEN EXCLUDED.sub_model_id ELSE listing_history.sub_model_id END,
 		body_type = CASE WHEN EXCLUDED.body_type != '' THEN EXCLUDED.body_type ELSE listing_history.body_type END,
 		year = CASE WHEN EXCLUDED.year > 0 THEN EXCLUDED.year ELSE listing_history.year END,
-		price = EXCLUDED.price,
+		-- A price CHANGE is the point of the product, so real values always win
+		-- — but 0 is not a price. It is what the parser yields when the feed row
+		-- omits the field, and letting it through erased the known price of a
+		-- listing (breaking the price_only filter, price sorting, deal scores and
+		-- the price-drop signal itself) on any partial payload. Same for hand,
+		-- which only ever counts upward: a 0 in an update is a missing field, not
+		-- a car that lost an owner. Zeros still insert fine on first sight.
+		price = CASE WHEN EXCLUDED.price > 0 THEN EXCLUDED.price ELSE listing_history.price END,
 		km = CASE WHEN EXCLUDED.km > 0 THEN EXCLUDED.km ELSE listing_history.km END,
-		hand = EXCLUDED.hand,
+		hand = CASE WHEN EXCLUDED.hand > 0 THEN EXCLUDED.hand ELSE listing_history.hand END,
 		city = CASE WHEN EXCLUDED.city != '' THEN EXCLUDED.city ELSE listing_history.city END,
 		page_link = CASE WHEN EXCLUDED.page_link != '' THEN EXCLUDED.page_link ELSE listing_history.page_link END,
 		image_url = CASE WHEN EXCLUDED.image_url != '' THEN EXCLUDED.image_url ELSE listing_history.image_url END,
@@ -68,6 +75,8 @@ const upsertListingSQL = `
 		base_price = COALESCE(EXCLUDED.base_price, listing_history.base_price),
 		posted_at = COALESCE(EXCLUDED.posted_at, listing_history.posted_at),
 		removed_at = NULL,
+		-- Re-observed: renew the retention clock (see PruneListings).
+		last_seen_at = NOW(),
 		score_condition = COALESCE(EXCLUDED.score_condition, listing_history.score_condition),
 		score_value = COALESCE(EXCLUDED.score_value, listing_history.score_value),
 		score_engine = COALESCE(EXCLUDED.score_engine, listing_history.score_engine),
@@ -862,11 +871,18 @@ func (s *Store) ResetUnenrichedAttempts(ctx context.Context) (int64, error) {
 	return result.RowsAffected()
 }
 
+// PruneListings drops listings nobody has seen for olderThan — measured from
+// the last time the source still served them, not from when we first found
+// them. A car can sit on Yad2 for longer than the retention window; pruning by
+// first_seen_at deleted such a listing while it was still live, and the next
+// ingest re-inserted it with a fresh first_seen_at — so it resurfaced in the UI
+// as newly found and lost its enrichment counters. Bookmarked listings are
+// exempt, as before.
 func (s *Store) PruneListings(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 	result, err := s.db.ExecContext(ctx, `
 		DELETE FROM listing_history
-		WHERE first_seen_at < $1
+		WHERE last_seen_at < $1
 		  AND NOT EXISTS (
 		      SELECT 1 FROM saved_listings
 		      WHERE saved_listings.token = listing_history.token

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -1203,6 +1203,19 @@ func TestPostgres_DeleteSearchCascade(t *testing.T) {
 // Prune & delete stale listings
 // ---------------------------------------------------------------------------
 
+// ageListingLastSeen backdates when the source was last seen serving a listing.
+// Retention keys on that (see PruneListings), and SaveListing always stamps it
+// with NOW() — because saving a listing IS observing it — so a test that wants
+// a listing the source has stopped serving has to say so explicitly.
+func ageListingLastSeen(t *testing.T, store *Store, token string, lastSeen time.Time) {
+	t.Helper()
+	if _, err := store.DB().Exec(
+		`UPDATE listing_history SET last_seen_at = $1 WHERE token = $2`,
+		lastSeen.UTC(), token); err != nil {
+		t.Fatalf("age last_seen_at for %q: %v", token, err)
+	}
+}
+
 func TestPostgres_PruneListings(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
@@ -1223,6 +1236,13 @@ func TestPostgres_PruneListings(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+
+	// Retention is measured from the last time the SOURCE still served the
+	// listing, not from when we first found it — a car can be listed for longer
+	// than the retention window and must not be pruned while it is still live.
+	// "old-1" is the one that has actually disappeared: nothing has re-observed
+	// it for 100 days.
+	ageListingLastSeen(t, store, "old-1", old)
 
 	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
 	if err != nil {
@@ -1258,6 +1278,11 @@ func TestPostgres_PruneListingsPreservesSaved(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = store.SaveBookmark(ctx, 100, "old-saved")
+
+	// Both are gone from the source (nothing has re-observed them for 100 days);
+	// only the bookmarked one may survive the prune.
+	ageListingLastSeen(t, store, "old-saved", old)
+	ageListingLastSeen(t, store, "old-unsaved", old)
 
 	pruned, _ := store.PruneListings(ctx, 90*24*time.Hour)
 	if pruned != 1 {

--- a/internal/storage/postgres/retention_test.go
+++ b/internal/storage/postgres/retention_test.go
@@ -1,0 +1,260 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// The bug this guards: cars sit on Yad2 for months and the extension re-pushes
+// every still-matching listing every 15 minutes, but a dedup claim was pruned
+// on a fixed timer from FIRST sight. Once the retention window elapsed under a
+// live listing, the next push re-claimed it as new and the user was re-alerted
+// about a car they had already been shown — again every 30 days, for as long as
+// the ad stayed up.
+func TestDedupPrune_KeepsClaimsForListingsStillBeingSeen(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	const (
+		token    = "still-for-sale"
+		chatID   = int64(1)
+		searchID = int64(1)
+	)
+
+	isNew, err := store.ClaimNew(ctx, token, chatID, searchID)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if !isNew {
+		t.Fatal("first sighting of a listing must be new (the user gets one alert)")
+	}
+
+	// Age the claim past any plausible retention window, as if the car had been
+	// listed for months.
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE seen_listings SET first_seen_at = NOW() - INTERVAL '90 days',
+		                          last_seen_at  = NOW() - INTERVAL '90 days'
+		 WHERE token = $1`, token); err != nil {
+		t.Fatalf("age claim: %v", err)
+	}
+
+	// The extension pushes it again, because it is still on Yad2. This must not
+	// alert (it is not new) and must renew the claim's retention clock.
+	isNew, err = store.ClaimNew(ctx, token, chatID, searchID)
+	if err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	if isNew {
+		t.Fatal("a listing we have already claimed must never report as new again")
+	}
+
+	// The daily prune now runs with a 30-day window.
+	pruned, err := store.Prune(ctx, 30*24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 0 {
+		t.Fatalf("prune deleted %d claim(s) for a listing that is still being seen", pruned)
+	}
+
+	// The real assertion: the next push after the prune must still be a
+	// duplicate, not a fresh alert.
+	isNew, err = store.ClaimNew(ctx, token, chatID, searchID)
+	if err != nil {
+		t.Fatalf("claim after prune: %v", err)
+	}
+	if isNew {
+		t.Fatal("listing re-alerted after the prune — the duplicate-alert bug is back")
+	}
+}
+
+// Retention still works: a listing that really is gone from the source stops
+// being re-claimed, ages out, and is pruned.
+func TestDedupPrune_DropsClaimsForListingsGoneFromTheSource(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	const (
+		token    = "sold-long-ago"
+		chatID   = int64(1)
+		searchID = int64(1)
+	)
+
+	if _, err := store.ClaimNew(ctx, token, chatID, searchID); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	// Nobody has re-observed it for 40 days: the car is gone.
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE seen_listings SET last_seen_at = NOW() - INTERVAL '40 days' WHERE token = $1`,
+		token); err != nil {
+		t.Fatalf("age claim: %v", err)
+	}
+
+	pruned, err := store.Prune(ctx, 30*24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("expected the stale claim to be pruned, got %d", pruned)
+	}
+}
+
+// Same shape for listing_history: a live listing must not be deleted and
+// re-inserted (which reset first_seen_at, resurfacing it in the UI as newly
+// found and clearing its enrichment counters).
+func TestPruneListings_KeepsListingsStillBeingSeen(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	const chatID = int64(1)
+	rec := storage.ListingRecord{
+		Token:       "long-lived-ad",
+		ChatID:      chatID,
+		SearchID:    1,
+		Price:       50000,
+		Year:        2019,
+		FirstSeenAt: time.Now().Add(-120 * 24 * time.Hour),
+	}
+	if err := store.SaveListing(ctx, rec); err != nil {
+		t.Fatalf("save listing: %v", err)
+	}
+
+	// It was first seen 120 days ago but the source still serves it, so the
+	// most recent push re-upserted it just now (SaveListing refreshes
+	// last_seen_at) — except on the very first insert, where the default is NOW.
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE listing_history SET first_seen_at = NOW() - INTERVAL '120 days' WHERE token = $1`,
+		rec.Token); err != nil {
+		t.Fatalf("age listing: %v", err)
+	}
+	// Re-observe it, as the extension would.
+	if err := store.SaveListing(ctx, rec); err != nil {
+		t.Fatalf("re-save listing: %v", err)
+	}
+
+	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune listings: %v", err)
+	}
+	if pruned != 0 {
+		t.Fatalf("prune deleted %d live listing(s) that the source is still serving", pruned)
+	}
+
+	got, err := store.GetListing(ctx, chatID, rec.Token)
+	if err != nil {
+		t.Fatalf("get listing: %v", err)
+	}
+	if got == nil {
+		t.Fatal("live listing was pruned")
+	}
+}
+
+func TestPruneListings_DropsListingsGoneFromTheSource(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	rec := storage.ListingRecord{
+		Token:       "vanished-ad",
+		ChatID:      1,
+		SearchID:    1,
+		Price:       50000,
+		FirstSeenAt: time.Now().Add(-120 * 24 * time.Hour),
+	}
+	if err := store.SaveListing(ctx, rec); err != nil {
+		t.Fatalf("save listing: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE listing_history SET last_seen_at = NOW() - INTERVAL '100 days' WHERE token = $1`,
+		rec.Token); err != nil {
+		t.Fatalf("age listing: %v", err)
+	}
+
+	pruned, err := store.PruneListings(ctx, 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune listings: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("expected the long-gone listing to be pruned, got %d", pruned)
+	}
+}
+
+// A price of 0 is what the parser yields when the feed omits the field — not a
+// car that became free. Letting it overwrite a known price erased the very
+// signal the product exists to track.
+func TestSaveListing_ZeroPriceDoesNotEraseAKnownPrice(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	const chatID = int64(1)
+	rec := storage.ListingRecord{
+		Token:       "priced-car",
+		ChatID:      chatID,
+		SearchID:    1,
+		Price:       75000,
+		Hand:        2,
+		Km:          40000,
+		FirstSeenAt: time.Now(),
+	}
+	if err := store.SaveListing(ctx, rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// A partial payload arrives: price and hand missing (parsed as 0).
+	partial := rec
+	partial.Price = 0
+	partial.Hand = 0
+	partial.Km = 0
+	if err := store.SaveListing(ctx, partial); err != nil {
+		t.Fatalf("save partial: %v", err)
+	}
+
+	got, err := store.GetListing(ctx, chatID, rec.Token)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Price != 75000 {
+		t.Errorf("price was erased by a partial payload: got %d, want 75000", got.Price)
+	}
+	if got.Hand != 2 {
+		t.Errorf("hand was erased by a partial payload: got %d, want 2", got.Hand)
+	}
+	if got.Km != 40000 {
+		t.Errorf("km was erased by a partial payload: got %d, want 40000", got.Km)
+	}
+}
+
+// The guard must not freeze prices: a real price change is the product's core
+// signal and still has to land.
+func TestSaveListing_RealPriceChangeStillLands(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	const chatID = int64(1)
+	rec := storage.ListingRecord{
+		Token:       "dropping-car",
+		ChatID:      chatID,
+		SearchID:    1,
+		Price:       75000,
+		FirstSeenAt: time.Now(),
+	}
+	if err := store.SaveListing(ctx, rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	dropped := rec
+	dropped.Price = 68000 // seller cut the price
+	if err := store.SaveListing(ctx, dropped); err != nil {
+		t.Fatalf("save drop: %v", err)
+	}
+
+	got, err := store.GetListing(ctx, chatID, rec.Token)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Price != 68000 {
+		t.Fatalf("price drop did not land: got %d, want 68000", got.Price)
+	}
+}

--- a/migrations/000031_last_seen_retention.down.sql
+++ b/migrations/000031_last_seen_retention.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_seen_listings_last_seen_at;
+CREATE INDEX IF NOT EXISTS idx_seen_listings_first_seen_at ON seen_listings (first_seen_at);
+
+ALTER TABLE listing_history DROP COLUMN IF EXISTS last_seen_at;
+ALTER TABLE seen_listings DROP COLUMN IF EXISTS last_seen_at;

--- a/migrations/000031_last_seen_retention.up.sql
+++ b/migrations/000031_last_seen_retention.up.sql
@@ -1,0 +1,34 @@
+-- Retention must be keyed on when a listing was LAST seen, not when it was
+-- first seen.
+--
+-- The extension re-pushes every listing that still matches a search on every
+-- 15-minute cycle, and cars sit on Yad2 for months. Pruning a dedup claim by
+-- first_seen_at therefore expired the claim of a listing that was still very
+-- much alive: the next push re-claimed it as new and the user was re-alerted
+-- about a car they had already seen — every storage.prune_after (30d) for as
+-- long as the ad stayed up. listing_history had the same shape at 90d: a live
+-- listing's row was deleted and re-inserted, resetting first_seen_at (so it
+-- resurfaced as "new" in the UI) along with its enrichment counters.
+--
+-- last_seen_at is refreshed on every re-observation (dedup claim / listing
+-- upsert), so retention now measures "gone from the source for N days", which
+-- is what the retention window was always meant to mean.
+
+ALTER TABLE seen_listings
+    ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE listing_history
+    ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Existing rows: the only evidence we have of their last observation is when
+-- they were first seen. Seeding from first_seen_at keeps the new prune's
+-- behaviour identical to the old one for rows nothing has re-observed yet, and
+-- the next ingest cycle refreshes everything that is still live.
+UPDATE seen_listings SET last_seen_at = first_seen_at;
+UPDATE listing_history SET last_seen_at = first_seen_at;
+
+-- The prune is the only reader of seen_listings.first_seen_at, and it now reads
+-- last_seen_at instead; move the index with it. (The composite
+-- idx_seen_listings_chatid_firstseen is left alone — different query shape.)
+DROP INDEX IF EXISTS idx_seen_listings_first_seen_at;
+CREATE INDEX IF NOT EXISTS idx_seen_listings_last_seen_at ON seen_listings (last_seen_at);


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this PR closes the two data-integrity items.

## 1. Users were re-alerted about the same car every 30 days — closes #1492

Cars sit on Yad2 for **months**, and the extension re-pushes every still-matching listing on **every 15-minute cycle**. But a dedup claim (`seen_listings`) was pruned on a fixed timer from **first** sight (`storage.prune_after`, default 30d).

So under a listing that was still very much alive: claim expires → next push re-claims it as *new* → **the user is alerted about a car they already saw**. Then again 30 days later, for as long as the ad stays up.

`listing_history` had the same shape at 90d: a live listing's row was deleted and re-inserted, resetting `first_seen_at` (it resurfaced in the UI as *newly found*) and clearing its enrichment counters.

**Fix:** retention keys on a new `last_seen_at`, refreshed on every re-observation — so the window now means *"gone from the source for N days"*, which is what it always meant to mean. `ClaimNew` touches the row on conflict and uses `RETURNING (xmax = 0)` to still report whether the claim was genuinely new.

## 2. A zero price erased a known price — closes #1500

Every field in `upsertListingSQL` was guarded against empty/zero overwrites **except `price` and `hand`**. But `0` is not a price — it is what the parser yields when the feed row omits the field. Any partial payload wiped the stored price, breaking the `price_only` filter, price sorting, deal scores, and **the price-drop signal itself**.

Real price changes still land (that's the product); only `0` is ignored, and only on *update* — a genuinely price-less listing still inserts as 0. Same for `hand`, which only counts upward.

## Verification

New `internal/storage/postgres/retention_test.go`, run against a real Postgres 17:

- **claim survives the prune while the listing is still being seen, and the next push does not re-alert** ← the actual bug
- a listing genuinely gone from the source still ages out and is pruned (retention still works)
- same pair for `listing_history`
- a partial payload (price/hand/km = 0) does not erase known values
- a real price drop still lands

**The regression guard is not vacuous:** I re-pointed `Prune` at `first_seen_at` (the old behavior) and confirmed the key test fails —
`retention_test.go:60: prune deleted 1 claim(s) for a listing that is still being seen`.

Full `./internal/storage/...`, `./internal/scheduler/...` and the api ingest/dedup tests pass.

## Note for review

Two **existing** tests (`TestPostgres_PruneListings`, `TestPostgres_PruneListingsPreservesSaved`) asserted the *old* semantics — backdate `first_seen_at`, expect deletion. They now age `last_seen_at` instead, preserving their real intent (bookmarked listings survive). That expectation change is deliberate and is the point of the fix; flagging it explicitly since changed test assertions deserve scrutiny.

## Migration

`000031_last_seen_retention` adds `last_seen_at` to both tables, backfills from `first_seen_at` (so behavior is unchanged for rows nothing has re-observed yet), and moves the prune's index. Down migration included.

closes #1492
closes #1500