### PR TITLE
fix(storage): reject fabricated price swings that poison the shared history

### DIFF
--- a/internal/storage/postgres/price_corroboration_test.go
+++ b/internal/storage/postgres/price_corroboration_test.go
@@ -1,0 +1,114 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+)
+
+func TestImplausiblePriceSwing(t *testing.T) {
+	cases := []struct {
+		name       string
+		prev, next int
+		want       bool
+	}{
+		{"normal drop", 80000, 74000, false},
+		{"normal rise", 74000, 78000, false},
+		{"exactly 3x is allowed", 20000, 60000, false},
+		{"more than 3x is rejected", 20000, 61000, true},
+		{"collapse to a third is allowed", 60000, 20000, false},
+		{"collapse below a third is rejected", 60000, 19000, true},
+		{"fabricated near-zero drop", 80000, 1, true},
+		{"absurd spike", 80000, 999999999, true},
+		{"zero next is always implausible", 80000, 0, true},
+		{"negative next", 80000, -5, true},
+		{"no prior price, positive is fine", 0, 50000, false},
+		{"no prior price, non-positive is not", 0, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := implausiblePriceSwing(c.prev, c.next); got != c.want {
+				t.Errorf("implausiblePriceSwing(%d, %d) = %v, want %v", c.prev, c.next, got, c.want)
+			}
+		})
+	}
+}
+
+// The cross-tenant poisoning scenario: a second user watching the same car
+// pushes a fabricated steep drop. It must neither enter the shared history nor
+// be reported as a change (which is what would fire a false "price dropped"
+// alert to the first user).
+func TestRecordPrice_RejectsAFabricatedSteepDrop(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	const token = "shared-car"
+
+	// User A's genuine price is observed first.
+	if _, _, err := store.RecordPrice(ctx, token, 80000); err != nil {
+		t.Fatal(err)
+	}
+
+	// User B pushes a fabricated collapse.
+	old, changed, err := store.RecordPrice(ctx, token, 5000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("a fabricated steep drop was reported as a change — it would fire a false alert")
+	}
+	if old != 80000 {
+		t.Fatalf("expected the real price preserved, got %d", old)
+	}
+
+	// The history still shows only the genuine price.
+	hist, err := store.GetPriceHistory(ctx, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hist) != 1 || hist[0].Price != 80000 {
+		t.Fatalf("fabricated price poisoned the history: %+v", hist)
+	}
+}
+
+// A genuine, plausible price drop must still be recorded and reported — that is
+// the product's whole point.
+func TestRecordPrice_RecordsAPlausibleDrop(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	const token = "dropping-car"
+
+	if _, _, err := store.RecordPrice(ctx, token, 80000); err != nil {
+		t.Fatal(err)
+	}
+	old, changed, err := store.RecordPrice(ctx, token, 73000) // a real ~9% cut
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || old != 80000 {
+		t.Fatalf("a genuine price drop was not recorded: changed=%v old=%d", changed, old)
+	}
+	hist, err := store.GetPriceHistory(ctx, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hist) != 2 {
+		t.Fatalf("expected two price points, got %d", len(hist))
+	}
+}
+
+// A non-positive first observation must not seed the history with junk.
+func TestRecordPrice_IgnoresANonPositiveFirstObservation(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	const token = "priceless"
+
+	if _, _, err := store.RecordPrice(ctx, token, 0); err != nil {
+		t.Fatal(err)
+	}
+	hist, err := store.GetPriceHistory(ctx, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hist) != 0 {
+		t.Fatalf("a zero price seeded the history: %+v", hist)
+	}
+}

--- a/internal/storage/postgres/prices.go
+++ b/internal/storage/postgres/prices.go
@@ -9,6 +9,35 @@ import (
 	"github.com/dsionov/carwatch/internal/storage"
 )
 
