### PR TITLE
perf(api): cache the Firebase UID to chatID mapping

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -229,6 +229,10 @@ func (s *Server) adminResetAll(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to reset data")
 		return
 	}
+	// Every user row is gone; drop any cached UID→chatID mappings with them.
+	if s.uidCache != nil {
+		s.uidCache.clear()
+	}
 	var total int64
 	for _, n := range counts {
 		total += n
@@ -477,6 +481,11 @@ func (s *Server) adminDeleteUser(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("admin: delete user", "chat_id", chatID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete user")
 		return
+	}
+	// Drop the UID→chatID cache so the deleted account cannot keep resolving
+	// from a stale entry for the rest of the TTL.
+	if s.uidCache != nil {
+		s.uidCache.clear()
 	}
 	s.logger.Info("admin: deleted user", "chat_id", chatID)
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -90,6 +90,7 @@ type Server struct {
 	extTokens     storage.ExtTokenStore
 	removalBud    *removalBudget
 	confirmTokens *confirmTokenStore
+	uidCache      *uidCache
 	vitals        *vitalsRing
 
 	// Cumulative HTTP API metrics (since process start); see observeHTTPRequest.
@@ -244,6 +245,7 @@ func New(c Config) *Server {
 		vitals:          newVitalsRing(),
 		removalBud:      newRemovalBudget(),
 		confirmTokens:   newConfirmTokenStore(),
+		uidCache:        newUIDCache(),
 		fetchSem:        make(chan struct{}, fetchCap),
 	}
 }
@@ -546,9 +548,9 @@ func (s *Server) optionalAuthMiddleware(next http.Handler) http.Handler {
 				return
 			}
 			userEmail = emailFromClaims(tok)
-			id, upsertErr := s.users.UpsertWebUser(r.Context(), tok.UID, userEmail)
-			if upsertErr != nil {
-				s.logger.Error("upsert web user", "error", upsertErr)
+			id, resolveErr := s.resolveWebUser(r.Context(), tok.UID, userEmail)
+			if resolveErr != nil {
+				s.logger.Error("resolve web user", "error", resolveErr)
 				writeError(w, http.StatusInternalServerError, "internal error")
 				return
 			}
@@ -610,9 +612,9 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				return
 			}
 			userEmail = emailFromClaims(tok)
-			id, err := s.users.UpsertWebUser(r.Context(), tok.UID, userEmail)
+			id, err := s.resolveWebUser(r.Context(), tok.UID, userEmail)
 			if err != nil {
-				s.logger.Error("upsert web user", "error", err)
+				s.logger.Error("resolve web user", "error", err)
 				writeError(w, http.StatusInternalServerError, "internal error")
 				return
 			}

--- a/internal/api/uid_cache.go
+++ b/internal/api/uid_cache.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Every authenticated request resolves the caller's Firebase UID to a chatID by
+// calling UpsertWebUser, which — for a user that already exists, i.e. all but
+// the very first request — opens a transaction and runs a SELECT that returns
+// the same chatID every time. On the 1 GB VM that redundant round trip is paid
+// on every poll: the web UI hits /scheduler/status every 30s per tab,
+// /notifications every 60s, and so on, all before the per-user rate limiter can
+// even see the request.
+//
+// uidCache memoizes the UID→chatID mapping so the steady state performs zero
+// user-table round trips. It is safe because UpsertWebUser does not mutate an
+// existing user (it does not update the email on a returning user), so the
+// mapping is stable for the life of the account; a short TTL bounds how long a
+// deleted account could still resolve, and admin deletion clears the cache
+// outright.
+const (
+	uidCacheTTL     = 15 * time.Minute
+	uidCacheMaxSize = 10000 // bound memory; a full cache just re-populates
+)
+
+type uidCacheEntry struct {
+	chatID  int64
+	expires time.Time
+}
+
+type uidCache struct {
+	mu sync.RWMutex
+	m  map[string]uidCacheEntry
+}
+
+func newUIDCache() *uidCache {
+	return &uidCache{m: make(map[string]uidCacheEntry)}
+}
+
+// get returns the cached chatID for a UID when present and unexpired.
+func (c *uidCache) get(uid string) (int64, bool) {
+	c.mu.RLock()
+	e, ok := c.m[uid]
+	c.mu.RUnlock()
+	if !ok || time.Now().After(e.expires) {
+		return 0, false
+	}
+	return e.chatID, true
+}
+
+// put records a UID→chatID mapping. When the cache is full it is cleared rather
+// than evicting one entry at a time: at this scale a full cache is unusual, and
+// a clear simply re-populates from the DB on the next requests.
+func (c *uidCache) put(uid string, chatID int64) {
+	c.mu.Lock()
+	if len(c.m) >= uidCacheMaxSize {
+		c.m = make(map[string]uidCacheEntry, uidCacheMaxSize)
+	}
+	c.m[uid] = uidCacheEntry{chatID: chatID, expires: time.Now().Add(uidCacheTTL)}
+	c.mu.Unlock()
+}
+
+// clear drops every entry. Called when a user is deleted or the data is reset,
+// so a stale mapping cannot outlive the account it points at.
+func (c *uidCache) clear() {
+	c.mu.Lock()
+	c.m = make(map[string]uidCacheEntry)
+	c.mu.Unlock()
+}
+
+// resolveWebUser maps a Firebase UID to its chatID, using the cache to avoid a
+// user-table round trip in the common case. On a miss it upserts (which creates
+// the user on first sight) and caches the result.
+func (s *Server) resolveWebUser(ctx context.Context, uid, email string) (int64, error) {
+	if s.uidCache != nil {
+		if id, ok := s.uidCache.get(uid); ok {
+			return id, nil
+		}
+	}
+	id, err := s.users.UpsertWebUser(ctx, uid, email)
+	if err != nil {
+		return 0, err
+	}
+	if s.uidCache != nil {
+		s.uidCache.put(uid, id)
+	}
+	return id, nil
+}

--- a/internal/api/uid_cache_test.go
+++ b/internal/api/uid_cache_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dsionov/carwatch/internal/storage"
+)
+
+// countingUserStore implements just the UpsertWebUser method resolveWebUser
+// touches, counting the calls. The embedded nil interface makes any other
+// method panic — which is the point: this test asserts resolveWebUser hits the
+// store at most once per UID.
+type countingUserStore struct {
+	storage.UserStore
+	mu    sync.Mutex
+	byUID map[string]int64
+	calls atomic.Int64
+	next  int64
+}
+
+func newCountingUserStore() *countingUserStore {
+	return &countingUserStore{byUID: make(map[string]int64)}
+}
+
+func (c *countingUserStore) UpsertWebUser(_ context.Context, uid, _ string) (int64, error) {
+	c.calls.Add(1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if id, ok := c.byUID[uid]; ok {
+		return id, nil
+	}
+	c.next++
+	c.byUID[uid] = c.next
+	return c.next, nil
+}
+
+func newCacheTestServer(users storage.UserStore) *Server {
+	return &Server{users: users, uidCache: newUIDCache(), logger: slog.Default()}
+}
+
+// The whole point: after the first resolution, repeated requests for the same
+// UID perform zero user-table round trips.
+func TestResolveWebUser_CachesAfterFirstLookup(t *testing.T) {
+	store := newCountingUserStore()
+	srv := newCacheTestServer(store)
+	ctx := context.Background()
+
+	first, err := srv.resolveWebUser(ctx, "uid-1", "a@x.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		id, err := srv.resolveWebUser(ctx, "uid-1", "a@x.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id != first {
+			t.Fatalf("cached chatID drifted: got %d, want %d", id, first)
+		}
+	}
+
+	if n := store.calls.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 user-table round trip for 51 requests, got %d", n)
+	}
+}
+
+// Different users each get resolved once and keep their own chatID.
+func TestResolveWebUser_DistinctPerUID(t *testing.T) {
+	store := newCountingUserStore()
+	srv := newCacheTestServer(store)
+	ctx := context.Background()
+
+	a, _ := srv.resolveWebUser(ctx, "uid-a", "a@x.com")
+	b, _ := srv.resolveWebUser(ctx, "uid-b", "b@x.com")
+	// Repeat both from cache.
+	_, _ = srv.resolveWebUser(ctx, "uid-a", "a@x.com")
+	_, _ = srv.resolveWebUser(ctx, "uid-b", "b@x.com")
+
+	if a == b {
+		t.Fatalf("two UIDs resolved to the same chatID (%d)", a)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("expected 2 round trips (one per UID), got %d", n)
+	}
+}
+
+// A cleared cache re-hits the store — this is what makes admin deletion take
+// effect promptly instead of a deleted account resolving for the whole TTL.
+func TestResolveWebUser_ClearForcesRelookup(t *testing.T) {
+	store := newCountingUserStore()
+	srv := newCacheTestServer(store)
+	ctx := context.Background()
+
+	_, _ = srv.resolveWebUser(ctx, "uid-1", "a@x.com")
+	srv.uidCache.clear()
+	_, _ = srv.resolveWebUser(ctx, "uid-1", "a@x.com")
+
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("expected a re-lookup after clear (2 round trips), got %d", n)
+	}
+}
+
+func TestUIDCache_TTLExpiry(t *testing.T) {
+	c := newUIDCache()
+	c.put("uid-1", 42)
+
+	if id, ok := c.get("uid-1"); !ok || id != 42 {
+		t.Fatalf("fresh entry not returned: id=%d ok=%v", id, ok)
+	}
+
+	// Force expiry.
+	c.mu.Lock()
+	e := c.m["uid-1"]
+	e.expires = time.Now().Add(-time.Minute)
+	c.m["uid-1"] = e
+	c.mu.Unlock()
+
+	if _, ok := c.get("uid-1"); ok {
+		t.Fatal("expired entry was returned")
+	}
+}
+
+func TestUIDCache_ClearedWhenFull(t *testing.T) {
+	c := newUIDCache()
+	// Fill to the cap, then one more triggers the clear-and-repopulate.
+	for i := 0; i < uidCacheMaxSize; i++ {
+		c.put("uid-"+strconv.Itoa(i), int64(i))
+	}
+	c.put("overflow", 999999)
+
+	// After the clear, the cache holds only the overflow entry.
+	c.mu.RLock()
+	size := len(c.m)
+	c.mu.RUnlock()
+	if size != 1 {
+		t.Fatalf("expected the cache to reset to just the overflow entry, size=%d", size)
+	}
+	if id, ok := c.get("overflow"); !ok || id != 999999 {
+		t.Fatalf("overflow entry missing after reset: id=%d ok=%v", id, ok)
+	}
+}


