### PR TITLE
test(ext): put the sole ingestion path under test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
       - 'docker-compose*.yaml'
       - 'web/**'
+      - 'extension/**'
 
 concurrency:
   group: ci-pr-${{ github.event.pull_request.number || github.ref }}
@@ -31,6 +32,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       web: ${{ steps.filter.outputs.web }}
       infra: ${{ steps.filter.outputs.infra }}
+      extension: ${{ steps.filter.outputs.extension }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
@@ -44,6 +46,8 @@ jobs:
               - 'Makefile'
             web:
               - 'web/**'
+            extension:
+              - 'extension/**'
             infra:
               - 'Dockerfile'
               - 'Caddyfile'
@@ -150,6 +154,23 @@ jobs:
         with:
           name: coverage
           path: .coverage/
+
+  extension:
+    name: Extension Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.extension == 'true'
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+      # The extension is the ONLY path listings enter the system by, and its
+      # parser encodes assumptions about a third-party payload that changes
+      # without notice. No npm install: the suite runs on node:test alone.
+      - name: Test
+        run: cd extension && npm test
 
   web:
     name: Web Build

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,17 +1,14 @@
-importScripts("parser.js");
+// lib.js holds the pure logic (feed query, merge, cache, chunking, block/gone
+// classification) so it can be unit-tested without a browser; parser.js turns
+// Yad2's JSON into listings. importScripts puts their functions in this global
+// scope.
+importScripts("lib.js", "parser.js");
 
 const ALARM_NAME = "carwatch-fetch";
 const FETCH_INTERVAL_MINUTES = 15;
 const DEFAULT_API_URL = "https://carwatch.duckdns.org";
 const FETCH_TIMEOUT_MS = 15000;
 
-// Yad2's own gateway JSON API. We call these from within a real yad2.co.il tab
-// (MAIN world) so the request carries the browser's Radware clearance cookie +
-// Chrome TLS fingerprint — the HTML /vehicles/cars route is a Radware challenge
-// shell and cannot be scraped, and a plain background fetch (no browser
-// fingerprint) is blocked. See extension/README notes / parser.js.
-const GW_FEED_URL = "https://gw.yad2.co.il/feed-search-vehicles/cars";
-const GW_ITEM_URL = "https://gw.yad2.co.il/vehicles-item";
 const YAD2_HOME = "https://www.yad2.co.il/";
 
 // Bound per-cycle request volume: one feed call per search, plus at most this
@@ -23,7 +20,6 @@ const MAX_ENRICH_PER_CYCLE = 30;
 // candidate is confirmed against its item page — a 404 means sold/delisted.
 // Bounded per cycle so a large backlog cannot spike our request volume.
 const MAX_VERIFY_PER_CYCLE = 10;
-const KNOWN_TOKENS_CAP = 3000;
 const ENRICH_DELAY_MS = 1500; // jittered inside the injected fetcher
 
 let isRunning = false;
@@ -74,28 +70,6 @@ async function getConfig() {
     apiUrl: data.apiUrl || DEFAULT_API_URL,
     authToken: data.authToken || "",
   };
-}
-
-function buildFeedURL(search) {
-  const params = new URLSearchParams();
-  if (search.manufacturer_id) params.set("manufacturer", search.manufacturer_id);
-  if (search.model_id) params.set("model", search.model_id);
-  if (search.year_min || search.year_max) {
-    params.set("year", `${search.year_min || 2000}-${search.year_max || 2030}`);
-  }
-  if (search.price_min || search.price_max) {
-    params.set("price", `${search.price_min || 0}-${search.price_max || 9999999}`);
-  }
-  if (search.max_km) params.set("km", `-1-${search.max_km}`);
-  if (search.max_hand) params.set("hand", `0-${search.max_hand}`);
-  if (search.engine_min_cc) params.set("engineval", `${search.engine_min_cc}--1`);
-  if (search.seller_filter === "private") params.set("ownerID", "1");
-  else if (["commercial", "dealer"].includes(search.seller_filter))
-    params.set("ownerID", "2");
-  if (search.photo_only) params.set("imgOnly", "1");
-  params.set("Order", "1");
-  params.set("page", "1");
-  return `${GW_FEED_URL}?${params}`;
 }
 
 function sleep(ms) {
@@ -242,29 +216,6 @@ async function fetchViaYad2Tab(tabId, urls) {
   return (results && results[0] && results[0].result) || [];
 }
 
-// A 404/410 from the item endpoint is Yad2 telling us the listing is gone
-// (sold or delisted) — a real answer, not a block. Keep it distinct from
-// looksBlocked: treating it as a block hides removals AND triggers pointless
-// tab reloads.
-function looksGone(r) {
-  return !!r && (r.status === 404 || r.status === 410);
-}
-
-// A response whose body is HTML (Radware "302/verifying" shell) rather than
-// JSON means the tab's clearance lapsed.
-function looksBlocked(r) {
-  if (looksGone(r)) return false;
-  const b = (r && r.body ? r.body : "").trimStart();
-  return r && r.status !== 200 ? true : b.startsWith("<");
-}
-
-// A fetch batch is unusable when executeScript returned nothing (a discarded
-// or broken tab yields an empty array, not looksBlocked-shaped results) or
-// when every result is a block/challenge page. Either warrants a tab reload.
-function batchUnusable(results) {
-  return results.length === 0 || results.every(looksBlocked);
-}
-
 // ---- enrichment cache (token -> resolved item fields) ----------------------
 //
 // Maps a token to the fields we resolved from the item endpoint (km, city,
@@ -280,21 +231,7 @@ async function getEnrichedCache() {
 }
 
 async function saveEnrichedCache(cache) {
-  const tokens = Object.keys(cache);
-  if (tokens.length > KNOWN_TOKENS_CAP) {
-    // Object keys keep insertion order — drop the oldest overflow.
-    for (const t of tokens.slice(0, tokens.length - KNOWN_TOKENS_CAP)) delete cache[t];
-  }
-  await chrome.storage.local.set({ enrichedCache: cache });
-}
-
-// Overlay resolved fields onto a feed listing without wiping known values with
-// blanks/zeros (the feed omits km/city/image; the item endpoint fills them).
-function applyEnrichment(listing, data) {
-  for (const [k, v] of Object.entries(data)) {
-    if (k === "token") continue;
-    if (v !== undefined && v !== "" && v !== 0) listing[k] = v;
-  }
+  await chrome.storage.local.set({ enrichedCache: trimCache(cache) });
 }
 
 function shuffle(a) {
@@ -352,10 +289,8 @@ async function runFetchCycle() {
     setBadge("...", "#888");
 
     const searches = await fetchSearches(config);
-    const activeSearches = searches.filter(
-      (s) => s.active && s.manufacturer_id > 0 && s.model_id > 0,
-    );
-    if (activeSearches.length === 0) {
+    const active = activeSearches(searches);
+    if (active.length === 0) {
       // Nothing to scan, but the extension is alive and will check again on
       // the next alarm — report that schedule so the web countdown stays real.
       const idleCycle = await getScanSchedule(cycleStartedAt);
@@ -367,17 +302,20 @@ async function runFetchCycle() {
 
     const tabId = await ensureYad2Tab();
 
-    // 1) Fetch each search's list feed.
-    let feedResults = await fetchViaYad2Tab(tabId, activeSearches.map(buildFeedURL));
+    // 1) Fetch each search's list feed. NB: the arrow is load-bearing —
+    // `.map(buildFeedURL)` would hand Array.map's index to buildFeedURL's page
+    // argument and request a different page per search.
+    const feedURLs = active.map((s) => buildFeedURL(s));
+    let feedResults = await fetchViaYad2Tab(tabId, feedURLs);
     if (batchUnusable(feedResults)) {
       console.warn("[CarWatch] feed batch unusable (empty or all blocked); reloading yad2 tab and retrying");
       await reloadYad2Tab(tabId);
-      feedResults = await fetchViaYad2Tab(tabId, activeSearches.map(buildFeedURL));
+      feedResults = await fetchViaYad2Tab(tabId, feedURLs);
     }
 
     // Merge into a token->listing map, preferring the row that already has km.
-    const byToken = new Map();
     let blocked = 0;
+    const parsedFeeds = [];
     for (const r of feedResults) {
       if (looksBlocked(r)) {
         blocked++;
@@ -388,11 +326,9 @@ async function runFetchCycle() {
         console.warn("[CarWatch] feed parse:", parsed.error, r.url);
         continue;
       }
-      for (const l of parsed.listings) {
-        const prev = byToken.get(l.token);
-        if (!prev || ((prev.km || 0) <= 0 && (l.km || 0) > 0)) byToken.set(l.token, l);
-      }
+      parsedFeeds.push(parsed.listings);
     }
+    const byToken = mergeFeedListings(parsedFeeds);
 
     // 2) Re-apply everything we've already resolved (self-healing: the km is
     // re-pushed every cycle so a dropped save recovers), then enrich only what
@@ -412,7 +348,7 @@ async function runFetchCycle() {
     // Diagnostics surfaced in the popup so failures are visible without DevTools.
     let itemGot = 0, itemOk = 0, itemBlocked = 0, itemParseErr = 0, gotKm = 0, itemErr = "";
     if (toEnrich.length) {
-      const itemURLs = toEnrich.map((l) => `${GW_ITEM_URL}/${l.token}`);
+      const itemURLs = toEnrich.map((l) => itemURL(l.token));
       let itemResults = await fetchViaYad2Tab(tabId, itemURLs);
       // If the batch was unusable — empty (a discarded/broken tab makes
       // executeScript return nothing) or every result blocked (stale clearance
@@ -462,13 +398,11 @@ async function runFetchCycle() {
     const removedTokens = [];
     let verifyTried = 0;
     if (!blocked) {
-      const candidates = Object.keys(cache).filter((t) => !byToken.has(t));
+      const candidates = removalCandidates(cache, byToken);
       const toVerify = shuffle(candidates).slice(0, MAX_VERIFY_PER_CYCLE);
       verifyTried = toVerify.length;
       if (toVerify.length) {
-        const byURL = new Map(
-          toVerify.map((t) => [`${GW_ITEM_URL}/${t}`, t]),
-        );
+        const byURL = new Map(toVerify.map((t) => [itemURL(t), t]));
         const results = await fetchViaYad2Tab(tabId, [...byURL.keys()]);
         for (const r of results) {
           const token = byURL.get(r.url);
@@ -519,11 +453,6 @@ async function fetchSearches(config) {
   return resp.json();
 }
 
-// The ingest endpoint rejects > 500 listings per request, so push in chunks.
-// A user with many/broad searches can exceed that; without chunking the whole
-// cycle's ingestion would 400 and be lost.
-const MAX_INGEST_BATCH = 400;
-
 async function pushListings(config, listings, removedTokens = [], cycle = null) {
   let last;
   // Removed tokens ride the FIRST chunk only, so a multi-chunk push applies
@@ -535,13 +464,8 @@ async function pushListings(config, listings, removedTokens = [], cycle = null) 
   // chunks that share the same started_at, so repeating it is safe and lets
   // any chunk (including a lost first one) sync the schedule.
   let pendingRemoved = removedTokens;
-  for (let i = 0; i < listings.length; i += MAX_INGEST_BATCH) {
-    last = await pushBatch(
-      config,
-      listings.slice(i, i + MAX_INGEST_BATCH),
-      pendingRemoved,
-      cycle,
-    );
+  for (const chunk of chunkListings(listings)) {
+    last = await pushBatch(config, chunk, pendingRemoved, cycle);
     pendingRemoved = [];
   }
   if (listings.length === 0 && (pendingRemoved.length > 0 || cycle)) {

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -1,0 +1,153 @@
+// Pure logic shared by the service worker, extracted so it can be tested
+// without a browser. Nothing in here may touch chrome.*, fetch, or timers —
+// background.js owns all of that. This is the code whose silent breakage costs
+// real data (wrong feed query, dropped listings, wiped km, wrongly retired
+// cars), so it is the code that gets tests.
+
+// Yad2's own gateway JSON API. Called from within a real yad2.co.il tab so the
+// request carries the browser's Radware clearance cookie + Chrome TLS
+// fingerprint; the HTML route is a challenge shell and a plain background fetch
+// is blocked.
+const GW_FEED_URL = "https://gw.yad2.co.il/feed-search-vehicles/cars";
+const GW_ITEM_URL = "https://gw.yad2.co.il/vehicles-item";
+
+// The ingest endpoint rejects > 500 listings per request, so pushes are
+// chunked. A user with many/broad searches can exceed that; without chunking
+// the whole cycle's ingestion would 400 and be lost.
+const MAX_INGEST_BATCH = 400;
+
+// Bound on the token->fields enrichment cache kept in chrome.storage.local.
+const KNOWN_TOKENS_CAP = 3000;
+
+// Translates a saved search into the gw feed query. Every mismatch here is a
+// silently wrong result set — too-broad (noise) or too-narrow (missed cars) —
+// so the mapping is pinned by tests.
+function buildFeedURL(search, page = 1) {
+  const params = new URLSearchParams();
+  if (search.manufacturer_id) params.set("manufacturer", search.manufacturer_id);
+  if (search.model_id) params.set("model", search.model_id);
+  if (search.year_min || search.year_max) {
+    params.set("year", `${search.year_min || 2000}-${search.year_max || 2030}`);
+  }
+  if (search.price_min || search.price_max) {
+    params.set("price", `${search.price_min || 0}-${search.price_max || 9999999}`);
+  }
+  if (search.max_km) params.set("km", `-1-${search.max_km}`);
+  if (search.max_hand) params.set("hand", `0-${search.max_hand}`);
+  if (search.engine_min_cc) params.set("engineval", `${search.engine_min_cc}--1`);
+  if (search.seller_filter === "private") params.set("ownerID", "1");
+  else if (["commercial", "dealer"].includes(search.seller_filter))
+    params.set("ownerID", "2");
+  if (search.photo_only) params.set("imgOnly", "1");
+  params.set("Order", "1");
+  params.set("page", String(page));
+  return `${GW_FEED_URL}?${params}`;
+}
+
+function itemURL(token) {
+  return `${GW_ITEM_URL}/${token}`;
+}
+
+// A 404/410 from the item endpoint is Yad2 telling us the listing is gone (sold
+// or delisted) — a real answer, not a block. Keep it distinct from looksBlocked:
+// treating it as a block hides removals AND triggers pointless tab reloads.
+function looksGone(r) {
+  return !!r && (r.status === 404 || r.status === 410);
+}
+
+// A response whose body is HTML (Radware "verifying" shell) rather than JSON
+// means the tab's clearance lapsed.
+function looksBlocked(r) {
+  if (looksGone(r)) return false;
+  const b = (r && r.body ? r.body : "").trimStart();
+  return r && r.status !== 200 ? true : b.startsWith("<");
+}
+
+// A fetch batch is unusable when executeScript returned nothing (a discarded or
+// broken tab yields an empty array, not looksBlocked-shaped results) or when
+// every result is a block/challenge page. Either warrants a tab reload.
+function batchUnusable(results) {
+  return results.length === 0 || results.every(looksBlocked);
+}
+
+// Overlay resolved item fields onto a feed listing WITHOUT wiping known values
+// with blanks/zeros: the feed omits km/city/image and the item endpoint fills
+// them, so a missing field must never overwrite a present one.
+function applyEnrichment(listing, data) {
+  for (const [k, v] of Object.entries(data)) {
+    if (k === "token") continue;
+    if (v !== undefined && v !== "" && v !== 0) listing[k] = v;
+  }
+}
+
+// Merge every search's feed into one token -> listing map, preferring the row
+// that already carries km (the same car can appear in several searches' feeds,
+// and only some rows come with km inline).
+function mergeFeedListings(parsedListingsPerFeed) {
+  const byToken = new Map();
+  for (const listings of parsedListingsPerFeed) {
+    for (const l of listings) {
+      const prev = byToken.get(l.token);
+      if (!prev || ((prev.km || 0) <= 0 && (l.km || 0) > 0)) byToken.set(l.token, l);
+    }
+  }
+  return byToken;
+}
+
+// Drop the oldest overflow from the enrichment cache. Object keys keep
+// insertion order, so the first keys are the oldest.
+function trimCache(cache, cap = KNOWN_TOKENS_CAP) {
+  const tokens = Object.keys(cache);
+  if (tokens.length > cap) {
+    for (const t of tokens.slice(0, tokens.length - cap)) delete cache[t];
+  }
+  return cache;
+}
+
+// Tokens we have resolved before that no feed returned this cycle. These are
+// only CANDIDATES for removal — the feed may be partial, and acting on absence
+// alone would retire live listings — so each is confirmed against its item page
+// (404 => gone) before anything is retired.
+function removalCandidates(cache, byToken) {
+  return Object.keys(cache).filter((t) => !byToken.has(t));
+}
+
+// Split a push into ingest-sized chunks. Returns [] for no listings: callers
+// decide whether a listing-less push is still worth sending (it can still carry
+// removals or a schedule report).
+function chunkListings(listings, size = MAX_INGEST_BATCH) {
+  const chunks = [];
+  for (let i = 0; i < listings.length; i += size) {
+    chunks.push(listings.slice(i, i + size));
+  }
+  return chunks;
+}
+
+// Which searches are worth scanning at all.
+function activeSearches(searches) {
+  return (searches || []).filter(
+    (s) => s.active && s.manufacturer_id > 0 && s.model_id > 0,
+  );
+}
+
+// Export for Node-based tests; harmless in the service worker, where these are
+// just globals defined by importScripts.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    GW_FEED_URL,
+    GW_ITEM_URL,
+    MAX_INGEST_BATCH,
+    KNOWN_TOKENS_CAP,
+    buildFeedURL,
+    itemURL,
+    looksGone,
+    looksBlocked,
+    batchUnusable,
+    applyEnrichment,
+    mergeFeedListings,
+    trimCache,
+    removalCandidates,
+    chunkListings,
+    activeSearches,
+  };
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "carwatch-extension",
+  "private": true,
+  "version": "1.5.0",
+  "description": "CarWatch Chrome extension — the sole ingestion path for Yad2 listings",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/extension/tests/fixtures.js
+++ b/extension/tests/fixtures.js
@@ -1,0 +1,93 @@
+// Fixtures shaped like the real gw.yad2.co.il responses.
+//
+// Refresh these whenever Yad2 changes its payload: capture a live response from
+// the DevTools network tab of a yad2 vehicles search (feed) and an item page
+// (item), trim to a couple of entries, and drop it in here. If Yad2's shape
+// changes and these are NOT refreshed, the tests keep passing while production
+// breaks — so treat a parser bug in the wild as a missing fixture.
+
+// GET https://gw.yad2.co.il/feed-search-vehicles/cars?...
+// Ads are grouped into seller buckets; private vs commercial matters for the
+// seller filter. Note `search_fields` is snake_case here (the item endpoint is
+// camelCase) and that most feed rows carry no km.
+const feedResponse = {
+  data: {
+    private: [
+      {
+        token: "priv-1",
+        price: 82000,
+        search_fields: {
+          manufacturer: { id: 27, text: "מאזדה", text_eng: "Mazda" },
+          model: { id: 10514, text: "3", text_eng: "3" },
+          sub_model: { id: 5, text: "1.5 אוט׳ Active" },
+          year: 2019,
+          hand: { id: 2, text: "יד שנייה" },
+          km: 64000,
+          engine_volume: 1500,
+          engine_type: { id: 1, text: "בנזין", text_eng: "Petrol" },
+          body_type: { id: 3, text: "סדאן", text_eng: "Sedan" },
+        },
+        address: { city: { text: "תל אביב" }, area: { text: "תל אביב והמרכז" } },
+        meta_data: { cover_image: "https://img.yad2.co.il/priv-1.jpg", description: "  רכב שמור  " },
+        dates: { start: "2026-07-01T09:00:00", update: "2026-07-14T06:00:00" },
+      },
+      {
+        // No km, no image: the common case the item-detail enrichment exists for.
+        token: "priv-2",
+        price: 0, // seller did not publish a price
+        search_fields: {
+          manufacturer: { id: 27, text: "מאזדה", text_eng: "Mazda" },
+          model: { id: 10514, text: "3" },
+          sub_model: { id: 6, text: "1.6 ידני" }, // manual: no "אוט׳" marker
+          year: 2018,
+          hand: { id: "3" }, // ids sometimes arrive as strings
+        },
+        address: { city: { text: "חיפה" } },
+        meta_data: {},
+        dates: { start: "2026-06-20T11:30:00" },
+      },
+    ],
+    commercial: [
+      {
+        token: "comm-1",
+        price: 91000,
+        search_fields: {
+          manufacturer: { id: 27, text: "מאזדה", text_eng: "Mazda" },
+          model: { id: 10514, text: "3" },
+          sub_model: { id: 7, text: "2.0 אוט׳ Premium" },
+          year: 2020,
+          km: 30000,
+        },
+        address: { city: { text: "ירושלים" } },
+        meta_data: { images: ["https://img.yad2.co.il/comm-1.jpg"] },
+        dates: { start: "2026-07-10T08:00:00" },
+      },
+    ],
+  },
+};
+
+// GET https://gw.yad2.co.il/vehicles-item/{token} — camelCase, and the source
+// of km/city/image for feed rows that lack them.
+const itemResponse = {
+  data: {
+    token: "priv-2",
+    price: 74000,
+    km: 88000,
+    hand: { id: 3 },
+    subModel: { id: 6, text: "1.6 אוט׳ Comfort" },
+    engineVolume: 1600,
+    engineType: { id: 1, text: "בנזין", text_eng: "Petrol" },
+    bodyType: { id: 3, text: "סדאן", text_eng: "Sedan" },
+    vehicleDates: { yearOfProduction: 2018 },
+    address: { city: { text: "חיפה" }, area: { text: "חיפה והצפון" } },
+    metaData: { coverImage: "https://img.yad2.co.il/priv-2.jpg", description: "יד שלישית" },
+    dates: { createdAt: "2026-06-20T11:30:00" },
+  },
+};
+
+// What Radware serves when the tab's clearance has lapsed: an HTML shell, not
+// JSON — and often with a 200 status, which is why the body must be sniffed.
+const radwareChallengeBody =
+  '<html><head><meta http-equiv="refresh" content="0"></head><body>Verifying...</body></html>';
+
+module.exports = { feedResponse, itemResponse, radwareChallengeBody };

--- a/extension/tests/lib.test.js
+++ b/extension/tests/lib.test.js
@@ -1,0 +1,193 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildFeedURL,
+  itemURL,
+  looksGone,
+  looksBlocked,
+  batchUnusable,
+  applyEnrichment,
+  mergeFeedListings,
+  trimCache,
+  removalCandidates,
+  chunkListings,
+  activeSearches,
+} = require("../lib.js");
+
+const params = (url) => new URL(url).searchParams;
+
+test("buildFeedURL maps a search onto the gw query", () => {
+  const p = params(
+    buildFeedURL({
+      manufacturer_id: 27,
+      model_id: 10514,
+      year_min: 2018,
+      year_max: 2021,
+      price_min: 50000,
+      price_max: 90000,
+      max_km: 100000,
+      max_hand: 2,
+      engine_min_cc: 1400,
+      photo_only: true,
+    }),
+  );
+
+  assert.equal(p.get("manufacturer"), "27");
+  assert.equal(p.get("model"), "10514");
+  assert.equal(p.get("year"), "2018-2021");
+  assert.equal(p.get("price"), "50000-90000");
+  assert.equal(p.get("km"), "-1-100000"); // Yad2 wants an open lower bound
+  assert.equal(p.get("hand"), "0-2");
+  assert.equal(p.get("engineval"), "1400--1");
+  assert.equal(p.get("imgOnly"), "1");
+  assert.equal(p.get("page"), "1");
+});
+
+test("buildFeedURL fills open-ended ranges rather than sending a half range", () => {
+  // A search with only an upper bound must still send a complete range, or Yad2
+  // ignores the filter entirely and the user gets unfiltered noise.
+  const p = params(buildFeedURL({ manufacturer_id: 1, model_id: 2, year_max: 2020, price_max: 60000 }));
+  assert.equal(p.get("year"), "2000-2020");
+  assert.equal(p.get("price"), "0-60000");
+});
+
+test("buildFeedURL omits filters that are not set", () => {
+  const p = params(buildFeedURL({ manufacturer_id: 1, model_id: 2 }));
+  for (const key of ["year", "price", "km", "hand", "engineval", "ownerID", "imgOnly"]) {
+    assert.equal(p.get(key), null, `${key} should be absent`);
+  }
+});
+
+test("buildFeedURL translates the seller filter to Yad2's ownerID", () => {
+  assert.equal(params(buildFeedURL({ seller_filter: "private" })).get("ownerID"), "1");
+  assert.equal(params(buildFeedURL({ seller_filter: "commercial" })).get("ownerID"), "2");
+  assert.equal(params(buildFeedURL({ seller_filter: "dealer" })).get("ownerID"), "2");
+  assert.equal(params(buildFeedURL({ seller_filter: "any" })).get("ownerID"), null);
+});
+
+test("buildFeedURL defaults to page 1 even when mapped over an array", () => {
+  // `searches.map(buildFeedURL)` would hand Array.map's index to the page
+  // argument — every search after the first would silently request a different
+  // page. The callers pass an arrow for this reason; this pins the default.
+  const searches = [{ manufacturer_id: 1, model_id: 2 }, { manufacturer_id: 3, model_id: 4 }];
+  const urls = searches.map((s) => buildFeedURL(s));
+  for (const u of urls) assert.equal(params(u).get("page"), "1");
+});
+
+test("looksGone recognises a retired listing, and never confuses it with a block", () => {
+  assert.ok(looksGone({ status: 404 }));
+  assert.ok(looksGone({ status: 410 }));
+  assert.ok(!looksGone({ status: 200 }));
+
+  // A "gone" answer is a real answer: classifying it as a block would hide
+  // removals and trigger pointless tab reloads.
+  assert.ok(!looksBlocked({ status: 404, body: "" }));
+});
+
+test("looksBlocked catches the Radware challenge shell served with a 200", () => {
+  assert.ok(looksBlocked({ status: 200, body: "<html>Verifying...</html>" }));
+  assert.ok(looksBlocked({ status: 200, body: "\n  <!doctype html>" })); // leading whitespace
+  assert.ok(looksBlocked({ status: 403, body: "{}" }));
+  assert.ok(looksBlocked({ status: 0, error: "NetworkError" }));
+  assert.ok(!looksBlocked({ status: 200, body: '{"data":{}}' }));
+});
+
+test("batchUnusable treats an empty result set as unusable", () => {
+  // A discarded/broken tab makes executeScript return nothing at all — not
+  // block-shaped results — and that must still trigger a tab reload.
+  assert.ok(batchUnusable([]));
+  assert.ok(batchUnusable([{ status: 200, body: "<html>" }]));
+  assert.ok(!batchUnusable([{ status: 200, body: "{}" }, { status: 200, body: "<html>" }]));
+});
+
+test("applyEnrichment never overwrites a known value with a blank or zero", () => {
+  const listing = { token: "t", km: 64000, city: "תל אביב", price: 82000 };
+  applyEnrichment(listing, { token: "t", km: 0, city: "", price: 0, image_url: "https://img/x.jpg" });
+
+  assert.equal(listing.km, 64000);
+  assert.equal(listing.city, "תל אביב");
+  assert.equal(listing.price, 82000);
+  assert.equal(listing.image_url, "https://img/x.jpg"); // real value still lands
+});
+
+test("applyEnrichment fills missing values and ignores the token", () => {
+  const listing = { token: "t", km: 0 };
+  applyEnrichment(listing, { token: "OTHER", km: 88000, city: "חיפה" });
+
+  assert.equal(listing.token, "t"); // never reassigned from the payload
+  assert.equal(listing.km, 88000);
+  assert.equal(listing.city, "חיפה");
+});
+
+test("mergeFeedListings prefers the row that already carries km", () => {
+  const withoutKm = { token: "a", km: 0, price: 1 };
+  const withKm = { token: "a", km: 50000, price: 1 };
+
+  // Order must not matter: the same car appears in several searches' feeds and
+  // only some rows come with km inline. Losing it means an extra item fetch at
+  // best, a km-less listing at worst.
+  assert.equal(mergeFeedListings([[withoutKm], [withKm]]).get("a").km, 50000);
+  assert.equal(mergeFeedListings([[withKm], [withoutKm]]).get("a").km, 50000);
+});
+
+test("mergeFeedListings collapses duplicates across feeds", () => {
+  const merged = mergeFeedListings([
+    [{ token: "a", km: 1 }, { token: "b", km: 2 }],
+    [{ token: "b", km: 2 }, { token: "c", km: 3 }],
+  ]);
+  assert.deepEqual([...merged.keys()].sort(), ["a", "b", "c"]);
+});
+
+test("trimCache drops the oldest entries once the cap is passed", () => {
+  const cache = {};
+  for (let i = 0; i < 5; i++) cache[`t${i}`] = { km: i };
+
+  trimCache(cache, 3);
+  assert.deepEqual(Object.keys(cache), ["t2", "t3", "t4"]); // oldest two gone
+});
+
+test("trimCache leaves an under-cap cache alone", () => {
+  const cache = { a: {}, b: {} };
+  trimCache(cache, 10);
+  assert.deepEqual(Object.keys(cache), ["a", "b"]);
+});
+
+test("removalCandidates only proposes tokens the feed stopped returning", () => {
+  const cache = { gone: {}, present: {} };
+  const byToken = new Map([["present", {}], ["new", {}]]);
+
+  // These are candidates ONLY: each is confirmed with a 404 against its item
+  // page before anything is retired, because a feed can be partial.
+  assert.deepEqual(removalCandidates(cache, byToken), ["gone"]);
+});
+
+test("chunkListings keeps a push under the ingest cap", () => {
+  const listings = Array.from({ length: 900 }, (_, i) => ({ token: `t${i}` }));
+  const chunks = chunkListings(listings, 400);
+
+  assert.deepEqual(chunks.map((c) => c.length), [400, 400, 100]);
+  // Nothing may be dropped: the endpoint 400s above its cap, and an unchunked
+  // push would lose the whole cycle's ingestion.
+  assert.equal(chunks.flat().length, 900);
+});
+
+test("chunkListings returns no chunks for an empty push", () => {
+  // The caller still sends a listing-less push when it carries removals or a
+  // schedule report — that decision lives there, not here.
+  assert.deepEqual(chunkListings([]), []);
+});
+
+test("activeSearches skips paused searches and ones with no car selected", () => {
+  const searches = [
+    { id: 1, active: true, manufacturer_id: 27, model_id: 10514 },
+    { id: 2, active: false, manufacturer_id: 27, model_id: 10514 }, // paused
+    { id: 3, active: true, manufacturer_id: 0, model_id: 10514 }, // incomplete
+    { id: 4, active: true, manufacturer_id: 27, model_id: 0 }, // incomplete
+  ];
+  assert.deepEqual(activeSearches(searches).map((s) => s.id), [1]);
+});
+
+test("itemURL builds the item-detail endpoint", () => {
+  assert.equal(itemURL("abc123"), "https://gw.yad2.co.il/vehicles-item/abc123");
+});

--- a/extension/tests/parser.test.js
+++ b/extension/tests/parser.test.js
@@ -1,0 +1,122 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { parseFeed, parseItemDetail } = require("../parser.js");
+const { feedResponse, itemResponse, radwareChallengeBody } = require("./fixtures.js");
+
+test("parseFeed reads every seller bucket and marks commercial correctly", () => {
+  const { listings, error } = parseFeed(JSON.stringify(feedResponse));
+  assert.equal(error, undefined);
+  assert.equal(listings.length, 3);
+
+  const priv = listings.find((l) => l.token === "priv-1");
+  const comm = listings.find((l) => l.token === "comm-1");
+  // The seller filter (private/commercial) is driven entirely by which bucket
+  // the ad came from — get this wrong and users' seller preference silently
+  // inverts.
+  assert.equal(priv.is_commercial, false);
+  assert.equal(comm.is_commercial, true);
+});
+
+test("parseFeed maps the fields the backend filters on", () => {
+  const { listings } = parseFeed(feedResponse); // object form is accepted too
+  const priv = listings.find((l) => l.token === "priv-1");
+
+  assert.equal(priv.manufacturer, "Mazda"); // text_eng preferred
+  assert.equal(priv.manufacturer_id, 27);
+  assert.equal(priv.model_id, 10514);
+  assert.equal(priv.year, 2019);
+  assert.equal(priv.price, 82000);
+  assert.equal(priv.km, 64000);
+  assert.equal(priv.hand, 2);
+  assert.equal(priv.city, "תל אביב");
+  assert.equal(priv.engine_volume, 1500);
+  assert.equal(priv.image_url, "https://img.yad2.co.il/priv-1.jpg");
+  assert.equal(priv.page_link, "https://www.yad2.co.il/vehicles/item/priv-1");
+  assert.equal(priv.description, "רכב שמור"); // trimmed
+});
+
+test("parseFeed derives gearbox from the Hebrew sub-model marker, not English", () => {
+  const { listings } = parseFeed(feedResponse);
+  const auto = listings.find((l) => l.token === "priv-1"); // "1.5 אוט׳ Active"
+  const manual = listings.find((l) => l.token === "priv-2"); // "1.6 ידני"
+
+  // The backend filter matches the exact Hebrew string "אוטומט". Emitting the
+  // item endpoint's English "Automatic" made every enriched listing FAIL the
+  // gearbox filter and get dropped — which is how km stopped saving.
+  assert.equal(auto.gear_box, "אוטומט");
+  // Non-automatics stay empty, which the filter skips (rather than asserting
+  // "manual" and excluding cars whose sub-model text is merely unusual).
+  assert.equal(manual.gear_box, "");
+});
+
+test("parseFeed uses the original publish date, never the feed-wide refresh date", () => {
+  const { listings } = parseFeed(feedResponse);
+  const priv = listings.find((l) => l.token === "priv-1");
+
+  // dates.start is unique per ad; dates.update/rebounce is the feed's
+  // "refreshed" timestamp — using it made every ad look posted today.
+  assert.equal(priv.created_at, "2026-07-01T09:00:00");
+});
+
+test("parseFeed tolerates string ids and missing optional fields", () => {
+  const { listings } = parseFeed(feedResponse);
+  const sparse = listings.find((l) => l.token === "priv-2");
+
+  assert.equal(sparse.hand, 3); // "3" -> 3
+  assert.equal(sparse.km, 0); // absent
+  assert.equal(sparse.image_url, ""); // absent
+  assert.equal(sparse.price, 0); // seller published no price
+  assert.equal(sparse.model, "3"); // falls back to Hebrew text when text_eng is absent
+});
+
+test("parseFeed dedupes a token that appears in more than one bucket", () => {
+  const dup = JSON.parse(JSON.stringify(feedResponse));
+  dup.data.platinum = [dup.data.private[0]];
+
+  const { listings } = parseFeed(dup);
+  const tokens = listings.map((l) => l.token);
+  assert.equal(new Set(tokens).size, tokens.length);
+});
+
+test("parseFeed reports an error instead of inventing listings", () => {
+  assert.ok(parseFeed("not json").error);
+  assert.ok(parseFeed(radwareChallengeBody).error);
+  // A payload with no known buckets is a shape change, not an empty result set:
+  // reporting zero listings here would look like "nothing for sale" and could
+  // mass-retire live cars.
+  assert.ok(parseFeed(JSON.stringify({ data: { unexpected: [] } })).error);
+});
+
+test("parseItemDetail extracts the fields the feed omits", () => {
+  const { fields, error } = parseItemDetail(JSON.stringify(itemResponse));
+  assert.equal(error, undefined);
+
+  assert.equal(fields.token, "priv-2");
+  assert.equal(fields.km, 88000);
+  assert.equal(fields.city, "חיפה");
+  assert.equal(fields.image_url, "https://img.yad2.co.il/priv-2.jpg");
+  assert.equal(fields.price, 74000);
+  assert.equal(fields.year, 2018);
+  assert.equal(fields.hand, 3);
+  assert.equal(fields.gear_box, "אוטומט"); // from the Hebrew subModel marker
+});
+
+test("parseItemDetail returns only present fields, so blanks cannot wipe known values", () => {
+  const bare = { data: { token: "t1", km: 0 } };
+  const { fields } = parseItemDetail(bare);
+
+  assert.equal(fields.token, "t1");
+  assert.equal(fields.km, 0); // explicitly present
+  // Absent fields must be absent from the result, not empty strings: the caller
+  // overlays these onto a feed listing.
+  assert.ok(!("city" in fields));
+  assert.ok(!("image_url" in fields));
+  assert.ok(!("price" in fields));
+});
+
+test("parseItemDetail rejects junk and challenge pages", () => {
+  assert.ok(parseItemDetail("not json").error);
+  assert.ok(parseItemDetail(radwareChallengeBody).error);
+  assert.ok(parseItemDetail(JSON.stringify({ data: {} })).error); // no token
+});


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this PR closes the extension-testing item and unblocks the extension work in #1490 / #1498 / #1499.

## Why

The extension is the **only** way listings enter CarWatch. Its parser encodes assumptions about a third-party payload that changes without notice. It had **zero** tests — `parser.js` even exported `module.exports` *"for Node-based tests"* that never existed.

Worse: **CI never looked at `extension/**` at all.** The workflow's paths filter didn't list it, so a change to the highest-risk code in the system ran *no checks whatsoever*.

## What

**`extension/lib.js`** — pure logic extracted from `background.js` so it can run without a browser: feed-query building, block/gone classification, feed merging, enrichment overlay, cache trimming, removal-candidate selection, push chunking, active-search selection. `background.js` keeps everything touching `chrome.*` / `fetch` / timers and pulls lib.js in via `importScripts`.

**No behaviour change** — this is extraction. Proven by loading the service worker in a sandboxed VM with a stubbed `chrome` API and a real `importScripts`: it loads, and all 14 functions it calls resolve in global scope.

**29 tests** (`node:test` — no dependencies, no `npm install`) covering what silently corrupts data when it breaks:

- the gw feed-query mapping (open-ended ranges, `ownerID` seller mapping, omitted filters)
- **gearbox derived from the Hebrew `אוט׳` marker**, not the item endpoint's English `"Automatic"` — using English made every enriched listing fail the backend gearbox filter and drop its km
- **`dates.start`, not `dates.update`** — the feed-wide refresh date made every ad look posted today
- seller bucket → `is_commercial` (get it wrong and the user's seller preference silently inverts)
- string ids, missing optional fields, cross-bucket duplicate tokens
- blanks/zeros must never overwrite known values (`applyEnrichment`)
- the **Radware challenge shell served with a 200** (body must be sniffed, not just the status)
- an **empty** batch = a discarded tab (must trigger a reload, not look like "no results")
- a shape change with no known buckets is an **error**, not "nothing for sale" — reporting zero listings there could mass-retire live cars
- chunking that must not drop a listing

Fixtures are shaped like real `gw.yad2.co.il` responses, with a note to refresh them from a live capture when Yad2 changes.

## A live hazard this caught

Adding a `page` argument to `buildFeedURL` means `searches.map(buildFeedURL)` would hand **`Array.map`'s index** to it — every search after the first would silently request a *different page*. Callers now pass an arrow, and a test pins the default. Exactly the class of bug this suite exists for.

## CI

New **Extension Tests** job, plus `extension/**` added to the workflow trigger and paths filter (it was missing from both).

```
ℹ tests 29
ℹ pass 29
ℹ fail 0
```

closes #1504