+// price_history is keyed by token alone and is fed by user-supplied ingest
+// pushes, so it is the one shared table written from untrusted input: any user
+// watching a car can push a price for it, and every user's price chart and
+// drop-detection for that car reads the same rows. A fabricated price is
+// therefore a cross-tenant poisoning vector — most damagingly a fake steep drop
+// that fires a "price dropped!" alert, the product's core trust signal.
+//
+// implausiblePriceSwing rejects the high-impact version of that: an extreme
+// single-step move that no real used-car listing makes. A price that jumps to
+// several times the last observation, or collapses to a small fraction of it,
+// is an error or manipulation, not a sale. Recording it would both corrupt the
+// chart and, on the downward side, trigger a false drop alert. A skipped
+// observation only means that one wild value is not charted; the listing's own
+// displayed price is unaffected (that is guarded separately in the upsert), and
+// a genuine price that is merely re-observed every cycle still lands the moment
+// it falls inside the plausible band.
+const (
+	maxPlausiblePriceRatio = 3.0 // > 3x the previous price
+	minPlausiblePriceRatio = 1.0 / 3.0
+)
+
+func implausiblePriceSwing(prev, next int) bool {
+	if prev <= 0 || next <= 0 {
+		return next <= 0 // a non-positive price is never a real observation
+	}
+	ratio := float64(next) / float64(prev)
+	return ratio > maxPlausiblePriceRatio || ratio < minPlausiblePriceRatio
+}
+
 func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPrice int, changed bool, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -23,7 +52,14 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	scanErr := row.Scan(&prev)
 
 	if scanErr == sql.ErrNoRows {
-		// First observation: insert initial price point.
+		// First observation: insert only if it is a real, positive price. A
+		// non-positive first observation would seed the whole history with junk.
+		if price <= 0 {
+			if err := tx.Commit(); err != nil {
+				return 0, false, fmt.Errorf("record price commit: %w", err)
+			}
+			return 0, false, nil
+		}
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO price_history (token, price) VALUES ($1, $2)`,
 			token, price); err != nil {
@@ -36,6 +72,15 @@ func (s *Store) RecordPrice(ctx context.Context, token string, price int) (oldPr
 	}
 	if scanErr != nil {
 		return 0, false, fmt.Errorf("record price scan prev: %w", scanErr)
+	}
+
+	// Refuse an implausible swing: it does not enter the history and, crucially,
+	// is not reported as a change — so it cannot fire a price-drop alert.
+	if price != prev && implausiblePriceSwing(prev, price) {
+		if err := tx.Commit(); err != nil {
+			return 0, false, fmt.Errorf("record price commit: %w", err)
+		}
+		return prev, false, nil
 	}
 
 	if price != prev {


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass (epic #1510). Closes the price-history poisoning item.

## The problem

`price_history` is keyed by **token alone** and fed by user-supplied ingest pushes — the one shared table written from untrusted input. Any user watching a car can push a price for it, and **every** user's price chart and drop-detection for that car reads the same rows.

So a fabricated price is a **cross-tenant poisoning vector**, most damagingly a fake *steep drop* — which fires a **"price dropped!"** alert (the product's core trust signal) to a *different* user.

## The fix

`RecordPrice` refuses an implausible single-step swing: > 3× the last observation, or < ⅓ of it, is an error or manipulation, not a used-car sale. Such an observation:
- does **not** enter the history, and
- is **not** reported as a change — so it **cannot fire a drop alert**.

A non-positive price is never recorded either (it would seed the history with junk). Genuine plausible drops still record and alert — that's the point — and the listing's own displayed price is untouched (guarded separately in the upsert, #1500).

## Verification

`price_corroboration_test.go`, against real Postgres:
- **the poisoning scenario**: a second user's fabricated collapse (80000 → 5000) is neither recorded nor reported as a change; the history still shows only the genuine price
- a genuine ~9% drop still records and reports `changed`
- a non-positive first observation doesn't seed the history
- boundary table for `implausiblePriceSwing` (exactly 3× / ⅓ allowed, beyond rejected)

`./internal/storage/postgres/` and `./internal/scheduler/...` pass.

## Scope note

This blocks the high-impact vector (wild swings, fake alerts). A *subtle* within-band fake is lower-impact and would need per-chat price history to fully close — flagged for the `search_listings` membership work.

closes #1502