### PR TITLE
feat(ext): fetch beyond page 1 so broad searches don't miss listings

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -348,9 +348,10 @@ async function runFetchCycle() {
 
     const tabId = await ensureYad2Tab();
 
-    // 1) Fetch each search's list feed. NB: the arrow is load-bearing —
-    // `.map(buildFeedURL)` would hand Array.map's index to buildFeedURL's page
-    // argument and request a different page per search.
+    // 1) Fetch page 1 of each search's list feed. NB: the arrow is
+    // load-bearing — `.map(buildFeedURL)` would hand Array.map's index to
+    // buildFeedURL's page argument and request a different page per search.
+    // Results come back in URL order, so feedResults[i] belongs to active[i].
     const feedURLs = active.map((s) => buildFeedURL(s));
     let feedResults = await fetchViaYad2Tab(tabId, feedURLs);
     if (batchUnusable(feedResults)) {
@@ -359,10 +360,14 @@ async function runFetchCycle() {
       feedResults = await fetchViaYad2Tab(tabId, feedURLs);
     }
 
-    // Merge into a token->listing map, preferring the row that already has km.
+    // Parse page 1, and remember how many pages each search spans so broad
+    // searches can have their later pages fetched too (page 1 alone silently
+    // dropped everything past it).
     let blocked = 0;
     const parsedFeeds = [];
-    for (const r of feedResults) {
+    const perSearchTotalPages = new Array(active.length).fill(1);
+    for (let i = 0; i < feedResults.length; i++) {
+      const r = feedResults[i];
       if (looksBlocked(r)) {
         blocked++;
         continue;
@@ -373,7 +378,34 @@ async function runFetchCycle() {
         continue;
       }
       parsedFeeds.push(parsed.listings);
+      if (i < perSearchTotalPages.length && parsed.totalPages > 0) {
+        perSearchTotalPages[i] = parsed.totalPages;
+      }
     }
+
+    // Fetch a bounded, fairly-distributed set of extra pages for the searches
+    // that span more than one. Skipped entirely when the feed was being blocked
+    // (no point spending the tab's clearance on more pages that will also fail).
+    let extraPagesFetched = 0;
+    if (!blocked) {
+      const plan = planExtraFeedPages(perSearchTotalPages);
+      if (plan.length) {
+        const extraURLs = plan.map((p) => buildFeedURL(active[p.searchIndex], p.page));
+        const extraResults = await fetchViaYad2Tab(tabId, extraURLs);
+        for (const r of extraResults) {
+          if (looksBlocked(r)) continue;
+          const parsed = parseFeed(r.body);
+          if (parsed.error) {
+            console.warn("[CarWatch] extra-page parse:", parsed.error, r.url);
+            continue;
+          }
+          parsedFeeds.push(parsed.listings);
+          extraPagesFetched++;
+        }
+      }
+    }
+
+    // Merge into a token->listing map, preferring the row that already has km.
     const byToken = mergeFeedListings(parsedFeeds);
 
     // 2) Re-apply everything we've already resolved (self-healing: the km is
@@ -504,7 +536,7 @@ async function runFetchCycle() {
       searches: activeSearches.length,
       listings: listings.length,
       enriched,
-      diag: `feeds ${feedResults.length - blocked}/${feedResults.length} ok · cache:${cachedApplied} · enrich try:${toEnrich.length} ret:${itemGot} ok:${itemOk} blk:${itemBlocked} perr:${itemParseErr} km:${gotKm} · gone:${removedTokens.length}/${verifyTried}${itemErr ? " · " + itemErr : ""}`,
+      diag: `feeds ${feedResults.length - blocked}/${feedResults.length} ok · pages+${extraPagesFetched} · cache:${cachedApplied} · enrich try:${toEnrich.length} ret:${itemGot} ok:${itemOk} blk:${itemBlocked} perr:${itemParseErr} km:${gotKm} · gone:${removedTokens.length}/${verifyTried}${itemErr ? " · " + itemErr : ""}`,
       error: blocked ? `${blocked} feed(s) blocked by anti-bot` : null,
     });
   } catch (err) {

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -16,6 +16,15 @@ const GW_ITEM_URL = "https://gw.yad2.co.il/vehicles-item";
 // the whole cycle's ingestion would 400 and be lost.
 const MAX_INGEST_BATCH = 400;
 
+// Feed pagination bounds. Only page 1 of each search was ever fetched, so a
+// broad search silently missed everything on page 2+. These cap the extra work:
+// at most MAX_PAGES_PER_SEARCH pages of any one search, and at most
+// MAX_EXTRA_FEED_PAGES_PER_CYCLE extra page-fetches across ALL searches in a
+// cycle — so a user with many broad searches cannot make one cycle balloon into
+// dozens of requests against Yad2.
+const MAX_PAGES_PER_SEARCH = 3;
+const MAX_EXTRA_FEED_PAGES_PER_CYCLE = 8;
+
 // Bound on the token->fields enrichment cache kept in chrome.storage.local.
 const KNOWN_TOKENS_CAP = 3000;
 
@@ -154,6 +163,33 @@ function activeSearches(searches) {
   );
 }
 
+// Plan which extra feed pages to fetch after page 1.
+//
+// Input: one entry per active search giving how many pages that search spans
+// (from the page-1 response's pagination). Output: a flat, bounded list of
+// { searchIndex, page } for pages 2..N, fairly distributed so one very broad
+// search cannot eat the whole per-cycle budget while others get nothing.
+//
+// Fairness matters: without it, a search with 50 pages would consume the entire
+// budget and a second search's page 2 would never be fetched. So this fills
+// round-robin — every search's page 2 before any search's page 3 — up to the
+// per-cycle cap.
+function planExtraFeedPages(
+  perSearchTotalPages,
+  maxPagesPerSearch = MAX_PAGES_PER_SEARCH,
+  maxTotal = MAX_EXTRA_FEED_PAGES_PER_CYCLE,
+) {
+  const plan = [];
+  // page goes 2, 3, ... up to the per-search cap; for each page, sweep searches.
+  for (let page = 2; page <= maxPagesPerSearch && plan.length < maxTotal; page++) {
+    for (let i = 0; i < perSearchTotalPages.length && plan.length < maxTotal; i++) {
+      const total = perSearchTotalPages[i] || 1;
+      if (page <= total) plan.push({ searchIndex: i, page });
+    }
+  }
+  return plan;
+}
+
 // Export for Node-based tests; harmless in the service worker, where these are
 // just globals defined by importScripts.
 if (typeof module !== "undefined" && module.exports) {
@@ -162,6 +198,9 @@ if (typeof module !== "undefined" && module.exports) {
     GW_ITEM_URL,
     MAX_INGEST_BATCH,
     KNOWN_TOKENS_CAP,
+    MAX_PAGES_PER_SEARCH,
+    MAX_EXTRA_FEED_PAGES_PER_CYCLE,
+    planExtraFeedPages,
     buildFeedURL,
     itemURL,
     looksGone,

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -93,8 +93,39 @@ function itemToListing(item, isCommercial) {
   return listing;
 }
 
+// firstPositiveInt returns the first argument that is a positive integer, or 0.
+function firstPositiveInt(...vals) {
+  for (const v of vals) {
+    const n = typeof v === "string" ? Number(v) : v;
+    if (typeof n === "number" && Number.isFinite(n) && n > 0) return Math.floor(n);
+  }
+  return 0;
+}
+
+// How many pages this search's result set spans, read from the feed's
+// pagination block. Yad2 has never documented the exact field names and has
+// changed its payload before, so this is deliberately defensive: it tries the
+// several shapes seen in the wild and DEFAULTS TO 1 when none match. A wrong
+// guess therefore costs nothing — pagination just does not kick in until the
+// field is confirmed — rather than causing over- or under-fetching.
+function extractTotalPages(root) {
+  const src = root && root.data && typeof root.data === "object" ? root.data : root;
+  const p = src && src.pagination;
+  if (p && typeof p === "object") {
+    const tp = firstPositiveInt(p.total_pages, p.pages_count, p.pages, p.last_page, p.totalPages);
+    if (tp) return tp;
+    const totalItems = firstPositiveInt(p.total_items, p.items_count, p.total, p.totalItems);
+    const perPage = firstPositiveInt(p.per_page, p.page_size, p.limit, p.perPage);
+    if (totalItems && perPage) return Math.ceil(totalItems / perPage);
+  }
+  return 1;
+}
+
 // Accepts the raw gw response (object or JSON string). Buckets live under
-// `.data`, but tolerate a top-level bucket object too.
+// `.data`, but tolerate a top-level bucket object too. Returns the parsed
+// listings plus `totalPages` so the caller can decide whether to fetch more
+// pages of the same search (a broad search spans several feed pages, and only
+// page 1 was ever fetched before — everything past it was silently missed).
 function parseFeed(json) {
   let data;
   try {
@@ -127,7 +158,7 @@ function parseFeed(json) {
     seen.add(l.token);
     return true;
   });
-  return { listings: deduped };
+  return { listings: deduped, totalPages: extractTotalPages(data) };
 }
 
 // Parses the per-item detail endpoint
@@ -181,5 +212,5 @@ function parseItemDetail(json) {
 
 // Export for Node-based tests; harmless in the service worker.
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { parseFeed, parseItemDetail, itemToListing };
+  module.exports = { parseFeed, parseItemDetail, itemToListing, extractTotalPages };
 }

--- a/extension/tests/pagination.test.js
+++ b/extension/tests/pagination.test.js
@@ -1,0 +1,95 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  planExtraFeedPages,
+  MAX_PAGES_PER_SEARCH,
+  MAX_EXTRA_FEED_PAGES_PER_CYCLE,
+} = require("../lib.js");
+const { parseFeed, extractTotalPages } = require("../parser.js");
+const { feedResponse } = require("./fixtures.js");
+
+test("planExtraFeedPages returns nothing when every search fits on one page", () => {
+  assert.deepEqual(planExtraFeedPages([1, 1, 1]), []);
+});
+
+test("planExtraFeedPages fetches pages 2..N up to the per-search cap", () => {
+  // One search spanning 5 pages, cap 3 → pages 2 and 3 only.
+  const plan = planExtraFeedPages([5], 3, 100);
+  assert.deepEqual(plan, [
+    { searchIndex: 0, page: 2 },
+    { searchIndex: 0, page: 3 },
+  ]);
+});
+
+test("planExtraFeedPages is fair: every search's page 2 before any search's page 3", () => {
+  // Two broad searches; round-robin means we don't starve the second one.
+  const plan = planExtraFeedPages([4, 4], 3, 100);
+  assert.deepEqual(plan, [
+    { searchIndex: 0, page: 2 },
+    { searchIndex: 1, page: 2 },
+    { searchIndex: 0, page: 3 },
+    { searchIndex: 1, page: 3 },
+  ]);
+});
+
+test("planExtraFeedPages respects the per-cycle total budget", () => {
+  // Five searches each with many pages, budget 3 → only 3 extra fetches, and
+  // they go to the earliest searches' page 2 (fairness fills page 2 first).
+  const plan = planExtraFeedPages([9, 9, 9, 9, 9], 3, 3);
+  assert.equal(plan.length, 3);
+  assert.ok(plan.every((p) => p.page === 2), "budget spent on page 2s first");
+  assert.deepEqual(plan.map((p) => p.searchIndex), [0, 1, 2]);
+});
+
+test("planExtraFeedPages skips searches that do not reach a given page", () => {
+  // Search 0 has 3 pages, search 1 has only 1. Search 1 never contributes.
+  const plan = planExtraFeedPages([3, 1], 3, 100);
+  assert.deepEqual(plan, [
+    { searchIndex: 0, page: 2 },
+    { searchIndex: 0, page: 3 },
+  ]);
+});
+
+test("the per-cycle budget bounds a pathological many-broad-searches cycle", () => {
+  const manyBroad = new Array(50).fill(20); // 50 searches, 20 pages each
+  const plan = planExtraFeedPages(manyBroad);
+  assert.ok(
+    plan.length <= MAX_EXTRA_FEED_PAGES_PER_CYCLE,
+    `plan of ${plan.length} exceeded the per-cycle cap ${MAX_EXTRA_FEED_PAGES_PER_CYCLE}`,
+  );
+});
+
+// --- extractTotalPages: defensive against the unknown gw payload shape ---
+
+test("extractTotalPages reads a total_pages field", () => {
+  assert.equal(extractTotalPages({ data: { pagination: { total_pages: 7 } } }), 7);
+  assert.equal(extractTotalPages({ pagination: { pages_count: 4 } }), 4);
+});
+
+test("extractTotalPages derives pages from total_items / per_page", () => {
+  assert.equal(extractTotalPages({ data: { pagination: { total_items: 95, per_page: 40 } } }), 3);
+});
+
+test("extractTotalPages defaults to 1 when the shape is unknown", () => {
+  // The whole point: a wrong guess must cost nothing (no pagination), never
+  // cause over-fetching.
+  assert.equal(extractTotalPages({ data: { private: [] } }), 1);
+  assert.equal(extractTotalPages({}), 1);
+  assert.equal(extractTotalPages({ pagination: "weird" }), 1);
+});
+
+test("parseFeed reports totalPages alongside the listings", () => {
+  const withPages = JSON.parse(JSON.stringify(feedResponse));
+  withPages.data.pagination = { current_page: 1, total_pages: 5, total_items: 187 };
+
+  const { listings, totalPages, error } = parseFeed(withPages);
+  assert.equal(error, undefined);
+  assert.ok(listings.length > 0);
+  assert.equal(totalPages, 5);
+});
+
+test("parseFeed defaults totalPages to 1 when the feed has no pagination block", () => {
+  const { totalPages } = parseFeed(feedResponse);
+  assert.equal(totalPages, 1);
+});


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass (epic #1510). Closes the pagination item.

## The gap

`buildFeedURL` hardcoded `page=1`. Any search whose result set spanned **more than one feed page** silently dropped everything past it — those cars were never ingested, never alerted, and (being absent from the fetched feed) could even be queued for 404 removal-verification churn every cycle.

## The fix

`parseFeed` now also reports `totalPages`, read **defensively** from the feed's pagination block: it tries the several field shapes seen in the wild (`total_pages` / `pages_count` / `total_items ÷ per_page` / …) and **defaults to 1 when none match** — so a wrong guess about Yad2's undocumented payload costs nothing rather than causing over-fetching.

The cycle then fetches a **bounded, fairly distributed** set of later pages:
- ≤ `MAX_PAGES_PER_SEARCH` (3) pages of any one search,
- ≤ `MAX_EXTRA_FEED_PAGES_PER_CYCLE` (8) extra fetches across all searches per cycle,
- filled **round-robin** (every search's page 2 before any search's page 3), so one very broad search can't starve the others or balloon a cycle into dozens of requests.

Extra pages are skipped while the feed is being blocked. The popup diag shows `pages+N`.

## Verification

Pure `planExtraFeedPages` (lib.js) and `extractTotalPages` (parser.js) with node tests:
- nothing extra when every search fits one page
- pages 2..N up to the per-search cap
- **fairness** (two broad searches interleave: page 2s before page 3s)
- the per-cycle budget caps a **pathological 50-search × 20-page** cycle
- `extractTotalPages` reads `total_pages`, derives from `total_items/per_page`, and **defaults to 1** for unknown/weird shapes
- `parseFeed` surfaces `totalPages` and defaults to 1 with no pagination block

52 extension tests pass; service worker loads in a sandboxed VM.

closes #1499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded feed results beyond the first page, helping surface more available listings for active searches.
  * Added pagination support to accurately identify and retrieve additional result pages.
  * Added balanced limits so searches receive fair coverage while keeping refreshes efficient.

* **Bug Fixes**
  * Improved handling of feeds with missing, malformed, or varying pagination information.
  * Prevented blocked feeds from triggering unnecessary additional page requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->