### PR TITLE
feat(api): require a confirm token for destructive admin operations

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -188,10 +188,14 @@ func humanBytes(b int64) string {
 
 func (s *Server) adminPurgeTable(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Table string `json:"table"`
+		Table        string `json:"table"`
+		ConfirmToken string `json:"confirm_token"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Table == "" {
 		writeError(w, http.StatusBadRequest, "table is required")
+		return
+	}
+	if !s.requireConfirmToken(w, r, body.ConfirmToken, "admin_purge") {
 		return
 	}
 
@@ -210,6 +214,15 @@ func (s *Server) adminPurgeTable(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) adminResetAll(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ConfirmToken string `json:"confirm_token"`
+	}
+	// Body is optional in shape but the confirm token within it is not.
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	if !s.requireConfirmToken(w, r, body.ConfirmToken, "admin_reset_all") {
+		return
+	}
+
 	counts, err := s.admin.ResetAllData(r.Context())
 	if err != nil {
 		s.logger.Error("admin: reset all data", "error", err)

--- a/internal/api/admin_confirm.go
+++ b/internal/api/admin_confirm.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// The destructive admin endpoints — reset-all and purge — delete production
+// data in a single call, recoverable only from the nightly backup. One misclick
+// in the admin UI, or a replayed request, and the data is gone. A confirm token
+// turns that into a deliberate two-step action: the client fetches a token,
+// then must echo it back within a short window on the destructive call.
+//
+// The store is in-memory and single-use. Tokens are short-lived, so a lost or
+// leaked one expires on its own, and a process restart simply invalidates any
+// outstanding tokens — which fails safe (a destructive call must re-confirm).
+
+const (
+	confirmTokenTTL      = 60 * time.Second
+	confirmTokenMaxPerIP = 32 // bound the map against a token-minting flood
+)
+
+type confirmToken struct {
+	token   string
+	expires time.Time
+}
+
+type confirmTokenStore struct {
+	mu     sync.Mutex
+	tokens map[int64]confirmToken // adminChatID -> outstanding token
+}
+
+func newConfirmTokenStore() *confirmTokenStore {
+	return &confirmTokenStore{tokens: make(map[int64]confirmToken)}
+}
+
+// issue mints a fresh confirm token for an admin, replacing any outstanding one.
+func (c *confirmTokenStore) issue(chatID int64) (string, time.Time, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", time.Time{}, err
+	}
+	tok := hex.EncodeToString(buf[:])
+	expires := time.Now().Add(confirmTokenTTL)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Opportunistically drop expired entries so an admin churning tokens cannot
+	// grow the map without bound.
+	if len(c.tokens) > confirmTokenMaxPerIP {
+		now := time.Now()
+		for id, t := range c.tokens {
+			if now.After(t.expires) {
+				delete(c.tokens, id)
+			}
+		}
+	}
+	c.tokens[chatID] = confirmToken{token: tok, expires: expires}
+	return tok, expires, nil
+}
+
+// consume validates and burns a token: it returns true at most once per issued
+// token, and only within its TTL.
+func (c *confirmTokenStore) consume(chatID int64, tok string) bool {
+	if tok == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	stored, ok := c.tokens[chatID]
+	if !ok {
+		return false
+	}
+	// Single-use regardless of outcome: a wrong or expired attempt burns it, so
+	// a destructive call always starts from a fresh, deliberate confirmation.
+	delete(c.tokens, chatID)
+	if time.Now().After(stored.expires) {
+		return false
+	}
+	return subtleEqual(stored.token, tok)
+}
+
+// subtleEqual is a constant-time-ish comparison; the tokens are short and
+// random, so timing is not a realistic vector, but there is no reason to leak.
+func subtleEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := 0; i < len(a); i++ {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
+}
+
+// adminConfirmToken mints a confirm token for the destructive admin endpoints.
+func (s *Server) adminConfirmToken(w http.ResponseWriter, r *http.Request) {
+	chatID, ok := requireChatID(w, r)
+	if !ok {
+		return
+	}
+	tok, expires, err := s.confirmTokens.issue(chatID)
+	if err != nil {
+		s.handlerLogger(r, "op", "admin_confirm_token").Error("failed to mint confirm token", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"confirm_token":      tok,
+		"expires_in_seconds": int(time.Until(expires).Seconds()),
+	})
+}
+
+// requireConfirmToken checks the confirm token supplied on a destructive call,
+// writing a 428 (Precondition Required) when it is missing or invalid so the
+// client knows to fetch one and retry. It also emits the audit line: who did
+// what is worth recording distinctly from the operation's own success log.
+func (s *Server) requireConfirmToken(w http.ResponseWriter, r *http.Request, confirmTok, op string) bool {
+	chatID, ok := chatIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "invalid user context")
+		return false
+	}
+	if !s.confirmTokens.consume(chatID, confirmTok) {
+		s.handlerLogger(r, "op", op).Warn("destructive admin op refused: missing or invalid confirm token",
+			"actor_chat_id", chatID, "email", emailFromContext(r.Context()))
+		writeError(w, http.StatusPreconditionRequired,
+			"this action requires a fresh confirm token (GET /api/v1/admin/confirm-token)")
+		return false
+	}
+	// Audit: a destructive action was deliberately confirmed. Kept as a distinct,
+	// greppable line — actor, action — separate from the op's result log.
+	s.handlerLogger(r, "op", op).Warn("AUDIT destructive admin op confirmed",
+		"actor_chat_id", chatID, "email", emailFromContext(r.Context()))
+	return true
+}

--- a/internal/api/admin_confirm_test.go
+++ b/internal/api/admin_confirm_test.go
@@ -1,0 +1,75 @@
+package api
+
+import "testing"
+
+func TestConfirmTokenStore_SingleUse(t *testing.T) {
+	store := newConfirmTokenStore()
+	const admin = int64(1)
+
+	tok, _, err := store.issue(admin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !store.consume(admin, tok) {
+		t.Fatal("a freshly issued token should be accepted once")
+	}
+	// Burned: a replay (the "misclick sends it twice" case) must not work.
+	if store.consume(admin, tok) {
+		t.Fatal("a confirm token was accepted twice — replay is possible")
+	}
+}
+
+func TestConfirmTokenStore_WrongTokenBurnsTheOutstandingOne(t *testing.T) {
+	store := newConfirmTokenStore()
+	const admin = int64(1)
+
+	tok, _, _ := store.issue(admin)
+	// A wrong attempt must fail AND invalidate the outstanding token, so a
+	// destructive call always starts from a fresh, deliberate confirmation.
+	if store.consume(admin, "not-the-token") {
+		t.Fatal("a wrong token was accepted")
+	}
+	if store.consume(admin, tok) {
+		t.Fatal("the real token still worked after a wrong attempt burned it")
+	}
+}
+
+func TestConfirmTokenStore_ExpiredTokenRejected(t *testing.T) {
+	store := newConfirmTokenStore()
+	const admin = int64(1)
+
+	tok, _, _ := store.issue(admin)
+	// Force expiry.
+	store.mu.Lock()
+	entry := store.tokens[admin]
+	entry.expires = entry.expires.Add(-2 * confirmTokenTTL)
+	store.tokens[admin] = entry
+	store.mu.Unlock()
+
+	if store.consume(admin, tok) {
+		t.Fatal("an expired confirm token was accepted")
+	}
+}
+
+func TestConfirmTokenStore_IsPerAdmin(t *testing.T) {
+	store := newConfirmTokenStore()
+	tok1, _, _ := store.issue(1)
+	// Admin 2 cannot use admin 1's token.
+	if store.consume(2, tok1) {
+		t.Fatal("one admin's confirm token was usable by another")
+	}
+	// Admin 1's own token still works (admin 2's failed attempt didn't burn it).
+	if !store.consume(1, tok1) {
+		t.Fatal("admin 1's token was consumed by admin 2's attempt")
+	}
+}
+
+func TestConfirmTokenStore_EmptyTokenNeverConsumes(t *testing.T) {
+	store := newConfirmTokenStore()
+	if _, _, err := store.issue(1); err != nil {
+		t.Fatal(err)
+	}
+	if store.consume(1, "") {
+		t.Fatal("an empty confirm token was accepted")
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -81,15 +81,16 @@ type Server struct {
 	pollingInterval  time.Duration
 	fetchSem         chan struct{}
 
-	logHub     *logstream.Hub
-	logLevel   *slog.LevelVar
-	cycleLog   storage.CycleLogStore
-	cycleStats storage.SearchCycleStatsStore
-	activity   storage.SearchActivityStore
-	extStatus  storage.ExtScanStatusStore
-	extTokens  storage.ExtTokenStore
-	removalBud *removalBudget
-	vitals     *vitalsRing
+	logHub        *logstream.Hub
+	logLevel      *slog.LevelVar
+	cycleLog      storage.CycleLogStore
+	cycleStats    storage.SearchCycleStatsStore
+	activity      storage.SearchActivityStore
+	extStatus     storage.ExtScanStatusStore
+	extTokens     storage.ExtTokenStore
+	removalBud    *removalBudget
+	confirmTokens *confirmTokenStore
+	vitals        *vitalsRing
 
 	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
 	httpReqTotal   atomic.Uint64
@@ -242,6 +243,7 @@ func New(c Config) *Server {
 		pollingInterval: c.PollingInterval,
 		vitals:          newVitalsRing(),
 		removalBud:      newRemovalBudget(),
+		confirmTokens:   newConfirmTokenStore(),
 		fetchSem:        make(chan struct{}, fetchCap),
 	}
 }
@@ -331,6 +333,7 @@ func (s *Server) Routes() http.Handler {
 		authMux.HandleFunc("GET /api/v1/admin/users", s.requireAdmin(s.adminListUsers))
 		authMux.HandleFunc("PATCH /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminSetUserActive))
 		authMux.HandleFunc("DELETE /api/v1/admin/users/{chatID}", s.requireAdmin(s.adminDeleteUser))
+		authMux.HandleFunc("GET /api/v1/admin/confirm-token", s.requireAdmin(s.adminConfirmToken))
 		authMux.HandleFunc("POST /api/v1/admin/purge", s.requireAdmin(s.adminPurgeTable))
 		authMux.HandleFunc("POST /api/v1/admin/reset-all", s.requireAdmin(s.adminResetAll))
 		authMux.HandleFunc("POST /api/v1/admin/vacuum", s.requireAdmin(s.adminVacuum))

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -777,15 +777,74 @@ func TestAdminListListings(t *testing.T) {
 func TestAdminPurgeTable(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
-	w := doRequest(t, srv, "POST", "/api/v1/admin/purge", map[string]string{"table": "seen_listings"})
+	w := doRequest(t, srv, "POST", "/api/v1/admin/purge",
+		map[string]string{"table": "seen_listings", "confirm_token": adminConfirm(t, srv)})
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	w = doRequest(t, srv, "POST", "/api/v1/admin/purge", map[string]string{"table": "users"})
+	w = doRequest(t, srv, "POST", "/api/v1/admin/purge",
+		map[string]string{"table": "users", "confirm_token": adminConfirm(t, srv)})
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for non-purgeable table, got %d", w.Code)
 	}
+}
+
+// adminConfirm fetches a fresh confirm token for the destructive admin ops.
+func adminConfirm(t *testing.T, srv *Server) string {
+	t.Helper()
+	w := doRequest(t, srv, "GET", "/api/v1/admin/confirm-token", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("confirm-token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ConfirmToken string `json:"confirm_token"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode confirm token: %v", err)
+	}
+	if resp.ConfirmToken == "" {
+		t.Fatal("confirm-token returned an empty token")
+	}
+	return resp.ConfirmToken
+}
+
+// The interlock: destructive admin endpoints must refuse without a fresh
+// confirm token, so a misclick or a replayed request cannot wipe production
+// data in one shot.
+func TestAdminDestructiveOps_RequireConfirmToken(t *testing.T) {
+	t.Run("purge without a token is refused", func(t *testing.T) {
+		srv, _ := setupTestServer(t)
+		w := doRequest(t, srv, "POST", "/api/v1/admin/purge", map[string]string{"table": "seen_listings"})
+		if w.Code != http.StatusPreconditionRequired {
+			t.Fatalf("expected 428 without a confirm token, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("reset-all without a token is refused", func(t *testing.T) {
+		srv, _ := setupTestServer(t)
+		w := doRequest(t, srv, "POST", "/api/v1/admin/reset-all", nil)
+		if w.Code != http.StatusPreconditionRequired {
+			t.Fatalf("expected 428 without a confirm token, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("a confirm token is single-use", func(t *testing.T) {
+		srv, _ := setupTestServer(t)
+		tok := adminConfirm(t, srv)
+
+		w := doRequest(t, srv, "POST", "/api/v1/admin/purge",
+			map[string]string{"table": "seen_listings", "confirm_token": tok})
+		if w.Code != http.StatusOK {
+			t.Fatalf("first use should succeed, got %d: %s", w.Code, w.Body.String())
+		}
+		// Replaying the same token must not work.
+		w = doRequest(t, srv, "POST", "/api/v1/admin/purge",
+			map[string]string{"table": "seen_listings", "confirm_token": tok})
+		if w.Code != http.StatusPreconditionRequired {
+			t.Fatalf("a replayed confirm token was accepted (got %d)", w.Code)
+		}
+	})
 }
 
 func TestAdminDeleteListing(t *testing.T) {


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass (epic #1510). Closes the admin-safety item.

## The problem

`reset-all` and `purge` delete production data in a **single call**, recoverable only from the nightly backup. There was **no interlock** — one misclick in the admin UI, or a replayed request, wiped the data with nothing but a log line to show for it.

## The fix

Both endpoints now require a fresh **confirm token**: the client fetches one from `GET /api/v1/admin/confirm-token` and echoes it back on the destructive call.

- **Short-lived** (60s), **single-use**, **per-admin** — a lost/leaked token expires on its own; a replay can't fire the action twice.
- Missing/invalid token → **428 Precondition Required** (tells the client to fetch one and retry).
- A confirmed op writes a distinct, greppable **`AUDIT`** log line naming the actor.

In-memory on purpose: a restart invalidates outstanding tokens, which **fails safe** — the next destructive call must re-confirm.

## Verification

- `admin_confirm_test.go`: single-use, a wrong attempt **burns** the outstanding token, expiry rejection, per-admin isolation, empty-token rejection.
- HTTP-level (`coverage_test.go`): `purge` and `reset-all` both **428 without a token**, and a token **cannot be replayed** (first use 200, second 428). The existing purge test now fetches a token first.
- `auth_matrix` still shows non-admin → 403 (the admin gate runs before the confirm gate).

Full admin test suite passes.

closes #1506