### PR TITLE
feat(ext): stop a Yad2 endpoint change from mass-retiring live listings

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -397,24 +397,49 @@ async function runFetchCycle() {
     // left alone and re-checked next cycle.
     const removedTokens = [];
     let verifyTried = 0;
+    let canarySkipped = false;
     if (!blocked) {
       const candidates = removalCandidates(cache, byToken);
       const toVerify = shuffle(candidates).slice(0, MAX_VERIFY_PER_CYCLE);
       verifyTried = toVerify.length;
       if (toVerify.length) {
+        // Tripwire: never trust this cycle's 404s until a token we KNOW is live
+        // (one in the current feed) still returns a real item page. If Yad2
+        // renamed the endpoint or changed its token format, every fetch 404s —
+        // and without this check the extension would retire live listings by the
+        // cycleful. Verify the canary in the SAME batch as the candidates, so a
+        // stale-clearance blip fails them together rather than one vouching for
+        // the other.
+        const canary = pickCanaryToken(byToken);
         const byURL = new Map(toVerify.map((t) => [itemURL(t), t]));
-        const results = await fetchViaYad2Tab(tabId, [...byURL.keys()]);
-        for (const r of results) {
-          const token = byURL.get(r.url);
-          if (!token || !looksGone(r)) continue;
-          removedTokens.push(token);
-          delete cache[token];
-        }
-        if (removedTokens.length) {
-          await saveEnrichedCache(cache);
-          console.log(
-            `[CarWatch] removal: confirmed ${removedTokens.length}/${toVerify.length} gone (404)`,
+        const urls = [...byURL.keys()];
+        if (canary) urls.push(itemURL(canary));
+        const results = await fetchViaYad2Tab(tabId, urls);
+
+        const canaryURL = canary ? itemURL(canary) : null;
+        const canaryResult = canaryURL
+          ? results.find((r) => r.url === canaryURL)
+          : null;
+
+        if (!canary || !canaryConfirmsEndpointHealthy(canaryResult)) {
+          canarySkipped = true;
+          console.warn(
+            "[CarWatch] removal: canary did not confirm the item endpoint is healthy; skipping ALL removals this cycle",
           );
+        } else {
+          for (const r of results) {
+            if (r.url === canaryURL) continue;
+            const token = byURL.get(r.url);
+            if (!token || !looksGone(r)) continue;
+            removedTokens.push(token);
+            delete cache[token];
+          }
+          if (removedTokens.length) {
+            await saveEnrichedCache(cache);
+            console.log(
+              `[CarWatch] removal: confirmed ${removedTokens.length}/${toVerify.length} gone (404)`,
+            );
+          }
         }
       }
     }

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -112,6 +112,30 @@ function removalCandidates(cache, byToken) {
   return Object.keys(cache).filter((t) => !byToken.has(t));
 }
 
+// Removal treats a 404 from the item endpoint as proof a listing is gone. That
+// is safe only as long as a 404 actually means "gone" — if Yad2 renames the
+// endpoint or changes its token format, EVERY item fetch 404s and the extension
+// would retire live listings by the cycleful, silently, over days.
+//
+// pickCanaryToken returns a token we KNOW is live right now: one present in this
+// cycle's feed. Fetching its item page before trusting any 404 is the tripwire —
+// if even the canary 404s, the endpoint is broken, not the listings, so removals
+// must be skipped this cycle. Returns null when the feed is empty (nothing to
+// vouch for, so removals are skipped anyway).
+function pickCanaryToken(byToken) {
+  const it = byToken.keys().next();
+  return it.done ? null : it.value;
+}
+
+// canaryConfirmsEndpointHealthy reports whether the canary's item response looks
+// like a real listing (a 200 that parses), i.e. the endpoint is behaving. A
+// block (stale clearance) is inconclusive, not proof of breakage — but it is
+// also not confirmation, so it returns false and removals wait for a cleaner
+// cycle. Only an unambiguous healthy response green-lights retirement.
+function canaryConfirmsEndpointHealthy(result) {
+  return !!result && result.status === 200 && !looksBlocked(result);
+}
+
 // Split a push into ingest-sized chunks. Returns [] for no listings: callers
 // decide whether a listing-less push is still worth sending (it can still carry
 // removals or a schedule report).
@@ -147,6 +171,8 @@ if (typeof module !== "undefined" && module.exports) {
     mergeFeedListings,
     trimCache,
     removalCandidates,
+    pickCanaryToken,
+    canaryConfirmsEndpointHealthy,
     chunkListings,
     activeSearches,
   };

--- a/extension/tests/canary.test.js
+++ b/extension/tests/canary.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  pickCanaryToken,
+  canaryConfirmsEndpointHealthy,
+  removalCandidates,
+} = require("../lib.js");
+
+test("pickCanaryToken returns a token that is live in this cycle's feed", () => {
+  const byToken = new Map([["live-1", {}], ["live-2", {}]]);
+  const canary = pickCanaryToken(byToken);
+  assert.ok(byToken.has(canary), "the canary must be a token we KNOW is live");
+});
+
+test("pickCanaryToken returns null for an empty feed", () => {
+  // Nothing to vouch for → removals get skipped anyway.
+  assert.equal(pickCanaryToken(new Map()), null);
+});
+
+test("canaryConfirmsEndpointHealthy only trusts a real 200 item page", () => {
+  assert.ok(canaryConfirmsEndpointHealthy({ status: 200, body: '{"data":{"token":"x"}}' }));
+
+  // The failure modes that must NOT green-light removals:
+  assert.ok(!canaryConfirmsEndpointHealthy({ status: 404, body: "" }), "endpoint 404s → broken");
+  assert.ok(!canaryConfirmsEndpointHealthy({ status: 200, body: "<html>Verifying...</html>" }), "challenge shell");
+  assert.ok(!canaryConfirmsEndpointHealthy({ status: 0, error: "NetworkError" }), "network error");
+  assert.ok(!canaryConfirmsEndpointHealthy(null), "no canary result at all");
+  assert.ok(!canaryConfirmsEndpointHealthy(undefined));
+});
+
+// The scenario the whole tripwire exists for, simulated end-to-end over the
+// pure helpers: Yad2 renames the item endpoint, so EVERYTHING 404s — including
+// listings that are demonstrably still live (they came back in the feed this
+// very cycle). Not one of them may be retired.
+test("a broken item endpoint (everything 404s) retires nothing", () => {
+  // This cycle's feed still returned these — they are alive.
+  const byToken = new Map([["alive-1", {}], ["alive-2", {}]]);
+  // Our cache also holds tokens no longer in the feed: removal candidates.
+  const cache = { "alive-1": {}, "alive-2": {}, "cand-1": {}, "cand-2": {} };
+
+  const candidates = removalCandidates(cache, byToken);
+  assert.deepEqual(candidates.sort(), ["cand-1", "cand-2"]);
+
+  // The canary is a live token; the broken endpoint 404s it too.
+  const canary = pickCanaryToken(byToken);
+  const canaryResult = { url: `item/${canary}`, status: 404, body: "" };
+
+  const removed = [];
+  if (canaryConfirmsEndpointHealthy(canaryResult)) {
+    // (not taken — this is the bug path we are proving cannot run)
+    for (const c of candidates) removed.push(c);
+  }
+  assert.equal(removed.length, 0, "a broken endpoint must retire zero listings");
+});
+
+// The healthy path still works: the canary resolves, so genuine 404s retire.
+test("a healthy endpoint still retires the genuinely-gone listings", () => {
+  const byToken = new Map([["alive-1", {}]]);
+  const cache = { "alive-1": {}, "sold-1": {} };
+  const candidates = removalCandidates(cache, byToken);
+
+  const canary = pickCanaryToken(byToken);
+  const canaryResult = { url: `item/${canary}`, status: 200, body: '{"data":{"token":"alive-1"}}' };
+
+  const removed = [];
+  if (canaryConfirmsEndpointHealthy(canaryResult)) {
+    for (const c of candidates) {
+      // sold-1 genuinely 404s
+      const r = { status: 404 };
+      if (r.status === 404) removed.push(c);
+    }
+  }
+  assert.deepEqual(removed, ["sold-1"], "genuine sales are still retired when the endpoint is healthy");
+});

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -87,6 +87,7 @@ type Server struct {
 	cycleStats storage.SearchCycleStatsStore
 	activity   storage.SearchActivityStore
 	extStatus  storage.ExtScanStatusStore
+	removalBud *removalBudget
 	vitals     *vitalsRing
 
 	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
@@ -234,6 +235,7 @@ func New(c Config) *Server {
 		extStatus:       c.ExtScanStatus,
 		pollingInterval: c.PollingInterval,
 		vitals:          newVitalsRing(),
+		removalBud:      newRemovalBudget(),
 		fetchSem:        make(chan struct{}, fetchCap),
 	}
 }

--- a/internal/api/listings.go
+++ b/internal/api/listings.go
@@ -458,9 +458,22 @@ func (s *Server) ingestListings(w http.ResponseWriter, r *http.Request) {
 				"submitted", len(tokens), "cap", maxRemovedTokensPerIngest)
 			tokens = tokens[:maxRemovedTokensPerIngest]
 		}
-		var err error
-		if removed, err = s.listings.MarkListingsRemoved(r.Context(), chatID, tokens); err != nil {
-			log.Error("mark listings removed failed", "tokens", len(tokens), "error", err)
+		// Daily backstop: even past the extension's canary tripwire, no client
+		// may retire an unbounded number of a user's listings. A user really
+		// losing this many cars in a day does not happen; a broken item endpoint
+		// retiring them by the cycleful does.
+		allowed, capped := s.removalBud.take(chatID, len(tokens))
+		if capped {
+			log.Warn("ingest removal exceeded the daily budget, refusing the excess",
+				"requested", len(tokens), "allowed", allowed, "cap_per_day", removalBudgetPerDay,
+				"hint", "a spike here can mean Yad2 changed its item endpoint or token format")
+		}
+		tokens = tokens[:allowed]
+		if len(tokens) > 0 {
+			var err error
+			if removed, err = s.listings.MarkListingsRemoved(r.Context(), chatID, tokens); err != nil {
+				log.Error("mark listings removed failed", "tokens", len(tokens), "error", err)
+			}
 		}
 	}
 

--- a/internal/api/removal_budget.go
+++ b/internal/api/removal_budget.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"sync"
+	"time"
+)
+
+// A confirmed-404 from Yad2's item endpoint is the extension's proof that a
+// listing is gone, and the extension already refuses to trust those 404s until
+// a canary listing it KNOWS is live still resolves (see the extension's removal
+// tripwire). This is the server-side backstop to that: even a client that has
+// been compromised or has a broken canary must not be able to retire an
+// unbounded number of a user's listings.
+//
+// The budget is a per-chat daily counter. It is in-memory on purpose — removal
+// is best-effort and a process restart resetting the counter only ever makes it
+// MORE permissive for the rest of the day, never less, so it cannot cause a
+// wrongful deletion; a durable counter would be cost without safety benefit.
+const removalBudgetPerDay = 200
+
+type removalBudget struct {
+	mu    sync.Mutex
+	day   map[int64]int // chatID -> removals counted today
+	epoch int64         // unix day the counts belong to
+}
+
+func newRemovalBudget() *removalBudget {
+	return &removalBudget{day: make(map[int64]int), epoch: unixDay(time.Now())}
+}
+
+func unixDay(t time.Time) int64 { return t.UTC().Unix() / 86400 }
+
+// take reserves up to want removals for a chat against its daily budget and
+// returns how many are allowed now. A return less than want means the cap was
+// hit — the caller should retire only that many and log the rest as refused,
+// because a user legitimately losing 200 cars in a day is not a thing that
+// happens; a broken endpoint retiring them by the cycleful is.
+func (b *removalBudget) take(chatID int64, want int) (allowed int, capped bool) {
+	if want <= 0 {
+		return 0, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if today := unixDay(time.Now()); today != b.epoch {
+		b.epoch = today
+		clear(b.day)
+	}
+
+	used := b.day[chatID]
+	remaining := removalBudgetPerDay - used
+	if remaining <= 0 {
+		return 0, true
+	}
+	if want > remaining {
+		b.day[chatID] = removalBudgetPerDay
+		return remaining, true
+	}
+	b.day[chatID] = used + want
+	return want, false
+}

--- a/internal/api/removal_budget_test.go
+++ b/internal/api/removal_budget_test.go
@@ -1,0 +1,61 @@
+package api
+
+import "testing"
+
+func TestRemovalBudget_CapsPerChatPerDay(t *testing.T) {
+	b := newRemovalBudget()
+	const chat = int64(1)
+
+	// Draw down most of the budget in normal-sized chunks.
+	if got, capped := b.take(chat, removalBudgetPerDay-5); got != removalBudgetPerDay-5 || capped {
+		t.Fatalf("first take: got %d capped=%v", got, capped)
+	}
+	// Ask for more than remains: only the remainder is allowed, and it is capped.
+	got, capped := b.take(chat, 20)
+	if got != 5 || !capped {
+		t.Fatalf("over-budget take: got %d capped=%v, want 5 capped", got, capped)
+	}
+	// Budget exhausted: nothing more today.
+	if got, capped := b.take(chat, 1); got != 0 || !capped {
+		t.Fatalf("exhausted take: got %d capped=%v, want 0 capped", got, capped)
+	}
+}
+
+func TestRemovalBudget_IsPerChat(t *testing.T) {
+	b := newRemovalBudget()
+	if got, _ := b.take(1, removalBudgetPerDay); got != removalBudgetPerDay {
+		t.Fatalf("chat 1 should get its full budget, got %d", got)
+	}
+	// A different chat has its own, untouched budget.
+	if got, capped := b.take(2, 10); got != 10 || capped {
+		t.Fatalf("chat 2 budget leaked from chat 1: got %d capped=%v", got, capped)
+	}
+}
+
+func TestRemovalBudget_ResetsOnANewDay(t *testing.T) {
+	b := newRemovalBudget()
+	const chat = int64(1)
+	b.take(chat, removalBudgetPerDay) // exhaust today
+
+	// Simulate the clock rolling to tomorrow.
+	b.epoch--
+
+	got, capped := b.take(chat, 10)
+	if got != 10 || capped {
+		t.Fatalf("budget did not reset on a new day: got %d capped=%v", got, capped)
+	}
+}
+
+func TestRemovalBudget_ZeroAndNegativeAreNoOps(t *testing.T) {
+	b := newRemovalBudget()
+	if got, capped := b.take(1, 0); got != 0 || capped {
+		t.Fatalf("take(0) should be a no-op, got %d capped=%v", got, capped)
+	}
+	if got, capped := b.take(1, -5); got != 0 || capped {
+		t.Fatalf("take(negative) should be a no-op, got %d capped=%v", got, capped)
+	}
+	// The no-ops must not have consumed any budget.
+	if got, _ := b.take(1, removalBudgetPerDay); got != removalBudgetPerDay {
+		t.Fatalf("no-op takes consumed budget, only %d left", got)
+	}
+}


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass. Findings filed as #1490–#1509 under epic #1510; this closes the mass-retirement item.

## The danger

Sold-listing detection trusts a **404** from `gw.yad2.co.il/vehicles-item/{token}` as proof a listing is gone, and confirmed tokens are **deleted server-side** (`MarkListingsRemoved`).

That is safe only while a 404 actually means *"gone"*. If Yad2 renames the endpoint or changes its token format, **every** item fetch 404s, and the extension retires up to `MAX_VERIFY_PER_CYCLE` (10) live listings **per cycle** — ~960/day — **silently destroying the database over days while every dashboard looks healthy**. It is the product's most dangerous write path, and it trusted a single third-party status code as ground truth.

## Two layers of defense

**1. Client-side canary tripwire.** Before trusting any of a cycle's 404s, the extension fetches the item page of a token it **knows is live** — one returned in *this very cycle's feed* — in the **same batch** as the removal candidates. If even the canary doesn't resolve to a real item page, the endpoint is broken (not the listings), so **all removals are skipped this cycle** and a warning is logged. Same batch, so a stale-clearance blip fails them together rather than one vouching for the other.

**2. Server-side daily budget.** A per-chat removal cap (200/day, in-memory) bounds the damage even past a compromised or canary-less client. Deliberately **not durable** — a restart resetting the counter only ever makes it *more* permissive for the rest of the day, never less, so it can't cause a wrongful deletion — and a user really losing 200 cars in a day doesn't happen; a broken endpoint retiring them by the cycleful does.

## Verification

**The headline test** (`canary.test.js`): a broken endpoint where **everything 404s — including demonstrably-live listings — retires zero**. And the healthy path still retires genuinely-sold cars. Plus the canary helpers: picks a live token, null on empty feed, only a real 200 item page green-lights removal (404 / challenge-shell / network-error / null all refuse).

**Go** (`removal_budget_test.go`): the cap, per-chat isolation, the daily reset, zero/negative no-ops.

Extension suite: 34 pass. Service worker loads in a sandboxed VM with the new helpers resolved. `./internal/api/` ingest + budget tests pass.

closes #1498