### PR TITLE
fix(api): treat ingest as the trust boundary it is

### DIFF
--- a/internal/api/ingest_validation.go
+++ b/internal/api/ingest_validation.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// The ingest endpoint is a trust boundary, not a private channel. It is
+// reachable by any authenticated user — the extension is merely its expected
+// client — and what it stores is later rendered as links and images in the web
+// UI and embedded in Telegram messages. So an ingested listing is treated as
+// what it is: attacker-controllable text and URLs.
+//
+// Values that fail validation are blanked rather than rejected: a single odd
+// field must not cost the user the whole cycle's listings. The token, which is
+// the listing's identity, is the one exception — a malformed token is dropped.
+
+// Field length caps. Yad2's real values are far below these; the caps exist so
+// a client cannot store megabytes of text per listing (the 1 MB body cap alone
+// would still allow it across many listings) or push a payload that breaks
+// rendering downstream.
+const (
+	maxDescriptionLen = 4000
+	maxNameFieldLen   = 200
+	maxURLLen         = 2048
+)
+
+// yad2TokenRe matches the shape of a Yad2 ad token: an opaque alphanumeric id.
+// Anything else is not a listing identity we can act on — and since the token
+// is what dedup and removal (MarkListingsRemoved) key on, junk here is worse
+// than useless.
+//
+// The character class does the security work (no path separators, quotes,
+// angle brackets, whitespace or non-ASCII); the length bound is deliberately
+// generous. Yad2 has never published its token format and it has changed
+// before, so a tight length would risk silently dropping every real listing the
+// day they lengthen it — the exact failure this validation exists to prevent.
+var yad2TokenRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// validIngestToken reports whether a token can identify a listing.
+func validIngestToken(token string) bool {
+	return yad2TokenRe.MatchString(token)
+}
+
+// allowedListingHosts are the hosts a listing's page may live on. The page_link
+// is presented to the user as *the* link to the ad — in the UI and inside
+// Telegram alerts — so allowing an arbitrary host would let one account deliver
+// a phishing link that arrives wearing CarWatch's own branding.
+var allowedListingHosts = []string{
+	"yad2.co.il",
+}
+
+// allowedImageHosts are the hosts a listing image may be loaded from. A foreign
+// image URL is both an exfiltration beacon (it reports every viewer's IP and
+// user-agent to whoever controls it) and a way to render arbitrary content in
+// the UI.
+var allowedImageHosts = []string{
+	"yad2.co.il",
+	"yit.co.il",
+}
+
+// hostAllowed reports whether host is one of allowed, or a subdomain of one.
+func hostAllowed(host string, allowed []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, a := range allowed {
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeURL returns raw when it is an https URL on an allowed host, and ""
+// otherwise. Empty in, empty out — a listing with no image is normal.
+func sanitizeURL(raw string, allowed []string) string {
+	if raw == "" || len(raw) > maxURLLen {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" {
+		return ""
+	}
+	if !hostAllowed(u.Hostname(), allowed) {
+		return ""
+	}
+	return raw
+}
+
+// truncateRunes caps s at max runes, cutting on a rune boundary so the result
+// is always valid UTF-8 (these fields are Hebrew; a byte-wise cut would corrupt
+// the final character).
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	count := 0
+	for i := range s {
+		count++
+		if count > max {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// sanitizeText trims a free-text field and caps its length. It also strips
+// control characters, which have no place in a listing field and can garble
+// logs and Telegram messages.
+func sanitizeText(s string, max int) string {
+	s = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r // legitimate inside a description
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+	return truncateRunes(strings.TrimSpace(s), max)
+}
+
+// sanitizeIngestListing normalizes one submitted listing in place, returning
+// false when it cannot be stored at all (no usable token).
+func sanitizeIngestListing(l *ingestListing) bool {
+	l.Token = strings.TrimSpace(l.Token)
+	if !validIngestToken(l.Token) {
+		return false
+	}
+
+	l.PageLink = sanitizeURL(l.PageLink, allowedListingHosts)
+	l.ImageURL = sanitizeURL(l.ImageURL, allowedImageHosts)
+
+	l.Manufacturer = sanitizeText(l.Manufacturer, maxNameFieldLen)
+	l.Model = sanitizeText(l.Model, maxNameFieldLen)
+	l.SubModel = sanitizeText(l.SubModel, maxNameFieldLen)
+	l.BodyType = sanitizeText(l.BodyType, maxNameFieldLen)
+	l.City = sanitizeText(l.City, maxNameFieldLen)
+	l.Area = sanitizeText(l.Area, maxNameFieldLen)
+	l.EngineType = sanitizeText(l.EngineType, maxNameFieldLen)
+	l.GearBox = sanitizeText(l.GearBox, maxNameFieldLen)
+	l.Description = sanitizeText(l.Description, maxDescriptionLen)
+
+	return true
+}
+
+// sanitizeRemovedTokens keeps only well-formed tokens. Removal deletes rows, so
+// a malformed token is never worth acting on.
+func sanitizeRemovedTokens(tokens []string) []string {
+	out := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		t = strings.TrimSpace(t)
+		if validIngestToken(t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/api/ingest_validation_test.go
+++ b/internal/api/ingest_validation_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidIngestToken(t *testing.T) {
+	// Yad2's token format is opaque and has changed before, so the length bound
+	// is generous on purpose — the character class is what does the security
+	// work. A tight bound would silently drop every real listing the day Yad2
+	// lengthens its ids.
+	valid := []string{"a", "abc", "abc123", "A1b2C3d4", "tok_en-1", strings.Repeat("a", 64)}
+	for _, tok := range valid {
+		if !validIngestToken(tok) {
+			t.Errorf("token %q should be accepted", tok)
+		}
+	}
+
+	invalid := []string{
+		"",
+		strings.Repeat("a", 65),     // absurdly long
+		"../../etc/passwd",          // path traversal shape
+		"tok en",                    // whitespace
+		"tok'; DROP TABLE--",        // SQL-ish junk
+		"<script>alert(1)</script>", // markup
+		"טוקן",                      // non-ASCII
+	}
+	for _, tok := range invalid {
+		if validIngestToken(tok) {
+			t.Errorf("token %q should be rejected", tok)
+		}
+	}
+}
+
+// page_link is presented as *the* link to the ad — in the web UI and inside
+// Telegram alerts. An arbitrary host there is a phishing link wearing CarWatch's
+// branding, so anything off-Yad2 is dropped.
+func TestSanitizeURL_ListingLink(t *testing.T) {
+	keep := []string{
+		"https://www.yad2.co.il/vehicles/item/abc123",
+		"https://yad2.co.il/vehicles/item/abc123",
+	}
+	for _, u := range keep {
+		if got := sanitizeURL(u, allowedListingHosts); got != u {
+			t.Errorf("legitimate listing link %q was rejected (got %q)", u, got)
+		}
+	}
+
+	drop := []string{
+		"https://evil.example.com/phish",
+		"https://yad2.co.il.evil.com/phish",  // suffix-confusion
+		"https://notyad2.co.il/phish",        // must not match on a bare substring
+		"http://www.yad2.co.il/vehicles/x",   // plaintext
+		"javascript:alert(1)",                // scheme abuse
+		"data:text/html;base64,PHNjcmlwdD4=", // inline payload
+		"//evil.com/x",                       // scheme-relative
+	}
+	for _, u := range drop {
+		if got := sanitizeURL(u, allowedListingHosts); got != "" {
+			t.Errorf("hostile listing link %q was accepted as %q", u, got)
+		}
+	}
+}
+
+func TestSanitizeURL_Image(t *testing.T) {
+	// The real Yad2 image host.
+	const real = "https://img.yad2.co.il/Pic/202607/car.jpeg"
+	if got := sanitizeURL(real, allowedImageHosts); got != real {
+		t.Errorf("real Yad2 image host was rejected: %q", got)
+	}
+	// A foreign image is an exfiltration beacon: it reports every viewer's IP
+	// and user-agent to whoever controls it.
+	if got := sanitizeURL("https://tracker.example.com/beacon.png", allowedImageHosts); got != "" {
+		t.Errorf("foreign image host was accepted as %q", got)
+	}
+	// Absurdly long URLs are rejected outright.
+	if got := sanitizeURL("https://img.yad2.co.il/"+strings.Repeat("a", maxURLLen), allowedImageHosts); got != "" {
+		t.Errorf("over-long URL was accepted as %q", got)
+	}
+}
+
+func TestSanitizeText_CapsLengthOnRuneBoundaries(t *testing.T) {
+	// These fields are Hebrew; a byte-wise cut would corrupt the final rune.
+	long := strings.Repeat("א", maxDescriptionLen+500)
+	got := sanitizeText(long, maxDescriptionLen)
+
+	if !isValidUTF8(got) {
+		t.Fatal("truncation produced invalid UTF-8")
+	}
+	if n := len([]rune(got)); n != maxDescriptionLen {
+		t.Fatalf("expected %d runes, got %d", maxDescriptionLen, n)
+	}
+}
+
+func TestSanitizeText_StripsControlCharactersButKeepsNewlines(t *testing.T) {
+	got := sanitizeText("clean\x00text\x07here\nsecond line", maxDescriptionLen)
+	if strings.ContainsAny(got, "\x00\x07") {
+		t.Errorf("control characters survived: %q", got)
+	}
+	if !strings.Contains(got, "\nsecond line") {
+		t.Errorf("newlines should survive inside a description: %q", got)
+	}
+}
+
+func TestSanitizeIngestListing(t *testing.T) {
+	t.Run("keeps a legitimate listing intact", func(t *testing.T) {
+		l := ingestListing{
+			Token:        "abc123",
+			Manufacturer: "Mazda",
+			Model:        "3",
+			City:         "תל אביב",
+			PageLink:     "https://www.yad2.co.il/vehicles/item/abc123",
+			ImageURL:     "https://img.yad2.co.il/Pic/car.jpeg",
+			Description:  "רכב שמור",
+		}
+		if !sanitizeIngestListing(&l) {
+			t.Fatal("a legitimate listing was dropped")
+		}
+		if l.PageLink == "" || l.ImageURL == "" || l.City != "תל אביב" {
+			t.Fatalf("legitimate fields were mangled: %+v", l)
+		}
+	})
+
+	t.Run("blanks hostile URLs but keeps the listing", func(t *testing.T) {
+		l := ingestListing{
+			Token:    "abc123",
+			PageLink: "https://evil.example.com/phish",
+			ImageURL: "https://tracker.example.com/beacon.png",
+			Model:    "3",
+		}
+		// One bad field must not cost the user the whole cycle's listings.
+		if !sanitizeIngestListing(&l) {
+			t.Fatal("listing was dropped when blanking the bad fields would do")
+		}
+		if l.PageLink != "" {
+			t.Errorf("phishing page_link survived: %q", l.PageLink)
+		}
+		if l.ImageURL != "" {
+			t.Errorf("beacon image_url survived: %q", l.ImageURL)
+		}
+		if l.Model != "3" {
+			t.Errorf("good field was lost: %q", l.Model)
+		}
+	})
+
+	t.Run("drops a listing with no usable token", func(t *testing.T) {
+		// The token is the listing's identity — it is what dedup and removal key
+		// on — so junk there is worse than useless.
+		l := ingestListing{Token: "'; DROP TABLE listing_history--"}
+		if sanitizeIngestListing(&l) {
+			t.Fatal("listing with a malformed token was accepted")
+		}
+	})
+}
+
+func TestSanitizeRemovedTokens(t *testing.T) {
+	// Removal deletes rows: only well-formed tokens are ever acted on.
+	got := sanitizeRemovedTokens([]string{"abc123", "", "../../x", "def456", "<script>"})
+	want := []string{"abc123", "def456"}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func isValidUTF8(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -325,10 +325,22 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The ingest endpoint is a trust boundary: any authenticated user can post
+	// to it, and what lands here is later rendered as links and images in the UI
+	// and embedded in Telegram alerts. Sanitize before anything is persisted.
+	// Bad fields are blanked rather than failing the push (one odd value must
+	// not cost the user the cycle's listings); an unusable token drops the row.
+	droppedTokens := 0
+	rejectedURLs := 0
 	raw := make([]model.RawListing, 0, len(req.Listings))
 	for _, l := range req.Listings {
-		if l.Token == "" {
+		hadPageLink, hadImage := l.PageLink != "", l.ImageURL != ""
+		if !sanitizeIngestListing(&l) {
+			droppedTokens++
 			continue
+		}
+		if (hadPageLink && l.PageLink == "") || (hadImage && l.ImageURL == "") {
+			rejectedURLs++
 		}
 		rl := model.RawListing{
 			Token:          l.Token,
@@ -439,7 +451,8 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 	// saved, so a removal failure must not fail the push.
 	removed := int64(0)
 	if len(req.RemovedTokens) > 0 {
-		tokens := req.RemovedTokens
+		// Removal deletes rows, so only well-formed tokens are ever acted on.
+		tokens := sanitizeRemovedTokens(req.RemovedTokens)
 		if len(tokens) > maxRemovedTokensPerIngest {
 			log.Warn("ingest sent more removed tokens than the cap, truncating",
 				"submitted", len(tokens), "cap", maxRemovedTokensPerIngest)
@@ -461,9 +474,22 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 		Notifications:   notified,
 	}, log)
 
+	// Rejected URLs are worth shouting about rather than silently blanking: the
+	// benign explanation is a hostile/buggy client, but the alarming one is that
+	// Yad2 moved its image CDN to a host the allowlist does not know — which
+	// would blank every listing photo at once. Same for dropped tokens: a sudden
+	// spike means the token format changed under us.
+	if rejectedURLs > 0 || droppedTokens > 0 {
+		log.Warn("ingest rejected some listing fields",
+			"rejected_urls", rejectedURLs, "dropped_tokens", droppedTokens,
+			"submitted", len(req.Listings),
+			"hint", "a spike here can mean Yad2 changed its link/image hosts or token format")
+	}
+
 	log.Info("ingest complete",
 		"submitted", len(req.Listings), "parsed_with_km", parsedWithKm,
 		"parsed", len(raw), "saved", totalSaved,
+		"dropped_tokens", droppedTokens, "rejected_urls", rejectedURLs,
 		"removed_reported", len(req.RemovedTokens), "removed_deleted", removed)
 
 	writeJSON(w, http.StatusOK, ingestResponse{


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this PR closes the ingest-validation item.

## The problem

`POST /api/v1/ext/ingest` accepted **arbitrary strings** for `page_link`, `image_url` and every text field, with only the global 1 MB body cap in the way. The endpoint is reachable by **any authenticated user** — the extension is merely its *expected* client — and what it stores is later rendered as links and images in the web UI and **embedded in Telegram alerts**.

- **`page_link` was a phishing vector.** A hostile client could store a link to any host, and it would reach the user as *the* link to the ad — wearing CarWatch's branding, inside a notification they trust.
- **`image_url` was an exfiltration beacon.** A foreign image reports every viewer's IP and user-agent to whoever serves it. (The SPA's CSP is `img-src … https:`, so the browser would happily load it — the allowlist here *is* the defense.)
- **Text fields were unbounded.**

## The fix

| field | rule |
|---|---|
| `page_link` | https on `yad2.co.il` (or a subdomain) |
| `image_url` | https on a Yad2 image host (`img.yad2.co.il` is the real one) |
| text fields | capped + control characters stripped |
| `token` | opaque id charset; unusable token ⇒ listing dropped |
| `removed_tokens` | validated — they *delete rows* |

Bad fields are **blanked, not rejected**: one odd value must not cost the user the whole cycle's listings. Truncation cuts on **rune** boundaries — these fields are Hebrew, and a byte-wise cut corrupts the final character.

## Two deliberate choices worth reviewing

**The token bound is loose on purpose** (`[A-Za-z0-9_-]{1,64}`). The character class does the security work — no path separators, quotes, angle brackets, whitespace, or non-ASCII. Yad2 has never published its token format and has changed it before, so a *tight* rule would silently drop every real listing the day they lengthen their ids — the exact class of failure this validation exists to prevent.

**Rejections are logged with a hint**, for the same reason: a spike in rejected URLs most likely means **Yad2 moved its image CDN**, not an attack. That must be visible rather than blanking every listing photo in silence.

## Verification

New `internal/api/ingest_validation_test.go`: suffix-confusion hosts (`yad2.co.il.evil.com`), substring hosts (`notyad2.co.il`), `javascript:`/`data:`/scheme-relative URLs, plaintext http, over-long URLs, control characters, rune-boundary truncation of Hebrew text, SQL/markup/traversal tokens, and — importantly — that **legitimate listings pass through untouched**.

Full `./internal/api/` suite (282s) and the **complete e2e suite including the extension ingest path** pass.

closes #1501