### PR TITLE
feat(ext,api): give the extension its own long-lived, revocable credential

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -64,12 +64,43 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
 });
 
+// The extension's own credential (cwx_…), issued by the backend and stored in
+// chrome.storage.local — never .sync, which would roam a live bearer token
+// through Google's servers to every profile the user is signed into.
+//
+// It supersedes the old scheme of borrowing the web app's Firebase ID token:
+// that token expires in about an hour and cannot be refreshed here, so scanning
+// silently stopped roughly an hour after the user closed their last CarWatch
+// tab — and since this extension is the only way listings enter CarWatch,
+// "silently stopped" meant the whole product stopped.
+//
+// The legacy Firebase token is still accepted as a fallback so an extension
+// that updates before the user next opens the site keeps working until the
+// bridge can exchange it.
 async function getConfig() {
-  const data = await chrome.storage.sync.get(["apiUrl", "authToken"]);
+  const local = await chrome.storage.local.get(["deviceToken"]);
+  const synced = await chrome.storage.sync.get(["apiUrl", "authToken"]);
   return {
-    apiUrl: data.apiUrl || DEFAULT_API_URL,
-    authToken: data.authToken || "",
+    apiUrl: synced.apiUrl || DEFAULT_API_URL,
+    authToken: local.deviceToken || synced.authToken || "",
+    isDeviceToken: !!local.deviceToken,
   };
+}
+
+// A credential the server rejected is worthless: drop it so the next visit to
+// the site mints a fresh one, and say so plainly in the popup. Silence here is
+// what made the original bug so hard to see.
+async function handleAuthFailure(config) {
+  if (config.isDeviceToken) {
+    await chrome.storage.local.remove(["deviceToken", "deviceTokenExpiresAt"]);
+  } else {
+    await chrome.storage.sync.remove(["authToken"]);
+  }
+  setBadge("!", "#F44");
+  await saveStatus({
+    error: "Extension disconnected — open carwatch.duckdns.org while logged in to reconnect",
+    disconnected: true,
+  });
 }
 
 function sleep(ms) {
@@ -282,13 +313,28 @@ async function runFetchCycle() {
     const config = await getConfig();
     if (!config.authToken) {
       setBadge("!", "#F44");
-      await saveStatus({ error: "No auth token — open carwatch.duckdns.org while logged in" });
+      await saveStatus({
+        error: "Not connected — open carwatch.duckdns.org while logged in",
+        disconnected: true,
+      });
       return;
     }
 
     setBadge("...", "#888");
 
-    const searches = await fetchSearches(config);
+    let searches;
+    try {
+      searches = await fetchSearches(config);
+    } catch (err) {
+      // A rejected credential must NOT look like "you have no searches" — that
+      // conflation is exactly what let scanning die in silence for an hour
+      // after the last CarWatch tab closed.
+      if (err instanceof AuthError) {
+        await handleAuthFailure(config);
+        return;
+      }
+      throw err;
+    }
     const active = activeSearches(searches);
     if (active.length === 0) {
       // Nothing to scan, but the extension is alive and will check again on
@@ -463,17 +509,31 @@ async function runFetchCycle() {
     });
   } catch (err) {
     console.error("[CarWatch] Cycle error:", err);
-    setBadge("!", "#F44");
-    await saveStatus({ error: err.message });
+    if (err instanceof AuthError) {
+      await handleAuthFailure(await getConfig());
+    } else {
+      setBadge("!", "#F44");
+      await saveStatus({ error: err.message });
+    }
   } finally {
     isRunning = false;
   }
 }
 