### PR DESCRIPTION
## Review

✅ Audited by the July 2026 deep-audit pass (epic #1510). Closes the auth-hot-path item.

## The cost

Every authenticated request resolved the caller's Firebase UID → chatID via `UpsertWebUser`, which — for any already-existing user (all but their first-ever request) — opens a **transaction** and runs a SELECT that returns the **same chatID every time**. On the 1 GB VM that redundant round trip is paid on every poll: `/scheduler/status` every 30s per tab, `/notifications` every 60s, etc. — and it runs *before* the per-user rate limiter can even see the request, so the limiter can't protect it.

## The fix

A small in-process **UID→chatID cache** (15-min TTL, size-capped at 10k) fronts the lookup. Steady state → **zero user-table round trips**.

Safe because `UpsertWebUser` **does not mutate an existing user** (it doesn't update the email on a returning user), so the mapping is stable for the account's life. The TTL bounds how long a deleted account could still resolve, and **admin user-deletion / reset-all clear the cache** so a deletion takes effect immediately rather than lingering for the TTL.

Both the strict and optional auth middlewares now route through `resolveWebUser`.

## Verification

`uid_cache_test.go`, with a counting user store:
- **51 requests for one UID → exactly 1 round trip** (the headline)
- distinct UIDs each resolve once and keep their own chatID
- `clear()` forces a re-lookup (what makes admin deletion prompt)
- TTL expiry drops an entry
- full-cache reset keeps only the overflow entry

Full `./internal/api/` suite passes (66s, real Postgres) — auth, optional-auth, device-token, and admin paths all green through the new `resolveWebUser`.

closes #1505