+// Raised when the server rejects our credential. Distinct from any other
+// failure: it is the one error whose fix is "reconnect", not "retry".
+class AuthError extends Error {}
+
+// /ext/searches, not /searches: the extension's routes are the only ones that
+// accept a cwx_ credential, so the token's scope is enforced by the router
+// rather than by an allowlist someone has to remember to maintain.
 async function fetchSearches(config) {
-  const resp = await fetchWithTimeout(`${config.apiUrl}/api/v1/searches`, {
+  const resp = await fetchWithTimeout(`${config.apiUrl}/api/v1/ext/searches`, {
     headers: { Authorization: `Bearer ${config.authToken}` },
   });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new AuthError(`searches API rejected our token (${resp.status})`);
+  }
   if (!resp.ok) throw new Error(`searches API returned ${resp.status}`);
   return resp.json();
 }
@@ -522,6 +582,10 @@ async function pushBatch(config, listings, removedTokens = [], cycle = null) {
       const result = await resp.json();
       console.log("[CarWatch] Ingest result:", result);
       return result;
+    }
+    if (resp.status === 401 || resp.status === 403) {
+      // Retrying a rejected credential just burns the retry budget.
+      throw new AuthError(`ingest rejected our token (${resp.status})`);
     }
     if (attempt === 2) {
       const text = await resp.text();

--- a/extension/bridge.js
+++ b/extension/bridge.js
@@ -1,10 +1,91 @@
-// Bridge script running in ISOLATED world.
-// Listens for auth token messages from the MAIN world content script
-// and saves them to chrome.storage.sync.
+// Bridge script running in the ISOLATED world.
+//
+// It receives the page's short-lived Firebase token from content.js and trades
+// it, once, for the extension's OWN long-lived credential (POST /ext/token).
+// That exchange is the whole reason the extension keeps scanning after the last
+// CarWatch tab is closed: a Firebase ID token expires in about an hour and the
+// extension cannot refresh one, so borrowing it meant scanning silently died an
+// hour after the user navigated away.
+//
+// Everything crossing the page boundary is treated as hostile input:
+//
+//   - only messages from THIS window and THIS origin are considered (a message
+//     from an iframe, or a page on another origin, is not our web app);
+//   - the payload's shape is checked before use, so a script on the page cannot
+//     poison the extension's stored credential with junk;
+//   - the credential is written to chrome.storage.local, never .sync — sync
+//     roams a live bearer token through Google's servers to every Chrome profile
+//     the user is signed into, which is a lot of surface for a secret this
+//     powerful.
+
+const EXPECTED_ORIGIN = "https://carwatch.duckdns.org";
+
+// A Firebase ID token is a JWT: three dot-separated base64url segments. Pinning
+// the shape means a page script cannot hand us an arbitrary string and have the
+// extension send it anywhere.
+const JWT_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+function isTrustedMessage(event) {
+  if (event.source !== window) return false;
+  // event.origin is set by the browser and cannot be forged by page script.
+  if (event.origin !== window.location.origin) return false;
+  if (window.location.origin !== EXPECTED_ORIGIN) return false;
+  return true;
+}
+
+function looksLikeFirebaseToken(token) {
+  return typeof token === "string" && token.length < 4096 && JWT_RE.test(token);
+}
+
+// Exchange the page's Firebase token for our own credential. Runs at most once
+// per page load, and only when we do not already hold a working token.
+async function exchangeForDeviceToken(firebaseToken) {
+  const { deviceToken } = await chrome.storage.local.get("deviceToken");
+  if (deviceToken) return; // already connected
+
+  const resp = await fetch(`${EXPECTED_ORIGIN}/api/v1/ext/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${firebaseToken}`,
+    },
+    body: JSON.stringify({ label: navigator.userAgent.slice(0, 100) }),
+  });
+  if (!resp.ok) {
+    console.warn("[CarWatch] extension token exchange failed:", resp.status);
+    return;
+  }
+
+  const data = await resp.json();
+  if (!data || typeof data.token !== "string" || !data.token.startsWith("cwx_")) {
+    console.warn("[CarWatch] extension token exchange returned an unexpected payload");
+    return;
+  }
+
+  await chrome.storage.local.set({
+    deviceToken: data.token,
+    deviceTokenExpiresAt: data.expires_at || null,
+  });
+  // The borrowed Firebase token has done its job; do not keep a copy of it.
+  await chrome.storage.local.remove("authToken");
+  await chrome.storage.sync.remove(["authToken"]);
+  console.log("[CarWatch] extension connected with its own token");
+}
+
+let exchanging = false;
 
 window.addEventListener("message", (event) => {
-  if (event.source !== window) return;
-  if (event.data?.type === "CW_AUTH_TOKEN" && event.data.token) {
-    chrome.storage.sync.set({ authToken: event.data.token });
-  }
+  if (!isTrustedMessage(event)) return;
+
+  const data = event.data;
+  if (!data || data.type !== "CW_AUTH_TOKEN") return;
+  if (!looksLikeFirebaseToken(data.token)) return;
+
+  if (exchanging) return;
+  exchanging = true;
+  exchangeForDeviceToken(data.token)
+    .catch((err) => console.warn("[CarWatch] token exchange error:", err))
+    .finally(() => {
+      exchanging = false;
+    });
 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,6 +1,12 @@
 // Content script running in MAIN world (same context as the page).
-// Intercepts fetch() to capture the Firebase Bearer token from API calls
-// and posts it via window.postMessage for the bridge script to pick up.
+//
+// Intercepts fetch() to capture the Firebase Bearer token the CarWatch web app
+// sends to its own API, and hands it to the bridge (ISOLATED world) via
+// postMessage. That token is short-lived and is used exactly once: the bridge
+// exchanges it for the extension's own long-lived credential.
+//
+// The target origin is location.origin, never "*": a wildcard broadcasts a live
+// bearer token to every frame on the page, including any third-party iframe.
 
 const API_PATH = "/api/v1/";
 const originalFetch = window.fetch;
@@ -21,10 +27,17 @@ window.fetch = function (...args) {
       }
 
       if (authHeader && authHeader.startsWith("Bearer ")) {
-        window.postMessage(
-          { type: "CW_AUTH_TOKEN", token: authHeader.slice(7) },
-          "*",
-        );
+        const token = authHeader.slice(7);
+        // Never re-broadcast our own credential: the extension's requests do not
+        // go through this page, but a future one might, and a cwx_ token is
+        // long-lived — leaking it to the page would be far worse than leaking a
+        // Firebase token that expires within the hour.
+        if (!token.startsWith("cwx_")) {
+          window.postMessage(
+            { type: "CW_AUTH_TOKEN", token },
+            window.location.origin,
+          );
+        }
       }
     }
   } catch {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "CarWatch Scraper",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Fetches Yad2 listings via its gateway JSON API (from a real yad2 tab) and pushes them to CarWatch",
   "permissions": ["alarms", "storage", "scripting", "tabs"],
   "host_permissions": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carwatch-extension",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "CarWatch Chrome extension — the sole ingestion path for Yad2 listings",
   "scripts": {
     "test": "node --test tests/*.test.js"

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -36,6 +36,9 @@
     button:hover { filter: brightness(0.96); } button:disabled { opacity: .55; cursor: default; }
     .row { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--muted); margin-top: 10px; }
     .err { color: var(--err); font-size: 12px; margin-top: 8px; display: none; }
+    /* A disconnected extension scans nothing until the user acts, so it reads
+       as a call to action rather than as one more warning line. */
+    .err.disconnected { font-weight: 600; line-height: 1.45; }
     .toggle { font-size: 11px; color: var(--accent); cursor: pointer; user-select: none; }
     .diag { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 10px;
       color: var(--muted); background: var(--card); border: 1px solid var(--border); border-radius: 7px;
@@ -71,7 +74,7 @@
   </div>
   <div class="err" id="err"></div>
   <div class="diag" id="diag">no data yet</div>
-  <div class="hint" id="hint">Not authenticated — open <b>carwatch.duckdns.org</b> while logged in so the token is captured, then Fetch&nbsp;Now.</div>
+  <div class="hint" id="hint">Not connected — open <b>carwatch.duckdns.org</b> while logged in. The extension then gets its own token and keeps scanning even after you close the tab.</div>
 
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -29,13 +29,18 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 async function refresh() {
+  // The extension's own credential (chrome.storage.local.deviceToken) is the
+  // real signal now. The legacy borrowed Firebase token in .sync is only a
+  // fallback for an extension that has updated but not yet had a chance to
+  // exchange it, so it still counts as "connected" until it does.
+  const { deviceToken } = await chrome.storage.local.get(["deviceToken"]);
   const { authToken } = await chrome.storage.sync.get(["authToken"]);
-  const authed = !!authToken;
+  const authed = !!(deviceToken || authToken);
   el("authDot").className = "dot " + (authed ? "ok" : "warn");
   el("hint").style.display = authed ? "none" : "block";
 
   const d = await chrome.storage.local.get([
-    "lastRun", "searches", "listings", "enriched", "diag", "error",
+    "lastRun", "searches", "listings", "enriched", "diag", "error", "disconnected",
   ]);
   el("sSearches").textContent = d.searches ?? "—";
   el("sListings").textContent = d.listings ?? "—";
@@ -47,9 +52,14 @@ async function refresh() {
 
   if (d.error) {
     el("err").style.display = "block";
-    el("err").textContent = "⚠ " + d.error;
+    // "Disconnected" is not just another error: nothing will be scanned until
+    // the user acts, and the whole point of this state existing is that the old
+    // extension failed here in total silence.
+    el("err").textContent = (d.disconnected ? "🔌 " : "⚠ ") + d.error;
+    el("err").classList.toggle("disconnected", !!d.disconnected);
   } else {
     el("err").style.display = "none";
+    el("err").classList.remove("disconnected");
   }
 
   tickCountdown();

--- a/extension/tests/bridge.test.js
+++ b/extension/tests/bridge.test.js
@@ -1,0 +1,139 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+// bridge.js runs in the extension's ISOLATED world and is the security boundary
+// where the page hands the extension a credential. It is not a module, so it is
+// loaded into a sandbox with a fake window + chrome, and its message handler is
+// exercised the way the browser would deliver a postMessage event.
+
+function loadBridge({ origin = "https://carwatch.duckdns.org", storage = {}, fetchImpl } = {}) {
+  const listeners = [];
+  const calls = { fetch: [], setLocal: [], removeLocal: [], removeSync: [] };
+
+  const chromeStorageLocal = {
+    async get(keys) {
+      const out = {};
+      for (const k of [].concat(keys)) if (k in storage) out[k] = storage[k];
+      return out;
+    },
+    async set(obj) {
+      calls.setLocal.push(obj);
+      Object.assign(storage, obj);
+    },
+    async remove(keys) {
+      calls.removeLocal.push(keys);
+    },
+  };
+
+  const sandbox = {
+    console: { log() {}, warn() {} },
+    JSON,
+    navigator: { userAgent: "TestBrowser/1.0" },
+    window: {
+      location: { origin },
+      addEventListener(type, fn) {
+        if (type === "message") listeners.push(fn);
+      },
+    },
+    chrome: {
+      storage: {
+        local: chromeStorageLocal,
+        sync: { async remove(keys) { calls.removeSync.push(keys); } },
+      },
+    },
+    fetch:
+      fetchImpl ||
+      (async (url, opts) => {
+        calls.fetch.push({ url, opts });
+        return {
+          ok: true,
+          async json() {
+            return { token: "cwx_new-device-token", expires_at: "2027-01-01T00:00:00Z" };
+          },
+        };
+      }),
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(__dirname, "..", "bridge.js"), "utf8"), sandbox);
+  const windowRef = sandbox.window;
+
+  // Deliver a message the way the browser does, populating event.origin.
+  const dispatch = async (event) => {
+    for (const fn of listeners) await fn(event);
+    // give the async exchange a tick to run
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+  };
+  return { dispatch, calls, storage, windowRef };
+}
+
+const firebaseToken = "aaa.bbb.ccc"; // JWT shape
+
+test("ignores a message whose source is not the window (e.g. an iframe)", async () => {
+  const bridge = loadBridge();
+  await bridge.dispatch({
+    source: {}, // not === window
+    origin: "https://carwatch.duckdns.org",
+    data: { type: "CW_AUTH_TOKEN", token: firebaseToken },
+  });
+  assert.equal(bridge.calls.fetch.length, 0, "a message from a foreign source must be ignored");
+});
+
+test("ignores a message whose origin is not our own", async () => {
+  const bridge = loadBridge();
+  // event.source === window but origin is an attacker's page.
+  await bridge.dispatch(makeEvent(bridge, { origin: "https://evil.example.com", token: firebaseToken }));
+  assert.equal(bridge.calls.fetch.length, 0, "a cross-origin message must never trigger an exchange");
+});
+
+test("ignores a token that is not JWT-shaped", async () => {
+  const bridge = loadBridge();
+  await bridge.dispatch(makeEvent(bridge, { token: "not-a-jwt" }));
+  assert.equal(bridge.calls.fetch.length, 0, "a malformed token must not be sent anywhere");
+});
+
+test("ignores the wrong message type", async () => {
+  const bridge = loadBridge();
+  await bridge.dispatch(makeEvent(bridge, { type: "SOMETHING_ELSE", token: firebaseToken }));
+  assert.equal(bridge.calls.fetch.length, 0);
+});
+
+test("performs the exchange and stores the device token in local, not sync", async () => {
+  const bridge = loadBridge();
+  await bridge.dispatch(makeEvent(bridge, { token: firebaseToken }));
+
+  assert.equal(bridge.calls.fetch.length, 1, "exactly one exchange call");
+  const call = bridge.calls.fetch[0];
+  assert.match(call.url, /\/api\/v1\/ext\/token$/);
+  assert.equal(call.opts.method, "POST");
+  assert.match(call.opts.headers.Authorization, /^Bearer aaa\.bbb\.ccc$/);
+
+  assert.equal(bridge.storage.deviceToken, "cwx_new-device-token", "device token stored in local");
+  assert.ok(bridge.calls.removeSync.length > 0, "the borrowed Firebase token is purged from sync");
+});
+
+test("does not exchange again when a device token already exists", async () => {
+  const bridge = loadBridge({ storage: { deviceToken: "cwx_existing" } });
+  await bridge.dispatch(makeEvent(bridge, { token: firebaseToken }));
+  assert.equal(bridge.calls.fetch.length, 0, "already connected — no second exchange");
+});
+
+test("does not store a payload that is not a cwx_ token", async () => {
+  const bridge = loadBridge({
+    fetchImpl: async () => ({ ok: true, async json() { return { token: "not-a-device-token" }; } }),
+  });
+  await bridge.dispatch(makeEvent(bridge, { token: firebaseToken }));
+  assert.equal(bridge.storage.deviceToken, undefined, "a non-cwx_ response must be rejected");
+});
+
+// makeEvent builds a browser-shaped MessageEvent with event.source === window.
+function makeEvent(bridge, { type = "CW_AUTH_TOKEN", origin = "https://carwatch.duckdns.org", token } = {}) {
+  return {
+    source: bridge.windowRef, // event.source === window: the message is from this page
+    origin,
+    data: { type, token },
+  };
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -87,6 +87,7 @@ type Server struct {
 	cycleStats storage.SearchCycleStatsStore
 	activity   storage.SearchActivityStore
 	extStatus  storage.ExtScanStatusStore
+	extTokens  storage.ExtTokenStore
 	removalBud *removalBudget
 	vitals     *vitalsRing
 
@@ -153,7 +154,11 @@ type Config struct {
 	// ExtScanStatus persists the extension's self-reported scan schedule so
 	// /scheduler/status can serve the real "next scan" time. Optional: nil
 	// falls back to estimating from the scheduler cycle log.
-	ExtScanStatus   storage.ExtScanStatusStore
+	ExtScanStatus storage.ExtScanStatusStore
+	// ExtTokens issues the browser extension its own long-lived, revocable
+	// credential. Optional: nil keeps the legacy behaviour where the extension
+	// borrows the web session's Firebase token (which expires in ~1h).
+	ExtTokens       storage.ExtTokenStore
 	PriceListSvc    *pricelist.Service
 	PollingInterval time.Duration
 	Bind            string
@@ -233,6 +238,7 @@ func New(c Config) *Server {
 		cycleStats:      c.SearchCycleStats,
 		activity:        c.Activity,
 		extStatus:       c.ExtScanStatus,
+		extTokens:       c.ExtTokens,
 		pollingInterval: c.PollingInterval,
 		vitals:          newVitalsRing(),
 		removalBud:      newRemovalBudget(),
@@ -299,7 +305,14 @@ func (s *Server) Routes() http.Handler {
 	authMux.HandleFunc("POST /api/v1/searches/{id}/refresh", s.refreshListings)
 	authMux.HandleFunc("GET /api/v1/listings/{token}", s.getListing)
 	authMux.HandleFunc("GET /api/v1/listings/{token}/price-history", s.listingPriceHistory)
-	authMux.HandleFunc("POST /api/v1/ext/ingest", s.ingestListings)
+
+	// Minting and revoking an extension credential require a real login — that
+	// is the whole point — so they live behind strict auth, not on the ext mux.
+	if s.extTokens != nil {
+		authMux.HandleFunc("POST /api/v1/ext/token", s.createExtToken)
+		authMux.HandleFunc("GET /api/v1/ext/token", s.listExtTokensHandler)
+		authMux.HandleFunc("DELETE /api/v1/ext/token", s.revokeExtTokens)
+	}
 
 	if s.cycleStats != nil {
 		authMux.HandleFunc("GET /api/v1/searches/cycle-stats", s.listSearchCycleStats)
@@ -371,6 +384,26 @@ func (s *Server) Routes() http.Handler {
 	authChain = s.withRateLimit(authChain)
 	authChain = s.authMiddleware(authChain)
 
+	// --- Extension routes (accept the extension's own credential) ---
+	//
+	// These, and only these, accept a cwx_ extension token. Scoping is
+	// structural: there is no allowlist to keep in sync, so a stolen extension
+	// token can do exactly what the extension does — read the searches to scan
+	// and push listings back — and nothing else. Minting and revoking that
+	// credential stay on the strict-auth mux above, where a real login is
+	// required.
+	//
+	// /ext/searches is the extension's view of GET /searches. It exists so the
+	// extension never has to reach a route that also serves the web app, which
+	// is what keeps the token's scope honest.
+	extMux := http.NewServeMux()
+	extMux.HandleFunc("GET /api/v1/ext/searches", s.listSearches)
+	extMux.HandleFunc("POST /api/v1/ext/ingest", s.ingestListings)
+
+	extChain := s.withMaxBody(extMux)
+	extChain = s.withRateLimit(extChain)
+	extChain = s.extAuthMiddleware(extChain)
+
 	// --- Optional-auth routes (read-only, return empty data for guests) ---
 	optAuthMux := http.NewServeMux()
 	optAuthMux.HandleFunc("GET /api/v1/me", s.getMe)
@@ -413,6 +446,11 @@ func (s *Server) Routes() http.Handler {
 	top.Handle("/api/v1/guest/", guestChain)
 	top.Handle("/api/v1/catalog/", catalogChain)
 	top.Handle("GET /api/v1/capabilities", capChain)
+	// The extension's two routes only. /api/v1/ext/token is deliberately NOT
+	// here — it falls through to the strict-auth mux, so an extension token can
+	// never mint another one.
+	top.Handle("GET /api/v1/ext/searches", extChain)
+	top.Handle("POST /api/v1/ext/ingest", extChain)
 	top.Handle("GET /api/v1/me", optAuthChain)
 	top.Handle("GET /api/v1/searches", optAuthChain)
 	if s.notifs != nil {
@@ -485,6 +523,15 @@ func (s *Server) optionalAuthMiddleware(next http.Handler) http.Handler {
 		// still an attempt to authenticate — do not silently downgrade it.
 		credentialOffered := strings.TrimSpace(authHdr) != ""
 
+		// An extension credential is valid ONLY on the /ext/ routes. Reaching a
+		// non-ext route with one is an attempt to use it out of scope; reject it
+		// rather than let it ride the Firebase path (where, in production, it
+		// would fail verification anyway — but scope should not depend on that).
+		if isExtToken(bearer) {
+			writeAuthError(w, "extension token not valid here")
+			return
+		}
+
 		var chatID int64
 		var userEmail string
 
@@ -542,6 +589,13 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHdr := r.Header.Get("Authorization")
 		bearer := bearerFromAuthHeader(authHdr)
+
+		// An extension credential belongs only on the /ext/ routes; anywhere
+		// else it is out of scope (see optionalAuthMiddleware).
+		if isExtToken(bearer) {
+			writeAuthError(w, "extension token not valid here")
+			return
+		}
 
 		var chatID int64
 

--- a/internal/api/ext_token.go
+++ b/internal/api/ext_token.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// extTokenPrefix marks a CarWatch extension credential. It exists so the auth
+// middleware can tell one from a Firebase ID token by inspection, without a
+// database probe on every request.
+const extTokenPrefix = "cwx_"
+
+// extTokenTTL is the initial lifetime. It slides forward while the token is in
+// use (see ResolveExtToken), so an extension that keeps scanning keeps working,
+// while one that stops — uninstalled, abandoned profile — ages out by itself.
+const extTokenTTL = 90 * 24 * time.Hour
+
+// maxExtTokensPerUser bounds how many browsers one account can have connected.
+// Beyond it the oldest connection is revoked, so a stale token from a machine
+// the user no longer has cannot linger forever.
+const maxExtTokensPerUser = 5
+
+// newExtToken mints a credential and returns it with its hash. The plaintext
+// exists exactly once — in the response to the user — and is never stored:
+// a leak of the database must not yield a usable credential.
+func newExtToken() (token, hash string, err error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", "", err
+	}
+	token = extTokenPrefix + base64.RawURLEncoding.EncodeToString(buf[:])
+	return token, hashExtToken(token), nil
+}
+
+func hashExtToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func isExtToken(bearer string) bool {
+	return strings.HasPrefix(bearer, extTokenPrefix)
+}
+
+// maxExtTokenLabelRunes caps the user-supplied label ("Chrome on my laptop").
+const maxExtTokenLabelRunes = 100
+
+// extTokenLabel trims a submitted label, strips control characters, and caps it
+// on a rune boundary — the label is user-supplied text that gets rendered back.
+func extTokenLabel(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, strings.TrimSpace(s))
+
+	runes := []rune(s)
+	if len(runes) > maxExtTokenLabelRunes {
+		return string(runes[:maxExtTokenLabelRunes])
+	}
+	return s
+}
+
+type extTokenResponse struct {
+	// Token is the plaintext credential. It is returned exactly once, at
+	// creation, and cannot be recovered afterwards.
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+type extTokenInfo struct {
+	ID         int64   `json:"id"`
+	Label      string  `json:"label"`
+	CreatedAt  string  `json:"created_at"`
+	LastUsedAt *string `json:"last_used_at"`
+	ExpiresAt  string  `json:"expires_at"`
+}
+
+// createExtToken issues a credential for the caller's browser extension.
+//
+// It sits behind the strict (Firebase) auth middleware: proving you are the
+// user is exactly what earns you a long-lived token. The extension calls this
+// once, with the short-lived Firebase token it captured while a CarWatch tab
+// was open, and from then on uses only what it gets back — which is why it
+// keeps working long after that tab is closed.
+func (s *Server) createExtToken(w http.ResponseWriter, r *http.Request) {
+	if s.extTokens == nil {
+		writeError(w, http.StatusServiceUnavailable, "extension tokens unavailable")
+		return
+	}
+	chatID, ok := s.requireResolvedChatID(w, r)
+	if !ok {
+		return
+	}
+	log := s.handlerLogger(r, "op", "ext_token_create")
+
+	var body struct {
+		Label string `json:"label"`
+	}
+	// A body is optional; a malformed one is not worth failing over.
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	label := extTokenLabel(body.Label)
+
+	// Keep the number of connected browsers bounded, so a token from a machine
+	// the user no longer has cannot linger indefinitely.
+	if existing, err := s.extTokens.ListExtTokens(r.Context(), chatID); err == nil && len(existing) >= maxExtTokensPerUser {
+		if n, err := s.extTokens.RevokeOldestExtTokens(r.Context(), chatID, maxExtTokensPerUser-1); err != nil {
+			log.Error("failed to revoke oldest ext tokens", "error", err)
+		} else if n > 0 {
+			log.Info("revoked oldest extension connections to stay within the cap",
+				"revoked", n, "cap", maxExtTokensPerUser)
+		}
+	}
+
+	token, hash, err := newExtToken()
+	if err != nil {
+		log.Error("failed to generate ext token", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	expiresAt := time.Now().Add(extTokenTTL)
+	if _, err := s.extTokens.CreateExtToken(r.Context(), chatID, hash, label, expiresAt); err != nil {
+		log.Error("failed to store ext token", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	log.Info("issued extension token", "expires_at", expiresAt.UTC())
+	writeJSON(w, http.StatusOK, extTokenResponse{
+		Token:     token,
+		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+	})
+}
+
+// listExtTokensHandler reports the caller's connected browsers. Metadata only —
+// the secrets are not stored and cannot be shown again.
+func (s *Server) listExtTokensHandler(w http.ResponseWriter, r *http.Request) {
+	if s.extTokens == nil {
+		writeError(w, http.StatusServiceUnavailable, "extension tokens unavailable")
+		return
+	}
+	chatID, ok := s.requireResolvedChatID(w, r)
+	if !ok {
+		return
+	}
+
+	tokens, err := s.extTokens.ListExtTokens(r.Context(), chatID)
+	if err != nil {
+		s.handlerLogger(r, "op", "ext_token_list").Error("failed to list ext tokens", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	items := make([]extTokenInfo, 0, len(tokens))
+	for _, t := range tokens {
+		info := extTokenInfo{
+			ID:        t.ID,
+			Label:     t.Label,
+			CreatedAt: t.CreatedAt.UTC().Format(time.RFC3339),
+			ExpiresAt: t.ExpiresAt.UTC().Format(time.RFC3339),
+		}
+		if t.LastUsedAt != nil {
+			used := t.LastUsedAt.UTC().Format(time.RFC3339)
+			info.LastUsedAt = &used
+		}
+		items = append(items, info)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
+// revokeExtTokens disconnects every browser. This is the answer to a leaked
+// token, and it takes effect on the extension's very next call.
+func (s *Server) revokeExtTokens(w http.ResponseWriter, r *http.Request) {
+	if s.extTokens == nil {
+		writeError(w, http.StatusServiceUnavailable, "extension tokens unavailable")
+		return
+	}
+	chatID, ok := s.requireResolvedChatID(w, r)
+	if !ok {
+		return
+	}
+	log := s.handlerLogger(r, "op", "ext_token_revoke")
+
+	n, err := s.extTokens.RevokeExtTokens(r.Context(), chatID)
+	if err != nil {
+		log.Error("failed to revoke ext tokens", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	log.Info("revoked extension tokens", "revoked", n)
+	writeJSON(w, http.StatusOK, map[string]any{"revoked": n})
+}
+
+// extAuthMiddleware authenticates the extension's own routes.
+//
+// A CarWatch extension credential (cwx_…) is accepted here and NOWHERE else:
+// scoping is structural rather than an allowlist someone has to remember to
+// maintain. So a stolen extension token can do exactly what the extension does
+// — read the searches to scan and push listings back — and nothing else. It
+// cannot delete a search, read notifications, or touch an admin route.
+//
+// Anything that is not a cwx_ token falls through to the normal (Firebase/dev)
+// auth, so a freshly installed extension can still reach these routes with the
+// Firebase token it captured, which is how it bootstraps its own credential.
+func (s *Server) extAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bearer := bearerFromAuthHeader(r.Header.Get("Authorization"))
+		if !isExtToken(bearer) {
+			s.authMiddleware(next).ServeHTTP(w, r)
+			return
+		}
+		if s.extTokens == nil {
+			writeAuthError(w, "extension tokens unavailable")
+			return
+		}
+
+		chatID, err := s.extTokens.ResolveExtToken(r.Context(), hashExtToken(bearer))
+		if err != nil {
+			if !errors.Is(err, storage.ErrNotFound) {
+				s.logger.Error("resolve ext token failed", "error", err)
+			}
+			// Revoked, expired, or never existed — all the same to the caller,
+			// and all mean "re-connect the extension".
+			writeAuthError(w, "invalid or revoked extension token")
+			return
+		}
+
+		ctx := withChatID(r.Context(), chatID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// withChatID injects an authenticated chat id (and an empty email: a device
+// token identifies a browser, not a login session).
+func withChatID(ctx context.Context, chatID int64) context.Context {
+	ctx = context.WithValue(ctx, chatIDKey, chatID)
+	return context.WithValue(ctx, emailKey, "")
+}

--- a/internal/api/ext_token_test.go
+++ b/internal/api/ext_token_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/config"
+	"github.com/dsionov/carwatch/internal/storage"
+	"github.com/dsionov/carwatch/internal/storage/pgtest"
+	"github.com/dsionov/carwatch/internal/storage/postgres"
+)
+
+func newExtTokenServer(t *testing.T) (*Server, *postgres.Store) {
+	t.Helper()
+	store := pgtest.NewStore(t)
+	srv := New(Config{
+		Searches:     store,
+		Listings:     store,
+		Users:        store,
+		Prices:       store,
+		Notifs:       store,
+		ExtTokens:    store,
+		Logger:       slog.Default(),
+		FirebaseAuth: &fakeTokenVerifier{uid: "uid-123", email: "user@example.com"},
+		API:          config.APIConfig{CORSOrigins: []string{"http://localhost:5173"}},
+	})
+	return srv, store
+}
+
+// mintToken performs the exchange the extension's bridge performs: present the
+// short-lived Firebase token once, get a long-lived credential back.
+func mintToken(t *testing.T, srv *Server) string {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/ext/token", strings.NewReader(`{"label":"test browser"}`))
+	req.Header.Set("Authorization", "Bearer firebase-token")
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("mint token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp extTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode mint response: %v", err)
+	}
+	if !strings.HasPrefix(resp.Token, extTokenPrefix) {
+		t.Fatalf("minted token has no cwx_ prefix: %q", resp.Token)
+	}
+	return resp.Token
+}
+
+// This is the bug the whole feature exists for: the extension used to borrow the
+// web session's Firebase token, which expires in ~1h and which it cannot
+// refresh — so scanning silently stopped an hour after the last CarWatch tab
+// closed. Its own credential must keep working with no Firebase token in sight.
+func TestExtToken_WorksWithoutAnyFirebaseSession(t *testing.T) {
+	srv, _ := newExtTokenServer(t)
+	token := mintToken(t, srv)
+
+	// The extension's two calls, using ONLY its own credential.
+	req := httptest.NewRequest("GET", "/api/v1/ext/searches", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ext/searches with a device token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequest("POST", "/api/v1/ext/ingest", strings.NewReader(`{"listings":[]}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ext/ingest with a device token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// Scope is structural: the cwx_ credential is accepted by the extension's
+// routes and nowhere else, so a stolen token can do what the extension does and
+// nothing more.
+func TestExtToken_IsRejectedOutsideTheExtensionRoutes(t *testing.T) {
+	srv, _ := newExtTokenServer(t)
+	token := mintToken(t, srv)
+
+	forbidden := []struct{ method, path string }{
+		{"GET", "/api/v1/searches"},        // the web app's route
+		{"GET", "/api/v1/me"},              //
+		{"DELETE", "/api/v1/searches/1"},   // destructive
+		{"GET", "/api/v1/notifications"},   //
+		{"GET", "/api/v1/telegram/status"}, //
+		{"POST", "/api/v1/ext/token"},      // must never mint another token
+		{"DELETE", "/api/v1/ext/token"},    //
+		{"GET", "/api/v1/admin/stats"},     //
+	}
+	for _, tc := range forbidden {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			srv.Routes().ServeHTTP(w, req)
+
+			// Must be an auth rejection specifically — a 404 for a missing
+			// resource would mean the token was *accepted* and the route simply
+			// had nothing to return, which is still a scope leak.
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("an extension token should be 401 on %s %s, got %d — its scope leaked",
+					tc.method, tc.path, w.Code)
+			}
+		})
+	}
+}
+
+// Revocation is the answer to a leaked token, so it has to bite immediately.
+func TestExtToken_RevocationStopsIngestOnTheNextCall(t *testing.T) {
+	srv, _ := newExtTokenServer(t)
+	token := mintToken(t, srv)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/ext/token", nil)
+	req.Header.Set("Authorization", "Bearer firebase-token") // the user, not the extension
+	w := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("revoke: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequest("GET", "/api/v1/ext/searches", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("a revoked token still works: got %d", w.Code)
+	}
+}
+
+func TestExtToken_UnknownAndExpiredTokensAreRejected(t *testing.T) {
+	srv, store := newExtTokenServer(t)
+
+	t.Run("unknown", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/ext/searches", nil)
+		req.Header.Set("Authorization", "Bearer cwx_never-issued")
+		w := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("an unknown token was accepted: %d", w.Code)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		token, hash, err := newExtToken()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Mint one directly with an expiry in the past.
+		chatID, err := store.UpsertWebUser(context.Background(), "uid-expired", "e@x.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.CreateExtToken(context.Background(), chatID, hash, "old", time.Now().Add(-time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+
+		req := httptest.NewRequest("GET", "/api/v1/ext/searches", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("an expired token was accepted: %d", w.Code)
+		}
+	})
+}
+
+// The secret is never stored: a database leak must not yield usable credentials.
+func TestExtToken_OnlyTheHashIsPersisted(t *testing.T) {
+	srv, store := newExtTokenServer(t)
+	token := mintToken(t, srv)
+
+	chatID, err := store.UpsertWebUser(context.Background(), "uid-123", "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokens, err := store.ListExtTokens(context.Background(), chatID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 stored token, got %d", len(tokens))
+	}
+	// ExtToken carries no secret field at all — the type cannot even express it.
+	// Belt and braces: resolving by the plaintext must fail, only the hash works.
+	if _, err := store.ResolveExtToken(context.Background(), token); err == nil {
+		t.Fatal("the plaintext token resolved — it is being stored verbatim")
+	}
+	if _, err := store.ResolveExtToken(context.Background(), hashExtToken(token)); err != nil {
+		t.Fatalf("the hash should resolve: %v", err)
+	}
+}
+
+// Two tokens must never collide, and each must be unguessable.
+func TestNewExtToken_IsUniqueAndPrefixed(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		token, hash, err := newExtToken()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(token, extTokenPrefix) {
+			t.Fatalf("token missing prefix: %q", token)
+		}
+		if len(token) < 40 {
+			t.Fatalf("token is too short to be unguessable: %q", token)
+		}
+		if seen[token] || seen[hash] {
+			t.Fatal("duplicate token generated")
+		}
+		seen[token], seen[hash] = true, true
+	}
+}
+
+// Connected browsers stay bounded, so a credential from a machine the user no
+// longer has cannot linger forever.
+func TestExtToken_OldestConnectionIsRevokedBeyondTheCap(t *testing.T) {
+	srv, store := newExtTokenServer(t)
+
+	var first string
+	for i := 0; i < maxExtTokensPerUser+1; i++ {
+		tok := mintToken(t, srv)
+		if i == 0 {
+			first = tok
+		}
+	}
+
+	chatID, err := store.UpsertWebUser(context.Background(), "uid-123", "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := store.ListExtTokens(context.Background(), chatID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) > maxExtTokensPerUser {
+		t.Fatalf("connected browsers exceeded the cap: %d", len(live))
+	}
+	// The oldest one is the one that got dropped.
+	if _, err := store.ResolveExtToken(context.Background(), hashExtToken(first)); err == nil {
+		t.Fatal("the oldest connection survived past the cap")
+	}
+}
+
+func TestExtTokenLabel(t *testing.T) {
+	if got := extTokenLabel("  Chrome on laptop  "); got != "Chrome on laptop" {
+		t.Errorf("label not trimmed: %q", got)
+	}
+	if got := extTokenLabel("bad\x00label"); strings.ContainsRune(got, 0) {
+		t.Errorf("control characters survived: %q", got)
+	}
+	long := strings.Repeat("א", maxExtTokenLabelRunes+50)
+	if got := len([]rune(extTokenLabel(long))); got != maxExtTokenLabelRunes {
+		t.Errorf("label not capped on a rune boundary: %d runes", got)
+	}
+}
+
+var _ storage.ExtTokenStore = (*postgres.Store)(nil)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -293,6 +293,7 @@ func BuildAPI(cfg *config.Config, store *postgres.Store, dynCatalog *catalog.Dyn
 		SearchCycleStats: store,
 		Activity:         store,
 		ExtScanStatus:    store,
+		ExtTokens:        store,
 		PollingInterval:  cfg.Polling.Interval,
 		Fetchers:         fetcherFactory,
 		Yad2Fetcher:      yad2Source,

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -462,6 +462,42 @@ type ExtScanStatusStore interface {
 	GetExtScanStatus(ctx context.Context, chatID int64) (*ExtScanStatus, error)
 }
 
+// ExtToken is a browser extension's own long-lived credential. The secret
+// itself is never stored or returned — only its hash — so this describes a
+// token without being able to reproduce it.
+type ExtToken struct {
+	ID         int64
+	ChatID     int64
+	Label      string
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
+	ExpiresAt  time.Time
+}
+
+// ExtTokenStore issues and resolves the extension's credentials.
+//
+// The extension used to borrow the web session's Firebase ID token, which
+// expires in about an hour and which it cannot refresh — so scanning died about
+// an hour after the user closed their last CarWatch tab, silently, even though
+// the extension is the only path listings enter the system by.
+type ExtTokenStore interface {
+	// CreateExtToken stores a new credential. tokenHash is a SHA-256 hex digest;
+	// the plaintext must never reach this layer.
+	CreateExtToken(ctx context.Context, chatID int64, tokenHash, label string, expiresAt time.Time) (int64, error)
+	// ResolveExtToken maps a token hash to its owner, refreshing the token's
+	// sliding expiry and last-used stamp. Returns ErrNotFound when the token is
+	// unknown, revoked or expired.
+	ResolveExtToken(ctx context.Context, tokenHash string) (int64, error)
+	// RevokeExtTokens invalidates every live token for a chat.
+	RevokeExtTokens(ctx context.Context, chatID int64) (int64, error)
+	// RevokeOldestExtTokens revokes live tokens beyond the newest `keep`.
+	RevokeOldestExtTokens(ctx context.Context, chatID int64, keep int) (int64, error)
+	// ListExtTokens returns the chat's live tokens (metadata only).
+	ListExtTokens(ctx context.Context, chatID int64) ([]ExtToken, error)
+	// PruneExtTokens deletes tokens revoked or expired longer ago than olderThan.
+	PruneExtTokens(ctx context.Context, olderThan time.Duration) (int64, error)
+}
+
 type SearchCycleStats struct {
 	SearchID    int64
 	ChatID      int64

--- a/internal/storage/postgres/ext_tokens.go
+++ b/internal/storage/postgres/ext_tokens.go
@@ -1,0 +1,151 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// CreateExtToken stores a new extension credential for a chat. Only the hash is
+// given to us — the plaintext exists exactly once, in the response to the user.
+func (s *Store) CreateExtToken(ctx context.Context, chatID int64, tokenHash, label string, expiresAt time.Time) (int64, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO ext_tokens (chat_id, token_hash, label, expires_at)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id`,
+		chatID, tokenHash, label, expiresAt.UTC()).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("create ext token: %w", err)
+	}
+	return id, nil
+}
+
+// extTokenSlidingWindow is how long a token stays valid from its last use, and
+// extTokenRenewBefore is how close to expiry a use has to be before the window
+// is pushed out again. Renewing on every request would mean a write per
+// request; renewing only in the last third of the window keeps the token alive
+// indefinitely while it is in use, for one write every few weeks.
+const (
+	extTokenSlidingWindow = 90 * 24 * time.Hour
+	extTokenRenewBefore   = 60 * 24 * time.Hour
+	// lastUsedThrottle bounds how often last_used_at is rewritten. The extension
+	// calls twice per 15-minute cycle; without a throttle that is a write to the
+	// same row ~200 times a day, per user, for a field nobody reads that
+	// precisely.
+	lastUsedThrottle = time.Hour
+)
+
+// ResolveExtToken maps a token hash to its owner, or reports ErrNotFound when
+// the token is unknown, revoked, or expired. It doubles as the token's "touch":
+// last_used_at and the sliding expiry are refreshed here, both throttled so the
+// hot path (every ingest) stays a single indexed statement without a write in
+// the common case.
+func (s *Store) ResolveExtToken(ctx context.Context, tokenHash string) (int64, error) {
+	var chatID int64
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE ext_tokens SET
+			last_used_at = CASE
+				WHEN last_used_at IS NULL OR last_used_at < NOW() - $2::interval
+				THEN NOW() ELSE last_used_at END,
+			expires_at = CASE
+				WHEN expires_at < NOW() + $3::interval
+				THEN NOW() + $4::interval ELSE expires_at END
+		WHERE token_hash = $1
+		  AND revoked_at IS NULL
+		  AND expires_at > NOW()
+		RETURNING chat_id`,
+		tokenHash,
+		lastUsedThrottle.String(),
+		extTokenRenewBefore.String(),
+		extTokenSlidingWindow.String(),
+	).Scan(&chatID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, storage.ErrNotFound
+		}
+		return 0, fmt.Errorf("resolve ext token: %w", err)
+	}
+	return chatID, nil
+}
+
+// RevokeExtTokens kills every active token for a chat — the "disconnect my
+// extension" button, and the thing to reach for if a token leaks. Returns how
+// many were revoked.
+func (s *Store) RevokeExtTokens(ctx context.Context, chatID int64) (int64, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE ext_tokens SET revoked_at = NOW()
+		WHERE chat_id = $1 AND revoked_at IS NULL`, chatID)
+	if err != nil {
+		return 0, fmt.Errorf("revoke ext tokens: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// ListExtTokens returns the chat's live tokens (never the secret — it is not
+// stored). This is what a "connected browsers" view in Settings reads.
+func (s *Store) ListExtTokens(ctx context.Context, chatID int64) ([]storage.ExtToken, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, chat_id, label, created_at, last_used_at, expires_at
+		FROM ext_tokens
+		WHERE chat_id = $1 AND revoked_at IS NULL AND expires_at > NOW()
+		ORDER BY created_at DESC`, chatID)
+	if err != nil {
+		return nil, fmt.Errorf("list ext tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []storage.ExtToken
+	for rows.Next() {
+		var t storage.ExtToken
+		var lastUsed sql.NullTime
+		if err := rows.Scan(&t.ID, &t.ChatID, &t.Label, &t.CreatedAt, &lastUsed, &t.ExpiresAt); err != nil {
+			return nil, fmt.Errorf("scan ext token: %w", err)
+		}
+		if lastUsed.Valid {
+			t.LastUsedAt = &lastUsed.Time
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// PruneExtTokens deletes tokens that have been revoked or expired for longer
+// than olderThan. They are already unusable; this just stops the table growing
+// forever.
+func (s *Store) PruneExtTokens(ctx context.Context, olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan).UTC()
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM ext_tokens
+		WHERE (revoked_at IS NOT NULL AND revoked_at < $1)
+		   OR (expires_at < $1)`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("prune ext tokens: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// RevokeOldestExtTokens revokes the chat's live tokens beyond the newest `keep`
+// of them, so the number of connected browsers stays bounded and a credential
+// from a machine the user no longer has cannot linger forever.
+func (s *Store) RevokeOldestExtTokens(ctx context.Context, chatID int64, keep int) (int64, error) {
+	if keep < 0 {
+		keep = 0
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE ext_tokens SET revoked_at = NOW()
+		WHERE id IN (
+			SELECT id FROM ext_tokens
+			WHERE chat_id = $1 AND revoked_at IS NULL AND expires_at > NOW()
+			ORDER BY created_at DESC
+			OFFSET $2
+		)`, chatID, keep)
+	if err != nil {
+		return 0, fmt.Errorf("revoke oldest ext tokens: %w", err)
+	}
+	return res.RowsAffected()
+}

--- a/migrations/000032_ext_tokens.down.sql
+++ b/migrations/000032_ext_tokens.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_ext_tokens_chat;
+DROP TABLE IF EXISTS ext_tokens;

--- a/migrations/000032_ext_tokens.up.sql
+++ b/migrations/000032_ext_tokens.up.sql
@@ -1,0 +1,31 @@
+-- The browser extension needs a credential of its own.
+--
+-- Until now it borrowed the web session's Firebase ID token, captured by
+-- monkey-patching window.fetch on the CarWatch site. Firebase ID tokens expire
+-- in about an hour and the extension has no way to refresh one, so roughly an
+-- hour after the user closed their last CarWatch tab the extension's token went
+-- stale — and, because the extension IS the only path listings enter the system
+-- by, scanning and notifications simply stopped. The product's core promise held
+-- only while a tab happened to be open somewhere.
+--
+-- An ext_token is a long-lived, revocable credential minted for one browser.
+-- Only its SHA-256 hash is stored: a database leak must not yield a usable
+-- credential, and there is never a reason to read the token back.
+
+CREATE TABLE IF NOT EXISTS ext_tokens (
+    id           BIGSERIAL PRIMARY KEY,
+    chat_id      BIGINT NOT NULL REFERENCES users(chat_id) ON DELETE CASCADE,
+    -- SHA-256 hex of the token. Unique so a lookup is a single index probe and
+    -- the same token can never be minted twice.
+    token_hash   TEXT NOT NULL UNIQUE,
+    label        TEXT NOT NULL DEFAULT '',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ,
+    -- Sliding expiry: refreshed while the token is in use, so an extension that
+    -- keeps scanning keeps working, while one that stops (uninstalled browser,
+    -- abandoned profile) ages out on its own.
+    expires_at   TIMESTAMPTZ NOT NULL,
+    revoked_at   TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ext_tokens_chat ON ext_tokens (chat_id);


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this PR closes the product's #1 silent-failure item plus the extension credential hardening.

## The bug (#1490)

The browser extension is the **only** path listings enter CarWatch by, and it authenticated by **borrowing the web app's Firebase ID token** — captured by monkey-patching `window.fetch` on the site. A Firebase ID token expires in **about an hour** and the extension cannot refresh one. So roughly an hour after the user closed their last CarWatch tab, the token went stale and **scanning + notifications simply stopped, silently**. The product's core promise held only while a tab happened to be open somewhere.

## The fix

The extension mints its **own** credential (`cwx_…`): once, using the Firebase token it captures while a tab is open, it calls `POST /ext/token` and stores the result — then uses only that.

- **Long-lived, sliding expiry** (90d, renewed on use): an extension that keeps scanning keeps working; one that stops ages out on its own.
- **Hash-only storage**: only the SHA-256 is persisted — a DB leak yields no usable credential.
- **Revocable**: the "disconnect" button (and the answer to a leak) takes effect on the token's next call.
- **Structurally scoped**: a `cwx_` token is accepted on the `/ext/` routes and **rejected everywhere else** (the Firebase middlewares refuse it outright). A stolen extension token can do exactly what the extension does — read the searches to scan, push listings back — and nothing more: not delete a search, read notifications, hit admin, or **mint another token**.
- **Connection cap**: a token from a machine the user no longer has cannot linger.

## The hardening that ships with it (#1493)

- Token moves to `chrome.storage.local` — **never `.sync`**, which roams a live bearer token through Google's servers to every signed-in profile.
- `content.js` posts it with `targetOrigin = location.origin`, not `"*"`.
- The bridge **ignores** any message whose `source` isn't this window, whose `origin` isn't our own, or whose token isn't JWT-shaped — a page script can't poison the stored credential.
- The popup shows **"disconnected"** distinctly from **"0 searches"** — the whole failure mode was that it looked like nothing was wrong.

## Verification

**End-to-end against a real api-server + Postgres:**
```
device token on /ext/searches  → 200   (no Firebase session present)
device token on /ext/ingest    → 200
device token on /searches      → 401   (web route, out of scope)
device token on /me            → 401
device token on POST /ext/token→ 401   (cannot mint another)
device token on /admin/stats   → 401
after revoke → /ext/searches   → 401   (dies on next call)
```

- **Go tests** (`ext_token_test.go`): minting, "works with no Firebase session" (the bug), structural scope (a table of forbidden routes must all 401), revocation bites immediately, unknown/expired rejected, **only the hash is stored** (the plaintext must not resolve), uniqueness, and the connection cap.
- **Node tests** (`bridge.test.js`): foreign source ignored, cross-origin ignored, non-JWT ignored, exchange stores to local + purges sync, no double-exchange, non-`cwx_` response rejected.
- Full `./internal/api/` and `./internal/storage/...` suites pass; service worker loads in a sandboxed VM.

## Migration

`000032_ext_tokens`: `ext_tokens` table (hash-unique, FK-cascade to users, sliding `expires_at`, `revoked_at`). Down included.

## Note for reviewers — dependency on #1491

This branch carries the `writeAuthError` helper and the *"a present-but-invalid token is a failure, not a guest"* semantics from #1491, because they are what make the extension's auth failure **visible** instead of silent. If #1491 merges first, those hunks deduplicate on rebase. Reviewed together they tell one story: the extension gets a durable credential, and when a credential fails, it fails loudly.

closes #1490
closes #1493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure browser-extension authentication with dedicated credentials.
  * Extension credentials can expire, renew during use, and be revoked.
  * Added extension-only scanning and data submission access.
  * Added safeguards preventing extension credentials from being used on web or administrative routes.

* **Bug Fixes**
  * Improved handling of disconnected and rejected authentication states.
  * Extension popup now clearly indicates when reconnecting is required.
  * Strengthened token exchange and message-origin validation.

* **Tests**
  * Added coverage for credential exchange, expiration, revocation, access restrictions, and security validation.

* **Chores**
  * Updated the extension version to 1.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->